### PR TITLE
# provide storage in the option class objects to cache the attribute …

### DIFF
--- a/workbench/tools/InstallAROS/ia_install.h
+++ b/workbench/tools/InstallAROS/ia_install.h
@@ -82,7 +82,12 @@ static const char KMsgNoDrives[] =
 
 #define MUIM_IC_BASE                            (TAG_USER + 0x00335000)
 #define MUIA_IC_BASE                            (TAG_USER + 0x00336000)
-#define MUIA_IO_BASE                            (TAG_USER + 0x00337000)
+#define MUIM_IO_BASE                            (TAG_USER + 0x00337000)
+#define MUIA_IO_BASE                            (TAG_USER + 0x00338000)
+
+/* ************************************************
+        Main Installer Class Methods/Attribs
+ * ************************************************/
 
 #define MUIM_IC_NextStep                        (MUIM_IC_BASE + 0x1)
 #define MUIM_IC_PrevStep                        (MUIM_IC_BASE + 0x2)
@@ -150,13 +155,22 @@ static const char KMsgNoDrives[] =
 #define MUIV_Inst_Cancelled                     (0x01)
 #define MUIV_Inst_Failed                        (0x10)
 
-/* InstallOption Attribs */
-#define MUIA_InstallOption_Obj                  (MUIA_IO_BASE + 0x1)
-#define MUIA_InstallOption_ID                   (MUIA_IO_BASE + 0x2)
+/* ************************************************
+        Install Option Class Methods/Attribs
+ * ************************************************/
+#define MUIM_InstallOption_Update               (MUIM_IO_BASE + 0x1)
 
-#define MUIV_InstallOptionID_Source             (-2L)
-#define MUIV_InstallOptionID_Dest               (-3L)
-#define MUIV_InstallOptionID_StorageAvail       (-4L)
+#define MUIA_InstallOption_Obj                  (MUIA_IO_BASE + 0x1)            /* Install GUI Object representing the object   */
+#define MUIA_InstallOption_ID                   (MUIA_IO_BASE + 0x2)            /* Install 'unique' Option ID                   */
+#define MUIA_InstallOption_ValueTag             (MUIA_IO_BASE + 0x3)            /* TAG used to access the GUI objects value     */
+#define MUIA_InstallOption_Value                (MUIA_IO_BASE + 0x4)            /* The current value for the option, at this
+                                                                                   stage.
+                                                                                   N.B. this value only changes when the stage
+                                                                                   changes                                      */
+
+#define MUIV_InstallOptionID_Source             (-2L)                           /* Generic attrib for an install source path    */
+#define MUIV_InstallOptionID_Dest               (-3L)                           /* Generic attrib for an install target path    */
+#define MUIV_InstallOptionID_StorageAvail       (-4L)                           /* Generic attrib for storage device (maybe)    */
 
 struct MUIP_CopyFiles
 {

--- a/workbench/tools/InstallAROS/ia_installoption_intern.h
+++ b/workbench/tools/InstallAROS/ia_installoption_intern.h
@@ -3,8 +3,10 @@
 
 struct InstallOption_Data
 {
-    Object      *io_Object;
-    char        *io_ID;
+    Object      *iod_Object;
+    char        *iod_ID;
+    IPTR        *iod_OptionTag;
+    IPTR        iod_OptionVal;
 };
 
 BOOPSI_DISPATCHER_PROTO(IPTR, InstallOption__Dispatcher, CLASS, self, message);

--- a/workbench/tools/InstallAROS/ia_main.c
+++ b/workbench/tools/InstallAROS/ia_main.c
@@ -446,7 +446,7 @@ int main(int argc, char *argv[])
 
     Object *app = ApplicationObject,
         MUIA_Application_Title,       __(MSG_TITLE),
-        MUIA_Application_Version,     (IPTR) "$VER: InstallAROS 1.22 (22.12.2020)",
+        MUIA_Application_Version,     (IPTR) "$VER: InstallAROS 1.23 (22.12.2020)",
         MUIA_Application_Copyright,   (IPTR) "Copyright © 2003-2020, The AROS Development Team. All rights reserved.",
         MUIA_Application_Author,      (IPTR) "John \"Forgoil\" Gustafsson, Nick Andrews & Neil Cafferkey",
         MUIA_Application_Description, __(MSG_DESCRIPTION),


### PR DESCRIPTION
…tag used to access the option objects value, and the current value.

# add a method to get the option object to update its cached state
# update the current pages option states when transitioning to the next stage during the install process.