### PR TITLE
expand the $(CPU) part of includes-asm_h locally, instead of in indiv…

### DIFF
--- a/arch/arm-all/arm-aeabi/mmakefile.src
+++ b/arch/arm-all/arm-aeabi/mmakefile.src
@@ -6,8 +6,8 @@
 include $(SRCDIR)/config/aros.cfg
 
 # TODO: Move this into the gcc source code ?
-#MM- compiler-stdc-arm : includes-asm_h-arm linklibs-aeabi-arm
-#MM- compiler-stdc-armeb: includes-asm_h-arm linklibs-aeabi-arm
+#MM- compiler-stdc-arm : includes-asm_h linklibs-aeabi-arm
+#MM- compiler-stdc-armeb: includes-asm_h linklibs-aeabi-arm
 
 %build_linklib mmake=linklibs-aeabi-arm \
     libname=aeabi files="uldiv ldiv l2f i2f i2d l2d llsl llsr lasr" \

--- a/arch/arm-all/exec/mmakefile.src
+++ b/arch/arm-all/exec/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 USER_INCLUDES	:= $(PRIV_EXEC_INCLUDES)
 USER_AFLAGS	:= $(PRIV_EXEC_INCLUDES) -I$(GENINCDIR)
 
-#MM- kernel-exec-arm: includes-asm_h-arm kernel-kernel-includes
+#MM- kernel-exec-arm: includes-asm_h kernel-kernel-includes
 
 %build_archspecific \
   mainmmake=kernel-exec modname=exec maindir=rom/exec \

--- a/arch/arm-all/posixc/mmakefile.src
+++ b/arch/arm-all/posixc/mmakefile.src
@@ -4,7 +4,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_AFLAGS 	:= -I$(GENINCDIR)
 
-#MM- compiler-posixc-arm : includes-asm_h-arm
+#MM- compiler-posixc-arm : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc modname=posixc maindir=compiler/posixc \

--- a/arch/arm-all/stdc/mmakefile.src
+++ b/arch/arm-all/stdc/mmakefile.src
@@ -11,4 +11,4 @@ USER_AFLAGS 	:= -I$(GENINCDIR)
   arch=arm \
   files="fenv" asmfiles="longjmp setjmp"
 
-#MM compiler-stdc-arm : includes-asm_h-arm
+#MM compiler-stdc-arm : includes-asm_h

--- a/arch/armeb-all/exec/mmakefile.src
+++ b/arch/armeb-all/exec/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 USER_INCLUDES	:= $(PRIV_EXEC_INCLUDES)
 USER_AFLAGS	:= $(PRIV_EXEC_INCLUDES) -I$(GENINCDIR)
 
-#MM- kernel-exec-armeb: includes-asm_h-armeb kernel-kernel-includes
+#MM- kernel-exec-armeb: includes-asm_h kernel-kernel-includes
 
 %build_archspecific \
   mainmmake=kernel-exec modname=exec maindir=rom/exec \

--- a/arch/armeb-all/posixc/mmakefile.src
+++ b/arch/armeb-all/posixc/mmakefile.src
@@ -4,7 +4,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_AFLAGS 	:= -I$(GENINCDIR)
 
-#MM- compiler-posixc-armeb : includes-asm_h-armeb
+#MM- compiler-posixc-armeb : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc modname=posixc maindir=compiler/posixc \

--- a/arch/armeb-all/stdc/mmakefile.src
+++ b/arch/armeb-all/stdc/mmakefile.src
@@ -11,4 +11,4 @@ USER_AFLAGS 	:= -I$(GENINCDIR)
   arch=armeb \
   files="fenv" asmfiles="longjmp setjmp"
 
-#MM compiler-stdc-armeb : includes-asm_h-armeb
+#MM compiler-stdc-armeb : includes-asm_h

--- a/arch/i386-all/exec/mmakefile.src
+++ b/arch/i386-all/exec/mmakefile.src
@@ -31,6 +31,6 @@ endif
   asmfiles=$(AFILES) files=$(FILES) \
   arch=i386
 
-#MM kernel-exec-i386 : includes-asm_h-i386 kernel-kernel-includes
+#MM kernel-exec-i386 : includes-asm_h kernel-kernel-includes
 
 %common

--- a/arch/i386-all/posixc/mmakefile.src
+++ b/arch/i386-all/posixc/mmakefile.src
@@ -4,7 +4,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_AFLAGS 	:= -I$(GENINCDIR)
 
-#MM- compiler-posixc-i386 : includes-asm_h-i386
+#MM- compiler-posixc-i386 : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc modname=posixc maindir=compiler/posixc \

