### PR TITLE
Fix type for row and column

### DIFF
--- a/workbench/tools/Edit/Utility.c
+++ b/workbench/tools/Edit/Utility.c
@@ -77,12 +77,12 @@ void draw_info(Project p)
 	UpdateTitle(Wnd, p);
 }
 
-CONST_STRPTR InfoTmpl = "%s%s    (%iu, %iu)";
+CONST_STRPTR InfoTmpl = "%s%s    (%ld, %ld)";
 
 /** Update window title **/
 void UpdateTitle(struct Window *W, Project p)
 {
-	struct { TEXT *name; TEXT *modified; STACKED ULONG x; STACKED ULONG y; } __packed info;
+	struct { TEXT *name; TEXT *modified; ULONG x; ULONG y; } __packed info;
 
 	info.name = p->path? p->path: p->name;
 	info.modified = (p->state & MODIFIED) ? STR_MODIF : "";


### PR DESCRIPTION
This implement the fix to the wrong row and column value displayed in the Editor title bar. 

Before on 64bit version the two number were random big numbers. 

The fix has been tested on x86-64 and i386 builds. 

Here a screenshot:
![image](https://github.com/user-attachments/assets/f6cbbfff-83a7-4c00-b79d-06e51176d1a7)
