### PR TITLE
Fix two sana2.h IO requests

### DIFF
--- a/compiler/include/devices/sana2.h
+++ b/compiler/include/devices/sana2.h
@@ -77,8 +77,8 @@
 #define S2_READORPHAN                   (CMD_NONSTD + 15)
 #define S2_ONLINE                       (CMD_NONSTD + 16)
 #define S2_OFFLINE                      (CMD_NONSTD + 17)
-#define S2_ADDMULTICASTADDRESSES        (CMD_NONSTD + 0xc000)
-#define S2_DELMULTICASTADDRESSES        (CMD_NONSTD + 0xc001)
+#define S2_ADDMULTICASTADDRESSES        0xc000
+#define S2_DELMULTICASTADDRESSES        0xc001
 
 #define S2ERR_NO_ERROR                  0
 #define S2ERR_NO_RESOURCES              1


### PR DESCRIPTION
S2_ADDMULTICASTADDRESSES and S2_DELMULTICASTADDRESSES had wrong values relative to CMD_NONSTD. This patch fix them to correct ones.