--- a/arch/i386-all/stdc/mmakefile.src
+++ b/arch/i386-all/stdc/mmakefile.src
@@ -81,4 +81,4 @@ STDC_I386_ASMFILES += \
   arch=i386 \
   files="$(STDC_I386_FILES)" linklibfiles="$(STDC_I386_SSE_FILES)" asmfiles="$(STDC_I386_ASMFILES)"
 
-#MM- compiler-stdc-i386 : includes-asm_h-i386
+#MM- compiler-stdc-i386 : includes-asm_h

--- a/arch/i386-pc/exec/mmakefile.src
+++ b/arch/i386-pc/exec/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 CFILES := cachecleare debug_init debug memoryrawio
 AFILES := cache userstate
 
-#MM kernel-exec-pc-i386 : kernel-kernel-includes kernel-exec-includes includes-asm_h-i386
+#MM kernel-exec-pc-i386 : kernel-kernel-includes kernel-exec-includes includes-asm_h
 
 USER_INCLUDES 	:= $(PRIV_EXEC_INCLUDES)
 USER_AFLAGS 	:= $(PRIV_EXEC_INCLUDES) -I$(GENINCDIR)

--- a/arch/i386-pc/kernel/mmakefile.src
+++ b/arch/i386-pc/kernel/mmakefile.src
@@ -18,8 +18,7 @@ USER_INCLUDES := $(PRIV_KERNEL_INCLUDES) $(PRIV_EXEC_INCLUDES) \
                  -I$(SRCDIR)/arch/all-native/kernel \
 		 -isystem $(SRCDIR)/arch/all-native/bootconsole/include
 
-#MM kernel-kernel-pc-i386 : kernel-pc-acpica-includes includes-asm_h-i386 linklibs-bootconsole
-
+#MM kernel-kernel-pc-i386 : kernel-pc-acpica-includes includes-asm_h linklibs-bootconsole
 
 %build_archspecific \
   mainmmake=kernel-kernel modname=kernel maindir=$(MAINDIR) \

--- a/arch/m68k-all/dos/mmakefile.src
+++ b/arch/m68k-all/dos/mmakefile.src
@@ -11,7 +11,7 @@ CFILES  := bstr_helper exit callglobvec \
 AFILES := callentry \
 	  $(BCPL_AFILES)
 
-#MM kernel-dos-m68k : kernel-dos-includes includes-asm_h-m68k
+#MM kernel-dos-m68k : kernel-dos-includes includes-asm_h
 
 USER_INCLUDES := -I$(SRCDIR)/arch/$(CPU)-$(ARCH)/dos \
                -I$(SRCDIR)/rom/dos

--- a/arch/m68k-all/exec/mmakefile.src
+++ b/arch/m68k-all/exec/mmakefile.src
@@ -32,6 +32,6 @@ TARGET_ISA_AFLAGS:=$(ISA_MC68060_FLAGS)
   files="$(FILES)" \
   arch=m68k
 
-#MM kernel-exec-m68k : includes-asm_h-m68k
+#MM kernel-exec-m68k : includes-asm_h
 
 %common

--- a/arch/m68k-all/kernel/mmakefile.src
+++ b/arch/m68k-all/kernel/mmakefile.src
@@ -2,7 +2,7 @@
 
 include $(SRCDIR)/config/aros.cfg
 
-#MM kernel-kernel-m68k : includes-asm_h-m68k
+#MM kernel-kernel-m68k : includes-asm_h
 
 FILES := \
         dispatch \

--- a/arch/m68k-all/posixc/mmakefile.src
+++ b/arch/m68k-all/posixc/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 USER_AFLAGS  := -I$(GENINCDIR)
 USER_CPPFLAGS := -DDEBUG=0
 
-#MM- compiler-posixc-m68k : includes-asm_h-m68k
+#MM- compiler-posixc-m68k : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc modname=posixc maindir=compiler/posixc \

--- a/arch/m68k-all/stdc/mmakefile.src
+++ b/arch/m68k-all/stdc/mmakefile.src
@@ -65,13 +65,13 @@ STDC_M68K_FILES += \
   arch=m68k \
   files="$(STDC_M68K_FILES)" asmfiles="$(STDC_M68K_ASMFILES)"
 
-#MM- compiler-stdc-m68k : includes-asm_h-m68k
+#MM- compiler-stdc-m68k : includes-asm_h
 
 #
 #
 #
 
