### PR TITLE
Fix copyright symbol to (C)

### DIFF
--- a/workbench/devs/diskimage/zune_gui/locale.h
+++ b/workbench/devs/diskimage/zune_gui/locale.h
@@ -98,7 +98,7 @@
 #define MSG_SETTINGS_PLUGINS_STR "Plugins..."
 #define MSG_PROJECT_CLOSE_STR "Close"
 #define MSG_OK_GAD_STR "Ok"
-#define MSG_ABOUT_REQ_STR "%s version %ld.%ld\n%s version %ld.%ld\n\nCopyright 0xA9 2007-2010 Fredrik Wikstrom\nWebsite: http://a500.org\nE-mail: fredrik0x40a500.org"
+#define MSG_ABOUT_REQ_STR "%s version %ld.%ld\n%s version %ld.%ld\n\nCopyright (C) 2007-2010 Fredrik Wikstrom\nWebsite: http://a500.org\nE-mail: fredrik0x40a500.org"
 #define MSG_ERROR_STR "Error"
 #define MSG_NOAISS_REQ_STR "AISS assign not found.\n\nDownload and install the latest version\nfrom here: http://masonicons.de"
 #define MSG_OLDAISS_REQ_STR "AISS v%ld.%ld or newer required.\n\nDownload and install the latest version\nfrom here: http://masonicons.de"

--- a/workbench/network/common/C/arp.c
+++ b/workbench/network/common/C/arp.c
@@ -36,10 +36,10 @@
  */
 
 static const char version[] __attribute__((used)) = "$VER: arp 3.2 (12.09.2005) "
-  "Copyright 0xA9 2005 Pavel Fedin <sonic_amiga@rambler.ru>\n"
-  "Copyright 0xA9 1993 AmiTCP/IP Group, <amitcp-group@hut.fi>\n"
+  "Copyright (C) 2005 Pavel Fedin <sonic_amiga@rambler.ru>\n"
+  "Copyright (C) 1993 AmiTCP/IP Group, <amitcp-group@hut.fi>\n"
   "Helsinki University of Technology, Finland.\n"
-  "Copyright 0xA9 1984 The Regents of the University of California.\n"
+  "Copyright (C) 1984 The Regents of the University of California.\n"
   "All rights reserved.\n";
 
 

--- a/workbench/prefs/PSI/psi.c
+++ b/workbench/prefs/PSI/psi.c
@@ -422,7 +422,7 @@ int main(int argc, char *argv[])
         app = ApplicationObject,
             MUIA_Application_Title      , "PSI",
             MUIA_Application_Version    , VersionString,
-            MUIA_Application_Copyright  , "0xA9 1995-97, Stefan Stuntz",
+            MUIA_Application_Copyright  , "(C) 1995-97, Stefan Stuntz",
             MUIA_Application_Author     , "Stefan Stuntz",
             MUIA_Application_Description, "Public Screen Inspector",
             MUIA_Application_SingleTask , TRUE,

--- a/workbench/prefs/font/main.c
+++ b/workbench/prefs/font/main.c
@@ -17,7 +17,7 @@
 #include "fpeditor.h"
 #include "prefs.h"
 
