### PR TITLE
Correct ROM range

### DIFF
--- a/arch/m68k-all/kernel/virtualtophysical.c
+++ b/arch/m68k-all/kernel/virtualtophysical.c
@@ -33,7 +33,7 @@ AROS_LH1(void *, KrnVirtualToPhysical,
 
         while (*curr_rom)
         {
-            if ((curr_rom[0] <= virtual) && (curr_rom[0] + KernelBase->kb_PlatformData->romsize >= virtual))
+            if (curr_rom[0] <= virtual && virtual < curr_rom[0] + KernelBase->kb_PlatformData->romsize)
                 return curr_rom[1] + (virtual - curr_rom[0]);
             curr_rom = &curr_rom[2];
         }

--- a/workbench/libs/commodities/cxbroker.c
+++ b/workbench/libs/commodities/cxbroker.c
@@ -120,36 +120,27 @@ extern struct InputEvent *cxIHandler();
     
     if (myerr == CBERR_OK)
     {
-	if ((co = CreateCxObj(CX_BROKER, (IPTR)nb, (IPTR)NULL)) != NULL)
-	{
-	    if (co->co_Ext.co_BExt->bext_MsgPort != NULL)
-	    {
-		if (!GPB(CxBase)->cx_Running)
-		{
-		    if (SetupIHandler((struct CommoditiesBase *)CxBase) == FALSE)
-		    {
-			goto sysErr;
-		    }
-		    else
-		    {
-			GPB(CxBase)->cx_Running = TRUE;
-		    }
-		}
-		else
-		{
-		    BrokerCommand(NULL, CXCMD_LIST_CHG);
-		}
-		
-		Enqueue(&GPB(CxBase)->cx_BrokerList, (struct Node *)co);
-		co->co_Flags |= COF_VALID;
-	    }
-	    else
-	    {
-		// Don't set error because Garshneblanker creates a broker
-		// with nb->nb_Port set to NULL
-		// myerr = CBERR_VERSION;
-	    }
-	}
+        if ((co = CreateCxObj(CX_BROKER, (IPTR)nb, (IPTR)NULL)) != NULL)
+        {
+          if (!GPB(CxBase)->cx_Running)
+            {
+              if (SetupIHandler((struct CommoditiesBase *)CxBase) == FALSE)
+                {
+                  goto sysErr;
+                }
+              else
+                {
+                  GPB(CxBase)->cx_Running = TRUE;
+                }
+            }
+          else
+                {
+                  BrokerCommand(NULL, CXCMD_LIST_CHG);
+                }
+
+          Enqueue(&GPB(CxBase)->cx_BrokerList, (struct Node *)co);
+          co->co_Flags |= COF_VALID;
+        }
 	else
 	{
 	sysErr:


### PR DESCRIPTION
The range reached one too far. Also make it easier to read by keeping
the address being compared between the range limits.