### PR TITLE
sll_halen is only decfined as -:

### DIFF
--- a/arch/all-unix/hidd/unixio/unixpkt_class.c
+++ b/arch/all-unix/hidd/unixio/unixpkt_class.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: Unix filedescriptor/socket IO
@@ -419,7 +419,7 @@ IPTR UXIO__Hidd_UnixIO__SendPacket(OOP_Class *cl, OOP_Object *o, struct pHidd_Un
         device.sll_ifindex = pd->ifindex;
         device.sll_family = AF_PACKET;
         memcpy(device.sll_addr, pd->ifaddr.sa_data, 6);
-        device.sll_halen = htons(6);
+        device.sll_halen = 6;
 
         do
         {

--- a/config/compiler.cfg.in
+++ b/config/compiler.cfg.in
@@ -134,6 +134,11 @@ CFLAGS_MS_BITFIELDS                     := @aros_cflags_ms_bitfields@
 CFLAGS_NO_MS_BITFIELDS                  := @aros_cflags_no_ms_bitfields@
 
 #
+# Clang/LLVM
+#
+CFLAGS_NO_INTEGRATED_AS                 := @aros_cflags_no_integrated_as@
+
+#
 # "Enable" compiler warning flags
 #
 

--- a/config/features
+++ b/config/features
@@ -808,6 +808,7 @@ aros_cxxflags_nopermissive
 aros_cxxflags_permissive
 aros_cflags_noexceptions
 aros_cflags_exceptions
+aros_cflags_no_integrated_as
 ac_ct_CXX
 CXXFLAGS
 CXX
@@ -2907,6 +2908,9 @@ $as_echo "$aros_targetcfg_dir" >&6; }
 
 #  -fvisibility=hidden
 
+# Clang/LLVM
+# -no-integrated-as
+
 # C features first
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4454,7 +4458,6 @@ fi
 
 CXXFLAGS="$save_cxxflags"
 
-
 # Check for additional C compiler options..
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4462,6 +4465,32 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} accepts -no-integrated-as" >&5
+$as_echo_n "checking whether ${CC} accepts -no-integrated-as... " >&6; }
+CFLAGS=-no-integrated-as
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  aros_no_integrated_as="yes"
+else
+  aros_no_integrated_as="no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $aros_no_integrated_as" >&5
+$as_echo "$aros_no_integrated_as" >&6; }
+if test "x-$aros_no_integrated_as" = "x-yes" ; then
+    aros_cflags_no_integrated_as=-no-integrated-as
+fi
 
 #-----------------------------------------------------------------------------
 #
@@ -6755,6 +6784,7 @@ rm -f $AROS_DEVELOPER/include/__testsincdir.h
 #
 # export the feature flags...
 #
+
 
 
 

--- a/config/features.in
+++ b/config/features.in
@@ -79,6 +79,9 @@ AC_MSG_RESULT($aros_targetcfg_dir)
 
 #  -fvisibility=hidden
 
+# Clang/LLVM
+# -no-integrated-as
+
 # C features first 
 AC_LANG_PUSH(C)
 
@@ -493,9 +496,16 @@ fi
 
 CXXFLAGS="$save_cxxflags"
 
-
 # Check for additional C compiler options..
 AC_LANG_PUSH(C)
+
+AC_MSG_CHECKING([whether ${CC} accepts -no-integrated-as])
+CFLAGS=-no-integrated-as
+AC_TRY_COMPILE(,, aros_no_integrated_as="yes", aros_no_integrated_as="no")
+AC_MSG_RESULT($aros_no_integrated_as)
+if test "x-$aros_no_integrated_as" = "x-yes" ; then
+    aros_cflags_no_integrated_as=-no-integrated-as
+fi
 
 #-----------------------------------------------------------------------------
 #
@@ -1355,6 +1365,7 @@ rm -f $AROS_DEVELOPER/include/__testsincdir.h
 #
 # export the feature flags...
 #
+AC_SUBST(aros_cflags_no_integrated_as)
 AC_SUBST(aros_cflags_exceptions)
 AC_SUBST(aros_cflags_noexceptions)
 AC_SUBST(aros_cxxflags_permissive)


### PR DESCRIPTION
           struct sockaddr_ll {
               unsigned short sll_family;   /* Always AF_PACKET */
               unsigned short sll_protocol; /* Physical-layer protocol */
               int            sll_ifindex;  /* Interface number */
               unsigned short sll_hatype;   /* ARP hardware type */
               unsigned char  sll_pkttype;  /* Packet type */
               unsigned char  sll_halen;    /* Length of address */
               unsigned char  sll_addr[8];  /* Physical-layer address */
           };

.. so dont use htons to byte swap it, which would result in 0 being used.