### PR TITLE
dont pass SysBase/DOSBase directly to functions, but pass the ShellSt…

### DIFF
--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2014, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -7,7 +7,8 @@
    Break support (and +(0L) before execution) -- CreateNewProc()?
  */
 
-#define DEBUG 0
+#include <aros/debug.h>
+
 #include <dos/dos.h>
 #include <dos/stdio.h>
 #include <dos/cliinit.h>
@@ -20,8 +21,6 @@
 
 #include <ctype.h>
 #include <string.h>
-
-#include <aros/debug.h>
 
 #include "Shell.h"
 
@@ -70,7 +69,7 @@ LONG interact(ShellState *ss)
     setInteractive(cli, ss);
 
     /* pre-allocate input buffer */
-    if ((error = bufferAppend("?", 1, &in, SysBase))) /* FIXME drop when readLine ok */
+    if ((error = bufferAppend("?", 1, &in, ss))) /* FIXME drop when readLine ok */
 	return error;
 
     do {
@@ -163,8 +162,8 @@ LONG interact(ShellState *ss)
         }
     } while (moreLeft);
 
-    bufferFree(&in, SysBase);
-    bufferFree(&out, SysBase);
+    bufferFree(&in, ss);
+    bufferFree(&out, ss);
 
     return error;
 }

--- a/workbench/c/Shell/Shell.h
+++ b/workbench/c/Shell/Shell.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2014, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -8,11 +8,6 @@
 
 #include <dos/dosextens.h>
 #include <dos/dos.h>	/* for BPTR		*/
-
-#include "buffer.h"
-
-#define FILE_MAX 256 /* max length of file name */
-#define LINE_MAX 512 /* max length of full command line */
 
 /* TODO move */
 /* Template options (copied *AND MODIFIED* from ReadArgs) */
@@ -25,50 +20,7 @@
 #define NUMERIC  0x04 /* /N */
 #define REST     0x08 /* /F */
 
-#define MAXARGS    32
-#define MAXARGLEN  32
-
-struct SArg
-{
-    TEXT   name[MAXARGLEN];
-    LONG   namelen;
-    LONG   len;
-    IPTR   def;
-    LONG   deflen;
-    UBYTE  type;
-};
-
-typedef struct _ShellState
-{
-    BPTR	newIn;
-    BPTR	newOut;
-    BPTR	oldIn;
-    BPTR	oldOut;
-
-    TEXT	command[FILE_MAX + 2];	/* command buffer */
-
-    BPTR	oldHomeDir;	/* shared lock on program file's directory */
-
-    LONG	cliNumber;
-
-    LONG	argcount;	/* script args count */
-    struct SArg	args[MAXARGS];	/* args definitions */
-    IPTR	arg[MAXARGS];	/* args values */
-    struct RDArgs *arg_rd;	/* Current RDArgs return state */
-
-    TEXT	bra, ket, dollar, dot;
-    TEXT        mchar0, pchar0;
-
-    struct _ShellState *stack;
-
-    ULONG	flags;		/* DOS/CliInit*() flags cache */
-
-    APTR        ss_DOSBase;
-    APTR        ss_SysBase;
-} ShellState;
-
-#define DOSBase (ss->ss_DOSBase)
-#define SysBase ((struct ExecBase *)ss->ss_SysBase)
+#include "buffer.h"
 
 /* Function: convertLine
  *

--- a/workbench/c/Shell/buffer.c
+++ b/workbench/c/Shell/buffer.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
 
@@ -10,11 +10,11 @@
 
 #include <string.h>
 
-#include "buffer.h"
+#include "Shell.h"
 
 #define BUF_SIZE 512
 
-static BOOL bufferExpand(Buffer *out, LONG size, APTR SysBase)
+static BOOL bufferExpand(Buffer *out, LONG size, ShellState *ss)
 {
     ULONG newLength = out->len + size;
 
@@ -41,10 +41,10 @@ static BOOL bufferExpand(Buffer *out, LONG size, APTR SysBase)
     return TRUE;
 }
 
-LONG bufferInsert(STRPTR str, ULONG size, Buffer *out, APTR SysBase)
+LONG bufferInsert(STRPTR str, ULONG size, Buffer *out, ShellState *ss)
 {
     ULONG newLength;
-    if (!bufferExpand(out, size, SysBase))
+    if (!bufferExpand(out, size, ss))
         return ERROR_NO_FREE_STORE;
 
     memmove(out->buf + size, out->buf, out->len);
@@ -56,10 +56,10 @@ LONG bufferInsert(STRPTR str, ULONG size, Buffer *out, APTR SysBase)
     return 0;
 }
 
-LONG bufferAppend(STRPTR str, ULONG size, Buffer *out, APTR SysBase)
+LONG bufferAppend(STRPTR str, ULONG size, Buffer *out, ShellState *ss)
 {
     ULONG newLength;
-    if (!bufferExpand(out, size, SysBase))
+    if (!bufferExpand(out, size, ss))
         return ERROR_NO_FREE_STORE;
 
     CopyMem(str, out->buf + out->len, size);
@@ -70,15 +70,15 @@ LONG bufferAppend(STRPTR str, ULONG size, Buffer *out, APTR SysBase)
     return 0;
 }
 
-LONG bufferCopy(Buffer *in, Buffer *out, ULONG size, APTR SysBase)
+LONG bufferCopy(Buffer *in, Buffer *out, ULONG size, ShellState *ss)
 {
     STRPTR s = in->buf + in->cur;
-    LONG ret = bufferAppend(s, size, out, SysBase);
+    LONG ret = bufferAppend(s, size, out, ss);
     in->cur += size;
     return ret;
 }
 
-void bufferFree(Buffer *b, APTR SysBase)
+void bufferFree(Buffer *b, ShellState *ss)
 {
     if (b->mem <= 0)
 	return;
@@ -91,7 +91,7 @@ void bufferFree(Buffer *b, APTR SysBase)
     b->mem = 0;
 }
 
-LONG bufferReadItem(STRPTR buf, ULONG size, Buffer *in, APTR DOSBase)
+LONG bufferReadItem(STRPTR buf, ULONG size, Buffer *in, ShellState *ss)
 {
     struct CSource tin = { in->buf, in->len, in->cur };
     LONG ret = ReadItem(buf, size, &tin);

--- a/workbench/c/Shell/buffer.h
+++ b/workbench/c/Shell/buffer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
 
@@ -10,6 +10,8 @@
 #include <exec/types.h>
 #endif
 
+#include "state.h"
+
 typedef struct {
     STRPTR buf;
     ULONG  len; /* write position */
