### PR TITLE
Vboxusb fix

### DIFF
--- a/rom/usb/pciusb/ehcichip.c
+++ b/rom/usb/pciusb/ehcichip.c
@@ -1524,7 +1524,8 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu) {
                     (hccparams & EHCF_64BITS) ? "Yes" : "No",
                     (hccparams & EHCF_PROGFRAMELIST) ? "Yes" : "No",
                     (hccparams & EHCF_ASYNCSCHEDPARK) ? "Yes" : "No"));
-                    hc->hc_EhciUsbCmd = (1UL<<EHUS_INTTHRESHOLD);
+
+        hc->hc_EhciUsbCmd = (1UL<<EHUS_INTTHRESHOLD);
 
         /* FIXME HERE: Process EHCF_64BITS flag and implement 64-bit addressing */
 

--- a/rom/usb/pciusb/ehcichip.c
+++ b/rom/usb/pciusb/ehcichip.c
@@ -857,22 +857,25 @@ void ehciScheduleIntTDs(struct PCIController *hc) {
         CONSTWRITEMEM32_LE(&predetd->etd_AltNextTD, EHCI_TERMINATE);
         predetd->etd_Succ = NULL;
 
-        // due to sillicon bugs, we fill in the first overlay ourselves.
-        etd = eqh->eqh_FirstTD;
-        eqh->eqh_CurrTD = etd->etd_Self;
-        eqh->eqh_NextTD = etd->etd_NextTD;
-        eqh->eqh_AltNextTD = etd->etd_AltNextTD;
-        eqh->eqh_CtrlStatus = etd->etd_CtrlStatus;
-        eqh->eqh_BufferPtr[0] = etd->etd_BufferPtr[0];
-        eqh->eqh_BufferPtr[1] = etd->etd_BufferPtr[1];
-        eqh->eqh_BufferPtr[2] = etd->etd_BufferPtr[2];
-        eqh->eqh_BufferPtr[3] = etd->etd_BufferPtr[3];
-        eqh->eqh_BufferPtr[4] = etd->etd_BufferPtr[4];
-        eqh->eqh_ExtBufferPtr[0] = etd->etd_ExtBufferPtr[0];
-        eqh->eqh_ExtBufferPtr[1] = etd->etd_ExtBufferPtr[1];
-        eqh->eqh_ExtBufferPtr[2] = etd->etd_ExtBufferPtr[2];
-        eqh->eqh_ExtBufferPtr[3] = etd->etd_ExtBufferPtr[3];
-        eqh->eqh_ExtBufferPtr[4] = etd->etd_ExtBufferPtr[4];
+        if (hc->hc_Quirks & HCQ_EHCI_OVERLAY_INT_FILL)
+        {
+            // due to sillicon bugs, we fill in the first overlay ourselves.
+            etd = eqh->eqh_FirstTD;
+            eqh->eqh_CurrTD = etd->etd_Self;
+            eqh->eqh_NextTD = etd->etd_NextTD;
+            eqh->eqh_AltNextTD = etd->etd_AltNextTD;
+            eqh->eqh_CtrlStatus = etd->etd_CtrlStatus;
+            eqh->eqh_BufferPtr[0] = etd->etd_BufferPtr[0];
+            eqh->eqh_BufferPtr[1] = etd->etd_BufferPtr[1];
+            eqh->eqh_BufferPtr[2] = etd->etd_BufferPtr[2];
+            eqh->eqh_BufferPtr[3] = etd->etd_BufferPtr[3];
+            eqh->eqh_BufferPtr[4] = etd->etd_BufferPtr[4];
+            eqh->eqh_ExtBufferPtr[0] = etd->etd_ExtBufferPtr[0];
+            eqh->eqh_ExtBufferPtr[1] = etd->etd_ExtBufferPtr[1];
+            eqh->eqh_ExtBufferPtr[2] = etd->etd_ExtBufferPtr[2];
+            eqh->eqh_ExtBufferPtr[3] = etd->etd_ExtBufferPtr[3];
+            eqh->eqh_ExtBufferPtr[4] = etd->etd_ExtBufferPtr[4];
+        }
 
         Remove(&ioreq->iouh_Req.io_Message.mn_Node);
         ioreq->iouh_DriverPrivate1 = eqh;
@@ -1043,22 +1046,25 @@ void ehciScheduleBulkTDs(struct PCIController *hc) {
         CONSTWRITEMEM32_LE(&predetd->etd_NextTD, EHCI_TERMINATE);
         CONSTWRITEMEM32_LE(&predetd->etd_AltNextTD, EHCI_TERMINATE);
 
-        // due to sillicon bugs, we fill in the first overlay ourselves.
-        etd = eqh->eqh_FirstTD;
-        eqh->eqh_CurrTD = etd->etd_Self;
-        eqh->eqh_NextTD = etd->etd_NextTD;
-        eqh->eqh_AltNextTD = etd->etd_AltNextTD;
-        eqh->eqh_CtrlStatus = etd->etd_CtrlStatus;
-        eqh->eqh_BufferPtr[0] = etd->etd_BufferPtr[0];
-        eqh->eqh_BufferPtr[1] = etd->etd_BufferPtr[1];
-        eqh->eqh_BufferPtr[2] = etd->etd_BufferPtr[2];
-        eqh->eqh_BufferPtr[3] = etd->etd_BufferPtr[3];
-        eqh->eqh_BufferPtr[4] = etd->etd_BufferPtr[4];
-        eqh->eqh_ExtBufferPtr[0] = etd->etd_ExtBufferPtr[0];
-        eqh->eqh_ExtBufferPtr[1] = etd->etd_ExtBufferPtr[1];
-        eqh->eqh_ExtBufferPtr[2] = etd->etd_ExtBufferPtr[2];
-        eqh->eqh_ExtBufferPtr[3] = etd->etd_ExtBufferPtr[3];
-        eqh->eqh_ExtBufferPtr[4] = etd->etd_ExtBufferPtr[4];
+        if (hc->hc_Quirks & HCQ_EHCI_OVERLAY_BULK_FILL)
+        {
+            // due to sillicon bugs, we fill in the first overlay ourselves.
+            etd = eqh->eqh_FirstTD;
+            eqh->eqh_CurrTD = etd->etd_Self;
+            eqh->eqh_NextTD = etd->etd_NextTD;
+            eqh->eqh_AltNextTD = etd->etd_AltNextTD;
+            eqh->eqh_CtrlStatus = etd->etd_CtrlStatus;
+            eqh->eqh_BufferPtr[0] = etd->etd_BufferPtr[0];
+            eqh->eqh_BufferPtr[1] = etd->etd_BufferPtr[1];
+            eqh->eqh_BufferPtr[2] = etd->etd_BufferPtr[2];
+            eqh->eqh_BufferPtr[3] = etd->etd_BufferPtr[3];
+            eqh->eqh_BufferPtr[4] = etd->etd_BufferPtr[4];
+            eqh->eqh_ExtBufferPtr[0] = etd->etd_ExtBufferPtr[0];
+            eqh->eqh_ExtBufferPtr[1] = etd->etd_ExtBufferPtr[1];
+            eqh->eqh_ExtBufferPtr[2] = etd->etd_ExtBufferPtr[2];
+            eqh->eqh_ExtBufferPtr[3] = etd->etd_ExtBufferPtr[3];
+            eqh->eqh_ExtBufferPtr[4] = etd->etd_ExtBufferPtr[4];
+        }
 
         Remove(&ioreq->iouh_Req.io_Message.mn_Node);
         ioreq->iouh_DriverPrivate1 = eqh;

--- a/rom/usb/pciusb/ehcichip.c
+++ b/rom/usb/pciusb/ehcichip.c
@@ -1564,7 +1564,7 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu) {
         KPRINTF(10, ("HW Regs USBSTS=%04lx\n", READREG32_LE(hc->hc_RegBase, EHCI_USBSTATUS)));
         KPRINTF(10, ("HW Regs FRAMECOUNT=%04lx\n", READREG32_LE(hc->hc_RegBase, EHCI_FRAMECOUNT)));
 
-        KPRINTF(1000, ("ehciInit returns TRUE...\n"));
+        KPRINTF(10, ("ehciInit returns TRUE...\n"));
         return TRUE;
     }
 

--- a/rom/usb/pciusb/pci_aros.c
+++ b/rom/usb/pciusb/pci_aros.c
@@ -46,14 +46,14 @@ static void handleQuirks(struct PCIController *hc)
 
     hc->hc_Quirks = 0;
     if (hc->hc_HCIType == HCITYPE_EHCI)
-        hc->hc_Quirks |= HCQ_EHCI_OVERLAY_CTRL_FILL;
+        hc->hc_Quirks |= (HCQ_EHCI_OVERLAY_CTRL_FILL|HCQ_EHCI_OVERLAY_INT_FILL|HCQ_EHCI_OVERLAY_BULK_FILL);
 
     OOP_GetAttr(hc->hc_PCIDeviceObject, aHidd_PCIDevice_VendorID, &vendorid);
     OOP_GetAttr(hc->hc_PCIDeviceObject, aHidd_PCIDevice_ProductID, &productid);
     if (vendorid == 0x8086 && productid == 0x265C)
     {
         /* This is needed for EHCI to work in VirtualBox */
-        hc->hc_Quirks &= ~(HCQ_EHCI_OVERLAY_CTRL_FILL);
+        hc->hc_Quirks &= ~(HCQ_EHCI_OVERLAY_CTRL_FILL|HCQ_EHCI_OVERLAY_INT_FILL|HCQ_EHCI_OVERLAY_BULK_FILL);
     }
 }
 

