### PR TITLE
Some keymap fixes

### DIFF
--- a/workbench/devs/keymaps/pc105_s.akmd
+++ b/workbench/devs/keymaps/pc105_s.akmd
@@ -18,7 +18,7 @@ KCF_SHIFT|KCF_ALT                       # 07
 KCF_SHIFT|KCF_ALT                       # 08
 KCF_SHIFT|KCF_ALT                       # 09
 KCF_SHIFT|KCF_ALT                       # 0A
-KCF_SHIFT|KCF_ALT                       # 0B
+KCF_DEAD|KC_VANILLA                     # 0B
 KCF_DEAD|KCF_SHIFT|KCF_ALT              # 0C
 KC_NOQUAL                               # 0D
 KC_NOQUAL                               # 0E
@@ -131,6 +131,18 @@ KCF_NOP                                 # 75
 KCF_NOP                                 # 76
 KCF_NOP                                 # 77
 ## end hikeymaptypes
+
+## begin deadkey
+id: KEY0B_descr
+0, '+',
+0, '?',
+0, '\\',
+0, 0,
+0, 0,
+0, 0,
+0, 0x1C,
+0, 0,
+## end deadkey
 
 ## begin deadkey
 id: KEY0C_descr
@@ -503,7 +515,7 @@ id: end_descr
 '«' ,'[' ,'(' ,'8'
 '»' ,']' ,')' ,'9'
 '°' ,'}' ,'=' ,'0'
-0   ,0x5C,'?' ,'+'
+id:KEY0B_descr
 id:KEY0C_descr
 0   ,0   ,0xBD,0xA7
 0   ,0   ,0   ,0
@@ -552,7 +564,7 @@ id:KEY38_descr
 0   ,'·' ,':' ,'.'
 0   ,0   ,'_' ,'-'
 0   ,0   ,0   ,0
-0   ,0   ,',', '.'
+0   ,0   ,'.', ','
 '7', '7', '7', '7'
 '8', '8', '8', '8'
 '9', '9', '9', '9'

--- a/workbench/devs/keymaps/pc105_usx.akmd
+++ b/workbench/devs/keymaps/pc105_usx.akmd
@@ -52,7 +52,7 @@ KC_VANILLA                      # 27 k
 KC_VANILLA                      # 28 l
 KCF_SHIFT                       # 29
 KCF_SHIFT                       # 2A
-KCF_SHIFT                       # 2B
+KCF_SHIFT|KCF_CONTROL           # 2B
 KC_NOQUAL                       # 2C
 KC_NOQUAL                       # 2D
 KC_NOQUAL                       # 2E
@@ -398,7 +398,7 @@ id: end_descr
 0xD8,0xF8,'L' ,'l'
 0xB0,0xB6,':' ,';'
 0xA8,0xB4,0x22,0x27
-0xA6,0xAC,0x7C,0x5C
+0,   0x1C,0x7C,0x5C
 0,   0,   0,   0
 '4', '4', '4', '4'
 '5', '5', '5', '5'


### PR DESCRIPTION
1) Swedish, US PC105:  Ctrl-\ now generates EOF as on AmigaOS.

2) Small fix for Swedish: . key on numpad should be ,
