### PR TITLE
Avoid doing datatype object layout twice

### DIFF
--- a/workbench/libs/datatypes/doasynclayout.c
+++ b/workbench/libs/datatypes/doasynclayout.c
@@ -53,15 +53,12 @@ void AsyncLayouter(void)
     
     while (!done)
     {
+        dtsi->si_Flags &= ~DTSIF_NEWSIZE;
 	DoMethodA(object, (Msg)&lm->lm_gplayout);
 	
         ObtainSemaphore(&(GPB(dtb)->dtb_Semaphores[SEM_ASYNC]));
         if (dtsi->si_Flags & DTSIF_NEWSIZE)
         {
-            /* Ensure the method is only called once more unless there's
-               another request to restart it */
-            dtsi->si_Flags &= ~DTSIF_NEWSIZE;
-
             /* Ensure Ctrl-C is cleared in case it was set again after the
                method saw it, or the method finished without seeing it */
             CheckSignal(SIGBREAKF_CTRL_C);


### PR DESCRIPTION
I could be wrong on this according to the comment, but I think the comment (which is removed in this commit) is confusing. The first part of the comment indicate it should be called once more (for what reason I do not know), and then it goes on about  "unless there's another request to restart it",  which seems out of place with the code.

There should be no reason to perform the layout twice, and doing it once seems to work with multiview, I tried with both a `.png` and a `.guide` file. I added some trace in my copy and it does the layout twice before and once after this change.

I suggest doing the layout only once.

The code works by having this process doing the layout, which can stop early on ctrl-c. This is done by another call to `DoAsyncLayout` before the layout is done. This sends the ctrl-c and sets the  `DTSIF_NEWSIZE` flag to cause the process to restart the layout.

Note:
There was a fix 4 years that introduced this behaviour. That fix also correctly added the semaphore and ctrl-c reset which I think were real bugs. If this double call really was needed at that time, then my guess is that it patched a symptom of anther problem. There should be no valid reason to call layout twice every time.

Anyway, have a look and think a bit about it.