### PR TITLE
Revert previous incorrect audio patch

### DIFF
--- a/arch/m68k-amiga/romboot/romboot.c
+++ b/arch/m68k-amiga/romboot/romboot.c
@@ -7,8 +7,6 @@
 #include <aros/debug.h>
 #include <exec/types.h>
 #include <exec/resident.h>
-#include <hardware/custom.h>
-#include <hardware/dmabits.h>
 #include <proto/expansion.h>
 #include <aros/asmcall.h>
 #include <libraries/expansionbase.h>
@@ -46,14 +44,6 @@ const struct Resident rb_tag =
    (STRPTR)version_string,
    (APTR)Init
 };
-
-static void reset_audio(void)
-{
-    volatile struct Custom *custom = (struct Custom *) 0xDFF000;
-
-    // Disable DMA for all four audio channels to get a clean state
-    custom->dmacon = 0x8000 | (DMAF_AUD0 | DMAF_AUD1 | DMAF_AUD2 | DMAF_AUD3);
-}
 
 // ROMTAG INIT time
 static void romtaginit(struct ExpansionBase *ExpansionBase)
@@ -132,7 +122,6 @@ static AROS_UFH3 (APTR, Init,
    if (res)
         uaegfxhack(res, "uaelib_demux");
 
-   reset_audio();
    romtaginit(eb);
 
    CloseLibrary((struct Library*)eb);


### PR DESCRIPTION
This reverts commit 4b38bdcce01da648fb6e592b2ec7f459478f2399.

The patch actually set audio DMA bits, which is not what AmigaOS does. Also, it had no effect on the bug when testing more systematically. The audio bug is just hard to reproduce.