@@ -17,15 +19,15 @@ typedef struct {
     ULONG  mem; /* allocated memory */
 } Buffer;
 
-LONG bufferAppend(STRPTR str, ULONG size, Buffer *out, APTR SysBase);
-LONG bufferInsert(STRPTR str, ULONG size, Buffer *out, APTR SysBase);
+LONG bufferAppend(STRPTR str, ULONG size, Buffer *out, ShellState *ss);
+LONG bufferInsert(STRPTR str, ULONG size, Buffer *out, ShellState *ss);
 
 /* read 'size' chars from 'in' and append them to 'out' */
-LONG bufferCopy(Buffer *in, Buffer *out, ULONG size, APTR SysBase);
+LONG bufferCopy(Buffer *in, Buffer *out, ULONG size, ShellState *ss);
 
-void bufferFree(Buffer *b, APTR SysBase);
+void bufferFree(Buffer *b, ShellState *ss);
 
-LONG bufferReadItem(STRPTR buf, ULONG size, Buffer *in, APTR DOSBase);
+LONG bufferReadItem(STRPTR buf, ULONG size, Buffer *in, ShellState *ss);
 
 void bufferReset(Buffer *b);
 

--- a/workbench/c/Shell/convertArg.c
+++ b/workbench/c/Shell/convertArg.c
@@ -1,9 +1,10 @@
 /*
-    Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
 
 #include <string.h>
+
 #include "Shell.h"
 
 /* subsitute one script argument and leaves the input after .ket */
@@ -19,7 +20,7 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
     {
         TEXT buf[16];
         LONG len = l2a(ss->cliNumber, buf);
-        bufferAppend(buf, len, out, SysBase);
+        bufferAppend(buf, len, out, ss);
         in->cur += 4;
         return 0;
     }
@@ -37,7 +38,7 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
                 if (*p == '<') /* input redirection */
                     return convertRedir(ss, in, out);
 
-                bufferAppend(s, q - s, out, SysBase);
+                bufferAppend(s, q - s, out, ss);
                 return 0;
             }
     }
@@ -74,10 +75,10 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
                 for (j = 0; (arg = m[j]); ++j)
                 {
                     if (j > 0)
-                        bufferAppend(" ", 1, out, SysBase);
+                        bufferAppend(" ", 1, out, ss);
 
                     len = cliLen(arg);
-                    bufferAppend(arg, len, out, SysBase);
+                    bufferAppend(arg, len, out, ss);
                 }
             }
             else
