### PR TITLE
Move the x86 exception/hw irq base definitions to aros/cpu.h, and inc…

### DIFF
--- a/arch/all-pc/_notes/x86-cpu-vectors.txt
+++ b/arch/all-pc/_notes/x86-cpu-vectors.txt
@@ -49,3 +49,11 @@ where they are handled in the Kernel (right)
 255
 
 * - May vary, depending on how many System CPU Exceptions are defined.
+
+Depending on the System, IRQs may be handled differently.
+# On machines where APIC is not available or disabled, only ExceptionsA, and the PIC interrupts will be Available/Used.
+# On ACPI machines with APIC, ExceptionsA & B will be used. If enough remaingin vectors are available, and MSI is not
+explicitly disabled by ACPI, then KrnAllocIRQ will allow allocating IRQTYPE_APIC IRQs.
+# If, on ACPI machines with APIC, an IOAPIC is available and enabled, the first 24 Device IRQs will be controlled/routed through it,
+otherwise the legacy PIC controller will be used.
+

--- a/arch/all-pc/_notes/x86-cpu-vectors.txt
+++ b/arch/all-pc/_notes/x86-cpu-vectors.txt
@@ -1,0 +1,51 @@
+X86 CPU Vectors and Interrupt handling.
+
+This diagram shows the relationship between the CPU vectors (on the left, their use cases in AROS (middle) and
+where they are handled in the Kernel (right)
+
+"x86" Vectors
+
+0
+|  ---                                  ------------------------------------------------------------------------
+|   |                                                  | ExceptionsA        | KernelBase->kb_Exceptions[0..31]
+|   |  ----- x86 CPU Exceptions                        |                    |
+|   |                                                  |                    |
+|   |                                                  |                    |
+|  ---     -----                        ------------------------------------------------------------------------
+|           | |                                        | Device IRQs        | KernelBase->kb_Interrupts[0.. 213(*)]
+|           | |                                        | #0 - #213(*)       |
+|           | |                                        |                    |
+|           | |      -----  PIC interrupts             | #2 is directly     |
+|           | |                                        | connected to PIC   |
+|           | |                                        | and unusable by the|
+|           |---                                       | IO-APIC            |
+|           |                                          |                    |
+|           |                                          |                    |
+|           |        ----- IO-APIC interrupts          |                    |
+|           |                                          |                    |
+|           |                                          |                    |
+|          ---   ---                                   |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |  ----- APIC/"MSI" interrupts       |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|                 |                                    |                    |
+|  ~~~           ~~~                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|   |                                                  | ExceptionsB        | KernelBase->kb_Exceptions[32..41(*)]
+|   |                                                  |                    |
+|   | ------ System CPU Exceptions                     |                    |
+|   |                                                  |                    |
+|   |                                                  |                    |
+|  ---                                   ----------------------------------------------------------------------
+255
+
+* - May vary, depending on how many System CPU Exceptions are defined.

--- a/arch/all-pc/hidds/pcipc/pcipc.conf
+++ b/arch/all-pc/hidds/pcipc/pcipc.conf
@@ -1,7 +1,7 @@
 ##begin config
 basename	PCIPC
 libbasetype	struct PCIPCBase
-version		1.4
+version		1.5
 residentpri     87
 oopbase_field   psd.OOPBase
 superclass      CLID_Hidd_PCIDriver
@@ -41,6 +41,7 @@ classdatatype  struct PCIPCDeviceData
 New
 .interface Hidd_PCIDevice
 VectorIRQ
+ArchVector
 ObtainVectors
 ReleaseVectors
 ##end methodlist

--- a/arch/all-pc/hidds/pcipc/pcipc_deviceclass.c
+++ b/arch/all-pc/hidds/pcipc/pcipc_deviceclass.c
@@ -14,11 +14,12 @@
 #include <proto/oop.h>
 #include <proto/acpica.h>
 
+#include <aros/cpu.h>
 #include <exec/types.h>
+#include <utility/tagitem.h>
+#include <oop/oop.h>
 #include <hidd/pci.h>
 #include <hardware/pci.h>
-#include <oop/oop.h>
-#include <utility/tagitem.h>
 
 #include <acpica/acnames.h>
 #include <acpica/accommon.h>
@@ -237,7 +238,7 @@ UBYTE PCIPCDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct p
                 }
                 DMSI(bug("[PCIPC:Device] %s: msimdr = %04x\n", __func__, msimdr);)
 
