### PR TITLE
Change detection of stalled connections

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -83,7 +83,7 @@ curl_ftp()
 
     for (( ; ; ))
     do
-        if !  eval "curl -f --retry 3 --retry-connrefused $curlextraflags --max-time 15 -C - \"$curlsrc\" -o $curloutput"; then
+        if !  eval "curl -f --retry 3 --retry-connrefused $curlextraflags --speed-limit 1 --speed-time 15 -C - \"$curlsrc\" -o $curloutput"; then
             if test "$ret" = false; then
                 break
             fi
@@ -132,7 +132,7 @@ curl_http() {
 
     for (( ; ; ))
     do
-        if ! eval "curl -fL --retry 3 --retry-connrefused $curlextraflags --max-time 15 -C - \"$curlsrc\" -o $curloutput"; then
+        if ! eval "curl -fL --retry 3 --retry-connrefused $curlextraflags --speed-limit 1 --speed-time 15 -C - \"$curlsrc\" -o $curloutput"; then
             if test "$ret" = false; then
                 break
             fi


### PR DESCRIPTION
--max-time is used for timeout of complete transaction, so in this case download had to complete in 15 seconds or less. Changing this to --speed-time and --speed-limit allows working with slower connection. Connection will now abort if download speed is 0 bytes in 15 seconds window.