@@ -98,7 +99,7 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
         }
 
         if (arg)
-            bufferAppend(arg, len, out, SysBase);
+            bufferAppend(arg, len, out, ss);
         break;
     }
 
@@ -108,7 +109,7 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
         in->cur = q - in->buf;
     }
     else
-        bufferCopy(in, out, 1, SysBase);
+        bufferCopy(in, out, 1, ss);
 
     return 0;
 }

--- a/workbench/c/Shell/convertBackTicks.c
+++ b/workbench/c/Shell/convertBackTicks.c
@@ -1,16 +1,15 @@
 /*
-    Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
+
+#include <aros/debug.h>
 
 #include <proto/dos.h>
 
 #include <stdio.h>
 
-#include "buffer.h"
 #include "Shell.h"
-
-#include <aros/debug.h>
 
 // TODO:  remove these comments when fixed and validated
 // TODO:  C++ style comments should be avoided
@@ -39,17 +38,17 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
 	if (p == '*')
 	{
 	    c = 0;
-	    bufferCopy(in, &embedIn, 1, SysBase);
+	    bufferCopy(in, &embedIn, 1, ss);
 	}
 	else if (c == '`')
 	    break;
 	else
-	    bufferCopy(in, &embedIn, 1, SysBase);
+	    bufferCopy(in, &embedIn, 1, ss);
     }
 
     if (c != '`')
     {
-	bufferCopy(&embedIn, out, embedIn.len, SysBase);
+	bufferCopy(&embedIn, out, embedIn.len, ss);
 	goto freebufs;
     }
 
@@ -103,7 +102,7 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
 		if (size <= 0 && buf[i] == '\n')
 		    --len;
 
-		bufferAppend(buf, len, out, SysBase);
+		bufferAppend(buf, len, out, ss);
 	    }
 	}
 
@@ -115,8 +114,8 @@ cleanup:
     Redirection_release(&ess);
     /* TODO: delete generated file */
 freebufs:
-    bufferFree(&embedIn, SysBase);
-    bufferFree(&embedOut, SysBase);
+    bufferFree(&embedIn, ss);
+    bufferFree(&embedOut, ss);
 
     D(bug("[Shell] embedded command done, error = %d\n", error));
     return error;

--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 1995-2015, The AROS Development Team. All rights reserved.
+    Copyright © 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
 
@@ -45,7 +45,7 @@ static LONG dotDef(ShellState *ss, STRPTR szz, Buffer *in, LONG len)
     in->cur += len;
     i = in->cur;
 
