### PR TITLE
Fix for memory issue in workbench editor.

### DIFF
--- a/workbench/tools/Edit/UndoRedo.h
+++ b/workbench/tools/Edit/UndoRedo.h
@@ -65,17 +65,23 @@ typedef JBUF *				JBuf;				/* Main type pointer */
 #define	OUT_OF_DATE		((STRPTR)-1)
 #define	NO_MEANING_VAL	((STRPTR)-2)
 
+#define COMMIT_TYPE \
+  union { \
+    APTR helper; \
+    struct { \
+      UBYTE pad[sizeof(APTR) - (2 * sizeof(UBYTE))]; \
+      UBYTE commit; \
+      UBYTE type; \
+    }; \
+};
+
 /** Datatypes specific to an operation (must be WORD aligned) **/
 typedef struct _AddChar
 {
 	LINE *line;									/* Line where operation occured */
 	UWORD pos;									/* Position in this line */
 	UWORD nbc;									/* Nb. of char inserted */
-#ifdef __AROS__
-	UWORD pad;									/* to get multiple-of-4 structure sizeof */
-#endif
-	UBYTE commit;								/* Savepoint */
-	UBYTE type;									/* ADD_CHAR */
+	COMMIT_TYPE
 }	*AddChar;
 
 /** Yes, no meaning changes, except type == REM_CHAR **/
@@ -85,11 +91,7 @@ typedef struct _RemLine
 {
 	LINE  *line;								/* Line removed */
 	LINE  *after;								/* Insert the line after this one */
-#ifdef __AROS__
-	UWORD pad;									/* to get multiple-of-4 structure sizeof */
-#endif
-	UBYTE  commit;								/* Savepoint */
-	UBYTE  type;								/* REM_LINE */
+	COMMIT_TYPE
 }	*RemLine;
 
 typedef struct _JoinLine
@@ -97,20 +99,12 @@ typedef struct _JoinLine
 	LINE  *line;								/* First line concerned */
 	LINE  *old;									/* Old line removed */
 	ULONG  pos;									/* Joined position */
-#ifdef __AROS__
-   UWORD pad;									/* to get multiple-of-4 structure sizeof */
-#endif
-	UBYTE  commit;								/* Savepoint */
-	UBYTE  type;								/* JOIN_LINE */
+	COMMIT_TYPE
 }	*JoinLine;
 
 typedef struct _GroupBy						/* Gather multiple operations */
 {
-#ifdef	__AROS__
-   UWORD pad;									/* to get multiple-of-4 structure sizeof */
-#endif
-	UBYTE  commit;								/* Savepoint */
-	UBYTE  type;								/* GROUP_BY */
+	COMMIT_TYPE
 }  *GroupBy;
 
 void flush_undo_buf ( JBuf );


### PR DESCRIPTION
This pr replace the following fields: 

```c
#ifdef __AROS__
	UWORD pad;									/* to get multiple-of-4 structure sizeof */
#endif
	UBYTE  commit;								/* Savepoint */
	UBYTE  type;		
```
in the structs; AddChar,  Remline, JoinLine, GroupBy, addressing a memory issue that was causing the program to crash when closing the files on 64 bit architectures (Issue reported here: https://github.com/deadwood2/AROS/issues/180) . 

The cause were a mix of factors: 
* difference in size of the various struct, although with a very similar structures
* some macros (IS_COMMIT, LAST_TYPE and others) try to access several fields using pointer notation (so expecting those value to be exactly at that position)
* pad variable was useful on 32bit architectures, but was not addressing 64 bit architectures

These fields were replaced by an  anonymous union declared with the following macro: 
```c
#define COMMIT_TYPE \
  union { \
    APTR helper; \
    struct { \
      UBYTE pad[sizeof(APTR) - (2 * sizeof(UBYTE))]; \
      UBYTE commit; \
      UBYTE type; \
    }; \
};
```

And now the `pad` variable is architecture independant, and the other fields should be assured to always be in the right position. 

Thanks @deanoburrito for his help in outlining this solution.