### PR TITLE
Kernel: adjust the mapping node element names and add comments to cla…

### DIFF
--- a/rom/kernel/kernel_interruptcontroller.c
+++ b/rom/kernel/kernel_interruptcontroller.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2017, The AROS Development Team. All rights reserved.
+    Copyright © 2017-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -94,6 +94,7 @@ BOOL krnInitInterrupt(struct KernelBase *KernelBase, icid_t irq, icid_t icid, ic
     return FALSE;
 }
 
+/* Returns a mapping node for a requested Device Interrupt */
 struct IntrMapping *krnInterruptMapping(struct KernelBase *KernelBase, icid_t irq)
 {
     struct IntrMapping *intrMap;
@@ -108,13 +109,14 @@ struct IntrMapping *krnInterruptMapping(struct KernelBase *KernelBase, icid_t ir
     return NULL;
 }
 
+/* Returns a mapping node for a requested controller Hardware Interrupt */
 struct IntrMapping *krnInterruptMapped(struct KernelBase *KernelBase, icid_t irq)
 {
     struct IntrMapping *intrMap;
 
     ForeachNode(&KernelBase->kb_InterruptMappings, intrMap)
     {
-        if (intrMap->im_IRQ == irq)
+        if (intrMap->im_Int == irq)
         {
             return intrMap;
         }

--- a/rom/kernel/kernel_interruptcontrollers.h
+++ b/rom/kernel/kernel_interruptcontrollers.h
@@ -31,11 +31,11 @@ struct IntrController
 {
     struct Node ic_Node;
     ULONG        ic_Count;
-    ULONG        ic_Type;                                                     /* IC drivers private "type"                      */
+    ULONG        ic_Type;                                                     /* IC drivers private "type"                              */
     ULONG        ic_Flags;
     APTR        ic_Private;
-    icid_t      (*ic_Register)(struct KernelBase *);                          /* one time initialization called during Add      */
-    BOOL        (*ic_Init)(struct KernelBase *, icid_t);                      /*                                                */
+    icid_t      (*ic_Register)(struct KernelBase *);                          /* one time initialization called during Add              */
+    BOOL        (*ic_Init)(struct KernelBase *, icid_t);                      /*                                                        */
     BOOL        (*ic_IntrEnable)(APTR, icid_t, icid_t);
     BOOL        (*ic_IntrDisable)(APTR, icid_t, icid_t);
     BOOL        (*ic_IntrAck)(APTR, icid_t, icid_t);
@@ -43,10 +43,14 @@ struct IntrController
 
 struct IntrMapping
 {
-    struct Node im_Node;                                                        /* NB - ln_Pri == source IRQ                    */
-    UBYTE       im_IRQ;                                                         /* actual IRQ to use                            */
-    UBYTE       im_Polarity;                                                    /* 0 = Default, 1 = HIGH, 2 = LOW                            */
-    UBYTE       im_Trig;                                                        /* 0 = Default, 1 = LEVEL, 2 = EDGE                          */
+    /*
+     * im_Node.ln_Pri contains the Device IRQ
+     * as used by KrnAddIRQHandler();
+     */
+    struct Node im_Node;
+    UBYTE       im_Int;                                                         /* controller specific hardware interrupt to use        */
+    UBYTE       im_Polarity;                                                    /* 0 = Default, 1 = HIGH, 2 = LOW                       */
+    UBYTE       im_Trig;                                                        /* 0 = Default, 1 = LEVEL, 2 = EDGE                     */
 };
 
 /*


### PR DESCRIPTION
…rify element roles. Add comment about the use of the support functions.

pc/IOAPIC: Adjust to match kernel changes, and use the correct functions to obtain
mapping nodes. create a reverse mapping for routed pins.