### PR TITLE
Kiwi1969 multiview

### DIFF
--- a/workbench/libs/datatypes/releasedatatype.c
+++ b/workbench/libs/datatypes/releasedatatype.c
@@ -7,6 +7,8 @@
 #include "datatypes_intern.h"
 #include <proto/exec.h>
 #include <exec/alerts.h>
+//#define DEBUG 1
+#include <aros/debug.h>
 
 /*****************************************************************************
 
@@ -58,7 +60,10 @@
     if(((struct CompoundDataType *)dt)->OpenCount)
         ((struct CompoundDataType*)dt)->OpenCount--;
     else
-        Alert(AN_Unknown);
+    {
+        D(bug("datatypes.library/ReleaseDataType : Datatype %x has invalid OpenCount value of %d\n", dt, ((struct CompoundDataType *)dt)->OpenCount));
+        //Alert(AN_Unknown);
+    }
 
     ReleaseSemaphore(&(GPB(DataTypesBase)->dtb_DTList)->dtl_Lock);
 


### PR DESCRIPTION
Fix bug introduced in last Multiview change, where if double-click on an icon, then the file doesn't always open) if there was a path in the icon such as SYS:Utilities/Multiview (causes the document path to get forgotten)
ie The method in Multiview to get full expanded filename from Wb parms has changed, and this resolved the issue.

All new features added into prior update are still intact (font name, fontsize, window sizes etc)

Also removed annoying requester that pops of on closure due to erroneous OpenCount, and replace with a conditional debug macro.

Some extra debug macro messages, which are turned off by default

This same fix has been posted on ApolloOS repo