### PR TITLE
Fix undeclared definition in ia_bootloader.c when building with grub1

### DIFF
--- a/workbench/tools/InstallAROS/ia_bootloader.c
+++ b/workbench/tools/InstallAROS/ia_bootloader.c
@@ -157,7 +157,7 @@ void BOOTLOADER_InitSupport(void)
                 D(bug("[InstallAROS] %s: bootloader installer found\n", __func__));
 #if defined(INSTALL_BL_GRUB)
 # if defined(GRUB) && (GRUB == 1)
-                if (i == BOOTLOADER_GRUB)
+                if (i == BOOTLOADER_GRUB1)
                     BootLoaderType = i;
 #endif
 #endif


### PR DESCRIPTION
I get the following error building `InstallAROS` in a [Debian Bookworm dockerfile](https://github.com/bitplane/qemount/blob/f694b2c4b8ef2078db7f7234158938635e184043/guests/aros/Dockerfile#L50-L80):

```
ia_bootloader.c: In function 'BOOTLOADER_InitSupport':
ia_bootloader.c:160:26: error: 'BOOTLOADER_GRUB' undeclared (first use in this function)
                 if (i == BOOTLOADER_GRUB)
                          ^~~~~~~~~~~~~~~
```

simple tpyo: a missing character.