### PR TITLE
Add -mavx to the ISA_FLAGS. correct the use of _mm256_set1_epi8, and …

### DIFF
--- a/arch/all-pc/utility/mmakefile.src
+++ b/arch/all-pc/utility/mmakefile.src
@@ -6,7 +6,7 @@ include $(SRCDIR)/config/aros.cfg
 -include $(SRCDIR)/arch/$(CPU)-all/utility/make.opts
 
 USER_INCLUDES := -I$(SRCDIR)/rom/utility
-USER_CFLAGS := -mavx
+ISA_FLAGS += -mavx
 
 FILES := \
     setmem_sse \

--- a/arch/all-pc/utility/setmem_avx.c
+++ b/arch/all-pc/utility/setmem_avx.c
@@ -7,6 +7,8 @@
 #include <aros/debug.h>
 #include <exec/types.h>
 
+#include <immintrin.h>
+
 #include "setmem_pc.h"
 
 /****i************************************************************************
@@ -65,7 +67,7 @@
         postsize = length - avxfillcount * 32 - presize;
 
         /* setup avx value .. */
-        __m256i c32 = _mm256_set1_epi8(val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val);
+        __m256i c32 = _mm256_set1_epi8( val);
 
         D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, presize));
 

--- a/arch/arm-native/kernel/kernel_startup.c
+++ b/arch/arm-native/kernel/kernel_startup.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2013-2015, The AROS Development Team. All rights reserved.
+    Copyright © 2013-2020, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -20,7 +20,9 @@
 #include <asm/io.h>
 #include <proto/kernel.h>
 #include <proto/exec.h>
+
 #include <strings.h>
+#include <string.h>
 
 #include "exec_intern.h"
 #include "etask.h"

--- a/rom/usb/classes/camdmidi/mmakefile.src
+++ b/rom/usb/classes/camdmidi/mmakefile.src
@@ -3,7 +3,7 @@
 include $(SRCDIR)/config/aros.cfg
 
 #MM- kernel-usb-classes-camdusbmidi : kernel-usb-classes-camdusbmidi-$(AROS_TARGET_CPU)
-#MM kernel-usb-classes-camd-usbmidi : kernel-usb-usbclass kernel-usb-poseidon-includes camdusbmidi-object
+#MM kernel-usb-classes-camd-usbmidi : kernel-usb-usbclass kernel-usb-poseidon-includes kernel-usb-classes-camdusbmidi-object
 
 #MM- kernel-usb-classes-camdusbmidi-i386 : kernel-usb-classes-camd-usbmidi
 #MM- kernel-usb-classes-camdusbmidi-x86_64 : kernel-usb-classes-camd-usbmidi


### PR DESCRIPTION
…include the correct header for avx intrinsics.