### PR TITLE
AllocPooled adjustments

### DIFF
--- a/rom/exec/createpool.c
+++ b/rom/exec/createpool.c
@@ -88,14 +88,14 @@
 
     /*
      * puddleSize needs to include MEMHEADER_TOTAL, allocator context size and
-     * ALLOCPOOLED_USER_OFFSET.
+     * MEMPOOL_WORSTALIGN.
      * This is because our puddles must be able to accommodate an allocation
      * of own size. Allocations of larger size will always use enlarged puddles.
      * Pointer is used for pointing back to the MemHeader from which the block
      * was allocated, in AllocVec()-alike manner. This way we get rid of slow
      * lookup in FreePooled().
      */
-    puddleSize += MEMHEADER_TOTAL + mhac_GetCtxSize() + ALLOCPOOLED_USER_OFFSET;
+    puddleSize += MEMHEADER_TOTAL + mhac_GetCtxSize() + MEMPOOL_WORSTALIGN;
 
     /* If mungwall is enabled, count also size of walls, at least for one allocation */
     if (PrivExecBase(SysBase)->IntFlags & EXECF_MungWall)

--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -934,7 +934,7 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
      * This is done in AllocVec()-alike manner; the pointer is placed before the block.
      * The Amiga platform has extra padding to not destroy the alignment.
      */
-    memSize += ALLOCPOOLED_USER_OFFSET;
+    memSize += MEMPOOL_WORSTALIGN;
     origSize = memSize;
 
     /* If mungwall is enabled, count also size of walls */
@@ -1062,7 +1062,7 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
 
         /* Remember where we were allocated from */
         *((struct MemHeader **)ret) = mh;
-        ret += ALLOCPOOLED_USER_OFFSET;
+        ret += MEMPOOL_WORSTALIGN;
     }
 
     /* Everything fine */
@@ -1088,8 +1088,8 @@ void InternalFreePooled(APTR poolHeader, APTR memory, IPTR memSize, struct Trace
     if (!memory || !memSize) return;
 
     /* Get MemHeader pointer. It is stored right before our block. */
-    freeStart = memory - ALLOCPOOLED_USER_OFFSET;
-    freeSize = memSize + ALLOCPOOLED_USER_OFFSET;
+    freeStart = memory - MEMPOOL_WORSTALIGN;
+    freeSize = memSize + MEMPOOL_WORSTALIGN;
     mh = *((struct MemHeader **)freeStart);
 
     /* Check walls first */

--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -932,7 +932,8 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
      * Memory blocks allocated from the pool store pointers to the MemHeader they were
      * allocated from. This is done in order to avoid slow lookups in InternalFreePooled().
      * This is done in AllocVec()-alike manner; the pointer is placed before the block.
-     * The Amiga platform has extra padding to not destroy the alignment.
+     * There is an architecture-dependent padding to keep the alignment given by
+     * the underlying allocator.
      */
     memSize += MEMPOOL_WORSTALIGN;
     origSize = memSize;

--- a/rom/exec/memory.h
+++ b/rom/exec/memory.h
@@ -29,14 +29,13 @@
 
 #define POOL_MAGIC AROS_MAKE_ID('P','o','O','l')
 
-// On AGA Amigas, AmiBlitz 3 allocation of wide sprites relies on that AllocPooled
-// returns at least eight byte aligned memory. AllocPooled on a classic Amiga even
-// aligns memory on 16 bytes on some occasions, so go with that.
-#ifdef AMIGA
-#define ALLOCPOOLED_USER_OFFSET 16
-#else /* AMIGA */
-#define ALLOCPOOLED_USER_OFFSET sizeof(struct MemHeader *)
-#endif /* AMIGA */
+/* On AGA Amigas, AmiBlitz 3 allocation of wide sprites relies on that AllocPooled
+ * returns at least eight byte aligned memory.
+ * Testing AmigaOS 3.1 on WinUAE with A600 and A1200 setups did not reproduce any
+ * AllocPooled results without eight bytes alignment, so it should be a decent
+ * approach to align to eight bytes.
+ */
+#define ALLOCPOOLED_USER_OFFSET 8
 
 /* Private Pool structure */
 struct Pool 

--- a/rom/exec/memory.h
+++ b/rom/exec/memory.h
@@ -32,10 +32,9 @@
 /* On AGA Amigas, AmiBlitz 3 allocation of wide sprites relies on that AllocPooled
  * returns at least eight byte aligned memory.
  * Testing AmigaOS 3.1 on WinUAE with A600 and A1200 setups did not reproduce any
- * AllocPooled results without eight bytes alignment, so it should be a decent
- * approach to align to eight bytes.
+ * AllocPooled results with less than eight bytes alignment.
  */
-#define ALLOCPOOLED_USER_OFFSET 8
+#define MEMPOOL_WORSTALIGN (AROS_WORSTALIGN > 8 ? AROS_WORSTALIGN : 8)
 
 /* Private Pool structure */
 struct Pool 

--- a/rom/exec/memory.h
+++ b/rom/exec/memory.h
@@ -33,6 +33,10 @@
  * returns at least eight byte aligned memory.
  * Testing AmigaOS 3.1 on WinUAE with A600 and A1200 setups did not reproduce any
  * AllocPooled results with less than eight bytes alignment.
+ * The underlying memory allocators respect AROS_WORSTALIGN. On systems where
+ * AROS_WORSTALIGN is four (the smallest value), the minimum alignment from
+ * the allocators involved is eight. The below definition ensures that the minimum
+ * alignment applies to memory returned by AllocPooled as well.
  */
 #define MEMPOOL_WORSTALIGN (AROS_WORSTALIGN > 8 ? AROS_WORSTALIGN : 8)
 

--- a/rom/exec/mungwall.c
+++ b/rom/exec/mungwall.c
@@ -61,15 +61,8 @@ APTR MungWall_Build(APTR res, APTR pool, IPTR origSize, ULONG requirements, stru
         /*
          * Initialize post-wall.
          * Fill only MUNGWALL_SIZE bytes, this is what we are guaranteed to have in the end.
-         * We can't assume anything about padding. AllocMem() does guarantee that the actual
-         * allocation start and size is a multiple of MEMCHUNK_TOTAL, but for example
-         * AllocPooled() doesn't. Pooled allocations are only IPTR-aligned (see InternalFreePooled(),
-         * in AROS pooled allocations are vectored, pool pointer is stored in an IPTR preceding the
-         * actual block in AllocVec()-alike manner).
-         * IPTR alignment is 100% correct since original AmigaOS(tm) autodocs say that even AllocMem()
-         * result is longword-aligned. AROS introduces additional assumption that AllocMem() result
-         * is aligned at least up to AROS_WORSTALIGN (CPU-specific value, see exec/memory.h), however
-         * this is still not true for other allocation functions (AllocVec() etc).
+         * We don't assume anything about padding but the walls preserve
+         * MEMCHUNK_TOTAL alignment.
          */
         memset(res + origSize, 0xDB, MUNGWALL_SIZE);
 


### PR DESCRIPTION
AMIGA define is not exclusive to the Amiga target. Just set the same offset for all targets willingly, and dial it down to 8 bytes which is what we have seen on AmigaOS. No pointer is larger than 8 bytes, unless AROS should run on IBM Teraspace systems and then that's a whole project :)

