### PR TITLE
cache the initial ldflags passed to configure for the host, and use t…

### DIFF
--- a/configure
+++ b/configure
@@ -4806,7 +4806,8 @@ aros_host_make="make"
 aros_host_cflags="$CFLAGS"
 aros_host_cxxflags="$CXXFLAGS"
 aros_host_cppflags="$CPPFLAGS"
-aros_host_ldflags="$LDFLAGS"
+aros_host_baseldflags="$LDFLAGS"
+aros_host_ldflags="$aros_host_baseldflags"
 aros_host_debug="-g -O0"
 aros_host_mkdep="\$(SRCDIR)/scripts/mkdep"
 aros_host_mkargs="--no-print-directory"
@@ -5146,6 +5147,7 @@ $as_echo "$as_me: WARNING: \"Unknown CPU for Darwin host -- $host_cpu\"" >&2;}
                 ;;
         esac
 
+        aros_kernel_ldflags="$aros_host_baseldflags $aros_kernel_ldflags"
         aros_host_ldflags="$aros_host_ldflags -liconv"
 
         ;;
@@ -9111,7 +9113,7 @@ $as_echo "$darwin_sdk_path" >&6; }
                 aros_object_format="elf_i386"
                 aros_kernel_ar_flags="-cr"
                 aros_target_strip_flags="-x"
-                kernel_tool_flags="-m32"
+                kernel_tool_flags=""
                 ;;
             *x86_64*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"

--- a/configure.in
+++ b/configure.in
@@ -207,7 +207,8 @@ aros_host_make="make"
 aros_host_cflags="$CFLAGS"
 aros_host_cxxflags="$CXXFLAGS"
 aros_host_cppflags="$CPPFLAGS"
-aros_host_ldflags="$LDFLAGS"
+aros_host_baseldflags="$LDFLAGS"
+aros_host_ldflags="$aros_host_baseldflags"
 aros_host_debug="-g -O0"
 aros_host_mkdep="\$(SRCDIR)/scripts/mkdep"
 aros_host_mkargs="--no-print-directory"
@@ -360,6 +361,7 @@ re-running configure])])
                 ;;
         esac
 
+        aros_kernel_ldflags="$aros_host_baseldflags $aros_kernel_ldflags"
         aros_host_ldflags="$aros_host_ldflags -liconv"
 
         ;;
@@ -1475,7 +1477,7 @@ case "$target_os" in
                 aros_object_format="elf_i386"
                 aros_kernel_ar_flags="-cr"
                 aros_target_strip_flags="-x"
-                kernel_tool_flags="-m32"
+                kernel_tool_flags=""
                 ;;
             *x86_64*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"


### PR DESCRIPTION
…hose in the host_ldflags. add the initial ldflags to the kernel_ldflags on darwin, since they may be needed for linking the kernel code. dont pass "-m32" to every command/flag - thats the purpose of the ISA flags.