### PR TITLE
absolute branch (jsr) is necessary since elf2hunk cannot deal with bs…

### DIFF
--- a/arch/m68k-amiga/timer/timer_init.c
+++ b/arch/m68k-amiga/timer/timer_init.c
@@ -132,7 +132,7 @@ static void TimerHook(struct Resource *cia, struct TimerBase *tb, WORD iCRBit)
 		void libname##_##funcname##_Wrapper(void) \
 	        { asm volatile ( \
 	        	"move.l %a0,%sp@-\n" \
-	        	"bsr " AS_STRING(AROS_SLIB_ENTRY(funcname, libname, funcid)) "\n" \
+	        	"jsr " AS_STRING(AROS_SLIB_ENTRY(funcname, libname, funcid)) "\n" \
 	        	"move.l %sp@+,%a0\n" \
 	        	"rts\n" ); } \
 		/* Insert into the library's jumptable */ \
@@ -144,7 +144,7 @@ static void TimerHook(struct Resource *cia, struct TimerBase *tb, WORD iCRBit)
 		void libname##_##funcname##_Wrapper(void) \
 	        { asm volatile ( \
 	        	"movem.l %a0-%a1,%sp@-\n" \
-	        	"bsr " AS_STRING(AROS_SLIB_ENTRY(funcname, libname, funcid)) "\n" \
+	        	"jsr " AS_STRING(AROS_SLIB_ENTRY(funcname, libname, funcid)) "\n" \
 	        	"movem.l %sp@+,%a0-%a1\n" \
 	        	"rts\n" ); } \
 		/* Insert into the library's jumptable */ \


### PR DESCRIPTION
since elf2hunk cannot deal with bsr.w yet. It gets confused by PC16 relocation within one hunk...