### PR TITLE
tidy the copyright notices. define separate interrupt status flags, i…

### DIFF
--- a/workbench/devs/AHI/Drivers/HDAudio/accel.c
+++ b/workbench/devs/AHI/Drivers/HDAudio/accel.c
@@ -6,13 +6,18 @@ Software distributed under the License is distributed on an "AS IS" basis, WITHO
 ANY KIND, either express or implied. See the License for the specific language governing rights and
 limitations under the License.
 
-(C) Copyright xxxx-2009 Davy Wentzler.
+(C) Copyright 2010-2021 The AROS Dev Team
 (C) Copyright 2009-2010 Stephen Jones.
+(C) Copyright xxxx-2009 Davy Wentzler.
 
 The Initial Developer of the Original Code is Davy Wentzler.
 
 All Rights Reserved.
 */
+
+#ifdef __AROS__
+#include <aros/debug.h>
+#endif
 
 #include <config.h>
 

--- a/workbench/devs/AHI/Drivers/HDAudio/driver-init.c
+++ b/workbench/devs/AHI/Drivers/HDAudio/driver-init.c
@@ -6,13 +6,18 @@ Software distributed under the License is distributed on an "AS IS" basis, WITHO
 ANY KIND, either express or implied. See the License for the specific language governing rights and
 limitations under the License.
 
-(C) Copyright xxxx-2009 Davy Wentzler.
+(C) Copyright 2010-2021 The AROS Dev Team
 (C) Copyright 2009-2010 Stephen Jones.
+(C) Copyright xxxx-2009 Davy Wentzler.
 
 The Initial Developer of the Original Code is Davy Wentzler.
 
 All Rights Reserved.
 */
+
+#ifdef __AROS__
+#include <aros/debug.h>
+#endif
 
 #include <exec/memory.h>
 
@@ -21,7 +26,6 @@ All Rights Reserved.
 #include <proto/exec.h>
 #include <clib/alib_protos.h>
 #ifdef __AROS__
-#include <aros/debug.h>
 struct DosLibrary* DOSBase;
 struct Library *StdCBase = NULL;
 #endif

--- a/workbench/devs/AHI/Drivers/HDAudio/interrupt.c
+++ b/workbench/devs/AHI/Drivers/HDAudio/interrupt.c
@@ -6,7 +6,7 @@ Software distributed under the License is distributed on an "AS IS" basis, WITHO
 ANY KIND, either express or implied. See the License for the specific language governing rights and
 limitations under the License.
 
-(C) Copyright 2010-2020 The AROS Developer Team
+(C) Copyright 2010-2021 The AROS Dev Team
 (C) Copyright 2009-2010 Stephen Jones.
 (C) Copyright xxxx-2009 Davy Wentzler.
 
@@ -14,6 +14,10 @@ The Initial Developer of the Original Code is Davy Wentzler.
 
 All Rights Reserved.
 */
+
+#ifdef __AROS__
+#include <aros/debug.h>
+#endif
 
 #include <config.h>
 
@@ -26,9 +30,6 @@ All Rights Reserved.
 #include "interrupt.h"
 #include "misc.h"
 #include "pci_wrapper.h"
-#ifdef __AROS__
-#include <aros/debug.h>
-#endif
 
 #define min(a,b) ((a)<(b)?(a):(b))
 
