### PR TITLE
Add PUBSCREEN to many preferences tools

### DIFF
--- a/workbench/prefs/appearance/main.c
+++ b/workbench/prefs/appearance/main.c
@@ -62,9 +62,6 @@ int main(int argc, char **argv)
                 End),
             End;
 
-            if (pScreen)
-                UnlockPubScreen(NULL, pScreen);
-
             if (application != NULL)
             {
                 SET(window, MUIA_Window_Open, TRUE);
@@ -72,6 +69,9 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/boingiconbar/main.c
+++ b/workbench/prefs/boingiconbar/main.c
@@ -83,9 +83,6 @@ int main(int argc, char **argv)
                 End),
             End;
 
-            if (pScreen)
-                UnlockPubScreen(NULL, pScreen);
-
             if (application != NULL)
             {
                 SET(window, MUIA_Window_Open, TRUE);
@@ -93,6 +90,9 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/boot/args.c
+++ b/workbench/prefs/boot/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2009-2011, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
  */
 
@@ -9,7 +9,7 @@
 #include "args.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR TEMPLATE = "FROM,SAVE/S";
+STATIC CONST_STRPTR TEMPLATE = "FROM,SAVE/S,PUBSCREEN/K";
 STATIC IPTR args[COUNT];
 STATIC struct RDArgs *rdargs;
 

--- a/workbench/prefs/boot/args.h
+++ b/workbench/prefs/boot/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2009-2013, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -12,6 +12,7 @@
 enum Argument {
     FROM,
     SAVE,
+    PUBSCREEN,
     COUNT /* Number of arguments */
 };
 

--- a/workbench/prefs/boot/main.c
+++ b/workbench/prefs/boot/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2009-2016, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -29,6 +29,11 @@ int main(int argc, char **argv)
     /* Show application unless SAVE parameter was used */
     if (!((BOOL)ARG(SAVE)))
     {
+        struct Screen *pScreen = NULL;
+
+        if (ARG(PUBSCREEN))
+            pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
         application = (Object *)ApplicationObject,
             MUIA_Application_Title,  __(MSG_NAME),
             MUIA_Application_Version, (IPTR)VERSION,
@@ -36,6 +41,7 @@ int main(int argc, char **argv)
             MUIA_Application_SingleTask, TRUE,
             MUIA_Application_Base, (IPTR)"BOOTPREF",
             SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                MUIA_Window_Screen, (IPTR)pScreen,
                 MUIA_Window_ID, MAKE_ID('B', 'O', 'O', 'T'),
                 WindowContents, (IPTR)BootEditorObject,
                 End,
@@ -50,6 +56,9 @@ int main(int argc, char **argv)
 
             MUI_DisposeObject(application);
         }
+
+        if (pScreen)
+            UnlockPubScreen(NULL, pScreen);
     }
 
     FreeArguments();

