### PR TITLE
Misc

### DIFF
--- a/arch/all-linux/kernel/mksigcore.sh
+++ b/arch/all-linux/kernel/mksigcore.sh
@@ -12,4 +12,4 @@ fi
 type=$(${CC} -D_SIGNAL_H -E "${sigcontextpath}" | grep "^struct sigcontext" | sed 's/{//')
 handler=__sighandler_t
 
-sed "s/@sigcontext@/$type/;s/@sighandler@/$handler/" "${1-.}/sigcore.h.${CPU}.src" > ${2}
+sed "s/@sigcontext@/$type/;s/@sighandler@/$handler/" "${1-.}/sigcore.h.${CPU}.src" > "${2}"

--- a/arch/all-unix/boot/mkbootconf.sh
+++ b/arch/all-unix/boot/mkbootconf.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sed "s%@arch@%$2%" ${1}
+sed "s%@arch@%$2%" "${1}"

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -5,7 +5,7 @@
 
 error()
 {    
-    echo $1
+    echo "$1"
     exit 1
 }
 
@@ -17,7 +17,6 @@ usage()
 fetch_mirrored()
 {
     local origin="$1" file="$2" destination="$3" mirrosgroup="$4" mirrors="$5"
-    local full_path
     local ret=false
 
     for mirror in $mirrors; do
@@ -36,7 +35,6 @@ gnu_mirrors="http://mirror.netcologne.de/gnu http://ftp.gnu.org/pub/gnu ftp://ft
 fetch_gnu()
 {
     local origin="$1" file="$2" destination="$3"
-    local full_path
     local ret=true
 
     if ! fetch_mirrored "$origin" "${file}" "$destination" "GNU" "${gnu_mirrors}"; then
@@ -54,7 +52,6 @@ sf_mirrors="http://downloads.sourceforge.net"
 fetch_sf()
 {
     local origin="$1" file="$2" destination="$3"
-    local full_path
     local ret=true
 
     if ! fetch_mirrored "$origin" "${file}" "$destination" "SourceForge" "${sf_mirrors}"; then
@@ -69,7 +66,6 @@ github_mirrors="https://github.com"
 fetch_github()
 {
     local origin="$1" file="$2" destination="$3"
-    local full_path
     local ret=true
 
     if ! fetch_mirrored "$origin" "$file" "$destination" "Github" "${github_mirrors}"; then
@@ -87,7 +83,7 @@ wget_try()
 
     for (( ; ; ))
     do
-        if ! wget -t 3 --retry-connrefused $wgetextraflags -T 15 -c "$wgetsrc" -O "$wgetoutput"; then
+        if ! wget -t 3 --retry-connrefused "$wgetextraflags" -T 15 -c "$wgetsrc" -O "$wgetoutput"; then
             if test "$ret" = false; then
                 break
             fi
@@ -107,8 +103,8 @@ fetch()
     
     local protocol
     
-    if echo $origin | grep ":" >/dev/null; then
-        protocol=`echo $origin | cut -d':' -f1`
+    if echo "$origin" | grep ":" >/dev/null; then
+        protocol=$(echo $origin | cut -d':' -f1)
     fi
 
     local ret=true
@@ -175,7 +171,7 @@ fetch_cached()
     local __dummy__
     foundvar=${foundvar:-__dummy__}
     
-    export $foundvar=
+    export "$foundvar"=
     
     test -e "$destination" -a ! -d "$destination" && \
         echo "fetch_cached: \`$destination' is not a diretory." && return 1
@@ -187,17 +183,17 @@ fetch_cached()
     
     if test "x$suffixes" != "x"; then
         for sfx in $suffixes; do
-	    fetch_multiple "$destination" "$file".$sfx "$destination" && \
-	        export $foundvar="$file".$sfx && return 0
+	    fetch_multiple "$destination" "$file.$sfx" "$destination" && \
+	        export $foundvar="$file.$sfx" && return 0
         done
        
 	for sfx in $suffixes; do
-	    fetch_multiple "$origins" "$file".$sfx "$destination" && \
-	        export $foundvar="$file".$sfx && return 0
+	    fetch_multiple "$origins" "$file.$sfx" "$destination" && \
+	        export $foundvar="$file.$sfx" && return 0
         done    
     else
         fetch_multiple "$destination $origins" "$file" "$destination" && \
-	    export $foundvar="$file" && return 0
+	    export "$foundvar"="$file" && return 0
     fi
     
     return 1
@@ -208,7 +204,7 @@ unpack()
     local location="$1" archive="$2" archivepath="$3";
     
     local old_PWD="$PWD"
-    cd $location
+    cd "$location"
     
     echo "Unpacking  \`$archive'..."
     
@@ -246,9 +242,9 @@ unpack_cached()
 	! mkdir -p "$location" && return 1
     fi
 
-    if ! test -f ${location}/.${archive}.unpacked;  then
+    if ! test -f "${location}/.${archive}.unpacked";  then
         if unpack "$location" "$archive" "$archivepath"; then
-	    echo yes > ${location}/.${archive}.unpacked
+	    echo yes > "${location}/.${archive}.unpacked"
 	    true
 	else
 	    false
@@ -264,15 +260,15 @@ do_patch()
     cd $location
     local abs_location="$PWD"
     
-    local patch=`echo "$patch_spec": | cut -d: -f1`
-    local subdir=`echo "$patch_spec": | cut -d: -f2`
-    local patch_opt=`echo "$patch_spec": | cut -d: -f3 | sed -e "s/,/ /g"`
+    local patch=$(echo "$patch_spec": | cut -d: -f1)
+    local subdir=$(echo "$patch_spec": | cut -d: -f2)
+    local patch_opt=$(echo "$patch_spec": | cut -d: -f3 | sed -e "s/,/ /g")
     
-    cd ${subdir:-.}
+    cd "${subdir:-.}"
     
     local ret=true
     
-    if ! patch -Z $patch_opt < $abs_location/$patch; then
+    if ! patch -Z "$patch_opt" < "$abs_location/$patch"; then
         ret=false
     fi
     
@@ -285,12 +281,12 @@ patch_cached()
 {
     local location="$1" patch="$2";
     
-    local patchname=`echo $patch | cut -d: -f1`
+    local patchname=$(echo "$patch" | cut -d: -f1)
     
     if test "x$patchname" != "x"; then
-        if ! test -f ${location}/.${patchname}.applied;  then
+        if ! test -f "${location}/.${patchname}.applied";  then
             if do_patch "$location" "$patch"; then
-	        echo yes > ${location}/.${patchname}.applied
+	        echo yes > "${location}/.${patchname}.applied"
 	        true
 	    else
 	        false
@@ -373,7 +369,7 @@ test -z "$archive2" && fetchunlock "$location" "$fetchlockfile" && error "fetch:
 archive="$archive2"
 
 for patch in $patches; do
-    patch=`echo $patch | cut -d: -f1`
+    patch=$(echo "$patch" | cut -d: -f1)
     if test "x$patch" != "x"; then
         if ! fetch_cached "$patches_origins" "$patch" "" "$destination"; then
             fetch_cached "$patches_origins" "$patch" "tar.bz2 tar.gz zip" "$destination" patch2

--- a/scripts/merger.sh
+++ b/scripts/merger.sh
@@ -16,7 +16,7 @@ rm -f conflicts.log added.log
 # First try to merge all the changes from olddir to yourdir into mydir
 # that means that only the files which are both in mydir, yourdir and olddir have to be processed
 
-find $mydir -type f -exec sh -c                                           \
+find "$mydir" -type f -exec sh -c                                           \
     'cur="`echo "{}" | cut -d/ -f2-`";                                    \
     if [ -e $olddir/"$cur" ] && [ -e $yourdir/"$cur" ]; then              \
         echo processing "$cur";                                           \
@@ -38,7 +38,7 @@ find $mydir -type f -exec sh -c                                           \
 # be copied either. All that means that if a file is present both in yourdir and olddir it doesn't need to be
 # copied
 
-find $yourdir -type f -exec sh -c                                      \
+find "$yourdir" -type f -exec sh -c                                      \
     'cur="`echo "{}" | cut -d/ -f2-`";                                 \
     if ! [ -e $olddir/"$cur" ] && ! [ -e $mydir/"$cur" ] &&            \
     (                                                                  \
@@ -67,13 +67,13 @@ find $yourdir -type f -exec sh -c                                      \
 echo Operation finished.
 
 if [ -e conflicts.log ]; then                                                                                   \
-    echo There were `wc -l conflicts.log` conflicts. Have a look at conflicts.log to see in which files.; \
+    echo There were $(wc -l conflicts.log) conflicts. Have a look at conflicts.log to see in which files.; \
 else                                                                                                            \
     echo There were no conflicts;                                                                               \
 fi
 
 if [ -e added.log ]; then                                                                            \
-    echo `wc -l added.log` files have been added. Have a look at added.log to see which ones.; \
+    echo $(wc -l added.log) files have been added. Have a look at added.log to see which ones.; \
 else                                                                                                 \
     echo No new files have been added;                                                               \
 fi

--- a/scripts/repo_id.sh
+++ b/scripts/repo_id.sh
@@ -3,14 +3,14 @@
 # get repository ID via svn or via git
 #
 
-inside_git_repo=`cd $1 && git rev-parse --is-inside-work-tree 2>/dev/null`
+inside_git_repo=$(cd $1 && git rev-parse --is-inside-work-tree 2>/dev/null)
 
-if test -d $1/.svn; then
-    cd $1
+if test -d "$1/.svn"; then
+    cd "$1"
     svn info | grep '^URL' | awk '{print $NF}'
 else
     if [ "$inside_git_repo" = "true" ]; then
-        cd $1
+        cd "$1"
         git config --get remote.origin.url
     else
         echo "Unknown"


### PR DESCRIPTION
clean up a few scripts so they correctly quote variables to prevent globbing/word splitting - and use $() instead of backticks.