--- a/rom/usb/pciusb/pci_aros.c
+++ b/rom/usb/pciusb/pci_aros.c
@@ -54,6 +54,9 @@ static void handleQuirks(struct PCIController *hc)
     {
         /* This is needed for EHCI to work in VirtualBox */
         hc->hc_Quirks &= ~(HCQ_EHCI_OVERLAY_CTRL_FILL|HCQ_EHCI_OVERLAY_INT_FILL|HCQ_EHCI_OVERLAY_BULK_FILL);
+        /* VirtualBox reports frame list size of 1024, but still issues interrupts at
+           speed of around 4 per second instead of ever 1024 ms */
+        hc->hc_Quirks |= HCQ_EHCI_VBOX_FRAMEROOLOVER;
     }
 }
 

--- a/rom/usb/pciusb/pciusb.conf
+++ b/rom/usb/pciusb/pciusb.conf
@@ -1,5 +1,5 @@
 ##begin config
-version 1.3
+version 1.4
 libbase base
 libbasetype struct PCIDevice
 libbasetypeextern struct Device

--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -183,7 +183,10 @@ struct PCIController
 #define HCF_ABORT	0x0010	/* Aborted requests available	 */
 
 /* hc_Quirks */
-#define HCQ_EHCI_OVERLAY_CTRL_FILL     (1 << 0)
+#define HCQ_EHCI_OVERLAY_CTRL_FILL      (1 << 0)
+#define HCQ_EHCI_OVERLAY_INT_FILL       (1 << 1)
+#define HCQ_EHCI_OVERLAY_BULK_FILL      (1 << 2)
+
 
 /* The device node - private
 */