--- a/workbench/prefs/font/args.c
+++ b/workbench/prefs/font/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/font/args.h
+++ b/workbench/prefs/font/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2003, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/font/main.c
+++ b/workbench/prefs/font/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2003-2017, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -33,6 +33,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title,  __(MSG_NAME),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -40,6 +45,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "FONTPREF",
                 SubWindow, (IPTR) (window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, MAKE_ID('F','W','I','N'),
                     WindowContents, (IPTR) FPEditorObject,
                     End,
@@ -54,6 +60,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/icontrol/args.c
+++ b/workbench/prefs/icontrol/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/icontrol/args.h
+++ b/workbench/prefs/icontrol/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 1995-2010, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/icontrol/main.c
+++ b/workbench/prefs/icontrol/main.c
@@ -1,5 +1,5 @@
 /*
-   Copyright © 1995-2016, The AROS Development Team. All rights reserved.
+   Copyright © 1995-2019, The AROS Development Team. All rights reserved.
    $Id$
  */
 
@@ -41,6 +41,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title, __(MSG_WINTITLE),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -48,6 +53,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "ICONTROLPREF",
                 SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, ID_ICTL,
                     WindowContents, (IPTR) IControlEditorObject,
                     End,
@@ -61,6 +67,9 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/input/args.c
+++ b/workbench/prefs/input/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004-2010, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/input/args.h
+++ b/workbench/prefs/input/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2003, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/input/main.c
+++ b/workbench/prefs/input/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright  2003-2017, The AROS Development Team. All rights reserved.
+    Copyright  2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -48,6 +48,11 @@ int main(int argc, char **argv)
             mempool = CreatePool(MEMF_PUBLIC | MEMF_CLEAR, 2048, 2048);
             if (mempool != 0)
             {
+                struct Screen *pScreen = NULL;
+
+                if (ARG(PUBSCREEN))
+                    pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
                 Prefs_ScanDirectory("DEVS:Keymaps/#?_~(#?.info)", &keymap_list, sizeof(struct KeymapEntry));
 
                 application = ApplicationObject,
@@ -57,6 +62,7 @@ int main(int argc, char **argv)
                     MUIA_Application_SingleTask, TRUE,
                     MUIA_Application_Base, (IPTR) "INPUTPREF",
                     SubWindow, (IPTR) (window = SystemPrefsWindowObject,
+                        MUIA_Window_Screen, (IPTR)pScreen,
                         MUIA_Window_ID, MAKE_ID('I','W','I','N'),
                         WindowContents, (IPTR) IPEditorObject,
                         TAG_DONE),
@@ -71,6 +77,9 @@ int main(int argc, char **argv)
 
                     MUI_DisposeObject(application);
                 }
+
+                if (pScreen)
+                    UnlockPubScreen(NULL, pScreen);
 
                 DeletePool((APTR)mempool);
             }

--- a/workbench/prefs/locale/args.c
+++ b/workbench/prefs/locale/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004-2010, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/locale/args.h
+++ b/workbench/prefs/locale/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2003-2010, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/locale/main.c
+++ b/workbench/prefs/locale/main.c
@@ -1,5 +1,5 @@
 /*
-   Copyright © 1995-2016, The AROS Development Team. All rights reserved.
+   Copyright © 1995-2019, The AROS Development Team. All rights reserved.
    $Id$
  */
 
@@ -49,6 +49,11 @@ int main(int argc, char **argv)
             }
             else
             {
+                struct Screen *pScreen = NULL;
+
+                if (ARG(PUBSCREEN))
+                    pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
                 application = (Object *)ApplicationObject,
                     MUIA_Application_Title, __(MSG_WINTITLE),
                     MUIA_Application_Version, (IPTR) VERSION,
@@ -56,6 +61,7 @@ int main(int argc, char **argv)
                     MUIA_Application_SingleTask, TRUE,
                     MUIA_Application_Base, (IPTR) "LOCALEPREF",
                     SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                        MUIA_Window_Screen, (IPTR)pScreen,
                         MUIA_Window_ID, ID_LCLE,
                         WindowContents, (IPTR) LocaleRegisterObject,
                         End,
@@ -69,6 +75,10 @@ int main(int argc, char **argv)
 
                     MUI_DisposeObject(application);
                 }
+
+                if (pScreen)
+                    UnlockPubScreen(NULL, pScreen);
+
             }
             FreeArguments();
         }

--- a/workbench/prefs/network/args.c
+++ b/workbench/prefs/network/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2009-2013, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -9,7 +9,7 @@
 #include "args.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR args[COUNT];
 STATIC struct RDArgs *rdargs;
 

--- a/workbench/prefs/network/args.h
+++ b/workbench/prefs/network/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2009-2011, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,6 +13,7 @@ enum Argument {
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT /* Number of arguments */
 };
 

