### PR TITLE
# Don't use loads of stack to do the file copies, instead work out a …

### DIFF
--- a/workbench/tools/InstallAROS/ia_diskio.c
+++ b/workbench/tools/InstallAROS/ia_diskio.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2018-2020, The AROS Development Team. All rights reserved.
+    Copyright © 2018-2021, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -733,7 +733,9 @@ BPTR RecursiveCreateDir(CONST_STRPTR dirpath)
     return lock;
 }
 
-BOOL BackUpFile(CONST_STRPTR filepath, CONST_STRPTR backuppath,
+BOOL BackUpFile(CONST_STRPTR filepath,
+    CONST_STRPTR backuppath,
+    struct InstallIO_Data *ioData,
     struct InstallC_UndoRecord * undorecord)
 {
     ULONG filepathlen = strlen(filepath);
@@ -742,7 +744,6 @@ BOOL BackUpFile(CONST_STRPTR filepath, CONST_STRPTR backuppath,
     STRPTR tmp = NULL;
     STRPTR pathpart = NULL;
     BPTR lock = BNULL, from = BNULL, to = BNULL;
-    static TEXT buffer[kBufSize];
     BOOL err = FALSE;
 
     if (undorecord == NULL)
@@ -813,20 +814,20 @@ BOOL BackUpFile(CONST_STRPTR filepath, CONST_STRPTR backuppath,
 
             do
             {
-                if ((s = Read(from, buffer, kBufSize)) == -1)
+                if ((s = Read(from, ioData->iio_Buffer, ioData->iio_BuffSize)) == -1)
                 {
                     err = TRUE;
                     break;
                 };
 
-                if (Write(to, buffer, s) == -1)
+                if (Write(to, ioData->iio_Buffer, s) == -1)
                 {
                     err = TRUE;
                     break;
                 };
 
             }
-            while (s == kBufSize && !err);
+            while (s == ioData->iio_BuffSize && !err);
 
             Close(to);
         }

--- a/workbench/tools/InstallAROS/ia_install.h
+++ b/workbench/tools/InstallAROS/ia_install.h
@@ -1,7 +1,7 @@
 #ifndef IA_INSTALL_H
 #define IA_INSTALL_H
 /*
-    Copyright © 2003-2020, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2021, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -10,7 +10,6 @@
 
 #include <libraries/mui.h>
 
-#define kBufSize          (4*65536)
 #define kExallBufSize          (4096)
 
 #define SYS_PART_NAME         "DH0"

--- a/workbench/tools/InstallAROS/ia_install_intern.h
+++ b/workbench/tools/InstallAROS/ia_install_intern.h
@@ -105,7 +105,12 @@ struct Install_DATA
     enum EStage                 instc_stage_prev;
     enum EStage                 instc_stage_next;
 
-    enum IO_OVERWRITE_FLAGS     IO_Always_overwrite;
+    struct InstallIO_Data
+    {
+        ULONG                   iio_BuffSize;
+        APTR                    iio_Buffer; 
+        enum IO_OVERWRITE_FLAGS iio_AlwaysOverwrite;
+    }                           instc_IOd;
 
     BOOL                        instc_default_usb;
     BOOL                        instc_cflag_driveset;

--- a/workbench/tools/InstallAROS/ia_main.c
+++ b/workbench/tools/InstallAROS/ia_main.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2003-2020, The AROS Development Team. All rights reserved.
+    Copyright © 2003-2021, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -466,7 +466,7 @@ int main(int argc, char *argv[])
 
     Object *app = ApplicationObject,
         MUIA_Application_Title,       __(MSG_TITLE),
-        MUIA_Application_Version,     (IPTR) "$VER: InstallAROS 1.23 (22.12.2020)",
+        MUIA_Application_Version,     (IPTR) "$VER: InstallAROS 1.24 (6.1.2021)",
         MUIA_Application_Copyright,   (IPTR) "Copyright © 2003-2020, The AROS Development Team. All rights reserved.",
         MUIA_Application_Author,      (IPTR) "John \"Forgoil\" Gustafsson, Nick Andrews & Neil Cafferkey",
         MUIA_Application_Description, __(MSG_DESCRIPTION),


### PR DESCRIPTION
…reasonable buffer to use when the installer class object is instantiated and allocate it there for use throughout the install.

# Use the newly allocated buffer instead of stack space in the copy routines.
# Free it on closure.