### PR TITLE
Merge Routing/IOAPIC fixes

### DIFF
--- a/arch/all-pc/kernel/acpi_ioapic.c
+++ b/arch/all-pc/kernel/acpi_ioapic.c
@@ -623,6 +623,10 @@ AROS_UFH2(IPTR, ACPI_hook_Table_Int_Src_Ovr_Parse,
     else
         intrMap->im_Trig = 0;
 
+    /*
+     * TODO: get the SCI interrupt value from FADT,
+     * instead of using hard coded "9"
+     */
     if ((intrMap->im_IRQ == 9)  && (intrMap->im_Polarity) && (intrMap->im_Trig))
     {
         defaultPol = intrMap->im_Polarity - 1;

--- a/rom/kernel/kernel_interruptcontrollers.h
+++ b/rom/kernel/kernel_interruptcontrollers.h
@@ -45,8 +45,8 @@ struct IntrMapping
 {
     struct Node im_Node;                                                        /* NB - ln_Pri == source IRQ                    */
     UBYTE       im_IRQ;                                                         /* actual IRQ to use                            */
-    UBYTE       im_Polarity;                                                    /* 0 = HIGH, 1 = LOW                            */
-    UBYTE       im_Trig;                                                        /* 0 = LEVEL, 1 = EDGE                          */
+    UBYTE       im_Polarity;                                                    /* 0 = Default, 1 = HIGH, 2 = LOW                            */
+    UBYTE       im_Trig;                                                        /* 0 = Default, 1 = LEVEL, 2 = EDGE                          */
 };
 
 /*


### PR DESCRIPTION
Adjust the default polarity/trigger level policy based on reported SCI values (if applicable).
May still need adjusted but should give the correct defaults to use for a given platform.
