### PR TITLE
Correct the test for cache blocks that are allocated memory

### DIFF
--- a/rom/filesys/fat/cache.c
+++ b/rom/filesys/fat/cache.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2010-2015, The AROS Development Team. All rights reserved.
+    Copyright © 2010-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     Disk cache.
@@ -109,7 +109,7 @@ APTR Cache_CreateCache(APTR priv, ULONG hash_size, ULONG block_count,
 
         c->blocks = AllocVec(sizeof(APTR) * block_count,
             MEMF_PUBLIC | MEMF_CLEAR);
-        if(c == NULL)
+        if(c->blocks == NULL)
             success = FALSE;
 
         for(i = 0; i < block_count && success; i++)


### PR DESCRIPTION
Also is line 81 correct? It is setting sysbase to the cache before it is allocated memory!