### PR TITLE
Refine i8042 helper naming

### DIFF
--- a/arch/all-pc/hidds/i8042/i8042_common.c
+++ b/arch/all-pc/hidds/i8042/i8042_common.c
@@ -9,7 +9,7 @@
 #include "i8042_kbd.h"
 #include "i8042_common.h"
 
-void kbd_usleep(struct IORequest* tmr, LONG usec)
+void i8042_delay(struct IORequest* tmr, LONG usec)
 {
     tmr->io_Command = TR_ADDREQUEST;
     ((struct timerequest*)tmr)->tr_time.tv_secs = 0;
@@ -18,56 +18,56 @@ void kbd_usleep(struct IORequest* tmr, LONG usec)
 }
 
 
-void kbd_write_cmd(struct IORequest* tmr, int cmd)
+void i8042_write_mode(struct IORequest* tmr, int cmd)
 {
-    kb_wait(tmr, 100);
-    kbd_write_command(KBD_CTRLCMD_WRITE_MODE);
-    kb_wait(tmr, 100);
-    kbd_write_output(cmd);
+    i8042_wait_for_write_ready(tmr, 100);
+    i8042_write_command_port(KBD_CTRLCMD_WRITE_MODE);
+    i8042_wait_for_write_ready(tmr, 100);
+    i8042_write_data_port(cmd);
 }
 
 /*
  * Aux (mouse) port uses longer delays, this is necessary
  * in order to detect IntelliMouse properly
  */
-void aux_write_ack(struct IORequest* tmr, int val)
+void i8042_mouse_write_ack(struct IORequest* tmr, int val)
 {
-    kb_wait(tmr, 1000);
-    kbd_write_command(KBD_CTRLCMD_WRITE_MOUSE);
-    kb_wait(tmr, 1000);
-    kbd_write_output(val);
-    kbd_wait_for_input(tmr);
+    i8042_wait_for_write_ready(tmr, 1000);
+    i8042_write_command_port(KBD_CTRLCMD_WRITE_MOUSE);
+    i8042_wait_for_write_ready(tmr, 1000);
+    i8042_write_data_port(val);
+    i8042_wait_for_input(tmr);
 }
 
-void aux_write_noack(struct IORequest* tmr, int val)
+void i8042_mouse_write_noack(struct IORequest* tmr, int val)
 {
-    kb_wait(tmr, 1000);
-    kbd_write_command(KBD_CTRLCMD_WRITE_MOUSE);
-    kb_wait(tmr, 1000);
-    kbd_write_output(val);
+    i8042_wait_for_write_ready(tmr, 1000);
+    i8042_write_command_port(KBD_CTRLCMD_WRITE_MOUSE);
+    i8042_wait_for_write_ready(tmr, 1000);
+    i8042_write_data_port(val);
 }
 
-void kbd_write_output_w(struct IORequest* tmr, int val)
+void i8042_write_data_with_wait(struct IORequest* tmr, int val)
 {
-    kb_wait(tmr, 100);
-    kbd_write_output(val);
+    i8042_wait_for_write_ready(tmr, 100);
+    i8042_write_data_port(val);
 }
 
-void kbd_write_command_w(struct IORequest* tmr, int val)
+void i8042_write_command_with_wait(struct IORequest* tmr, int val)
 {
-    kb_wait(tmr, 100);
-    kbd_write_command(val);
+    i8042_wait_for_write_ready(tmr, 100);
+    i8042_write_command_port(val);
 }
 
-int kbd_read_data(void)
+int i8042_read_data(void)
 {
     LONG        retval = KBD_NO_DATA;
     UBYTE       status;
     
-    status = kbd_read_status();
+    status = i8042_read_status_port();
     if (status & KBD_STATUS_OBF)
     {
-        UBYTE   data = kbd_read_input();
+        UBYTE   data = i8042_read_data_port();
         
         retval = data;
         if (status & (KBD_STATUS_GTO | KBD_STATUS_PERR))
@@ -77,7 +77,7 @@ int kbd_read_data(void)
     return retval;
 }
 
-int kbd_clear_input(void)
+int i8042_kbd_clear_input(void)
 {
     int maxread = 100, lastcode = KBD_NO_DATA;
     UBYTE status;
@@ -85,8 +85,8 @@ int kbd_clear_input(void)
     do
     {
         int code;
-        status = kbd_read_status();
-        if ((code = kbd_read_data()) == KBD_NO_DATA)
+        status = i8042_read_status_port();
+        if ((code = i8042_read_data()) == KBD_NO_DATA)
             break;
         if (!(status & KBD_STATUS_MOUSE_OBF))
             lastcode = code;

--- a/arch/all-pc/hidds/i8042/i8042_mouse.h
+++ b/arch/all-pc/hidds/i8042/i8042_mouse.h
@@ -2,7 +2,7 @@
 #define I8042_MOUSE_H
 
 /*
-    Copyright © 1995-2025, The AROS Development Team. All rights reserved.
+    Copyright Â© 1995-2025, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: Include for the mouse native HIDD.
@@ -70,7 +70,7 @@ struct mouse_data
 /****************************************************************************************/
 
 /* Prototypes */
-void ps2mouse_getstate(OOP_Class *, OOP_Object *, struct pHidd_Mouse_Event *);
-extern void PS2Mouse_InitTask(OOP_Class *, OOP_Object *);
+void i8042_mouse_get_state(OOP_Class *, OOP_Object *, struct pHidd_Mouse_Event *);
+extern void i8042_mouse_init_task(OOP_Class *, OOP_Object *);
 
 #endif /* I8042_MOUSE_H */

--- a/arch/all-pc/hidds/i8042/i8042_mouseclass.c
+++ b/arch/all-pc/hidds/i8042/i8042_mouseclass.c
@@ -77,7 +77,7 @@ OOP_Object * i8042Mouse__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_Ne
         D(bug("[i8042:Mouse] %s: callback data @ 0x%p\n", __func__, data->callbackdata));
 
         /* Search for PS/2 mouse */
-        NewCreateTask(TASKTAG_PC,           PS2Mouse_InitTask,
+        NewCreateTask(TASKTAG_PC,           i8042_mouse_init_task,
                          TASKTAG_NAME,      (IPTR)i8042mpname,
                          TASKTAG_STACKSIZE, 1024,
                          TASKTAG_PRI,       100,
@@ -123,7 +123,7 @@ VOID i8042Mouse__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
     if (IS_HIDDMOUSE_ATTR(msg->attrID, idx)) {
         switch (idx) {
         case aoHidd_Mouse_State:
-            ps2mouse_getstate(cl, o, (struct pHidd_Mouse_Event *)msg->storage);
+            i8042_mouse_get_state(cl, o, (struct pHidd_Mouse_Event *)msg->storage);
             return;
 
         case aoHidd_Mouse_RelativeCoords:


### PR DESCRIPTION
# use descriptive/consistent naming of functions.
# re-name generic functions for clarity.
