### PR TITLE
add -mavx to the ISA_FLAGS, not CFLAGS.

### DIFF
--- a/arch/all-pc/utility/mmakefile.src
+++ b/arch/all-pc/utility/mmakefile.src
@@ -6,7 +6,7 @@ include $(SRCDIR)/config/aros.cfg
 -include $(SRCDIR)/arch/$(CPU)-all/utility/make.opts
 
 USER_INCLUDES := -I$(SRCDIR)/rom/utility
-USER_CFLAGS := -mavx
+ISA_FLAGS += -mavx
 
 FILES := \
     setmem_sse \

--- a/arch/all-pc/utility/setmem_avx.c
+++ b/arch/all-pc/utility/setmem_avx.c
@@ -7,6 +7,8 @@
 #include <aros/debug.h>
 #include <exec/types.h>
 
+#include <immintrin.h>
+
 #include "setmem_pc.h"
 
 /****i************************************************************************
@@ -65,7 +67,7 @@
         postsize = length - avxfillcount * 32 - presize;
 
         /* setup avx value .. */
-        __m256i c32 = _mm256_set1_epi8(val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val);
+        __m256i c32 = _mm256_set1_epi8( val);
 
         D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, presize));
 
@@ -86,7 +88,7 @@
                 p += (32 << 2);
                 i += 3;
             }
-            if ((avxfillcount - i) > 1)
+            else if ((avxfillcount - i) > 1)
             {
                 _mm256_store_si256((__m256i*)p, c32);
                 _mm256_store_si256((__m256i*)((IPTR)p + 32), c32);

--- a/arch/all-pc/utility/setmem_sse.c
+++ b/arch/all-pc/utility/setmem_sse.c
@@ -53,7 +53,7 @@
     ULONG postsize;
     char val;
 
-    D(bug("[utility:pc] %s(0x%p, %02x, %d)\n", __func__, destination, c, length));
+    D(bug("[utility:pc] %s(0x%p, %02x, %d)\n", __func__, destination, c, length);)
 
     p = (char *) destination;
     val = (char) c;
@@ -64,23 +64,26 @@
 
         presize = (((IPTR) destination + 15 ) & ~15) - (IPTR)destination;
         ssefillcount = (length - presize) / 16;
-        postsize = length - ssefillcount * 16 - presize;
+        postsize = length - (ssefillcount * 16) - presize;
 
         /* setup sse value .. */
         __m128i c16 = _mm_set_epi8(val, val, val, val, val, val, val, val, val, val, val, val, val, val, val, val);
 
-        D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, presize));
+        D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, presize);)
 
         /* fill inital bytes ... */
         __smallsetmem(p, val, presize);
         p += presize;
 
-        D(bug("[utility:pc] %s: 0x%p, %d x 16\n", __func__, p, ssefillcount));
+        D(bug("[utility:pc] %s: 0x%p, %d x 16\n", __func__, p, ssefillcount);)
 
         /* sse fill 16bytes at a time ... */
         for (i = 0; i < ssefillcount; ++i) {
+            D(bug("[utility:pc] %s: fill ", __func__);)
+
             if ((ssefillcount - i) > 3)
             {
+                D(bug("x4");)
                 _mm_store_si128((__m128i*)p, c16);
                 _mm_store_si128((__m128i*)((IPTR)p + 16), c16);
                 _mm_store_si128((__m128i*)((IPTR)p + 32), c16);
@@ -88,8 +91,9 @@
                 p += (16 << 2);
                 i += 3;
             }
-            if ((ssefillcount - 0) > 1)
+            else if ((ssefillcount - i) > 1)
             {
+                D(bug("x2");)
                 _mm_store_si128((__m128i*)p, c16);
                 _mm_store_si128((__m128i*)((IPTR)p + 16), c16);
                 p += (16 << 1);
@@ -97,9 +101,11 @@
             }
             else
             {
+                D(bug("x1");)
                 _mm_store_si128((__m128i*)p, c16);
                 p += 16;
             }
+            D(bug("\n");)
         }
     }
     else
@@ -107,7 +113,7 @@
         postsize = length;
     }
 
-    D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, postsize));
+    D(bug("[utility:pc] %s: 0x%p, %d\n", __func__, p, postsize);)
 
     /* file remainder ... */
     __smallsetmem(p, val, postsize);


### PR DESCRIPTION
fix a typo, and missing else clause in both versions of setmem. add the missing intrinsics header.