### PR TITLE
rexxsyslib: CreateArgstring and CreateRexxMsg should return value in both A0 and D0 on Amiga

### DIFF
--- a/compiler/arossupport/include/debug.h
+++ b/compiler/arossupport/include/debug.h
@@ -289,6 +289,11 @@
 
 #endif /* MDEBUG */
 
+#ifdef __mc68000__
+#   define M68K_RETURN_INREG(val, reg)  asm volatile("move.l %0, %%" reg :: "r"(val) : reg)
+#else
+#   define M68K_RETURN_INREG(val, reg)
+#endif
 
 #if DEBUG
 #   define D(x...)     Indent x
@@ -305,7 +310,13 @@
 #   define ReturnPtr(name,type,val) {  type __aros_val = (type)val; \
 				    ExitFunc kprintf ("Exit " name "=%p\n", \
 				    (APTR)__aros_val); return __aros_val; }
-#   define ReturnStr(name,type,val) { type __aros_val = (type)val; \
+#   define ReturnPtrReg(name,type,val,reg) { \
+        type __aros_val = (type)(val); \
+        ExitFunc kprintf("Exit " name "=%p (" reg ")\n", (APTR)__aros_val); \
+        M68K_RETURN_INREG(__aros_val, reg); \
+        return __aros_val; \
+    }
+#   define ReturnStr(name,type,val) { type __aros_val = (type)val;      \
 				    ExitFunc kprintf ("Exit " name "=\"%s\"\n", \
 				    __aros_val); return __aros_val; }
 #   define ReturnInt(name,type,val) { type __aros_val = (type)val; \
@@ -330,6 +341,11 @@
 
 #   define ReturnVoid(name)                 return
 #   define ReturnPtr(name,type,val)         return val
+#   define ReturnPtrReg(name,type,val,reg) { \
+        type __aros_val = (type)(val); \
+        M68K_RETURN_INREG(__aros_val, reg); \
+        return __aros_val; \
+    }
 #   define ReturnStr(name,type,val)         return val
 #   define ReturnInt(name,type,val)         return val
 #   define ReturnXInt(name,type,val)        return val

--- a/workbench/libs/rexxsyslib/createargstring.c
+++ b/workbench/libs/rexxsyslib/createargstring.c
@@ -68,14 +68,6 @@
     CopyMem(string, ra->ra_Buff, length);
     *(ra->ra_Buff + length) = '\0';
     
-#ifdef __mc68000__
-    // On Amiga, this return value is expected in A0 too.
-    APTR asmarg = ra->ra_Buff;
-    asm volatile("move.l %0, %%a0\n"
-                 :: "r" (asmarg) : "a0");
-    return asmarg;
-#else
-    ReturnPtr("CreateArgString", UBYTE *, ra->ra_Buff);
-#endif
+    ReturnPtrReg("CreateArgString", UBYTE *, ra->ra_Buff, "a0");
     AROS_LIBFUNC_EXIT
 } /* CreateArgstring */

--- a/workbench/libs/rexxsyslib/createrexxmsg.c
+++ b/workbench/libs/rexxsyslib/createrexxmsg.c
@@ -64,13 +64,6 @@
     rm->rm_FileExt = (STRPTR)extension;
     rm->rm_CommAddr = (STRPTR)host;
     
-#ifdef __mc68000__
-    // On Amiga, this return value is expected in A0 too.
-    asm volatile("move.l %0, %%a0\n"
-                 :: "r" (rm) : "a0");
-    return rm;
-#else
-    ReturnPtr("CreateRexxMsg", struct RexxMsg *, rm);
-#endif
+    ReturnPtrReg("CreateRexxMsg", struct RexxMsg *, rm, "a0");
     AROS_LIBFUNC_EXIT
 } /* CreateRexxMsg */


### PR DESCRIPTION
Autodocs say so and I have confirmed the behaviour for CreateArgstring on AmigaOS 3.1.

The return value is copied to A0 for all __mc68000__ targets for a simpler condition.
