### PR TITLE
Deluxe Galaga AGA needs GFXF_AA_MLISA in ChipRevBits0 to understand that AGA is available

### DIFF
--- a/arch/m68k-amiga/graphics/setchiprev.c
+++ b/arch/m68k-amiga/graphics/setchiprev.c
@@ -23,7 +23,7 @@ AROS_LH1(ULONG, SetChipRev,
 
     vposr = custom->vposr & 0x7f00;
     if ((vposr & 0x0200) == 0x0200) {
-        chipflags = GFXF_AA_ALICE | GFXF_HR_AGNUS | GFXF_AA_LISA | GFXF_HR_DENISE;
+        chipflags = GFXF_AA_ALICE | GFXF_HR_AGNUS | GFXF_AA_LISA | GFXF_AA_MLISA | GFXF_HR_DENISE;
     } else if (vposr >= 0x2000) {
         chipflags = GFXF_HR_AGNUS;
         // ECS Agnus can be combined with different Denise chips.

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -65,7 +65,7 @@ VOID resetcustom(struct amigavideo_staticdata *csd)
     custom->color[0] = DEFAULT_BORDER_GRAY;
 
     // Use AGA modes and create AGA copperlists only if AGA is "enabled"
-    csd->aga_enabled = csd->aga && GfxBase->ChipRevBits0 == SETCHIPREV_AA;
+    csd->aga_enabled = csd->aga && (GfxBase->ChipRevBits0 & SETCHIPREV_AA) == SETCHIPREV_AA;
 }
 
 static VOID waitvblank(struct amigavideo_staticdata *csd)
@@ -567,9 +567,9 @@ BOOL setmode(struct amigavideo_staticdata *csd, struct amigabm_data *bm)
             // This is a compatibility hack because our display
             // database currently contains all AGA modes even if AGA
             // is "disabled".
-            GfxBase->ChipRevBits0 = SETCHIPREV_AA;
+            GfxBase->ChipRevBits0 = SETCHIPREV_AA | GFXF_AA_MLISA;
             csd->aga_enabled = TRUE;
-            csd->fmode_bpl = csd->aga && csd->aga_enabled ? 2 : 0;
+            csd->fmode_bpl = 2;
             fetchunit = fetchunits[csd->fmode_bpl * 4 + bm->res];
             maxplanes = fm_maxplanes[csd->fmode_bpl * 4 + bm->res];
         }


### PR DESCRIPTION
The initial settings screen for Deluxe Galaga AGA now shows. Before, the game was not launched at all.