-                vectirq = (msimdr & 0xFF) + msg->vector;
+                vectirq = ((msimdr & 0xFF) + msg->vector) - HW_IRQ_BASE;
             }
             else
             {
@@ -347,14 +348,14 @@ BOOL PCIPCDev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o, struc
                 
                 cmeth.wcw.mID = HiddPCIDeviceBase + moHidd_PCIDevice_WriteConfigWord;
                 cmeth.wcw.reg = capmsi + PCIMSI_DATA64;
-                cmeth.wcw.val = apicIRQBase;
+                cmeth.wcw.val = HW_IRQ_BASE + apicIRQBase;
                 OOP_DoMethod(o, &cmeth.wcw.mID);
             }
             else
             {
                 cmeth.wcw.mID = HiddPCIDeviceBase + moHidd_PCIDevice_WriteConfigWord;
                 cmeth.wcw.reg = capmsi + PCIMSI_DATA32;
-                cmeth.wcw.val = apicIRQBase;
+                cmeth.wcw.val = HW_IRQ_BASE + apicIRQBase;
                 OOP_DoMethod(o, &cmeth.wcw.mID);
             }
 

--- a/arch/all-pc/hidds/pcipc/pcipc_deviceclass.c
+++ b/arch/all-pc/hidds/pcipc/pcipc_deviceclass.c
@@ -222,7 +222,7 @@ UBYTE PCIPCDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct p
         {
             DMSI(bug("[PCIPC:Device] %s: MSI Queue size = %u\n", __func__, (1 <<((msiflags & PCIMSIF_MMEN_MASK) >> 4)));)
             /* MSI is enabled .. but is the requested vector valid? */
-            if (msg->vector < data->msicnt)
+            if (msg->vectorno < data->msicnt)
             {
                 UWORD msimdr;
 
@@ -238,11 +238,11 @@ UBYTE PCIPCDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct p
                 }
                 DMSI(bug("[PCIPC:Device] %s: msimdr = %04x\n", __func__, msimdr);)
 
-                vectirq = ((msimdr & 0xFF) + msg->vector) - HW_IRQ_BASE;
+                vectirq = ((msimdr & 0xFF) + msg->vectorno) - HW_IRQ_BASE;
             }
             else
             {
-                bug("[PCIPC:Device] %s: Illegal MSI vector %u\n", __func__, msg->vector);
+                bug("[PCIPC:Device] %s: Illegal MSI vector %u\n", __func__, msg->vectorno);
             }
         }
         else
@@ -256,7 +256,7 @@ UBYTE PCIPCDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct p
     }
 
     /* If MSI wasnt enabled and they have just asked for the first vector - return the PCI int line */
-    if (!vectirq && msg->vector == 0)
+    if (!vectirq && msg->vectorno == 0)
     {
         struct pHidd_PCIDevice_ReadConfigByte cmeth;
         cmeth.mID = HiddPCIDeviceBase + moHidd_PCIDevice_ReadConfigByte;
@@ -264,6 +264,13 @@ UBYTE PCIPCDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct p
         vectirq = (UBYTE)OOP_DoMethod(o, &cmeth.mID);
     }
     return vectirq;
+}
+
+UBYTE PCIPCDev__Hidd_PCIDevice__ArchVector(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_ArchVector *msg)
+{
+    D(bug("[PCIPC:Device] %s()\n", __func__);)
+
+    return 0;
 }
 
 BOOL PCIPCDev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_ObtainVectors *msg)

--- a/arch/all-pc/kernel/apic_ia32.h
+++ b/arch/all-pc/kernel/apic_ia32.h
@@ -1,12 +1,14 @@
 #ifndef APIC_IA32_H
 #define APIC_IA32_H
 /*
-    Copyright © 1995-2018, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: IA-32 APIC hardware definitions.
     Lang: english
 */
+
+#include <aros/cpu.h>
 
 #include "i8259a.h"
 
@@ -15,7 +17,6 @@
 // eventually remapped to LAPIC with help of IOAPIC). Official APIC IRQ base starts right
 // after legacy XT-PIC
 #define APIC_IRQ_MAX            256
-#define X86_CPU_EXCEPT_COUNT    32
 #define APIC_IRQ_BASE           (X86_CPU_EXCEPT_COUNT + I8259A_IRQCOUNT)
 
 // Local APIC exceptions, with SysCall being the last (int $0xff)! The numeric values start
