### PR TITLE
Correct use of PUBSCREEN environment variable in LockPubScreen

### DIFF
--- a/rom/intuition/lockpubscreen.c
+++ b/rom/intuition/lockpubscreen.c
@@ -9,7 +9,7 @@
 #include <dos/dos.h>
 #include "intuition_intern.h"
 
-static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
+extern struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
 
 /*****************************************************************************
 
@@ -241,7 +241,7 @@ static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
 
 
 /* case insensitive FindName() */
-static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name)
+struct PubScreenNode *findcasename(struct List *list, const UBYTE *name)
 {
     struct Node *node;
 

--- a/rom/intuition/unlockpubscreen.c
+++ b/rom/intuition/unlockpubscreen.c
@@ -6,7 +6,7 @@
 
 #include "intuition_intern.h"
 
-static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
+extern struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
 
 /*****************************************************************************
 
@@ -113,20 +113,3 @@ static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name);
 
     AROS_LIBFUNC_EXIT
 } /* UnlockPubScreen */
-
-
-/* case insensitive FindName() */
-static struct PubScreenNode *findcasename(struct List *list, const UBYTE *name)
-{
-    struct Node *node;
-
-    for (node = GetHead(list); node; node = GetSucc(node))
-    {
-        if(node->ln_Name)
-        {
-            if (!strcasecmp (node->ln_Name, name))
-                break;
-        }
-    }
-    return (struct PubScreenNode *)node;
-}


### PR DESCRIPTION
This makes the new PUBSCREEN environment variable work correctly.

I also noticed that LockPubScreen() could probably benefit from being cleaned up a bit. It locks the public screen list in two places and the code to deal with if no screen was found and defaulting the Workbench is a little bit hard to read. I have not done that in this pull request.