### PR TITLE
fix broken behaviour in InternalFormatString.

### DIFF
--- a/workbench/libs/locale/formatstring.c
+++ b/workbench/libs/locale/formatstring.c
@@ -46,7 +46,7 @@ APTR InternalFormatString(const struct Locale * locale,
     template_pos = 0;           /* Current position in the template string */
     state = OUTPUT;             /* current state of parsing */
     end = FALSE;
-    max_argpos = 1;
+    max_argpos = 0;
     arg_counter = 0;
     max_argpos_datasize = 0;
 
@@ -571,6 +571,9 @@ APTR InternalFormatString(const struct Locale * locale,
         }
     }
 
+    if (max_argpos == 0)
+        return dataStream;
+
     return (APTR)(ARG(max_argpos) + max_argpos_datasize);
 }
 
@@ -629,13 +632,7 @@ APTR InternalFormatString(const struct Locale * locale,
                                 dataStream, indices, putCharFunc);
 
     CloseLocale(def_locale);
-    // TODO: Fix InternalFormatString so the following isnt needed...
-    if ((indexSize == 0) && (retval != (APTR)dataStream))
-    {
-        bug("[locale] %s: fixup retval for fmt with 0 args (0x%p -> 0x%p)\n", __func__, retval, dataStream);
-        bug("[locale] %s: InternalFormatString returned wrong value - DEBUG!\n", __func__);
-        retval = (APTR)dataStream;
-    }
+
     return retval;
 
     AROS_LIBFUNC_EXIT


### PR DESCRIPTION
if 0 arguments are specified - it should return the original dataStream value.
if 1 argument is specified, it needs to provide the datasize or it returns its own position again incorrectly. having max_argpos set to 1, results in the args data size being ignored if it is the only arg.