### PR TITLE
Fixed Window pointer check

### DIFF
--- a/workbench/libs/reqtools/req.c
+++ b/workbench/libs/reqtools/req.c
@@ -300,7 +300,7 @@ ULONG ASM SAVEDS GetString (
     idcmpflags = glob->idcmp | IDCMP_REFRESHWINDOW|IDCMP_GADGETUP|IDCMP_RAWKEY;
     if (mode != IS_EZREQUEST) idcmpflags |= IDCMP_MOUSEBUTTONS|IDCMP_ACTIVEWINDOW;
 
-    if (!glob->prwin || !glob->prwin->UserPort
+    if ((LONG) glob->prwin <= 0 || !glob->prwin->UserPort
 		     || (glob->prwin->UserPort->mp_SigTask != ThisProcess()))
 	glob->shareidcmp = FALSE;
 


### PR DESCRIPTION
The Window pointer can be -1. This is a flag that prevents DOS to open requesters (no disk in drive, ..). Without this extended test, reqtools library can cause a DSI/illegal memory access when called from an AREXX script that uses CALL PRAGMA('W', 'N').