### PR TITLE
Amiga chipset fixes

### DIFF
--- a/arch/m68k-amiga/graphics/setchiprev.c
+++ b/arch/m68k-amiga/graphics/setchiprev.c
@@ -22,8 +22,7 @@ AROS_LH1(ULONG, SetChipRev,
     UBYTE chipflags = 0;
 
     vposr = custom->vposr & 0x7f00;
-    if (vposr >= 0x2200 && vposr < 0x3000 // PAL AGA
-        || vposr >= 0x3200) { // NTSC AA
+    if ((vposr & 0x0200) == 0x0200) {
         chipflags = GFXF_AA_ALICE | GFXF_HR_AGNUS | GFXF_AA_LISA | GFXF_HR_DENISE;
     } else if (vposr >= 0x2000) {
         chipflags = GFXF_HR_AGNUS;

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -1561,7 +1561,7 @@ VOID initcustom(struct amigavideo_staticdata *csd)
     csd->starty = STANDARD_VIEW_Y;
 
     vposr = custom->vposr;
-    csd->aga = (vposr & 0x0f00) == 0x0300;
+    csd->aga = (vposr & 0x0200) == 0x0200;
     csd->ecs_agnus = (vposr & 0x2000) == 0x2000;
     val = custom->deniseid;
     custom->deniseid = custom->dmaconr;

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_compositorclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_compositorclass.c
@@ -113,7 +113,7 @@ VOID METHOD(AmigaVideoCompositor, Hidd_Compositor, BitMapStackChanged)
     struct HIDD_ViewPortData * vpdata;
     OOP_Object *bm = NULL;
     struct amigabm_data *bmdata, *bmdatprev;
-        UWORD visdwidth, visdheight;
+    UWORD visdwidth, visdheight;
 
     D(bug("[AmigaVideo:Compositor] %s()\n", __func__));
 
@@ -177,7 +177,7 @@ VOID METHOD(AmigaVideoCompositor, Hidd_Compositor, BitMapStackChanged)
             if (vpdata->Bitmap && (OOP_OCLASS(vpdata->Bitmap) == csd->amigabmclass))
             {
                 struct Node *next;
-                                UWORD modeheight = 200;
+                UWORD modeheight = 200;
 
                 bmdata = OOP_INST_DATA(OOP_OCLASS(vpdata->Bitmap), vpdata->Bitmap);
                 bmdata->node.ln_Pri = scdepth++;
@@ -198,7 +198,7 @@ VOID METHOD(AmigaVideoCompositor, Hidd_Compositor, BitMapStackChanged)
                     continue;
                 }
 
-                if ((csd->ecs_agnus) && ((bmdata->modeid & MONITOR_ID_MASK) == PAL_MONITOR_ID)) {
+                if ((bmdata->modeid & MONITOR_ID_MASK) == PAL_MONITOR_ID) {
                     modeheight += 56;
                     csd->palmode = TRUE;
                 }
@@ -208,8 +208,10 @@ VOID METHOD(AmigaVideoCompositor, Hidd_Compositor, BitMapStackChanged)
                     modeheight <<= bmdata->interlace;
                     csd->interlaced = TRUE;
                 }
+
                 if (visdheight < modeheight)
-                        visdheight = modeheight;
+                    visdheight = modeheight;
+
                 switch (bmdata->res)
                 {
                 case 2:

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
@@ -23,6 +23,7 @@ struct copper2data
     UWORD                       *copper2_palette;
     UWORD                       *copper2_palette_aga_lo;
     UWORD                       *copper2_scroll;
+    UWORD                       *copper2_diwstop;
     UWORD                       *copper2_bpl;
     UWORD                       *copper2_fmode;
     UWORD                       *copper2_tail;

--- a/arch/m68k-amiga/timer/initcustom.c
+++ b/arch/m68k-amiga/timer/initcustom.c
@@ -70,7 +70,8 @@ void InitCustom(struct GfxBase *gfx)
 
         Enable();
 
-        if (vposr >= 0x2200) {
+        // 0x2200, 0x2300, 0x3200, 0x3300 are all AGA
+        if ((vposr & 0x0200) == 0x0200) {
                 gfx->MemType = BUS_32 | DBL_CAS;
         }
 


### PR DESCRIPTION
AGA chip detection should now be correct in all places.

Display is no longer corrupted on OCS chipset, and the mouse pointer can travel over the whole display area.
