### PR TITLE
append full filename to panel statusbar in wanderer

### DIFF
--- a/workbench/system/Wanderer/panel_statusbar.c
+++ b/workbench/system/Wanderer/panel_statusbar.c
@@ -50,6 +50,8 @@
 #include "iconwindow.h"
 #include "iconwindow_attributes.h"
 
+#include "panel_statusbar.h"
+
 extern struct List                     iconwindow_Extensions;
 
 /*** Private Data *********************************************************/
@@ -62,15 +64,6 @@ static struct iconWindow_Extension      panelStatusBar__Extension;
 static struct List                      panelStatusBar__StatusBars;
 static struct NotifyRequest             panelStatusBar__PrefsNotifyRequest;
 static Object                           *panelStatusBar__PrefsNotificationObject;
-
-struct panel_StatusBar_DATA
-{
-    struct Node                         iwp_Node;
-    IPTR                                iwp_Flags;
-    Object                              *iwp_StatusBar_StatusBarObj;
-    Object                              *iwp_StatusBar_StatusTextObj;
-    struct Hook                         iwp_StatusBar_updateHook;
-};
 
 /// From panel_toolbar
 STRPTR ExpandEnvName(CONST_STRPTR env_path);

--- a/workbench/system/Wanderer/panel_statusbar.h
+++ b/workbench/system/Wanderer/panel_statusbar.h
@@ -1,0 +1,12 @@
+#ifndef _PANEL_STATUSBAR_H_
+#define _PANEL_STATUSBAR_H_
+
+struct panel_StatusBar_DATA
+{
+    struct Node                         iwp_Node;
+    IPTR                                iwp_Flags;
+    Object                              *iwp_StatusBar_StatusBarObj;
+    Object                              *iwp_StatusBar_StatusTextObj;
+    struct Hook                         iwp_StatusBar_updateHook;
+};
+#endif


### PR DESCRIPTION
This pull request is to try to fix lack of full filename visibility on wanderer. 

When file/folder name  is longer than 10 characters, it is truncated, and there is no way to see its full name, neither on list view nor on icon view. 

This simple PR is trying to partially fix this issue. 

When a file/folder is clicked on the status bar the string: "Selected: fullfilename" is appended to the already existing one. 

The case covered are only when mouse is clicked: 
* no "selected" string and file is selected  -> nme of selectred file  appended the filename
* "selected" is present and file is selected -> THe current filename  is replaced with the new name
* clicked on an area where there are no files (causing current selections to be cleared) -> Selected string is removed
* Multiple files are being selected (with shift pressed) -> Only the last filename is appended.


This cover only the mouse click events. So far i was unable to find/understand how the slection via keyboard is fired in wanderer (if anyone knows it i can try to extend this code also to the keyboard case). 

This is a screenshot of the output: 
<img width="778" height="319" alt="image" src="https://github.com/user-attachments/assets/06e98970-ff06-47c4-8d26-c40cbebeff7a" />

Another thing is that to be able to access the panel_Statusbar objects, I had to move  the `panel_StatusBar_DATA` struct  outside the `panel_statusbar.c` file and create an header for it (`panel_statusbar.h`) 

I hope this doesn't break any coding rule (or any logic inside the Wanderer Code, but the main problem is that i haven't found another way to access the statusbar from the iconwindov events., if there is a better way please let me kwno. 