### PR TITLE
use double quotes to prevent globbing and word splitting.

### DIFF
--- a/arch/all-linux/kernel/mksigcore.sh
+++ b/arch/all-linux/kernel/mksigcore.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 sigcontextpath=/usr/include/bits/sigcontext.h
-if [ ! -f $sigcontextpath ] ; then
+if [ ! -f "$sigcontextpath" ] ; then
     sigcontextpath=/usr/include/${CPU}-linux-gnu/bits/sigcontext.h
-    if [ ! -f $sigcontextpath ] ; then
+    if [ ! -f "$sigcontextpath" ] ; then
         echo "Could not find bits/sigcontext.h"
         exit 20
     fi
 fi
 
-type=`${CC} -D_SIGNAL_H -E ${sigcontextpath} | grep "^struct sigcontext" | sed 's/{//'`
+type=$(${CC} -D_SIGNAL_H -E "${sigcontextpath}" | grep "^struct sigcontext" | sed 's/{//')
 handler=__sighandler_t
 
-sed "s/@sigcontext@/$type/;s/@sighandler@/$handler/" ${1-.}/sigcore.h.${CPU}.src > ${2}
+sed "s/@sigcontext@/$type/;s/@sighandler@/$handler/" "${1-.}/sigcore.h.${CPU}.src" > ${2}


### PR DESCRIPTION
use $() notiation instead of backticks.