### PR TITLE
Add target variant "classic" for m68k-amiga

### DIFF
--- a/arch/m68k-amiga/boot/aros-dbg.ld
+++ b/arch/m68k-amiga/boot/aros-dbg.ld
@@ -7,15 +7,15 @@ MEMORY {
 SECTIONS
 {
  .start.MEMF_LOCAL           : { _ext_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/start_objs.ld
+INCLUDE start_objs.ld
                                } >valid
  .kick.MEMF_KICK             : { _kick_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/any_objs.ld
+INCLUDE any_objs.ld
                                  _kick_end = .;
                                  _ext_end = .;
                                } >valid
  .rom.MEMF_LOCAL             : { _rom_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/local_objs.ld
+INCLUDE local_objs.ld
                                   /* This is for the static libs */
                                  *(.text .text.* .rodata .rodata.*)
                                  *(.eh_frame)

--- a/arch/m68k-amiga/boot/aros-ram.ld
+++ b/arch/m68k-amiga/boot/aros-ram.ld
@@ -6,14 +6,14 @@ MEMORY {
 SECTIONS 
 {
   .start.MEMF_LOCAL           : {
-INCLUDE ../../../bin/amiga-m68k/gen/start_objs.ld
+INCLUDE start_objs.ld
                                 } >valid
   .kick.MEMF_KICK             : { _kick_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/any_objs.ld
+INCLUDE any_objs.ld
                                   _kick_end = .; 
                                 } >valid
   .rom.MEMF_LOCAL             : { _rom_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/local_objs.ld
+INCLUDE local_objs.ld
                                    /* This is for the static libs */
                                   *(.text .text.* .rodata .rodata.*)
                                   *(.eh_frame)

--- a/arch/m68k-amiga/boot/aros-rom.ld
+++ b/arch/m68k-amiga/boot/aros-rom.ld
@@ -6,11 +6,11 @@ MEMORY {
 SECTIONS 
 {
   .ext                        : { _ext_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/ext_objs.ld
+INCLUDE ext_objs.ld
                                   _ext_end = .; 
                                 } >valid
   .rom                        : { _rom_start = .;
-INCLUDE ../../../bin/amiga-m68k/gen/rom_objs.ld
+INCLUDE rom_objs.ld
                                    /* This is for the static libs */
                                   *(.text .text.* .rodata .rodata.*)
                                   *(.eh_frame)

--- a/arch/m68k-amiga/boot/mmakefile.src
+++ b/arch/m68k-amiga/boot/mmakefile.src
@@ -208,6 +208,7 @@ $(GENDIR)/boot/aros-amiga-m68k-reloc.elf : $(DEPLIBS) $(SRCDIR)/$(CURDIR)/mmakef
 	@$(ECHO) Linking $@...
 	$(Q)$(KERNEL_CC) -Wl,-r \
 		-static -nostartfiles -nostdlib \
+		-L$(GENDIR) \
 		-Wl,-Map=$(GENDIR)/boot/aros-amiga-m68k-reloc.elf.map \
 		-Wl,--defsym -Wl,start=0x0 \
 		-Wl,--defsym -Wl,SysBase=0x4 \
@@ -355,6 +356,7 @@ $(GENDIR)/boot/aros-amiga-m68k-ram.elf : $(DEPLIBS) $(SRCDIR)/$(CURDIR)/mmakefil
 	@$(ECHO) Linking $@...
 	$(Q)$(KERNEL_CC) -Wl,-r \
 		-static -nostartfiles -nostdlib \
+		-L$(GENDIR) \
 		-Wl,-Map=$(GENDIR)/boot/aros-amiga-m68k-ram.elf.map \
 		-Wl,--defsym -Wl,start=0x0 \
 		-Wl,--defsym -Wl,SysBase=0x4 \
@@ -373,6 +375,7 @@ $(GENDIR)/boot/objtest/%.tst : $(KOBJSDIR)/%.ko $(GENDIR)/boot/objtest
 	@$(ECHO) Test Linking $@...
 	$(KERNEL_CC) -Wl,-r \
 		-static -nostartfiles -nostdlib \
+		-L$(GENDIR) \
 		-Wl,--defsym -Wl,start=0x0 \
 		-Wl,--defsym -Wl,SysBase=0x4 \
 		-Wl,--defsym -Wl,AbsExecBase=0x4 \
@@ -407,6 +410,7 @@ $(AROSARCHDIR)/aros.elf.dbg : $(DEPLIBS) $(SRCDIR)/$(CURDIR)/mmakefile.src \
 		$(ECHO) Linking $@...; \
 		$(KERNEL_CC) -Wl,-r \
 		-static -nostartfiles -nostdlib \
+		-L$(GENDIR) \
 		-Wl,--defsym -Wl,start=0x0 \
 		-Wl,--defsym -Wl,SysBase=0x4 \
 		-Wl,--defsym -Wl,AbsExecBase=0x4 \

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -26,6 +26,7 @@
 
 #define AROS_NESTING_SUPERVISOR         @aros_nesting_supervisor@
 
+@CLASSIC_VARIANT_DEFINE@
 @PLATFORM_EXECSMP@
 @ENABLE_EXECSMP@
 

--- a/configure
+++ b/configure
@@ -684,6 +684,7 @@ gcc_default_float_abi
 gcc_default_fpu
 gcc_default_cpu_tune
 gcc_default_cpu
+CLASSIC_VARIANT_DEFINE
 aros_nesting_supervisor
 target_grub2_version
 aros_enable_mmu
@@ -9452,6 +9453,11 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enableval" >&5
 printf "%s\n" "$enableval" >&6; }
 
+# Target variant "classic" implies aros-prefs "classic" if it is not set.
+if test "$target_variant" = "classic" -a "$config_prefs_set" = ""; then
+    config_prefs_set="classic"
+fi
+
 #-----------------------------------------------------------------------------
 # Target-specific defaults. You can override then on a per-target basis.
 #
@@ -9459,6 +9465,10 @@ printf "%s\n" "$enableval" >&6; }
 target_bootloader="none"
 PLATFORM_EXECSMP=
 ENABLE_EXECSMP=
+
+#-----------------------------------------------------------------------------
+# This only applies to amiga target.
+CLASSIC_VARIANT_DEFINE=
 
 #-----------------------------------------------------------------------------
 # Additional options for some specific targets
@@ -10570,6 +10580,9 @@ fi
         aros_target_arch="amiga"
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__ -D_AMIGA -DAMIGA"
         aros_shared_default="no"
+        if test "$aros_target_variant" = "classic" ; then
+            CLASSIC_VARIANT_DEFINE="#define AROS_VARIANT_CLASSIC"
+        fi
 
         case "$target_cpu" in
             *m68k*)
@@ -18060,6 +18073,9 @@ aros_kernel_ranlib=$aros_kernel_ranlib
 
 
 # Unix/Hosted version related
+
+
+# Define set if classic variant is chosen
 
 
 # ARM default GCC target related

--- a/configure.in
+++ b/configure.in
@@ -1106,6 +1106,11 @@ else
 fi
 AC_MSG_RESULT($enableval)
 
+# Target variant "classic" implies aros-prefs "classic" if it is not set.
+if test "$target_variant" = "classic" -a "$config_prefs_set" = ""; then
+    config_prefs_set="classic"
+fi
+
 #-----------------------------------------------------------------------------
 # Target-specific defaults. You can override then on a per-target basis.
 #
@@ -1113,6 +1118,10 @@ AC_MSG_RESULT($enableval)
 target_bootloader="none"
 PLATFORM_EXECSMP=
 ENABLE_EXECSMP=
+
+#-----------------------------------------------------------------------------
+# Classic variant is possible for Amiga target.
+CLASSIC_VARIANT_DEFINE=
 
 #-----------------------------------------------------------------------------
 # Additional options for some specific targets
@@ -1958,6 +1967,9 @@ case "$target_os" in
         aros_target_arch="amiga"
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__ -D_AMIGA -DAMIGA"
         aros_shared_default="no"
+        if test "$aros_target_variant" = "classic" ; then
+            CLASSIC_VARIANT_DEFINE="#define AROS_VARIANT_CLASSIC"
+        fi
 
         case "$target_cpu" in
             *m68k*)
@@ -3664,6 +3676,9 @@ AC_SUBST(target_grub2_version)
 
 # Unix/Hosted version related
 AC_SUBST(aros_nesting_supervisor)
+
+# Define set if classic variant is chosen
+AC_SUBST(CLASSIC_VARIANT_DEFINE)
 
 # ARM default GCC target related
 AC_SUBST(gcc_default_cpu)

--- a/rom/intuition/openscreen.c
+++ b/rom/intuition/openscreen.c
@@ -1731,7 +1731,7 @@ static const char THIS_FILE[] = __FILE__;
         */
         UpdateScreenBitMap(&screen->Screen, IntuitionBase);
 
-#ifdef __MORPHOS__
+#if defined(__MORPHOS__) || defined(AROS_VARIANT_CLASSIC)
         screen->Screen.WBorTop    = 2;
         screen->Screen.WBorLeft   = 4;
         screen->Screen.WBorRight  = 4;

--- a/rom/usb/mmakefile.src
+++ b/rom/usb/mmakefile.src
@@ -20,7 +20,9 @@ include $(SRCDIR)/config/aros.cfg
 #MM      kernel-usb-shellapps \
 #MM      kernel-usb-trident
 
-#MM- kernel-usb-amiga-m68k : kernel-usb-nopci
+#MM- kernel-usb-amiga-m68k : kernel-usb-amiga-m68k-$(AROS_TARGET_VARIANT)
+
+#MM- kernel-usb-amiga-m68k- : kernel-usb-nopci
 
 # Clean up
 #MM- kernel-usb-clean : \

--- a/workbench/s/Startup-Sequence
+++ b/workbench/s/Startup-Sequence
@@ -87,7 +87,9 @@ EndIf
 
 AddDataTypes REFRESH QUIET
 IPrefs
-PsdStackLoader >NIL:
+If EXISTS "C:PsdStackLoader"
+    PsdStackLoader >NIL:
+EndIf
 Run <NIL: >NIL: QUIET ConClip
 
 If EXISTS "C:RexxMast"


### PR DESCRIPTION
The normal AROS build is not great on an original Amiga system, be it real or emulated. This new target variant aims to provide a more fitting build for such systems.
