### PR TITLE
Time64

### DIFF
--- a/developer/demos/simple_timer.c
+++ b/developer/demos/simple_timer.c
@@ -202,8 +202,8 @@ void wait_for_timer(struct timerequest *tr, struct timeval *tv )
 
 tr->tr_node.io_Command = TR_ADDREQUEST; /* add a new timer request */
 
-/* structure assignment */
-tr->tr_time = *tv;
+tr->tr_time.tv_secs = tv->tv_secs;
+tr->tr_time.tv_micro = tv->tv_micro;
 
 /* post request to the timer -- will go to sleep till done */
 DoIO((struct IORequest *) tr );
@@ -239,8 +239,8 @@ if (tr == 0 )
 tr->tr_node.io_Command = TR_GETSYSTIME;
 DoIO((struct IORequest *) tr );
 
-/* structure assignment */
-*tv = tr->tr_time;
+tv->tv_secs = tr->tr_time.tv_secs;
+tv->tv_micro = tr->tr_time.tv_micro;
 
 delete_timer( tr );
 return( 0 );

--- a/rom/devs/input/processevents.c
+++ b/rom/devs/input/processevents.c
@@ -42,7 +42,8 @@
 
 #define SEND_KEYTIMER_REQUEST(timerio,time)             \
         timerio->tr_node.io_Command = TR_ADDREQUEST;    \
-        timerio->tr_time = time;                        \
+        timerio->tr_time.tv_secs = time.tv_secs;        \
+        timerio->tr_time.tv_micro = time.tv_micro;      \
         SendIO((struct IORequest *)timerio)
 
 #define ABORT_KEYTIMER_REQUEST \
@@ -427,13 +428,17 @@ void ProcessEvents(struct inputbase *InputDevice)
                     } break;
 
                 case IND_SETTHRESH:
-                    InputDevice->KeyRepeatThreshold =
-                        ((struct timerequest *)ioreq)->tr_time;
+                    InputDevice->KeyRepeatThreshold.tv_secs =
+                        ((struct timerequest *)ioreq)->tr_time.tv_secs;
+                    InputDevice->KeyRepeatThreshold.tv_micro =
+                        ((struct timerequest *)ioreq)->tr_time.tv_micro;
                     break;
 
                 case IND_SETPERIOD:
-                    InputDevice->KeyRepeatInterval =
-                        ((struct timerequest *)ioreq)->tr_time;
+                    InputDevice->KeyRepeatInterval.tv_secs =
+                        ((struct timerequest *)ioreq)->tr_time.tv_secs;
+                    InputDevice->KeyRepeatInterval.tv_micro =
+                        ((struct timerequest *)ioreq)->tr_time.tv_micro;
                     break;
 
                 }