@@ -52,13 +53,16 @@ CardInterrupt( struct HDAudioChip* card )
 {
     ULONG intreq;
     LONG  handled = 0;
+    D(UWORD statests;)
     UBYTE rirb_status;
     int i;
 
     intreq = pci_inl(HD_INTSTS, card);
 
-    if (intreq & HD_INTCTL_GLOBAL)
+    D(bug("[HDAudio] %s(%08x)\n", __func__, intreq);)
+    if (intreq & HD_INTSTS_GIS)
     {
+        D(bug("[HDAudio] %s: Global Interrupt\n", __func__);)
         if (intreq & 0x3fffffff) // stream interrupt
         {
 //            ULONG position;
@@ -154,16 +158,14 @@ CardInterrupt( struct HDAudioChip* card )
             }
         }
 
-        if (intreq & HD_INTCTL_CIE)
+        if (intreq & HD_INTSTS_CIS)
         {
-            //D(bug("[HDAudio] CIE\n"));
+            D(bug("[HDAudio] %s: Controller Interrupt\n", __func__);)
             pci_outb(0x4, HD_INTSTS + 3, card); // only byte access allowed
-           
-  //          if (card->is_playing)
-    //            D(bug("[HDAudio] CIE irq! rirb is %x, STATESTS = %x\n", pci_inb(HD_RIRBSTS, card), pci_inw(HD_STATESTS, card)));
-        
+
             // check for RIRB status
             rirb_status = pci_inb(HD_RIRBSTS, card);
+            D(bug("[HDAudio] %s: RIRB = %02x\n", __func__, rirb_status);)
             if (rirb_status & 0x5)
             {
                 if (rirb_status & 0x4) // RIRBOIS
@@ -182,8 +184,12 @@ CardInterrupt( struct HDAudioChip* card )
                     //D(bug("[HDAudio] RIRB IRQ!\n"));
                 }
 
-                pci_outb(0x5, HD_RIRBSTS, card);
+                pci_outb(rirb_status, HD_RIRBSTS, card);
             }
+            D(
+              statests = pci_inw(HD_STATESTS, card);
+              bug("[HDAudio] %s: STATESTS = %04x\n", __func__, statests);
+            )
         }
         
         handled = 1;

--- a/workbench/devs/AHI/Drivers/HDAudio/main.c
+++ b/workbench/devs/AHI/Drivers/HDAudio/main.c
@@ -6,7 +6,7 @@ Software distributed under the License is distributed on an "AS IS" basis, WITHO
 ANY KIND, either express or implied. See the License for the specific language governing rights and
 limitations under the License.
 
-(C) Copyright 2010-2020 The AROS Developer Team
+(C) Copyright 2010-2021 The AROS Dev Team
 (C) Copyright 2009-2010 Stephen Jones.
 (C) Copyright xxxx-2009 Davy Wentzler.
 
@@ -14,6 +14,10 @@ The Initial Developer of the Original Code is Davy Wentzler.
 
 All Rights Reserved.
 */
+
+#ifdef __AROS__
+#include <aros/debug.h>
+#endif
 
 #include <config.h>
 
@@ -26,9 +30,7 @@ All Rights Reserved.
 #include <proto/exec.h>
 #include <proto/dos.h>
 #include <proto/utility.h>
-#ifdef __AROS__
-#include <aros/debug.h>
-#endif
+
 #include <string.h>
 
 #include "library.h"

--- a/workbench/devs/AHI/Drivers/HDAudio/regs.h
+++ b/workbench/devs/AHI/Drivers/HDAudio/regs.h
@@ -7,13 +7,15 @@
 #define HD_VMIN 0x2
 #define HD_VMAJ 0x3
 #define HD_GCTL 0x8
+#define HD_WAKEEN 0xC
 #define HD_STATESTS 0xE
 
 #define HD_INTCTL 0x20 // interrupt control
-  #define HD_INTCTL_GLOBAL 0x80000000
-  #define HD_INTCTL_CIE    0x40000000
+  #define HD_INTCTL_GIE 0x80000000
+  #define HD_INTCTL_CIE 0x40000000
 #define HD_INTSTS 0x24 // interrupt status
-
+  #define HD_INTSTS_GIS 0x80000000
+  #define HD_INTSTS_CIS 0x40000000
 
 // CORB
 #define HD_CORB_LOW 0x40


### PR DESCRIPTION
…nstead of using the interrupt control flags. define WAKEEN, and clear it so that we do not get state change interrupts for the codecs (which we do not handle!), aswell as pending interrupts before enabling them. Use the PCI driver method to add the interrupt handler. Do not continue adding the device if it fails to add the interrupt handler.