--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -107,6 +107,7 @@ struct PCIController
     UWORD		  hc_HCIType;
     UWORD		  hc_NumPorts;
     UWORD		  hc_Flags;	    /* See below */
+    ULONG		  hc_Quirks;	/* See below */
 
     volatile APTR	  hc_RegBase;
 
@@ -180,6 +181,9 @@ struct PCIController
 #define HCF_STOP_BULK	0x0004	/* Bulk transfers stopped	 */
 #define HCF_STOP_CTRL	0x0008	/* Control transfers stopped	 */
 #define HCF_ABORT	0x0010	/* Aborted requests available	 */
+
+/* hc_Quirks */
+#define HCQ_EHCI_OVERLAY_CTRL_FILL     (1 << 0)
 
 /* The device node - private
 */

--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -139,6 +139,8 @@ struct PCIController
     volatile BOOL	  hc_AsyncAdvanced;
     struct EhciQH	 *hc_EhciAsyncFreeQH;
     struct EhciTD	 *hc_ShortPktEndTD;
+    UWORD		  hc_EhciTimeoutShift;
+
 
     struct OhciED	 *hc_OhciCtrlHeadED;
     struct OhciED	 *hc_OhciCtrlTailED;
@@ -186,6 +188,7 @@ struct PCIController
 #define HCQ_EHCI_OVERLAY_CTRL_FILL      (1 << 0)
 #define HCQ_EHCI_OVERLAY_INT_FILL       (1 << 1)
 #define HCQ_EHCI_OVERLAY_BULK_FILL      (1 << 2)
