### PR TITLE
Make intmax_t and uintmax_t long long by default

### DIFF
--- a/compiler/crt/posixc/posixc.conf
+++ b/compiler/crt/posixc/posixc.conf
@@ -1,5 +1,5 @@
 ##begin config
-version 0.25
+version 0.26
 basename PosixC
 libbasetypeextern struct PosixCBase
 libbasetype struct PosixCIntBase

--- a/compiler/crt/stdc/stdc.conf
+++ b/compiler/crt/stdc/stdc.conf
@@ -1,5 +1,5 @@
 ##begin config
-version 0.37
+version 0.38
 basename StdC
 libbasetypeextern struct StdCBase
 libbasetype struct StdCIntBase

--- a/compiler/include/aros/cpu.h
+++ b/compiler/include/aros/cpu.h
@@ -134,7 +134,7 @@
 #endif
 
 #ifndef AROS_LARGEST_TYPE
-#define AROS_LARGEST_TYPE           long
+#define AROS_LARGEST_TYPE           long long
 #endif
 
 #ifndef AROS_ATOMIC_TYPE


### PR DESCRIPTION
intmax_t and uintmax_t was long by default, which made them 32 bits on systems where long is 32 bits. This violates C99 section 7.18.1.5 and C11,17 section 7.20.1.5 since intmax_t and uintmax_t are supposed to fit values from any signed/unsigned integer type, but are smaller than signed/unsigned long long which is guaranteed to exist starting with C99, which came out > 25 years ago.
