### PR TITLE
Fixed bug in ScrollLayer. The offset was subtracted instead of added

### DIFF
--- a/rom/hyperlayers/scrolllayer.c
+++ b/rom/hyperlayers/scrolllayer.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2007, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -85,8 +85,8 @@
   }
   else
   {
-    l->Scroll_X -= dx;
-    l->Scroll_Y -= dy;
+    l->Scroll_X += dx;
+    l->Scroll_Y += dy;
   }
   
   UnlockLayer(l);


### PR DESCRIPTION
to non-superbitmapped layers.

I tested this change against os3, and AROS behaved differently for the following small test.
AROS did not display the second rectangle before the fix, as it put it outside of the visible area.

#include <intuition/intuition.h>
#include <proto/intuition.h>
#include <proto/graphics.h>
#include <proto/layers.h>
#include <exec/types.h>

int main(int argc, char **argv) {
    struct Window *window = OpenWindowTags(NULL,
                                             WA_Width, 200L,
                                             WA_Height, 200L,
                                             WA_Left, 10L,
                                             WA_Top, 40L,
                                             WA_Activate, TRUE,
                                             WA_Flags, WFLG_RMBTRAP | WFLG_CLOSEGADGET | WFLG_DEPTHGADGET,
                                             WA_Title, (IPTR) "Layertest",
                                             WA_SimpleRefresh, TRUE,
                                             WA_MinWidth, 15,
                                             WA_MinHeight, 15,
                                             WA_ReportMouse, TRUE,
                                             WA_NewLookMenus, TRUE,
                                             TAG_DONE, 0L);

    SetAPen(window->RPort, 1);
    RectFill(window->RPort, 4, 4, 50, 50);
    ScrollLayer(0, window->RPort->Layer, -70, -70);
    SetAPen(window->RPort, 2);
    RectFill(window->RPort, 4, 4, 40, 40);
    return 0;
}
