### PR TITLE
GFLG_GADGHIGHBITS: Fix incorrect usages.

### DIFF
--- a/rom/intuition/gadgetclass.c
+++ b/rom/intuition/gadgetclass.c
@@ -208,7 +208,8 @@ static ULONG set_gadgetclass(Class *cl, struct ExtGadget *eg, struct opSet *msg)
             case GA_SelectRender:
                 eg->SelectRender = (APTR)tidata;
                 {
-                    eg->Flags |= (GFLG_GADGIMAGE & GFLG_GADGHIMAGE);
+                    eg->Flags &= ~GFLG_GADGHIGHBITS;
+                    eg->Flags |= (GFLG_GADGIMAGE | GFLG_GADGHIMAGE);
                 }
                 retval = 1UL;
                 break;
@@ -554,7 +555,7 @@ IPTR GadgetClass__OM_GET(Class *cl, struct ExtGadget *eg, struct opGet *msg)
             break;
 
         case GA_SelectRender:
-            *msg->opg_Storage = (IPTR)((eg->Flags & GFLG_GADGHIMAGE) ? eg->SelectRender : 0);
+            *msg->opg_Storage = (IPTR)(((eg->Flags & GFLG_GADGHIGHBITS) == GFLG_GADGHIMAGE) ? eg->SelectRender : 0);
             break;
 
         case GA_SpecialInfo:

--- a/rom/intuition/inputhandler.c
+++ b/rom/intuition/inputhandler.c
@@ -826,11 +826,8 @@ static struct Gadget *Process_RawMouse(struct InputEvent *ie, struct IIHData *ii
             {
                 gadget->Activation |= GACT_ACTIVEGADGET;
                 iihdata->MouseWasInsideBoolGadget = TRUE;
-                if (gadget->Flags & GFLG_GADGHIMAGE)
-                {
                 gadget->Flags ^= GFLG_SELECTED;
                 RefreshBoolGadgetState(gadget, w, req, IntuitionBase);
-                }
             }
             else
             {
@@ -963,13 +960,10 @@ static struct Gadget *Process_RawMouse(struct InputEvent *ie, struct IIHData *ii
         gadget->Activation &= ~GACT_ACTIVEGADGET;
         if (gadget->Activation & GACT_RELVERIFY)
         {
-            if (gadget->Flags & GFLG_GADGHIMAGE)
-            {
             if (inside)
             {
                 gadget->Flags ^= GFLG_SELECTED;
                 RefreshBoolGadgetState(gadget, w, req, IntuitionBase);
-            }
             }
 
             if (inside)

--- a/workbench/libs/icon/diskobjPNGio.c
+++ b/workbench/libs/icon/diskobjPNGio.c
@@ -305,6 +305,7 @@ STATIC BOOL MakePlanarImages(struct NativeIcon *icon, struct IconBase *IconBase)
     if (MakePlanarImage(icon, (struct Image **) &icon->ni_DiskObject.do_Gadget.SelectRender,
             (UBYTE *)icon->ni_Image[1].ARGB, IconBase))
     {
+        icon->ni_DiskObject.do_Gadget.Flags &= ~GFLG_GADGHIGHBITS;
         icon->ni_DiskObject.do_Gadget.Flags |= GFLG_GADGHIMAGE;
     }
 

--- a/workbench/libs/icon/diskobjio.c
+++ b/workbench/libs/icon/diskobjio.c
@@ -575,7 +575,7 @@ kprintf ("ProcessSelectRender\n");
 
     /* Not all icon with second image seem to have GFLG_GADGHIMAGE set */
     
-    if (icon->do_Gadget.SelectRender || (icon->do_Gadget.Flags & GFLG_GADGHIMAGE))
+    if (icon->do_Gadget.SelectRender || (icon->do_Gadget.Flags & GFLG_GADGHIGHBITS) == GFLG_GADGHIMAGE)
     {
         switch (data->sdd_Mode)
         {

--- a/workbench/libs/icon/layouticon.c
+++ b/workbench/libs/icon/layouticon.c
@@ -254,7 +254,7 @@ static void ScaleRect(ULONG *Target, const ULONG *Source, int SrcWidth, int SrcH
             ULONG state;
             BOOL flood = FALSE;
 
-            if (i == 1 && (icon->do_Gadget.Flags & GFLG_GADGHIMAGE)) {
+            if (i == 1 && ((icon->do_Gadget.Flags & GFLG_GADGHIGHBITS) == GFLG_GADGHIMAGE)) {
                 gi = icon->do_Gadget.SelectRender;
             } else if (icon->do_Gadget.Flags & GFLG_GADGIMAGE) {
                 gi = icon->do_Gadget.GadgetRender;
@@ -263,7 +263,7 @@ static void ScaleRect(ULONG *Target, const ULONG *Source, int SrcWidth, int SrcH
             if (gi == NULL)
                 continue;
 
-            if (i == 1 && (icon->do_Gadget.Flags & GFLG_GADGHCOMP))
+            if (i == 1 && ((icon->do_Gadget.Flags & GFLG_GADGHIGHBITS) == GFLG_GADGHCOMP))
                 state = IDS_SELECTED;
             else
                 state = IDS_NORMAL;


### PR DESCRIPTION
GFLG_GADGHIGHBITS was being used incorrectly in a few locations in Inutition and Icon libraries.

Specifically, GFLG_GADGHIGHBITS is a mask against the set of one of the following:
   GFLG_GADGHCOMP
   GFLG_GADGHBOX
   GFLG_GADGHIMAGE
   GFLG_GADGHNONE