-#MM- test-clib-m68k: includes-asm_h-m68k test-clib-m68k-jmptests
+#MM- test-clib-m68k: includes-asm_h test-clib-m68k-jmptests
 
 USER_AFLAGS := -I$(GENINCDIR) # -DDEBUG_MAGIC=0x40506070 -DDEBUG=1
 AFILES:=jmptests setjmp longjmp ../posixc/vfork ../posixc/vfork_longjmp

--- a/arch/m68k-all/utility/mmakefile.src
+++ b/arch/m68k-all/utility/mmakefile.src
@@ -14,6 +14,6 @@ TARGET_ISA_AFLAGS:=$(ISA_MC68020_FLAGS)
   mainmmake=kernel-utility modname=utility maindir=rom/utility arch=m68k \
   files="$(FILES)" asmfiles="$(AFILES)" compiler=kernel
 
-#MM kernel-utility-m68k : includes-asm_h-m68k
+#MM kernel-utility-m68k : includes-asm_h
 
 %common

--- a/arch/m68k-amiga/exec/mmakefile.src
+++ b/arch/m68k-amiga/exec/mmakefile.src
@@ -8,7 +8,7 @@ AFILES		:= enable disable readgayle
 #MM kernel-exec-amiga-m68k : \
 #MM     kernel-kernel-amiga-m68k-includes \
 #MM     kernel-exec-includes \
-#MM     includes-asm_h-m68k \
+#MM     includes-asm_h \
 #MM     kernel-kernel-includes
 
 USER_INCLUDES     := $(PRIV_EXEC_INCLUDES)

--- a/arch/m68k-amiga/graphics/mmakefile.src
+++ b/arch/m68k-amiga/graphics/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 CFILES  := setchiprev vbeampos
 AFILES  := attemptlocklayerrom locklayerrom unlocklayerrom waitblit
 
-#MM kernel-graphics-amiga-m68k : kernel-hidd-includes kernel-graphics-includes includes-asm_h-m68k kernel-hidd-graphics-includes
+#MM kernel-graphics-amiga-m68k : kernel-hidd-includes kernel-graphics-includes includes-asm_h kernel-hidd-graphics-includes
 
 USER_INCLUDES := -I$(SRCDIR)/arch/$(CPU)-$(ARCH)/graphics \
                -I$(SRCDIR)/rom/graphics

--- a/arch/m68k-mac/exec/mmakefile.src
+++ b/arch/m68k-mac/exec/mmakefile.src
@@ -10,7 +10,7 @@ AFILES          := coldreboot ints superstate sys_trap1_handler \
 		detect_memory_handlers setsr supervisor userstate \
 		execstubs stackswap switchtouser
 
-#MM kernel-exec-mac-m68k : kernel-exec-includes includes-asm_h-m68k
+#MM kernel-exec-mac-m68k : kernel-exec-includes includes-asm_h
 
 #USER_INCLUDES      := -I../ $(PRIV_EXEC_INCLUDES) -I$(GENINCDIR)
 #USER_CPPFLAGS      := -D__AROS__

--- a/arch/ppc-all/exec/mmakefile.src
+++ b/arch/ppc-all/exec/mmakefile.src
@@ -12,6 +12,6 @@ USER_CPPFLAGS := -DHOST_OS_$(ARCH)
   files="alert_cpu cachecleare newstackswap preparecontext" \
   arch=ppc modname=exec
 
-#MM kernel-exec-ppc : includes-asm_h-ppc
+#MM kernel-exec-ppc : includes-asm_h
 
 %common

--- a/arch/ppc-all/posixc/mmakefile.src
+++ b/arch/ppc-all/posixc/mmakefile.src
@@ -4,7 +4,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_AFLAGS 	:= -I$(GENINCDIR)
 
-#MM- compiler-posixc-ppc : includes-asm_h-ppc
+#MM- compiler-posixc-ppc : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc maindir=compiler/posixc \

--- a/arch/ppc-all/stdc/mmakefile.src
+++ b/arch/ppc-all/stdc/mmakefile.src
@@ -11,4 +11,4 @@ USER_AFLAGS 	:= -I$(GENINCDIR)
   arch=ppc modname=stdc \
   files="fenv" asmfiles="longjmp setjmp"
 
-#MM compiler-stdc-ppc : includes-asm_h-ppc
+#MM compiler-stdc-ppc : includes-asm_h

--- a/arch/x86_64-all/exec/mmakefile.src
+++ b/arch/x86_64-all/exec/mmakefile.src
@@ -30,6 +30,6 @@ endif
   asmfiles=$(AFILES) files=$(FILES) \
   arch=x86_64 modname=exec
 
