### PR TITLE
Faster implementation of PutImageLUT in amigavideo.hidd.

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo.conf
@@ -2,7 +2,7 @@
 basename 	AmigaVideoCl
 libbase 	AmigaVideoClBase
 libbasetype 	struct amigavideoclbase
-version 	45.7
+version 	45.8
 residentpri     9
 classid         CLID_Hidd_Gfx_AmigaVideo
 superclass      CLID_Hidd_Gfx


### PR DESCRIPTION
For each row, it uses the old method to copy pixels up to the point that the destination is byte-aligned, and then writes a full plane byte at a time. Any remaining pixels are also written the old way.

The nomedia animation with the eyes is 2x faster in WinUAE cycle exact mode.