+#define HCQ_EHCI_VBOX_FRAMEROOLOVER     (1 << 3)
 
 
 /* The device node - private

--- a/rom/usb/pciusb/uhwcmd.c
+++ b/rom/usb/pciusb/uhwcmd.c
@@ -807,7 +807,7 @@ WORD cmdControlXFerRootHub(struct IOUsbHWReq *ioreq,
                                     KPRINTF(10, ("EHCI: Reset=%s\n", newval & EHPF_PORTRESET ? "BAD!" : "GOOD"));
                                     KPRINTF(10, ("EHCI: Highspeed=%s\n", newval & EHPF_PORTENABLE ? "YES!" : "NO"));
                                     KPRINTF(10, ("EHCI: Port status=%08lx\n", newval));
-                                    if(!(newval & EHPF_PORTENABLE) && unit->hu_PortMap11[idx - 1] != NULL)
+                                    if(!(newval & EHPF_PORTENABLE))
                                     {
                                         // if not highspeed, release ownership
                                         KPRINTF(20, ("EHCI: Transferring ownership to UHCI/OHCI port %ld\n", unit->hu_PortNum11[idx - 1]));

--- a/rom/usb/pciusb/uhwcmd.c
+++ b/rom/usb/pciusb/uhwcmd.c
@@ -797,11 +797,14 @@ WORD cmdControlXFerRootHub(struct IOUsbHWReq *ioreq,
                                     newval &= ~(EHPF_PORTSUSPEND|EHPF_PORTENABLE);
                                     newval |= EHPF_PORTRESET;
                                     WRITEREG32_LE(hc->hc_RegBase, portreg, newval);
-                                    uhwDelayMS(50, unit);
+                                    uhwDelayMS(200, unit); /* Spec is 50ms, FreeBSD source suggests 200ms */
                                     newval = READREG32_LE(hc->hc_RegBase, portreg) & ~(EHPF_OVERCURRENTCHG|EHPF_ENABLECHANGE|EHPF_CONNECTCHANGE|EHPF_PORTSUSPEND|EHPF_PORTENABLE);
-                                    KPRINTF(10, ("EHCI: Reset=%s\n", newval & EHPF_PORTRESET ? "GOOD" : "BAD!"));
-                                    newval &= ~EHPF_PORTRESET;
-                                    WRITEREG32_LE(hc->hc_RegBase, portreg, newval);
+                                    KPRINTF(10, ("EHCI: Reset=%s\n", newval & EHPF_PORTRESET ? "BAD!" : "GOOD"));
+                                    if (newval & EHPF_PORTRESET)
+                                    {
+                                        newval &= ~EHPF_PORTRESET;
+                                        WRITEREG32_LE(hc->hc_RegBase, portreg, newval);
+                                    }
                                     uhwDelayMS(10, unit);
                                     newval = READREG32_LE(hc->hc_RegBase, portreg) & ~(EHPF_OVERCURRENTCHG|EHPF_ENABLECHANGE|EHPF_CONNECTCHANGE|EHPF_PORTSUSPEND);
                                     KPRINTF(10, ("EHCI: Reset=%s\n", newval & EHPF_PORTRESET ? "BAD!" : "GOOD"));


### PR DESCRIPTION
Fixes that enable USB2.0 under VirtualBox 6.1.18. Tested on ABIv0.