### PR TITLE
Better Window pointer check

### DIFF
--- a/workbench/libs/reqtools/req.c
+++ b/workbench/libs/reqtools/req.c
@@ -300,7 +300,7 @@ ULONG ASM SAVEDS GetString (
     idcmpflags = glob->idcmp | IDCMP_REFRESHWINDOW|IDCMP_GADGETUP|IDCMP_RAWKEY;
     if (mode != IS_EZREQUEST) idcmpflags |= IDCMP_MOUSEBUTTONS|IDCMP_ACTIVEWINDOW;
 
-    if ((LONG) glob->prwin <= 0 || !glob->prwin->UserPort
+    if (!glob->prwin || (ULONG) glob->prwin == ~0 || !glob->prwin->UserPort
 		     || (glob->prwin->UserPort->mp_SigTask != ThisProcess()))
 	glob->shareidcmp = FALSE;
 


### PR DESCRIPTION
For AmigaOS 4 the Window pointer might be in the upper 2GB of address space making it a negative long. Instead of checking for less than or equals to 0, check for the special case of -1 directly.