### PR TITLE
stdio: don't try to both define and prototype getchar

### DIFF
--- a/compiler/posixc/include/aros/posixc/stdio.h
+++ b/compiler/posixc/include/aros/posixc/stdio.h
@@ -374,7 +374,9 @@ int puts(const char *s);
 int putchar(int c);
 int printf(const char * restrict format, ...);
 char *gets(char *s);
+#ifndef getchar
 int getchar(void);
+#endif
 size_t fwrite(const void * restrict ptr, size_t size, size_t nmemb,
     FILE * restrict stream);
 long int ftell(FILE *stream);

--- a/compiler/stdc/include/aros/stdc/stdio.h
+++ b/compiler/stdc/include/aros/stdc/stdio.h
@@ -132,8 +132,9 @@ int getc(FILE *stream);
 #if (!defined(_XOPEN_SOURCE) && \
      !defined(_POSIX_SOURCE) && \
      !defined(_BSD_SOURCE))
+#ifdef _STDIO_H_NOMACRO
 int getchar(void);
-#ifndef _STDIO_H_NOMACRO
+#else
 #define getchar()       fgetc(stdin)
 #endif
 char *gets(char *s);


### PR DESCRIPTION
In stdc, if _STDIO_H_NOMACRO is not set (default), getchar will be
prototyped, and then immediately defined.

Later in posixc, if compiling with without NO_POSIX_WRAPPERS (that is,
_XOPEN_SOURCE or _POSIX_SOURCE or _BSD_SOURCE is defined, see
aros/features.h), getchar is prototyped again, except this time it is
already a macro, and the preprocessor gets confused (it thinks void is
an argument).

So, in stdc we force getchar to be either a prototype or a macro, and in
posixc we only prototype getchar if its not already a macro.

The twisty maze of feature macros has done my head in, and I can't be
sure what the impacts are, but I don't think it matters: ultimately, we
compile clean and getchar is provided to any program that wants it in an
ABI-safe way.