### PR TITLE
Fix crash during boot of native compile with --enable-debug

### DIFF
--- a/rom/log/log_event.c
+++ b/rom/log/log_event.c
@@ -192,6 +192,9 @@ AROS_LH7(struct logEntry *, logAddEntryA,
                 {
                     DateStamp(&leP->le_DateStamp);
                 } else {
+                    return(NULL);
+                    // The below does not work since there is no device reference in the request.
+                    // Just say no above so the system can boot.
                     struct timerequest tr;
                     CopyMem(&LIBBASE->lrb_TimerIOReq, &tr, sizeof(struct timerequest));
                     tr.tr_node.io_Command = TR_GETSYSTIME;

--- a/rom/log/log_event.c
+++ b/rom/log/log_event.c
@@ -192,6 +192,7 @@ AROS_LH7(struct logEntry *, logAddEntryA,
                 {
                     DateStamp(&leP->le_DateStamp);
                 } else {
+                    FreeVecPooled(lrHandle->lrh_Pool, leP);
                     return(NULL);
                     // The below does not work since there is no device reference in the request.
                     // Just say no above so the system can boot.
@@ -217,7 +218,7 @@ AROS_LH7(struct logEntry *, logAddEntryA,
 #endif
                 return((struct logEntry *)&leP->le_Node);
             }
-            FreeVec(leP);
+            FreeVecPooled(lrHandle->lrh_Pool, leP);
         }
     }
 

--- a/rom/log/log_event.c
+++ b/rom/log/log_event.c
@@ -196,13 +196,13 @@ AROS_LH7(struct logEntry *, logAddEntryA,
                     return(NULL);
                     // The below does not work since there is no device reference in the request.
                     // Just say no above so the system can boot.
-                    struct timerequest tr;
-                    CopyMem(&LIBBASE->lrb_TimerIOReq, &tr, sizeof(struct timerequest));
-                    tr.tr_node.io_Command = TR_GETSYSTIME;
-                    DoIO((struct IORequest *) &tr);
-                    leP->le_DateStamp.ds_Days = tr.tr_time.tv_secs / (24*60*60);
-                    leP->le_DateStamp.ds_Minute = (tr.tr_time.tv_secs / 60) % 60;
-                    leP->le_DateStamp.ds_Tick = (tr.tr_time.tv_secs % 60) * 50;
+                    //struct timerequest tr;
+                    //CopyMem(&LIBBASE->lrb_TimerIOReq, &tr, sizeof(struct timerequest));
+                    //tr.tr_node.io_Command = TR_GETSYSTIME;
+                    //DoIO((struct IORequest *) &tr);
+                    //leP->le_DateStamp.ds_Days = tr.tr_time.tv_secs / (24*60*60);
+                    //leP->le_DateStamp.ds_Minute = (tr.tr_time.tv_secs / 60) % 60;
+                    //leP->le_DateStamp.ds_Tick = (tr.tr_time.tv_secs % 60) * 50;
                 }
                 
                 Forbid();


### PR DESCRIPTION
The WIP resource log.resource made AROS crash during boot if AROS was compiled with --enable-debug. This pull request makes logAddEntryA refuse to add the log entry instead of attempting to perform I/O on a device null pointer. It also fixes some memory management errors.

log.resource does not perform any actual log broadcasting currently anyway, so I consider this a reasonable fix for now.