-#define VERSION "$VER: Fonts 1.1 ("ADATE") 0xA9 AROS Dev Team"
+#define VERSION "$VER: Fonts 1.1 ("ADATE") (C) AROS Dev Team"
 
 int main(int argc, char **argv)
 {

--- a/workbench/prefs/screenmode/main.c
+++ b/workbench/prefs/screenmode/main.c
@@ -21,7 +21,7 @@
 #include "smeditor.h"
 
 #define VERSION "ScreenMode Preferences 1.11 (11.01.2020)"
-#define COPYRIGHT "Copyright 0xA9 1995-2020, The AROS Development Team"
+#define COPYRIGHT "Copyright (C) 1995-2020, The AROS Development Team"
 
 static const char vers[] = VERSION;
 static const char version[] __attribute__((used)) = "$VER: " VERSION "\n";

--- a/workbench/prefs/time/main.c
+++ b/workbench/prefs/time/main.c
@@ -479,7 +479,7 @@ static struct Screen *MakeGUI(void)
     app = ApplicationObject,
         MUIA_Application_Title, (IPTR)"Time",
         MUIA_Application_Version, (IPTR)VERSIONSTR,
-        MUIA_Application_Copyright, (IPTR)"Copyright 0xA9 1995-2011, The AROS Development Team",
+        MUIA_Application_Copyright, (IPTR)"Copyright (C) 1995-2011, The AROS Development Team",
         MUIA_Application_Author, (IPTR)"The AROS Development Team",
         MUIA_Application_Description, (IPTR)MSG(MSG_WINTITLE),
         MUIA_Application_SingleTask, TRUE,

--- a/workbench/prefs/trackdisk/trackdisk_prefs.c
+++ b/workbench/prefs/trackdisk/trackdisk_prefs.c
@@ -73,7 +73,7 @@ int main(void)
         MUIA_Application_Description, __(MSG_DESCRIPTION),
 	    MUIA_Application_SingleTask, TRUE,
         MUIA_Application_Title, __(MSG_NAME),
-	MUIA_Application_Version, (IPTR)"$VER: Trackdisk 41.5 (30.11.2007) 0xA9 2007 Pavel Fedin and Team AROS",
+	MUIA_Application_Version, (IPTR)"$VER: Trackdisk 41.5 (30.11.2007) (C) 2007 Pavel Fedin and Team AROS",
 	    MUIA_Application_Window,
 	    MainWin = MUI_NewObject("Window.mui", MUIA_Window_ID, MAKE_ID('M', 'A', 'I', 'N'),
             MUIA_Window_Title,__(MSG_WINDOW_TITLE),

--- a/workbench/prefs/wanderer/main.c
+++ b/workbench/prefs/wanderer/main.c
@@ -23,7 +23,7 @@
 #include "locale.h"
 #include "wpeditor.h"
 
-#define VERSIONSTR "$VER: Wanderer Prefs 1.4 (14.01.2012) 0xA9 1995-2012 The AROS Development Team"
+#define VERSIONSTR "$VER: Wanderer Prefs 1.4 (14.01.2012) (C) 1995-2012 The AROS Development Team"
 
 int main(void)
 {

--- a/workbench/utilities/Clock/main.c
+++ b/workbench/utilities/Clock/main.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
     application = (Object *)ApplicationObject,
         MUIA_Application_Title, (IPTR) MSG(MSG_WINDOW_TITLE),
         MUIA_Application_Version, (IPTR) versionString,
-        MUIA_Application_Copyright, (IPTR)"0xA9 2006, The AROS Development Team",
+        MUIA_Application_Copyright, (IPTR)"(C) 2006, The AROS Development Team",
         MUIA_Application_Description, (IPTR) MSG(MSG_DESCRIPTION),
         MUIA_Application_Base, (IPTR) "CLOCK",
         SubWindow, (IPTR) (window = (Object *)WindowObject,

--- a/workbench/utilities/Clock/version.h
+++ b/workbench/utilities/Clock/version.h
@@ -9,6 +9,6 @@
 #define VERSION 	1
 #define REVISION 	4
 #define DATESTR 	"10.02.2006"
-#define VERSIONSTR	"$VER: Clock 1.4 (" DATESTR ") 0xA9 AROS Dev Team"
+#define VERSIONSTR	"$VER: Clock 1.4 (" DATESTR ") (C) AROS Dev Team"
 
 #endif /* _VERSION_H */

--- a/workbench/utilities/Installer/texts.h
+++ b/workbench/utilities/Installer/texts.h
@@ -63,7 +63,7 @@
 #define ABOUT_ON_INSTALLER  "About Installer"
 #define ABOUT_INSTALLER                        \
 " This is AROS Installer V%d.%d\n"        \
-" Copyright 0xA9 1995-2003, The AROS Development Team.\n"\
+" Copyright (C) 1995-2003, The AROS Development Team.\n"\
 " All rights reserved.\n"                \
 "\n"                                        \
 " It is intended to be compatible to\n"        \


### PR DESCRIPTION
Change to just a pure text copyright symbol (C), which also silences the same warnings. This fixes my stupid mistakes.