### PR TITLE
Fix for https://github.com/deadw00d/AROS/issues/63

### DIFF
--- a/arch/all-pc/utility/mmakefile.src
+++ b/arch/all-pc/utility/mmakefile.src
@@ -5,15 +5,31 @@ include $(SRCDIR)/config/aros.cfg
 -include $(SRCDIR)/arch/$(CPU)-all/utility/make.opts
 
 USER_INCLUDES := -I$(SRCDIR)/rom/utility
-ISA_FLAGS += -mavx
 
 FILES := \
-    setmem_sse \
-    setmem_avx \
+    setmem_sse
 
-#MM- kernel-utility-pc : includes
+#MM- kernel-utility-pc : kernel-utility-pc-avx includes
 
 %build_archspecific mainmmake=kernel-utility modname=utility maindir=rom/utility \
     arch=pc files=$(FILES)
+
+ISA_FLAGS += -mavx
+
+GENDIR_UTILITY_ARCH := $(GENDIR)/rom/utility/utility/arch
+
+AVX_FILES := \
+    setmem_avx
+
+AVX_OBJS := $(addprefix $(GENDIR_UTILITY_ARCH)/, $(addsuffix .o, $(AVX_FILES)))
+AVX_DEPS := $(addprefix $(GENDIR_UTILITY_ARCH)/, $(addsuffix .d, $(AVX_FILES)))
+
+#MM
+kernel-utility-pc-avx : $(AVX_OBJS)
+
+%rule_compile_multi mmake=kernel-utility-pc-avx \
+    basenames=$(AVX_FILES) targetdir=$(GENDIR_UTILITY_ARCH)
+
+%include_deps depstargets=kernel-utility-pc-avx deps=$(AVX_DEPS)
 
 %common


### PR DESCRIPTION
Use -mavx only for setmem_avx. Otherwise gcc generates AVX versions
of vmovdqa opcode to handle XMM registers.