### PR TITLE
move the libinit components rules out of make.tail and into the libin…

### DIFF
--- a/compiler/libinit/mmakefile.src
+++ b/compiler/libinit/mmakefile.src
@@ -11,3 +11,22 @@ include $(SRCDIR)/config/aros.cfg
 
 %build_linklib mmake=linklibs-libinit \
     libname=libinit files="libinit"
+
+
+# Special kickstart module header
+$(GENDIR)/$(KICKSTART_BEGIN).o : $(SRCDIR)/$(KICKSTART_BEGIN).c
+	@$(ECHO) "Compiling  $<"
+	@$(TARGET_CC) $(TARGET_SYSROOT) -c $(TARGET_ISA_CFLAGS) $(TARGET_CFLAGS) $(CFLAGS) $< -o $@
+
+#MM
+libinit-kickentry : $(GENDIR)/$(KICKSTART_BEGIN).o
+
+# Disk-based module header
+$(GENDIR)/compiler/libinit/libentry.o : $(SRCDIR)/compiler/libinit/libentry.c
+	@$(ECHO) "Compiling  $<"
+	@$(TARGET_CC) $(TARGET_SYSROOT) -c $(TARGET_ISA_CFLAGS) $(TARGET_CFLAGS) $(CFLAGS) $< -o $@
+
+#MM
+libinit-libentry : $(GENDIR)/compiler/libinit/libentry.o $(GENDIR)/$(KICKSTART_BEGIN).o
+
+#MM- linklibs-startup : libinit-libentry libinit-kickentry

--- a/config/make.tail
+++ b/config/make.tail
@@ -16,12 +16,3 @@ include $(SRCDIR)/tools/genmodule/Makefile.deps
 $(GENMODULE) : $(GENMODULE_DEPS)
 	@$(CALL) $(MAKE) $(MKARGS) -C $(SRCDIR)/tools/genmodule TOP=$(TOP) SRCDIR=$(SRCDIR) $(GENMODULE)
 
-# Disk-based module header
-$(GENDIR)/compiler/libinit/libentry.o : $(SRCDIR)/compiler/libinit/libentry.c
-	@$(ECHO) "Compiling  $<"
-	@$(TARGET_CC) $(TARGET_SYSROOT) -c $(TARGET_ISA_CFLAGS) $(TARGET_CFLAGS) $(CFLAGS) $< -o $@
-
-# Special kickstart module header
-$(GENDIR)/$(KICKSTART_BEGIN).o : $(SRCDIR)/$(KICKSTART_BEGIN).c
-	@$(ECHO) "Compiling  $<"
-	@$(TARGET_CC) $(TARGET_SYSROOT) -c $(TARGET_ISA_CFLAGS) $(TARGET_CFLAGS) $(CFLAGS) $< -o $@


### PR DESCRIPTION
…it mmakefile. - we only want the rule for genmodule itself in tail, and having them here means any module may potentially cause them to compiler - perhaps with wrong flags depending on what that module has done in its mmakefile...