-    if ((result = bufferReadItem(buf, sizeof(buf), in, DOSBase)) == ITEM_UNQUOTED)
+    if ((result = bufferReadItem(buf, sizeof(buf), in, ss)) == ITEM_UNQUOTED)
     {
 	len = in->cur - i;
 
@@ -56,7 +56,7 @@ static LONG dotDef(ShellState *ss, STRPTR szz, Buffer *in, LONG len)
 	a = ss->args + i;
 	i = ++in->cur;
 
-	switch (bufferReadItem(buf, sizeof(buf), in, DOSBase))
+	switch (bufferReadItem(buf, sizeof(buf), in, ss))
 	{
 	case ITEM_QUOTED:
 	case ITEM_UNQUOTED:

--- a/workbench/c/Shell/convertRedir.c
+++ b/workbench/c/Shell/convertRedir.c
@@ -1,11 +1,10 @@
 /*
-    Copyright (C) 1995-2016, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
 
 #include <proto/dos.h>
 
-#include "buffer.h"
 #include "Shell.h"
 
 LONG convertRedir(ShellState *ss, Buffer *in, Buffer *out)
@@ -40,7 +39,7 @@ LONG convertRedir(ShellState *ss, Buffer *in, Buffer *out)
 
     in->cur = s - in->buf;
 
-    switch (bufferReadItem(file, FILE_MAX, in, DOSBase))
+    switch (bufferReadItem(file, FILE_MAX, in, ss))
     {
     case ITEM_QUOTED:
     case ITEM_UNQUOTED:

--- a/workbench/c/Shell/convertVar.c
+++ b/workbench/c/Shell/convertVar.c
@@ -1,15 +1,15 @@
 /*
-    Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
+
+#include <aros/debug.h>
 
 #include <proto/dos.h>
 
 #include <ctype.h>
 
 #include "Shell.h"
-
-#include <aros/debug.h>
 
 /* environment variables handling (locals and globals) */
 LONG convertVar(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
@@ -67,12 +67,12 @@ LONG convertVar(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
     if ((bra != 1) && (i > 0) && ((len = GetVar(varName, varValue, 256, LV_VAR)) != -1))
     {
 	D(bug("[Shell] found var: %s = %s\n", varName, varValue));
-	bufferAppend(varValue, len, out, SysBase);
+	bufferAppend(varValue, len, out, ss);
     }
     else
     {
 	D(bug("[Shell] var not found: %s\n", varName));
-	bufferAppend(p, ++i + bra, out, SysBase);
+	bufferAppend(p, ++i + bra, out, ss);
     }
 
     /* Restore original pr_WindowPtr */

--- a/workbench/c/Shell/readLine.c
+++ b/workbench/c/Shell/readLine.c
@@ -1,17 +1,18 @@
 /*
-    Copyright (C) 1995-2020, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
     $Id$
  */
+
+#include <aros/debug.h>
 
 #include <dos/stdio.h>
 
 #include <proto/dos.h>
-
-#include "Shell.h"
-
-#include <aros/debug.h>
+#include <proto/arossupport.h>
 
 #include <string.h>
+
+#include "Shell.h"
 
 #define PIPE_NAME "PIPE "
 
@@ -98,19 +99,21 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
     }
 
     if (i >= LINE_MAX) {
-        D(bug("[Shell] ERROR_LINE_TOO_LONG\n"));
+        D(bug("[Shell] %s: ERROR_LINE_TOO_LONG\n", __func__);)
         return ERROR_LINE_TOO_LONG;
     }
 
     buf[j] = '\0';
-    bufferAppend(buf, j, out, SysBase);
+    bufferAppend(buf, j, out, ss);
 
     if (checkPipe(pchar, mchar, buf, j))
-        bufferInsert(PIPE_NAME, strlen(PIPE_NAME), out, SysBase);
+        bufferInsert(PIPE_NAME, strlen(PIPE_NAME), out, ss);
 
     *moreLeft = (c != ENDSTREAMCH);
 
-    D(bug("[Shell] readLine %d%s: %s", j, *moreLeft ?  "" : "'", buf));
+    D(
+        bug("[Shell] readLine %d%s: %s", j, *moreLeft ?  "" : "'", buf);
+    )
     return 0;
 }
 

--- a/workbench/c/Shell/state.h
+++ b/workbench/c/Shell/state.h
@@ -1,0 +1,60 @@
+/*
+    Copyright © 2021, The AROS Development Team. All rights reserved.
+    $Id$
+*/
+
+#ifndef SHELL_STATE_H
+#define SHELL_STATE_H 1
+
+#include <dos/dosextens.h>
+#include <dos/dos.h>	/* for BPTR		*/
+
+#define FILE_MAX 256 /* max length of file name */
+#define LINE_MAX 512 /* max length of full command line */
+
+#define MAXARGS    32
+#define MAXARGLEN  32
+
+struct SArg
+{
+    TEXT   name[MAXARGLEN];
+    LONG   namelen;
+    LONG   len;
+    IPTR   def;
+    LONG   deflen;
+    UBYTE  type;
+};
+
+typedef struct _ShellState
+{
+    BPTR	newIn;
+    BPTR	newOut;
+    BPTR	oldIn;
+    BPTR	oldOut;
+
+    TEXT	command[FILE_MAX + 2];	/* command buffer */
+
+    BPTR	oldHomeDir;	/* shared lock on program file's directory */
+
+    LONG	cliNumber;
+
+    LONG	argcount;	/* script args count */
+    struct SArg	args[MAXARGS];	/* args definitions */
+    IPTR	arg[MAXARGS];	/* args values */
+    struct RDArgs *arg_rd;	/* Current RDArgs return state */
+
+    TEXT	bra, ket, dollar, dot;
+    TEXT        mchar0, pchar0;
+
+    struct _ShellState *stack;
+
+    ULONG	flags;		/* DOS/CliInit*() flags cache */
+
+    APTR        ss_DOSBase;
+    APTR        ss_SysBase;
+} ShellState;
+
+#define DOSBase (ss->ss_DOSBase)
+#define SysBase ((struct ExecBase *)ss->ss_SysBase)
+
+#endif


### PR DESCRIPTION
…ate so that both can be accessed, allowing Debug to be enabled again without pulling in SysBase.