--- a/rom/filesys/SFS/FS/filesystemmain.c
+++ b/rom/filesys/SFS/FS/filesystemmain.c
@@ -4815,7 +4815,8 @@ static void diskchangenotify(ULONG class) {
                 ie.ie_Code = 0;
                 ie.ie_Qualifier = IEQUALIFIER_MULTIBROADCAST;
                 ie.ie_EventAddress = 0;
-                ie.ie_TimeStamp = tv;
+                ie.ie_TimeStamp.tv_secs=tv.tv_secs;
+                ie.ie_TimeStamp.tv_micro=tv.tv_micro;
 
                 inputreq->io_Command = IND_WRITEEVENT;
                 inputreq->io_Length  = sizeof(struct InputEvent);

--- a/rom/intuition/setprefs.c
+++ b/rom/intuition/setprefs.c
@@ -125,7 +125,8 @@ static void SetColors(UWORD *p, UBYTE first, UBYTE cnt, struct IntuitionBase *In
                     req.tr_node.io_Device = GetPrivIBase(IntuitionBase)->InputIO->io_Device;
                     req.tr_node.io_Unit = GetPrivIBase(IntuitionBase)->InputIO->io_Unit;
                     req.tr_node.io_Command = IND_SETTHRESH;
-                    req.tr_time = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptDelay;
+                    req.tr_time.tv_secs = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptDelay.tv_secs;
+                    req.tr_time.tv_micro = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptDelay.tv_micro;
                     DoIO(&req.tr_node);
 
             #ifndef __MORPHOS__
@@ -156,7 +157,8 @@ static void SetColors(UWORD *p, UBYTE first, UBYTE cnt, struct IntuitionBase *In
                 req.tr_node.io_Device = GetPrivIBase(IntuitionBase)->InputIO->io_Device;
                 req.tr_node.io_Unit = GetPrivIBase(IntuitionBase)->InputIO->io_Unit;
                 req.tr_node.io_Command = IND_SETPERIOD;
-                req.tr_time = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptSpeed;
+                req.tr_time.tv_secs = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptSpeed.tv_secs;
+                req.tr_time.tv_micro = GetPrivIBase(IntuitionBase)->ActivePreferences.KeyRptSpeed.tv_micro;
                 DoIO(&req.tr_node);
     
             #ifndef __MORPHOS__

--- a/rom/timer/lowlevel.c
+++ b/rom/timer/lowlevel.c
@@ -116,14 +116,18 @@ BOOL common_BeginIO(struct timerequest *timereq, struct TimerBase *TimerBase)
 #endif
 
     case TR_GETSYSTIME:
-        GetSysTime(&timereq->tr_time);
+    {
+        struct timeval tv;
+        GetSysTime(&tv);
+        timereq->tr_time.tv_secs = tv.tv_secs;
+        timereq->tr_time.tv_micro = tv.tv_micro;
 
         if (!(timereq->tr_node.io_Flags & IOF_QUICK))
             ReplyMsg(&timereq->tr_node.io_Message);
 
         replyit = FALSE; /* Because replyit will clear the timeval */
         break;
-
+    }
     case TR_SETSYSTIME:
         Disable();
 

--- a/workbench/c/WaitX.c
+++ b/workbench/c/WaitX.c
@@ -267,7 +267,10 @@ LONG MainEntry(struct ExecBase *SysBase)
 
         if (clock)
         {
-            GetSysTime(&TimerReq->tr_time); /* Get current System Time */
+            struct timeval tv;
+            GetSysTime(&tv); /* Get current System Time */
+            TimerReq->tr_time.tv_secs = tv.tv_secs;
+            TimerReq->tr_time.tv_micro = tv.tv_micro;
             Amiga2Date(TimerReq->tr_time.tv_secs, clock); /* Fill in current date/time as default */
 
             if (ArgArray[TEM_DATE])

--- a/workbench/devs/printer/driver.c
+++ b/workbench/devs/printer/driver.c
@@ -275,7 +275,8 @@ static LONG pd_PRead(char * buffer, LONG *length, struct timeval *tv)
     pd->pd_TIOR.tr_node.io_Command = TR_ADDREQUEST;
     pd->pd_TIOR.tr_node.io_Flags = 0;
     pd->pd_TIOR.tr_node.io_Message.mn_Length = sizeof(pd->pd_TIOR);
-    pd->pd_TIOR.tr_time = *tv;
+    pd->pd_TIOR.tr_time.tv_secs = tv->tv_secs;
+    pd->pd_TIOR.tr_time.tv_micro = tv->tv_micro;
     SendIO((struct IORequest *)&pd->pd_TIOR);
 
     io->io_Command = CMD_READ;

--- a/workbench/network/common/C/ping.c
+++ b/workbench/network/common/C/ping.c
@@ -755,7 +755,7 @@ catcher()
   pinger();
 
   if (!npackets || ntransmitted < npackets) {
-    timermsg->tr_time.tv_sec = interval;
+    timermsg->tr_time.tv_secs = interval;
     SendIO((struct IORequest*)timermsg);
   } else {
     if (nreceived) {
@@ -764,7 +764,7 @@ catcher()
 	waittime = 1;
     } else
       waittime = MAXWAIT;
-    timermsg->tr_time.tv_sec = waittime;
+    timermsg->tr_time.tv_secs = waittime;
     SendIO((struct IORequest*)timermsg);
   }
 #else

--- a/workbench/network/stacks/AROSTCP/bsdsocket/kern/amiga_time.h
+++ b/workbench/network/stacks/AROSTCP/bsdsocket/kern/amiga_time.h
@@ -62,7 +62,8 @@ struct timeoutRequest {
 static inline void
 sendTimeoutRequest(struct timeoutRequest *tr)
 {
-  tr->timeout_request.tr_time = tr->timeout_timeval;
+  tr->timeout_request.tr_time.tv_secs = tr->timeout_timeval.tv_sec;
+  tr->timeout_request.tr_time.tv_micro = tr->timeout_timeval.tv_usec;
   SendIO((struct IORequest *)&(tr->timeout_request));
 }
 

--- a/workbench/network/stacks/AROSTCP/bsdsocket/kern/kern_synch.c
+++ b/workbench/network/stacks/AROSTCP/bsdsocket/kern/kern_synch.c
@@ -127,7 +127,8 @@ D(bug("[AROSTCP](kern_synch.c) tsleep_send_timeout()\n"));
     /*
      * set the timeout
      */
-    p->tsleep_timer->tr_time = *time_out;
+    p->tsleep_timer->tr_time.tv_secs = time_out->tv_sec;
+    p->tsleep_timer->tr_time.tv_micro = time_out->tv_usec;
     /*
      * Enable signalling again
      */

--- a/workbench/system/Workbook/wbicon.c
+++ b/workbench/system/Workbook/wbicon.c
@@ -243,7 +243,8 @@ static IPTR wbIconGoActive(Class *cl, Object *obj, struct gpInput *gpi)
                            gpi->gpi_IEvent->ie_TimeStamp.tv_secs,
                            gpi->gpi_IEvent->ie_TimeStamp.tv_micro);
 
-    my->LastActive = gpi->gpi_IEvent->ie_TimeStamp;
+    my->LastActive.tv_secs = gpi->gpi_IEvent->ie_TimeStamp.tv_secs;
+    my->LastActive.tv_micro = gpi->gpi_IEvent->ie_TimeStamp.tv_micro;
 
     if (dclicked)
     {


### PR DESCRIPTION
This is a proposal of implementation of future 64-bit time support. What the changes do now is to freeze certain elements on 32-bit "forever" - essentially places where relative time is used and 32-bits is enough as well as document how the implementation can be done in future in a way that no longer breaks compatibility.

Note: side effect of these structure changes is that structure copying no longer works in some cases even though structures have same fields. This means field by field copying is needed.