### PR TITLE
move the vararg handling, and call, into the helper function so that …

### DIFF
--- a/workbench/libs/locale/formatstring.c
+++ b/workbench/libs/locale/formatstring.c
@@ -16,8 +16,6 @@
 #include <aros/asmcall.h>
 #include "locale_intern.h"
 
-#include <clib/alib_protos.h>
-
 #include <aros/debug.h>
 
 typedef QUAD FMTLARGESTTYPE;
@@ -615,9 +613,6 @@ APTR InternalFormatString(const struct Locale * locale,
     ULONG indexSize = 0;
     APTR retval;
     struct Locale *def_locale = NULL;
-    va_list nullarg;
-
-    localeGenNullList(nullarg);
 
     if (locale == NULL)
     {
@@ -626,11 +621,9 @@ APTR InternalFormatString(const struct Locale * locale,
     }
 
     /* Generate the indexes for the provided datastream */
-    GetDataStreamFromFormat(fmtTemplate, nullarg, NULL, NULL, NULL, &indexSize);
+    localeDataStreamFromFormat(fmtTemplate, NULL, NULL, NULL, &indexSize);
     indices = alloca(indexSize);
-    GetDataStreamFromFormat(fmtTemplate, nullarg, NULL, NULL, indices, &indexSize);
-
-    va_end(nullarg);
+    localeDataStreamFromFormat(fmtTemplate, NULL, NULL, indices, &indexSize);
 
     retval = InternalFormatString(locale, fmtTemplate,
                                 dataStream, indices, putCharFunc);

--- a/workbench/libs/locale/locale_intern.h
+++ b/workbench/libs/locale/locale_intern.h
@@ -27,6 +27,9 @@
 #ifdef __MORPHOS__
 #include <aros/libcall.h>
 #endif
+#ifndef CLIB_ALIB_PROTOS_H
+#include <clib/alib_protos.h>
+#endif
 
 /* aros_print_not_implemented() macro: */
 #include <aros/debug.h>
@@ -155,9 +158,14 @@ struct IntCatalog
 #define ID_CSET MAKE_ID('C','S','E','T')
 #define ID_STRS MAKE_ID('S','T','R','S')
 
-static void localeGenNullList(va_list empty, ...)
+static void localeDataStreamFromFormat(CONST_STRPTR format, APTR dataStream,  ULONG *dataSize,
+                             ULONG *indexStream, ULONG *indexSize, ...)
 {
-    va_start(empty, empty);
+    va_list empty;
+    va_start(empty, indexSize);
+    GetDataStreamFromFormat(format, empty, dataStream, dataSize,
+                        indexStream, indexSize);
+    va_end(empty);
 }
 
 void dispose_catalog(struct IntCatalog * cat,

--- a/workbench/libs/locale/locrawdofmt.c
+++ b/workbench/libs/locale/locrawdofmt.c
@@ -18,8 +18,6 @@
 #include <stdarg.h>
 #include <alloca.h>
 
-#include <clib/alib_protos.h>
-
 AROS_UFH3(VOID, LocRawDoFmtFormatStringFunc,
     AROS_UFHA(struct Hook *, hook, A0),
     AROS_UFHA(struct Locale *, locale, A2),
@@ -211,21 +209,16 @@ AROS_UFH3(VOID, LocRawDoFmtFormatStringFunc_SysV,
     ULONG *iStream;
     APTR dStream;
     ULONG iSize = 0, dSize = 0;
-    va_list nullarg;
-
-    localeGenNullList(nullarg);
 
     /* Scan to determine the location of the positional arguments */
-    GetDataStreamFromFormat(FormatString, nullarg, NULL, NULL,
+    localeDataStreamFromFormat(FormatString, NULL, NULL,
                             NULL, &iSize);
     iStream = alloca(iSize);
 
     /* Scan to determine the size of the repacked datastream */
-    GetDataStreamFromFormat(FormatString, nullarg, NULL, &dSize,
+    localeDataStreamFromFormat(FormatString, NULL, &dSize,
                             iStream, &iSize);
     dStream = alloca(dSize);
-
-    va_end(nullarg);
 
     /* Repack the va_list into the datastream */
     GetDataStreamFromFormat(FormatString, DataStream, dStream, &dSize,


### PR DESCRIPTION
…it can correctly construct an empty va_list to pass to the function in question.