### PR TITLE
Fix unicode handling in scalos build script

### DIFF
--- a/scripts/cpy-dir-rec.py
+++ b/scripts/cpy-dir-rec.py
@@ -32,7 +32,8 @@ def copy_tree(src, dst, ignore):
     # directories like Locale/Help/Español on non-western systems, where locale
     # is different from Latin-1 (e. g. russian).
     # See http://docs.python.org/2/howto/unicode.html#unicode-filenames
-    names = os.listdir(unicode(src))
+    src_u = unicode(src, "utf-8").encode("utf-8")
+    names = os.listdir(src_u)
 
     if not os.path.exists(dst):
         os.makedirs(dst)


### PR DESCRIPTION
Hi,

this small patch should solve a unicode handling in a py2 script.

See https://github.com/AmigaPorts/AROS-main/pull/2 for context

This PR replaces that one.

Thanks for reviewing!