### PR TITLE
gcc-6.5.0-aros.diff: Fix cross-compilation on Darwin/arm64

### DIFF
--- a/tools/crosstools/gnu/gcc-6.5.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-6.5.0-aros.diff
@@ -2479,3 +2479,17 @@ diff -ruN gcc-6.5.0/libstdc++-v3/include/std/ratio gcc-6.5.0.aros/libstdc++-v3/i
        static constexpr int __shift = __builtin_clzll(__d);
        static constexpr int __coshift_ = sizeof(uintmax_t) * 8 - __shift;
        static constexpr int __coshift = (__shift != 0) ? __coshift_ : 0;
+diff -ur gcc-6.5.0.orig/gcc/config.host gcc-6.5.0/gcc/config.host
+--- gcc-6.5.0/gcc/config.host	2019-02-28 18:31:13
++++ gcc-6.5.0.aros/gcc/config.host	2024-02-08 19:48:17
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 


### PR DESCRIPTION
This fixes the following error while compiling the toolchain:

ld: warning: ignoring duplicate libraries: '../libcpp/libcpp.a', '../libdecnumber/libdecnumber.a', 'libcommon.a'
ld: Undefined symbols:
  _host_hooks, referenced from:
      c_common_no_more_pch() in c-pch.o
      gt_pch_save(__sFILE*) in libbackend.a[92](ggc-common.o)
      gt_pch_save(__sFILE*) in libbackend.a[92](ggc-common.o)
      gt_pch_restore(__sFILE*) in libbackend.a[92](ggc-common.o)
      toplev::main(int, char**) in libbackend.a[252](toplev.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
