### PR TITLE
Update icon_init.c

### DIFF
--- a/workbench/libs/icon/icon_init.c
+++ b/workbench/libs/icon/icon_init.c
@@ -85,7 +85,7 @@ static int GM_UNIQUENAME(Expunge)(LIBBASETYPEPTR LIBBASE)
     if (IntuitionBase) CloseLibrary(IntuitionBase);
     if (GfxBase)       CloseLibrary(GfxBase);
     if (DOSBase)       CloseLibrary(DOSBase);
-    if (IntuitionBase) CloseLibrary(IntuitionBase);
+    if (UtilityBase)   CloseLibrary(UtilityBase);
     
     return TRUE;
 }


### PR DESCRIPTION
fix typo on CloseLibrary()