### PR TITLE
643 fix fedora40 build

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -75,20 +75,20 @@ fetch_github()
     $ret
 }
 
-wget_ftp()
+curl_ftp()
 {
-    local wgetsrc="$1" wgetoutput="$2"
-    local wgetextraflags
+    local curlsrc="$1" curloutput="$2"
+    local curlextraflags
     local ret=true
 
     for (( ; ; ))
     do
-        if !  eval "wget -t 3 --retry-connrefused $wgetextraflags -T 15 -c \"$wgetsrc\" -O $wgetoutput"; then
+        if !  eval "curl -f --retry 3 --retry-connrefused $curlextraflags --max-time 15 -C - \"$curlsrc\" -o $curloutput"; then
             if test "$ret" = false; then
                 break
             fi
             ret=false
-            wgetextraflags="--secure-protocol=TLSv1"
+            curlextraflags="--tlsv1 --tls-max 1.0"
         else
             ret=true
             break
@@ -171,7 +171,7 @@ fetch()
             rm -f "$destination/$file.tmp"
             ;;
         ftp)    
-            if ! wget_ftp "$origin/$file" "$destination/$file.tmp"; then
+            if ! curl_ftp "$origin/$file" "$destination/$file.tmp"; then
                 ret=false
             else
                 mv "$destination/$file.tmp" "$destination/$file"


### PR DESCRIPTION
This PR fixes issue https://github.com/aros-development-team/AROS/issues/643

It replaces wget with curl in scripts/fetch.sh, since wget can now be two different tools, and one of them does not support FTP and has different behaviour for HTTP that got exposed in the script.

Tested by building pc-x86_64 with smp from scratch on Fedora 40 and WSL2.
