### PR TITLE
fix Raspberry Pi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /.externalToolBuilders
 /autom4te.cache
 /.vscode
+*.swp
 
 # /arch/.unmaintained/amiga/workbench/hidds/graphics/intuition/
 /arch/.unmaintained/amiga/workbench/hidds/graphics/intuition/*.bak

--- a/arch/arm-native/kernel/mmakefile.src
+++ b/arch/arm-native/kernel/mmakefile.src
@@ -76,6 +76,7 @@ $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_librar
 		@$(ECHO) "Creating   $@"
 		%mkdirs_q $(OSGENDIR)/boot
 		@$(TARGET_LD) -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static -laeabi
+		$(TARGET_OBJCOPY) --only-keep-debug $@ $@.dbg
 		@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $@
 
 #MM kernel-kernel-raspi-arm : includes

--- a/arch/arm-native/kernel/platform_bcm2708.c
+++ b/arch/arm-native/kernel/platform_bcm2708.c
@@ -2,6 +2,8 @@
     Copyright (C) 2015-2016, The AROS Development Team. All rights reserved.
 */
 
+#undef __AROSEXEC_SMP
+
 #include <aros/types/spinlock_s.h>
 #include <aros/kernel.h>
 #include <aros/symbolsets.h>
@@ -92,7 +94,7 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
         asm volatile ("mrc p15, 0, %0, c2, c0, 0":"=r"(tmp));
         ((uint32_t *)(trampoline_dst + trampoline_data_offset))[0] = tmp; // pde
         ((uint32_t *)(trampoline_dst + trampoline_data_offset))[1] = (uint32_t)cpu_Register;
-
+#if 0
         for (cpu = 1; cpu < 4; cpu ++)
         {
             cpu_stack = (uint32_t *)AllocMem(AROS_STACKSIZE*sizeof(uint32_t), MEMF_CLEAR); /* MEMF_PRIVATE */
@@ -138,6 +140,7 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
             KrnSpinLock(&startup_lock, NULL, SPINLOCK_MODE_WRITE);
             KrnSpinUnLock(&startup_lock);
         }
+#endif
     }
 }
 

--- a/arch/arm-raspi/boot/bc/screen_fb.c
+++ b/arch/arm-raspi/boot/bc/screen_fb.c
@@ -15,6 +15,7 @@
  * These variables need to survive accross warm reboot, so we explicitly place them in .data section.
  */
 __attribute__((section(".data"))) char *fb_Mirror = NULL;
+__attribute__((section(".data"))) int fb_is_initialized  = 0;
 
 __attribute__((section(".data"))) static unsigned int fb_BytesPerLine = 0; /* Bytes per line  */
 __attribute__((section(".data"))) static unsigned int fb_BytesPerPix  = 0; /* Bytes per pixel */
@@ -102,6 +103,7 @@ void fb_Init(unsigned int width, unsigned int height, unsigned int depth, unsign
     fb_Mirror = malloc(scr_Width * (height + fontHeight - 1) / fontHeight);
 
     fb_Resize(height);
+    fb_is_initialized = 1;
 }
 
 void fb_Resize(unsigned int height)

--- a/arch/arm-raspi/boot/devicetree.c
+++ b/arch/arm-raspi/boot/devicetree.c
@@ -157,6 +157,14 @@ of_node_t * dt_find_node_by_phandle(uint32_t phandle)
 #define MAX_KEY_SIZE    64
 char ptrbuf[64];
 
