### PR TITLE
rom/filesys/afs: Fix issue where OpenFromLock() returns NULL on success

### DIFF
--- a/rom/filesys/afs/main.c
+++ b/rom/filesys/afs/main.c
@@ -536,6 +536,7 @@ LONG AFS_work(struct ExecBase *SysBase)
                     struct FileLock      *fl = BADDR(dp->dp_Arg2);
                     fh->fh_Arg1 = (SIPTR)fl->fl_Key;
                     FreeMem(fl, sizeof(*fl));
+                    ok = DOSTRUE;
                     break;
                 }
                 case ACTION_EXAMINE_OBJECT:


### PR DESCRIPTION
On AFS filesystems, the ACTION_FH_FROM_LOCK case was not setting 'ok', leading to the dos packet replying with DOSFALSE in all cases, and the `OpenFromLock()` on an AFS filesystem was returning `fh = BNULL` and `IoErr() == 0` on success.