--- a/workbench/prefs/network/main.c
+++ b/workbench/prefs/network/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2009-2016, The AROS Development Team. All rights reserved.
+    Copyright © 2009-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -34,6 +34,11 @@ int main(int argc, char **argv)
     /* Show application unless SAVE or USE parameters were used */
     if (!((BOOL)ARG(SAVE)) && !((BOOL)ARG(USE)))
     {
+        struct Screen *pScreen = NULL;
+
+        if (ARG(PUBSCREEN))
+            pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
         application = (Object *)ApplicationObject,
             MUIA_Application_Title,  __(MSG_NAME),
             MUIA_Application_Version, (IPTR)VERSION,
@@ -41,6 +46,7 @@ int main(int argc, char **argv)
             MUIA_Application_SingleTask, TRUE,
             MUIA_Application_Base, (IPTR)"NETPREF",
             SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                MUIA_Window_Screen, (IPTR)pScreen,
                 MUIA_Window_ID, MAKE_ID('N', 'E', 'T', 'P'),
                 WindowContents, (IPTR)NetPEditorObject,
                 End,
@@ -55,6 +61,8 @@ int main(int argc, char **argv)
 
             MUI_DisposeObject(application);
         }
+        if (pScreen)
+            UnlockPubScreen(NULL, pScreen);
     }
 
     FreeArguments();

--- a/workbench/prefs/palette/args.c
+++ b/workbench/prefs/palette/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/palette/args.h
+++ b/workbench/prefs/palette/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/palette/main.c
+++ b/workbench/prefs/palette/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2010-2016, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -55,6 +55,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title, __(MSG_WINTITLE),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -62,6 +67,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "PALETTEPREF",
                 SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, ID_PALT,
                     WindowContents, (IPTR) PalEditorObject,
                     End,
@@ -75,6 +81,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/pointer/args.c
+++ b/workbench/prefs/pointer/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/pointer/args.h
+++ b/workbench/prefs/pointer/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/pointer/main.c
+++ b/workbench/prefs/pointer/main.c
@@ -41,6 +41,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title, __(MSG_WINTITLE),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -48,6 +53,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "POINTERPREF",
                 SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, ID_NPTR,
                     WindowContents, (IPTR) PTEditorObject,
                     End,
@@ -61,6 +67,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/printer/args.c
+++ b/workbench/prefs/printer/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/printer/args.h
+++ b/workbench/prefs/printer/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2003, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/printer/main.c
+++ b/workbench/prefs/printer/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2016, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2019, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -46,6 +46,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Author, (IPTR)"Jason McMullan <jason.mcmullan@gmail.com>",
                 MUIA_Application_Copyright, (IPTR)"2012, AROS Team",
@@ -56,6 +61,7 @@ int main(int argc, char **argv)
                 MUIA_Application_Base, (IPTR) "PRINTERPREF",
                 SubWindow, (IPTR)(window =
                     SystemPrefsWindowObject,
+                        MUIA_Window_Screen, (IPTR)pScreen,
                         MUIA_Window_ID, ID_PTXT,
                         WindowContents, (IPTR)
                                 PrinterEditorObject,
@@ -70,6 +76,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/reqtools/args.c
+++ b/workbench/prefs/reqtools/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2013, The AROS Development Team. All rights reserved.
+    Copyright © 2013-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/reqtools/args.h
+++ b/workbench/prefs/reqtools/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2013, The AROS Development Team. All rights reserved.
+    Copyright © 2013-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/reqtools/main.c
+++ b/workbench/prefs/reqtools/main.c
@@ -1,5 +1,5 @@
 /*
-   Copyright © 2013-2016, The AROS Development Team. All rights reserved.
+   Copyright © 2013-2019, The AROS Development Team. All rights reserved.
    $Id$
  */
 
@@ -41,6 +41,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title, __(MSG_WINDOW_TITLE),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -48,6 +53,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "REQTOOLSPREF",
                 SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, MAKE_ID('R', 'Q', 'T', 'S'),
                     WindowContents, (IPTR) ReqToolsEditorObject,
                     End,
@@ -61,6 +67,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/screenmode/args.c
+++ b/workbench/prefs/screenmode/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/screenmode/args.h
+++ b/workbench/prefs/screenmode/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2010, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/screenmode/main.c
+++ b/workbench/prefs/screenmode/main.c
@@ -41,6 +41,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             app = (Object *) ApplicationObject,
                 MUIA_Application_Title, (IPTR) __(MSG_NAME),
                 MUIA_Application_Version, (IPTR) vers,
@@ -50,7 +55,8 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "SCREENMODEPREF",
                 SubWindow, (IPTR)(win = (Object *) SystemPrefsWindowObject,
-                MUIA_Window_ID, MAKE_ID('S','W','I','N'),
+                  MUIA_Window_Screen, (IPTR)pScreen,
+                  MUIA_Window_ID, MAKE_ID('S','W','I','N'),
                     WindowContents, (IPTR) SMEditorObject,
                     End,
                 End),
@@ -64,6 +70,8 @@ int main(int argc, char **argv)
             
                 MUI_DisposeObject(app);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/prefs/serial/args.c
+++ b/workbench/prefs/serial/args.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 /*** Global Variables *******************************************************/
-STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S";
+STATIC CONST_STRPTR   TEMPLATE = "FROM,USE/S,SAVE/S,PUBSCREEN/K";
 STATIC IPTR           args[COUNT];
 STATIC struct RDArgs *rdargs;
 STATIC BPTR           olddir = (BPTR)-1;

--- a/workbench/prefs/serial/args.h
+++ b/workbench/prefs/serial/args.h
@@ -2,7 +2,7 @@
 #define _ARGS_H_
 
 /*
-    Copyright © 2003, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2019, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -14,6 +14,7 @@ enum Argument
     FROM,
     USE,
     SAVE,
+    PUBSCREEN,
     COUNT  /* Number of arguments */
 };
 