+// Compare up to the at sign (if there's a unit address) or end of string
+static int node_name_matches(const char *name, const char *search)
+{
+    const char *atSign = strchr(name, '@');
+    int nameLen = atSign ? atSign - name : strlen(name);
+    return nameLen == strlen(search) && strncmp(name, search, nameLen) == 0;
+}
+
 of_node_t * dt_find_node(char *key)
 {
     int i;
@@ -181,7 +189,7 @@ of_node_t * dt_find_node(char *key)
 
             ForeachNode(&ret->on_children, node)
             {
-                if (!strcmp(node->on_name, ptrbuf))
+                if (node_name_matches(node->on_name, ptrbuf))
                 {
                     ret = node;
                     break;

--- a/arch/arm-raspi/boot/elf.c
+++ b/arch/arm-raspi/boot/elf.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define DELF(x) /* x */
+#define DELF(x) x
 
 uint32_t        int_shnum;
 uint32_t        int_shstrndx;
@@ -244,6 +244,7 @@ static int relocate(struct elfheader *eh, struct sheader *sh, long shrel_idx,
                 if (ELF_R_TYPE(rel->info) == R_ARM_V4BX)
                         continue;
 
+                //kprintf("[BOOT:ELF] symbol '%s'\n", (char *)((uint32_t) sh[shsymtab->link].addr) + sym->name);
                 switch (sym->shindex)
                 {
                 case SHN_UNDEF:
@@ -427,8 +428,9 @@ int loadElf(void *elf_file)
                                 {
                                         if (sh[i].size)
                                         {
-                                                DELF(kprintf("[BOOT:ELF] %s section loaded at %p (Virtual addr: %p, requestet addr: %p)\n",
+                                                DELF(kprintf("[BOOT:ELF] %s section '%s' loaded at %p (Virtual addr: %p, requestet addr: %p)\n",
                                                                 sh[i].flags & SHF_WRITE ? "RW":"RO",
+                                                                (char *)elf_file + sh[eh->shstrndx].offset + sh[i].name,
                                                                                 sh[i].addr,
                                                                                 sh[i].addr + virtoffset,
                                                                                 deltas[i]));

--- a/arch/arm-raspi/boot/include/vc_fb.h
+++ b/arch/arm-raspi/boot/include/vc_fb.h
@@ -9,6 +9,7 @@
 
 extern int vcfb_init(void);
 extern void fb_Putc(char chr);
+extern int fb_is_initialized;
 
 #if !defined(KRN_Dummy)
 #define KRN_Dummy               (TAG_USER + 0x03d00000)

--- a/arch/arm-raspi/boot/kprintf.c
+++ b/arch/arm-raspi/boot/kprintf.c
@@ -5,15 +5,28 @@
 #include <stdio.h>
 
 #include "serialdebug.h"
+#include "vc_fb.h"
 //#include "bootconsole.h"
 
 void putBytes(const char *str)
 {
-    while(*str)
+    const char *s;
+    
+    s = str;
+    while(*s)
     {
-//        fb_Putc(*str);
-        putByte(*str++);
+        putByte(*s++);
     }
+    /*
+    if (fb_is_initialized)
+    {
+        s = str;
+        while (*s)
+        {
+            fb_Putc(*s++);
+        }
+    }
+    */
 }
 
 static char tmpbuf[512];

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -10,7 +10,7 @@ KERNEL_LDFLAGS  =
 USER_INCLUDES   := -isystem $(SRCDIR)/$(CURDIR)/include -I$(SRCDIR)/rom/openfirmware
 USER_CPPFLAGS   := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"
 USER_CPPFLAGS   += -DUSE_UBOOT
-OPTIMIZATION_CFLAGS := -O2
+OPTIMIZATION_CFLAGS := -O0 -fno-inline
 
 ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 
@@ -171,16 +171,19 @@ distfiles-raspi-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
 	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\ninitramfs $(ARM_BSP) 0x00800000" > $@
 
+$(info KERNEL_LD is $(KERNEL_LD))
+#KERNEL_LD := /usr/bin/arm-none-eabi-ld
+
 $(AROSDIR)/aros-armeb-raspi.img: $(TARGETDIR)/core-be.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"
 	@$(KERNEL_LD) --be8 --format elf32-bigarm --entry=bootstrap --script=$(SRCDIR)/$(CURDIR)/ldscript-be.lds $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $ $(TARGETDIR)/core-be.bin.o -L$(AROS_LIB) -lstdc.static -laeabi -o $(OSGENDIR)/boot/aros-armeb-raspi.img.elf
-	@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $(OSGENDIR)/boot/aros-armeb-raspi.img.elf
+	#@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $(OSGENDIR)/boot/aros-armeb-raspi.img.elf
 	$(TARGET_OBJCOPY) -O binary $(OSGENDIR)/boot/aros-armeb-raspi.img.elf $@
 
 $(AROSDIR)/aros-arm-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"
 	@$(KERNEL_LD) -Map $(OSGENDIR)/boot/aros-arm-raspi.img.map --entry=bootstrap --script=$(SRCDIR)/$(CURDIR)/ldscript-le.lds $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $ $(TARGETDIR)/core.bin.o -L$(AROS_LIB) -lstdc.static -laeabi -o $(OSGENDIR)/boot/aros-arm-raspi.img.elf
-	@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $(OSGENDIR)/boot/aros-arm-raspi.img.elf
+	#@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $(OSGENDIR)/boot/aros-arm-raspi.img.elf
 	@$(TARGET_OBJCOPY) -O binary $(OSGENDIR)/boot/aros-arm-raspi.img.elf $@
 
 $(TARGETDIR)/core-be.bin.o: $(OSGENDIR)/boot/core.elf
@@ -206,8 +209,11 @@ distfiles-raspi : $(AROSDIR)/aros-arm-raspi.img  $(AROSDIR)/$(ARM_BSP) $(AROSDIR
 clean ::
 	-$(RM) $(TESTS)
 
+$(info flags are $(KERNEL_ISA_FLAGS))
+
 $(TARGETDIR)/%.o : %.c
 	%compile_q
+	%compile_q opt="$(strip $(CFLAGS) $(CPPFLAGS) -S)" to="$(@:.o=.disas)"
 
 $(TARGETDIR)/%.o : %.S
 	%compile_q

--- a/arch/arm-raspi/boot/mmu.c
+++ b/arch/arm-raspi/boot/mmu.c
@@ -9,7 +9,7 @@
 #include "mmu.h"
 #include "boot.h"
 
-#define DMMU(x)
+#define DMMU(x) x
 
 void mmu_init()
 {
@@ -66,6 +66,8 @@ void mmu_unmap_section(uint32_t virt, uint32_t length)
 
     uint32_t start = virt & ~(1024*1024-1);
     uint32_t end = (start + length) & ~(1024*1024-1);
+
+    DMMU(kprintf("[BOOT] MMU unmap %p:%p\n", virt, virt+length-1));
 
     start >>= 20;
     end >>= 20;

--- a/arch/arm-raspi/boot/vc_fb.c
+++ b/arch/arm-raspi/boot/vc_fb.c
@@ -21,7 +21,7 @@
 #define ARM_PERIIOBASE (__arm_periiobase)
 extern uint32_t __arm_periiobase;
 
-#define D(x) /* x */
+#define D(x) x
 
 int vcfb_init(void)
 {

--- a/compiler/include/dos/elf.h
+++ b/compiler/include/dos/elf.h
@@ -374,7 +374,7 @@ struct attrs_subsection
 #elif defined(__arm__)
 #define AROS_ELF_MACHINE EM_ARM
 #define AROS_ELF_REL     SHT_RELA
-#define relo             rela
+#define relo             rel
 #endif
 #if defined(__riscv64)
 #define AROS_ELF_MACHINE EM_RISCV

--- a/config/make.tmpl
+++ b/config/make.tmpl
@@ -26,17 +26,18 @@ endif
 #------------------------------------------------------------------------------
 # Compile the file %(from) to %(to) with %(cmd). Write any errors to %(err)
 # and use the options in %(opt). Use %(iquote) and %(iquote_end) for supplying -iquote or -I- flags
+# TODO: find some way to pass -mword-relocations to the ARM compiler without doing it here!!!
 %define compile_q cmd="$(strip $(TARGET_CC) $(TARGET_SYSROOT))" opt="$(strip $(CFLAGS) $(CPPFLAGS))" from="$<" to="$@" incextra="$(TOP)/$(CURDIR)" iquote="$(CFLAGS_IQUOTE)" iquote_end="$(CFLAGS_IQUOTE_END)"
 	%fileactionmsg msg="Compiling" file="%(from)"
-	$(Q)$(IF) %(cmd) %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__="\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))"\" -c %(from) -o %(to) > $(GENDIR)/cerrors 2>&1 ; then \
+	$(Q)$(IF) %(cmd) -mword-relocations %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__="\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))"\" -c %(from) -o %(to) > $(GENDIR)/cerrors 2>&1 ; then \
 		$(IF) $(TEST) -s $(GENDIR)/cerrors ; then \
-			$(ECHO) "%(from): %(cmd) %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__=\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))\" -c %(from) -o %(to)" >> $(GENDIR)/errors ; \
+			$(ECHO) "%(from): %(cmd) -mword-relocations %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__=\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))\" -c %(from) -o %(to)" >> $(GENDIR)/errors ; \
 			tee < $(GENDIR)/cerrors -a $(GENDIR)/errors ; \
 		else \
 			$(NOP) ; \
 		fi ; \
 	else \
-		$(ECHO) "Compile failed: %(cmd) %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__=\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))\" -c %(from) -o %(to)" 1>&2 ; \
+		$(ECHO) "Compile failed: %(cmd) -mword-relocations %(iquote) $(dir %(from)) %(iquote) %(incextra) %(iquote) $(SRCDIR)/$(CURDIR) %(iquote) . %(iquote_end) %(opt) -D__SRCFILENAME__=\"$(subst $(TOP)/,,$(subst $(SRCDIR)/,,$(abspath %(from))))\" -c %(from) -o %(to)" 1>&2 ; \
 		tee < $(GENDIR)/cerrors -a $(GENDIR)/errors 1>&2 ; \
 		exit 1 ; \
 	fi

--- a/rom/exec/exec_debug.h
+++ b/rom/exec/exec_debug.h
@@ -90,6 +90,8 @@
 #define DEBUG_WaitIO 0
 #define DEBUG_WaitPort 0
 
+#undef NO_RUNTIME_DEBUG
+
 /* Runtime debugging */
 #ifdef NO_RUNTIME_DEBUG
 

--- a/rom/exec/exec_init.c
+++ b/rom/exec/exec_init.c
@@ -4,7 +4,7 @@
     Desc: exec.library resident and initialization.
 */
 
-#define DEBUG 0
+#define DEBUG 1
 
 #include <aros/config.h>
 

--- a/rom/task/task_init.c
+++ b/rom/task/task_init.c
@@ -16,6 +16,8 @@
 #endif
 #include "task_intern.h"
 
+#define D(x) x
+
 extern APTR AROS_SLIB_ENTRY(NewAddTask, Task, 176)();
 extern void AROS_SLIB_ENTRY(RemTask, Task, 48)();
 

--- a/tools/crosstools/gnu/binutils-2.32-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.32-aros.diff
@@ -336,11 +336,11 @@ diff -ruN binutils-2.32/bfd/elf32-arm.c binutils-2.32-aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
 +#define elf_backend_rela_normal		1
 +#undef  elf_backend_want_plt_sym

--- a/workbench/classes/datatypes/heic/mmakefile.src
+++ b/workbench/classes/datatypes/heic/mmakefile.src
@@ -4,12 +4,12 @@ include $(SRCDIR)/config/aros.cfg
 
 CLASSFILES := webpclass
 
-#MM- workbench-datatypes-complete: workbench-datatypes-heic
-#MM workbench-datatypes-heic : \
-#MM includes \
-#MM linklibs \
-#MM workbench-libs-z \
-#MM datatypes-heic-linklibs-heif
+##MM- workbench-datatypes-complete: workbench-datatypes-heic
+##MM workbench-datatypes-heic : \
+##MM includes \
+##MM linklibs \
+##MM workbench-libs-z \
+##MM datatypes-heic-linklibs-heif
 
 #MM datatypes-heic-linklibs-heif : \
 #MM includes \


### PR DESCRIPTION
I've ran into plenty of issues trying to get AROS running on a Raspberry Pi 3, so this ongoing PR attempts to fix a few of them.

In binutils, I disabled RELA relocations and use REL instead, since the addends all get ignored during the final link of an ELF file for some reason, breaking a lot of code (notably the PC-relative jumps like non-local "bl" which use these to adjust for the PC prefetch bias).

I am also compiling everything with `-mword-relocations`. arch/arm-raspi/boot/elf.c doesn't seem to compute R_ARM_MOVT_ABS relocations properly (frankly, I don't know exactly how these are supposed to work, either), and compiling with the `-mword-relocations` flag avoids generating these (uses pool loads instead). 

The boot process gets quite far, but there are a few `bad pointer` and `Software Failure!` errors generated.