### PR TITLE
Fixes

### DIFF
--- a/arch/x86_64-all/posixc/vfork.s
+++ b/arch/x86_64-all/posixc/vfork.s
@@ -16,14 +16,14 @@
     .set    stack,   15*8
 
 AROS_CDEFNAME(vfork):
-    lea     (-bufsize)(%rsp), %rsp /* _JMPLEN + 1 longs on the stack
-		                   it's our temporary jmp_buf */
+    lea     (-bufsize)(%rsp), %rsp  /* _JMPLEN + 1 longs on the stack
+                                    it's our temporary jmp_buf */
     mov     %rsp, %rdi
-    call    setjmp              /* fill jmp_buf on the stack with
-	                           current register values */
-    mov     bufsize(%rsp), %rax    /* set return address in jmp_buf */
-    mov     %rax, 0(%rdi)       /* to this function call return 
-	                           address */
-    lea     bufsize(%rsp), %rax    /* set stack value in jmp_buf */
-    mov     %rax, 120(%rdi)     /* this function call */
-    call    __vfork             /* __vfork call won't return */
+    call    setjmp                  /* fill jmp_buf on the stack with
+                                    current register values */
+    mov     bufsize(%rsp), %rax     /* set return address in jmp_buf */
+    mov     %rax, 0(%rdi)           /* to this function call return
+                                    address */
+    lea     bufsize(%rsp), %rax     /* set stack value in jmp_buf */
+    mov     %rax, 120(%rdi)         /* this function call */
+    call    __vfork                 /* __vfork call won't return */

--- a/arch/x86_64-all/posixc/vfork.s
+++ b/arch/x86_64-all/posixc/vfork.s
@@ -26,4 +26,5 @@ AROS_CDEFNAME(vfork):
                                     address */
     lea     bufsize(%rsp), %rax     /* set stack value in jmp_buf */
     mov     %rax, stack(%rdi)       /* this function call */
+    sub     $0x8, %rsp              /* align stack to 16 bytes */
     call    __vfork                 /* __vfork call won't return */

--- a/arch/x86_64-all/posixc/vfork.s
+++ b/arch/x86_64-all/posixc/vfork.s
@@ -25,5 +25,5 @@ AROS_CDEFNAME(vfork):
     mov     %rax, 0(%rdi)           /* to this function call return
                                     address */
     lea     bufsize(%rsp), %rax     /* set stack value in jmp_buf */
-    mov     %rax, 120(%rdi)         /* this function call */
+    mov     %rax, stack(%rdi)       /* this function call */
     call    __vfork                 /* __vfork call won't return */

--- a/arch/x86_64-all/posixc/vfork_longjmp.s
+++ b/arch/x86_64-all/posixc/vfork_longjmp.s
@@ -6,42 +6,42 @@
 /* This function works the same as longjmp() except it lacks the argument 
    check. It's used only by vfork() implementation. */
 
-	#include "aros/x86_64/asm.h"
+    #include "aros/x86_64/asm.h"
 
-	.text
-	_ALIGNMENT
-	.globl	AROS_CDEFNAME(vfork_longjmp)
-	_FUNCTION(AROS_CDEFNAME(vfork_longjmp))
+    .text
+    _ALIGNMENT
+    .globl    AROS_CDEFNAME(vfork_longjmp)
+    _FUNCTION(AROS_CDEFNAME(vfork_longjmp))
 
-	.set	FirstArg, 8 /* Skip Return-Adress */
-	.set	env, FirstArg
-	.set	val, env+8
+    .set    FirstArg, 8     /* Skip Return-Adress */
+    .set    env, FirstArg
+    .set    val, env+8
 
 AROS_CDEFNAME(vfork_longjmp):
     mov %rdi, %rax
-	/* Restore stack pointer and all registers from env */
-	mov 120(%rax),%rsp /* Restore original stack */
+    /* Restore stack pointer and all registers from env */
+    mov 120(%rax),%rsp      /* Restore original stack */
 
-	mov 0(%rax),%rcx
-	mov %rcx,retaddr(%rsp) /* Restore return address */
+    mov 0(%rax),%rcx
+    mov %rcx,retaddr(%rsp)  /* Restore return address */
 
-	push %rsi /* Save return value on new stack */
+    push %rsi               /* Save return value on new stack */
 
-	/* Restore all registers */
-	mov 8(%rax),%rbx /* %ebx */
-	mov 16(%rax),%rcx /* %ecx */
-	mov 24(%rax),%rdx /* %edx */
-	mov 32(%rax),%rsi /* %esi */
-	mov 40(%rax),%rdi /* %edi */
-	mov 48(%rax),%rbp /* %ebp */
-	mov 56(%rax),%r8
-	mov 64(%rax),%r9
-	mov 72(%rax),%r10
-	mov 80(%rax),%r11
-	mov 88(%rax),%r12
-	mov 96(%rax),%r13
-	mov 104(%rax),%r14
-	mov 112(%rax),%r15
+    /* Restore all registers */
+    mov 8(%rax),%rbx        /* %rbx */
+    mov 16(%rax),%rcx       /* %rcx */
+    mov 24(%rax),%rdx       /* %rdx */
+    mov 32(%rax),%rsi       /* %rsi */
+    mov 40(%rax),%rdi       /* %rdi */
+    mov 48(%rax),%rbp       /* %rbp */
+    mov 56(%rax),%r8
+    mov 64(%rax),%r9
+    mov 72(%rax),%r10
+    mov 80(%rax),%r11
+    mov 88(%rax),%r12
+    mov 96(%rax),%r13
+    mov 104(%rax),%r14
+    mov 112(%rax),%r15
 
-	pop %rax /* Fetch return value */
-	ret
+    pop %rax                /* Fetch return value */
+    ret


### PR DESCRIPTION
Fixes related to aligning stack to 16 bytes in vfork to follow ABI.
Problems visible when movaps is issued (results if SIGSEV).