@@ -147,6 +148,8 @@ enum
 /*
  * MS HyperV CPUID definitions
  */
+
+// TODO: Move to public header
 
 #define HYPERV_CPUID_MIN			0x40000005
 #define HYPERV_CPUID_MAX			0x4000ffff

--- a/arch/all-pc/utility/mmakefile.src
+++ b/arch/all-pc/utility/mmakefile.src
@@ -6,9 +6,11 @@ include $(SRCDIR)/config/aros.cfg
 -include $(SRCDIR)/arch/$(CPU)-all/utility/make.opts
 
 USER_INCLUDES := -I$(SRCDIR)/rom/utility
+USER_CFLAGS := -mavx
 
 FILES := \
-    setmem_sse
+    setmem_sse \
+    setmem_avx \
 
 #MM- kernel-utility-pc : includes
 

--- a/arch/all-pc/utility/setmem_avx.c
+++ b/arch/all-pc/utility/setmem_avx.c
@@ -77,7 +77,7 @@
 
         /* avx fill 32bytes at a time ... */
         for (i = 0; i < avxfillcount; ++i) {
-            if (avxfillcount > 3)
+            if ((avxfillcount - i) > 3)
             {
                 _mm256_store_si256((__m256i*)p, c32);
                 _mm256_store_si256((__m256i*)((IPTR)p + 32), c32);
@@ -86,7 +86,7 @@
                 p += (32 << 2);
                 i += 3;
             }
-            if (avxfillcount > 1)
+            if ((avxfillcount - i) > 1)
             {
                 _mm256_store_si256((__m256i*)p, c32);
                 _mm256_store_si256((__m256i*)((IPTR)p + 32), c32);

--- a/arch/all-pc/utility/setmem_avx.c
+++ b/arch/all-pc/utility/setmem_avx.c
@@ -1,4 +1,4 @@
-#ifdef __SSE__
+#ifdef __AVX__
 /*
     Copyright © 2020, The AROS Development Team. All rights reserved.
     $Id$
@@ -7,8 +7,6 @@
 #include <aros/debug.h>
 #include <exec/types.h>
 
-#include <emmintrin.h>
-
 #include "setmem_pc.h"
 
 /****i************************************************************************
@@ -16,7 +14,7 @@
     NAME */
 #include <proto/utility.h>
 
-        AROS_LH3(APTR, SetMem_SSE,
+        AROS_LH3(APTR, SetMem_AVX,
 
 /*  SYNOPSIS */
         AROS_LHA(APTR, destination, A0),
@@ -58,16 +56,16 @@
     p = (char *) destination;
     val = (char) c;
 
-    if (length > 15)
+    if (length > 31)
     {
-        ULONG presize, ssefillcount;
+        ULONG presize, avxfillcount;
 
-        presize = (((IPTR) destination + 15 ) & ~15) - (IPTR)destination;
-        ssefillcount = (length - presize) / 16;
-        postsize = length - ssefillcount * 16 - presize;
+        presize = (((IPTR) destination + 31 ) & ~31) - (IPTR)destination;
+        avxfillcount = (length - presize) / 32;
+        postsize = length - avxfillcount * 32 - presize;
 
-        /* setup sse value .. */
-        __m128i c16 = _mm_set_epi8(val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val);
+        /* setup avx value .. */
+        __m256i c32 = _mm256_set1_epi8(val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val);
 
         D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, presize));
 
@@ -75,30 +73,30 @@
         __smallsetmem(p, val, presize);
         p += presize;
 
-        D(bug("[utility:pc] %s: 0x%p, %d x 16\n", __func__, p, ssefillcount));
+        D(bug("[utility:pc] %s: 0x%p, %d x 32\n", __func__, p, avxfillcount));
 
-        /* sse fill 16bytes at a time ... */
-        for (i = 0; i < ssefillcount; ++i) {
-            if (ssefillcount > 3)
+        /* avx fill 32bytes at a time ... */
+        for (i = 0; i < avxfillcount; ++i) {
+            if (avxfillcount > 3)
             {
-                _mm_store_si128((__m128i*)p, c16);
-                _mm_store_si128((__m128i*)((IPTR)p + 16), c16);
-                _mm_store_si128((__m128i*)((IPTR)p + 32), c16);
-                _mm_store_si128((__m128i*)((IPTR)p + 48), c16);
-                p += (16 << 2);
+                _mm256_store_si256((__m256i*)p, c32);
+                _mm256_store_si256((__m256i*)((IPTR)p + 32), c32);
+                _mm256_store_si256((__m256i*)((IPTR)p + 64), c32);
+                _mm256_store_si256((__m256i*)((IPTR)p + 96), c32);
+                p += (32 << 2);
                 i += 3;
             }
-            if (ssefillcount > 1)
+            if (avxfillcount > 1)
             {
-                _mm_store_si128((__m128i*)p, c16);
-                _mm_store_si128((__m128i*)((IPTR)p + 16), c16);
-                p += (16 << 1);
+                _mm256_store_si256((__m256i*)p, c32);
+                _mm256_store_si256((__m256i*)((IPTR)p + 32), c32);
+                p += (32 << 1);
                 i += 1;
             }
             else
             {
-                _mm_store_si128((__m128i*)p, c16);
-                p += 16;
+                _mm256_store_si256((__m256i*)p, c32);
+                p += 32;
             }
         }
     }
@@ -117,7 +115,7 @@
     AROS_LIBFUNC_EXIT
 }
 
-#if defined(USE_SSE_COPYMEM)
-AROS_MAKE_ALIAS(AROS_SLIB_ENTRY(SetMem_SSE,Utility,66),AROS_SLIB_ENTRY(SetMem,Utility,66));
-#endif /* USE_SSE_COPYMEM */
-#endif /* __SSE__ */
+#if defined(USE_AVX_COPYMEM)
+AROS_MAKE_ALIAS(AROS_SLIB_ENTRY(SetMem_AVX,Utility,66),AROS_SLIB_ENTRY(SetMem,Utility,66));
+#endif /* USE_AVX_COPYMEM */
+#endif /* __AVX__ */

--- a/arch/all-pc/utility/setmem_pc.h
+++ b/arch/all-pc/utility/setmem_pc.h
@@ -1,0 +1,16 @@
+#ifndef SETMEM_PC_H
+#define SETMEM_PC_H
+
+/* support function for small copies ..*/
+static VOID __smallsetmem(APTR destination, UBYTE c, ULONG length)
+{
+    int i;
+
+    register char *p = (char *) destination;
+
+    for (i = 0; i < length; i++) {
+        p[i] = c;
+    }
+}
+
+#endif

--- a/arch/all-pc/utility/setmem_sse.c
+++ b/arch/all-pc/utility/setmem_sse.c
@@ -79,7 +79,7 @@
 
         /* sse fill 16bytes at a time ... */
         for (i = 0; i < ssefillcount; ++i) {
-            if (ssefillcount > 3)
+            if ((ssefillcount - i) > 3)
             {
                 _mm_store_si128((__m128i*)p, c16);
                 _mm_store_si128((__m128i*)((IPTR)p + 16), c16);
@@ -88,7 +88,7 @@
                 p += (16 << 2);
                 i += 3;
             }
-            if (ssefillcount > 1)
+            if ((ssefillcount - 0) > 1)
             {
                 _mm_store_si128((__m128i*)p, c16);
                 _mm_store_si128((__m128i*)((IPTR)p + 16), c16);

--- a/arch/i386-all/include/aros/cpu.h
+++ b/arch/i386-all/include/aros/cpu.h
@@ -2,7 +2,7 @@
 #define AROS_I386_CPU_H
 
 /*
-    Copyright © 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     NOTE: This file must compile *without* any other header !
@@ -10,6 +10,13 @@
     Desc: CPU-specific definitions for 32-bit x86 processors
     Lang: english
 */
+
+/*
+ *  The first Hardware IRQ starts at 32
+ *  (0 - 31 are x86 cpu exceptions, see below..)
+ */
+#define X86_CPU_EXCEPT_COUNT    32
+#define HW_IRQ_BASE     X86_CPU_EXCEPT_COUNT
 
 typedef  unsigned char cpuid_t;
 typedef  unsigned char apicid_t;

--- a/arch/x86_64-all/include/aros/cpu.h
+++ b/arch/x86_64-all/include/aros/cpu.h
@@ -11,6 +11,13 @@
     Lang: english
 */
 
+/*
+ *  The first Hardware IRQ starts at 32
+ *  (0 - 31 are x86 cpu exceptions, see below..)
+ */
+#define X86_CPU_EXCEPT_COUNT    32
+#define HW_IRQ_BASE     X86_CPU_EXCEPT_COUNT
+
 typedef  unsigned char cpuid_t;
 typedef  unsigned char apicid_t;
 typedef  void *cpumask_t;

--- a/rom/hidds/pci/pci.conf
+++ b/rom/hidds/pci/pci.conf
@@ -173,7 +173,8 @@ VOID Release()
 IPTR HasExtendedConfig()
 VOID SetMSIEnabled(UBYTE val)
 VOID ClearAndSetMSIXFlags(UWORD clear, UWORD set)
-UBYTE VectorIRQ(ULONG vector)
+UBYTE VectorIRQ(ULONG vectorno)
+UBYTE ArchVector(ULONG vectorno)
 BOOL ObtainVectors(const struct TagItem *requirements)
 VOID ReleaseVectors()
 ##end   methodlist
@@ -257,6 +258,7 @@ HasExtendedConfig
 SetMSIEnabled
 ClearAndSetMSIXFlags
 VectorIRQ
+ArchVector
 ObtainVectors
 ReleaseVectors
 ##end methodlist

--- a/rom/hidds/pci/pci.conf
+++ b/rom/hidds/pci/pci.conf
@@ -1,6 +1,6 @@
 ##begin config
 basename	PCI
-version		40.5
+version		40.6
 libbasetype	struct pcibase
 classptr_field  psd.pciClass
 classid         CLID_Hidd_PCI

--- a/rom/hidds/pci/pcideviceclass.c
+++ b/rom/hidds/pci/pcideviceclass.c
@@ -207,7 +207,7 @@ void PCIDev__Hidd_PCIDevice__ClearAndSetMSIXFlags(OOP_Class *cl, OOP_Object *o, 
     SYNOPSIS
         UBYTE OOP_DoMethod(OOP_Object *obj, struct pHidd_PCIDevice_VectorIRQ *Msg);
 
-        UBYTE HIDD_PCIDevice_VectorIRQ(OOP_Object *obj, ULONG vector);
+        UBYTE HIDD_PCIDevice_VectorIRQ(OOP_Object *obj, ULONG vectorno);
 
     LOCATION
         CLID_Hidd_PCIDevice
@@ -217,7 +217,7 @@ void PCIDev__Hidd_PCIDevice__ClearAndSetMSIXFlags(OOP_Class *cl, OOP_Object *o, 
 
     INPUTS
         obj   - Pointer to the device object.
-        vector - Vector to return the IRQ for.
+        vectorno - Vector to return the IRQ for.
 
     RESULT
         Returns the Hardware IRQ on success, for use with AddIntServer.
@@ -240,12 +240,54 @@ UBYTE PCIDev__Hidd_PCIDevice__VectorIRQ(OOP_Class *cl, OOP_Object *o, struct pHi
 
     D(bug("[PCIDevice] %s()\n", __func__);)
 
-    if (msg->vector == 0)
+    if (msg->vectorno == 0)
     {
         vectirq = getByte(cl, o, PCICS_INT_LINE);
     }
     return vectirq;
 }
+
+
+/*****************************************************************************************
+
+    NAME
+        moHidd_PCIDevice_ArchVector
+
+    SYNOPSIS
+        UBYTE OOP_DoMethod(OOP_Object *obj, struct pHidd_PCIDevice_ArchVector *Msg);
+
+        UBYTE HIDD_PCIDevice_ArchVector(OOP_Object *obj, ULONG vectorno);
+
+    LOCATION
+        CLID_Hidd_PCIDevice
+
+    FUNCTION
+        Returns the Hardware IRQ for a given device MSI vector.
+
+    INPUTS
+        obj   - Pointer to the device object.
+        vectorno - Vector to return the IRQ for.
+
+    RESULT
+        Returns the Arch specific CPU vector on success.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        moHidd_PCIDevice_ObtainVectors, AddIntServer
+
+    INTERNALS
+
+*****************************************************************************************/
+UBYTE PCIDev__Hidd_PCIDevice__ArchVector(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_ArchVector *msg)
+{
+    return 0;
+}
+
 
 
 /*****************************************************************************************


### PR DESCRIPTION
…lude from there in the kernel headers.

Use the correct CPU vector to program the PCI MSI interrupts. Tidy debug and minor refactor in the PCI driver code.