### PR TITLE
Fix mismatch between top border colour and topmost screen background colour

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -110,7 +110,9 @@ VOID setfmode(struct amigavideo_staticdata *csd, struct amigabm_data *bm)
     csd->copper1[15] = fmode & 0xc;
 }
 
-VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm, UBYTE *palette)
+static void updatecopper1frombm(struct amigavideo_staticdata *, struct amigabm_data *);
+
+VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm, UBYTE *palette, BOOL update_copper1)
 {
     struct copper2data *c2d = &bm->copld, *c2di = &bm->copsd;
 
@@ -167,6 +169,9 @@ VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm,
             if (bm->interlace)
                 c2di->copper2_palette[i * 2 + 1] = val;
         }
+    }
+    if (update_copper1) {
+        updatecopper1frombm(csd, bm);
     }
     D(bug("[AmigaVideo] %s: copper colors set\n", __func__));
 }
@@ -787,7 +792,8 @@ BOOL setcolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm, struc
     }
 
     if ((bm->bmcl) && (bm->bmcl->CopLStart))
-        setcoppercolors(csd, bm, bm->palette);
+        setcoppercolors(csd, bm, bm->palette,
+                        (void *)bm == (void *)csd->compositedbms->lh_Head);
 
     return TRUE;
 }
@@ -1684,7 +1690,8 @@ VOID AmigaVideoCl__Hidd_AmigaGfx__EnableAGA(OOP_Class *cl, OOP_Object *o, void *
         copperlist_end = (IPTR)populatebmcopperlist(csd, bm, &bm->copld, bm->bmcl->CopLStart, FALSE);
         bm->bmcl->Count = (copperlist_end - (IPTR)bm->bmcl->CopLStart) >> 2;
         setfmode(csd, bm);
-        setcoppercolors(csd, bm, bm->palette);
+        setcoppercolors(csd, bm, bm->palette,
+                        (void *)bm == (void *)csd->compositedbms->lh_Head);
         setcopperscroll2(csd, bm, &bm->copld, bm->bmcl->CopLStart, FALSE);
     }
 }

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
@@ -1173,7 +1173,8 @@ ULONG AmigaVideoCl__Hidd_Gfx__PrepareViewPorts(OOP_Class *cl, OOP_Object *o, str
             }
 
             setfmode(csd, bmdata);
-            setcoppercolors(csd, bmdata, bmdata->palette);
+            setcoppercolors(csd, bmdata, bmdata->palette,
+                            (void *)vpd == (void *)msg->Data);
 
             /* handle the viewports 'struct UCopList *' */
             if (vpd->vpe->ViewPort->UCopIns && vpd->vpe->ViewPort->UCopIns->FirstCopList)

--- a/arch/m68k-amiga/hidd/amigavideo/chipset.h
+++ b/arch/m68k-amiga/hidd/amigavideo/chipset.h
@@ -87,6 +87,6 @@ VOID setcopperlisttail(struct amigavideo_staticdata *, UWORD *, UWORD *, BOOL);
 UWORD *populatebmcopperlist(struct amigavideo_staticdata *, struct amigabm_data *, struct copper2data *, UWORD *, BOOL);
 VOID updatebmbplcon(struct amigavideo_staticdata *, struct amigabm_data *, struct copper2data *);
 VOID setcopperscroll(struct amigavideo_staticdata *, struct amigabm_data *, BOOL);
-VOID setcoppercolors(struct amigavideo_staticdata *, struct amigabm_data *, UBYTE *);
+VOID setcoppercolors(struct amigavideo_staticdata *, struct amigabm_data *, UBYTE *, BOOL);
 
 #endif


### PR DESCRIPTION
Before: top border was always grey.
After: top border matches color 0 of the topmost screen.