-#MM kernel-exec-x86_64 : includes-asm_h-x86_64 kernel-kernel-includes
+#MM kernel-exec-x86_64 : includes-asm_h kernel-kernel-includes
 
 %common

--- a/arch/x86_64-all/posixc/mmakefile.src
+++ b/arch/x86_64-all/posixc/mmakefile.src
@@ -4,7 +4,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_AFLAGS 	:= -I$(GENINCDIR)
 
-#MM- compiler-posixc-x86_64 : includes-asm_h-x86_64
+#MM- compiler-posixc-x86_64 : includes-asm_h
 
 %build_archspecific \
   mainmmake=compiler-posixc maindir=compiler/posixc \

--- a/arch/x86_64-all/stdc/mmakefile.src
+++ b/arch/x86_64-all/stdc/mmakefile.src
@@ -44,4 +44,4 @@ STDC_X8664_ASMFILES += \
   arch=x86_64 \
   files="$(STDC_X8664_FILES)" asmfiles="$(STDC_X8664_ASMFILES)"
 
-#MM compiler-stdc-x86_64 : includes-asm_h-x86_64
+#MM compiler-stdc-x86_64 : includes-asm_h

--- a/arch/x86_64-pc/exec/mmakefile.src
+++ b/arch/x86_64-pc/exec/mmakefile.src
@@ -10,7 +10,7 @@ include $(SRCDIR)/config/aros.cfg
 
 AFILES := userstate
 
-#MM kernel-exec-pc-x86_64 : kernel-kernel-pc-x86_64-includes kernel-exec-includes includes-asm_h-x86_64
+#MM kernel-exec-pc-x86_64 : kernel-kernel-pc-x86_64-includes kernel-exec-includes includes-asm_h
 
 USER_AFLAGS := -isystem $(GENINCDIR)
 

--- a/arch/x86_64-pc/kernel/mmakefile.src
+++ b/arch/x86_64-pc/kernel/mmakefile.src
@@ -19,8 +19,8 @@ USER_AFLAGS   := -I$(GENINCDIR) -I$(SRCDIR)/arch/all-pc/kernel
 USER_INCLUDES := $(PRIV_KERNEL_INCLUDES) -I$(SRCDIR)/arch/all-native/kernel \
 		 -isystem $(SRCDIR)/arch/all-native/bootconsole/include
 
-#MM kernel-kernel-pc-x86_64 : kernel-pc-acpica-includes includes-asm_h-$(CPU) includes kernel-kernel-includes linklibs-bootconsole
-#MM kernel-kernel-pc-x86_64-kobj : includes-asm_h-$(CPU) includes kernel-kernel-includes linklibs-bootconsole
+#MM kernel-kernel-pc-x86_64 : kernel-pc-acpica-includes includes-asm_h includes kernel-kernel-includes linklibs-bootconsole
+#MM kernel-kernel-pc-x86_64-kobj : includes-asm_h includes kernel-kernel-includes linklibs-bootconsole
 #MM kernel-kernel-pc-x86_64-quick : kernel-kernel-native-quick
 #MM kernel-kernel-pc-x86_64-kobj-quick : kernel-kernel-native-quick
 

--- a/compiler/include/mmakefile
+++ b/compiler/include/mmakefile
@@ -127,6 +127,11 @@ includes-asm_h-$(CPU) : $(GENINCDIR)/aros/$(CPU)/asm.h
 
 .PHONY : includes-asm_h-$(CPU)
 
+#MM includes-asm_h : includes-copy includes-asm_h-$(CPU)
+#MM
+includes-asm_h:
+	$(NOP)
+
 ifeq ($(AROS_TOOLCHAIN),gnu)
 GREPTOKEN := ".asciz"
 else

--- a/rom/filesys/pfs3/fs/m68k/mmakefile.src
+++ b/rom/filesys/pfs3/fs/m68k/mmakefile.src
@@ -8,10 +8,10 @@ AFILES := \
 USER_AFLAGS := -I$(GENINCDIR)
 
 #MM- kernel-fs-pfs3ds-ks13-amiga-m68k : \
-#MM     includes-asm_h-m68k
+#MM     includes-asm_h
 
 #MM- kernel-fs-pfs3-ks13-amiga-m68k : \
-#MM     includes-asm_h-m68k
+#MM     includes-asm_h
 
 %build_archspecific \
         mainmmake=kernel-fs-pfs3ds-ks13 \


### PR DESCRIPTION
…idual mmakefiles, so that metamake doesnt choke on it. make sure that includes-copy has completed before generating asm.h -> it requires the afore-mentioned headers.