--- a/workbench/prefs/serial/main.c
+++ b/workbench/prefs/serial/main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2016, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2019, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -47,6 +47,11 @@ int main(int argc, char **argv)
         }
         else
         {
+            struct Screen *pScreen = NULL;
+
+            if (ARG(PUBSCREEN))
+                pScreen = LockPubScreen((CONST_STRPTR)ARG(PUBSCREEN));
+
             application = (Object *)ApplicationObject,
                 MUIA_Application_Title, __(MSG_WINTITLE),
                 MUIA_Application_Version, (IPTR) VERSION,
@@ -54,6 +59,7 @@ int main(int argc, char **argv)
                 MUIA_Application_SingleTask, TRUE,
                 MUIA_Application_Base, (IPTR) "SERIALPREF",
                 SubWindow, (IPTR)(window = (Object *)SystemPrefsWindowObject,
+                    MUIA_Window_Screen, (IPTR)pScreen,
                     MUIA_Window_ID, ID_SERL,
                     WindowContents, (IPTR) SerEditorObject,
                     End,
@@ -67,6 +73,8 @@ int main(int argc, char **argv)
 
                 MUI_DisposeObject(application);
             }
+            if (pScreen)
+                UnlockPubScreen(NULL, pScreen);
         }
         FreeArguments();
     }

--- a/workbench/utilities/Clock/main.c
+++ b/workbench/utilities/Clock/main.c
@@ -121,7 +121,7 @@ static void GetArguments(int argc, char **argv)
 	if (args[ARG_TOP])    optionTop    = *(LONG*)args[ARG_TOP];
 	if (args[ARG_WIDTH])  optionWidth  = *(LONG*)args[ARG_WIDTH];
 	if (args[ARG_HEIGHT]) optionHeight = *(LONG*)args[ARG_HEIGHT];
-	if (args[ARG_HEIGHT]) optionPubscr = StrDup((STRPTR)args[ARG_PUBSCREEN]);
+	if (args[ARG_PUBSCREEN]) optionPubscr = StrDup((STRPTR)args[ARG_PUBSCREEN]);
 
 	FreeArgs(rdargs);
 #       undef TMPSIZE


### PR DESCRIPTION
This adds the PUBSCREEN option to several preferences tools as done before by @Kalamatee and corrects both the ordinary Clock tool and Clock preferences that both had the option but in various ways did not implement it properly.

I also moved the public screen release to after the window is opened, to make it safe.

The Pointer preferences tool does not start at all on my machine, so it has not been verified properly in this commit, even though I made the changes to it anyway.
