### PR TITLE
This filling of a structure is trivial, and so isn't uncompliant.

### DIFF
--- a/workbench/devs/AHI/Device/misc.c
+++ b/workbench/devs/AHI/Device/misc.c
@@ -156,8 +156,6 @@ SprintfA( char *dst, const char *fmt, IPTR* args )
 void
 AHIInitSemaphore( struct SignalSemaphore* sigSem )
 {
-  // TODO: Verify license compatibility (Code mostly stolen from AROS).
-
   sigSem->ss_WaitQueue.mlh_Head     = (struct MinNode *)&sigSem->ss_WaitQueue.mlh_Tail;
   sigSem->ss_WaitQueue.mlh_Tail     = NULL;
   sigSem->ss_WaitQueue.mlh_TailPred = (struct MinNode *)&sigSem->ss_WaitQueue.mlh_Head;


### PR DESCRIPTION
Found this in #122 as license compliance is my thing.

Since this is just filling a structure, it's trivial and not really relevant for compliance. There aren't many different ways to write this function.

This closes #122