### PR TITLE
AHI: Fix assembly sources and build system for LLVM/Clang toolchain compatibility

### DIFF
--- a/workbench/devs/AHI/Drivers/Alsa/ALSA.s
+++ b/workbench/devs/AHI/Drivers/Alsa/ALSA.s
@@ -22,4 +22,4 @@
 
     FORM_END
 
-    .END
+    .end

--- a/workbench/devs/AHI/Drivers/CMI8738/CMI8738.s
+++ b/workbench/devs/AHI/Drivers/CMI8738/CMI8738.s
@@ -63,5 +63,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/Common/MODEFILE.s
+++ b/workbench/devs/AHI/Drivers/Common/MODEFILE.s
@@ -1,53 +1,53 @@
 
-	.MACRO	LONG num
-.ifdef	LITTLE_ENDIAN
+	.macro	LONG num
+#if defined(LITTLE_ENDIAN)
 	.byte	((\num)>>24)&255
 	.byte	((\num)>>16)&255
 	.byte	((\num)>> 8)&255
 	.byte	((\num)>> 0)&255
-.else
+#else
 	.long	\num
-.endif
-	.ENDM
+#endif
+	.endm
 
-	.MACRO	LONG2 num1,num2
-.ifdef	LITTLE_ENDIAN
+	.macro	LONG2 num1,num2
+#if defined(LITTLE_ENDIAN)
 	.byte	((\num1)>>24)&255
 	.byte	((\num1)>>16)&255
 	.byte	((\num1)>> 8)&255
 	.byte	((\num1)>> 0)&255
-	
+
 	.byte	((\num2)>>24)&255
 	.byte	((\num2)>>16)&255
 	.byte	((\num2)>> 8)&255
 	.byte	((\num2)>> 0)&255
-.else
+#else
 	.long	\num1, \num2
-.endif
-	.ENDM
+#endif
+	.endm
 
-	.MACRO	FORM_START name
+	.macro	FORM_START name
 	.ascii	"FORM"
 	LONG	FORMEND-FORMSTART
 FORMSTART:
 	.ascii	"\name"
-	.ENDM
+	.endm
 
-	.MACRO	FORM_END name
+	.macro	FORM_END name
 FORMEND:
 	.balign	2,0
-	.ENDM
+	.endm
 
-	.MACRO	CHUNK_START name
+	.macro	CHUNK_START name
 	.ascii	"\name"
 	LONG	101f-100f
 100:
-	.ENDM
+	.endm
 
-	.MACRO	CHUNK_END
+	.macro	CHUNK_END
 101:
 	.balign	2,0
-	.ENDM
+	.endm
 
 .SET AHI_TagBase,     2147483648
 .SET AHI_TagBaseR,    AHI_TagBase+32768

--- a/workbench/devs/AHI/Drivers/Device/DEVICE.s
+++ b/workbench/devs/AHI/Drivers/Device/DEVICE.s
@@ -63,5 +63,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/EMU10kx/EMU10KX-2.s
+++ b/workbench/devs/AHI/Drivers/EMU10kx/EMU10KX-2.s
@@ -1,29 +1,29 @@
 
 
-	.MACRO	FORM_START name
+	.macro	FORM_START name
 CHUNKCNT	.ASSIGNA 0
 	.ascii	"FORM"
 	.long	FORMEND-FORMSTART
 FORMSTART:
 	.ascii	"\name"
-	.ENDM
+	.endm
 
-	.MACRO	FORM_END name
+	.macro	FORM_END name
 FORMEND:
 	.balign	2
-	.ENDM
+	.endm
 
-	.MACRO	CHUNK_START name
+	.macro	CHUNK_START name
 	.ascii	"\name"
 	.long	CHUNKEND\&CHUNKCNT-CHUNKSTART\&CHUNKCNT
 CHUNKSTART\&CHUNKCNT:
-	.ENDM
+	.endm
 
-	.MACRO	CHUNK_END
+	.macro	CHUNK_END
 CHUNKEND\&CHUNKCNT:
 CHUNKCNT	.ASSIGNA \&CHUNKCNT+1
 	.balign	2
-	.ENDM
+	.endm
 
 AHIDB_AudioID	.EQU	2147483648+100
 AHIDB_Volume	.EQU	2147483648+103

--- a/workbench/devs/AHI/Drivers/EMU10kx/EMU10KX.s
+++ b/workbench/devs/AHI/Drivers/EMU10kx/EMU10KX.s
@@ -78,4 +78,4 @@
 
 	FORM_END
 
-	.END
+	.end

--- a/workbench/devs/AHI/Drivers/Envy24/ENVY24.s
+++ b/workbench/devs/AHI/Drivers/Envy24/ENVY24.s
@@ -63,5 +63,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/Envy24HT/ENVY24HT.s
+++ b/workbench/devs/AHI/Drivers/Envy24HT/ENVY24HT.s
@@ -63,5 +63,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/Filesave/FILESAVE.s
+++ b/workbench/devs/AHI/Drivers/Filesave/FILESAVE.s
@@ -285,5 +285,5 @@
 
 	FORM_END
 	.balign	4,0
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/HDAudio/HDAUDIO.s
+++ b/workbench/devs/AHI/Drivers/HDAudio/HDAUDIO.s
@@ -21,5 +21,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/OSS/OSS.s
+++ b/workbench/devs/AHI/Drivers/OSS/OSS.s
@@ -63,5 +63,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/PulseAudio/PULSEAUDIO.s
+++ b/workbench/devs/AHI/Drivers/PulseAudio/PULSEAUDIO.s
@@ -22,4 +22,4 @@
 
     FORM_END
 
-    .END
+    .end

--- a/workbench/devs/AHI/Drivers/SB128/SB128.s
+++ b/workbench/devs/AHI/Drivers/SB128/SB128.s
@@ -35,5 +35,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/VIA-AC97/VIA-AC97.s
+++ b/workbench/devs/AHI/Drivers/VIA-AC97/VIA-AC97.s
@@ -68,5 +68,5 @@
 		
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/Void/VOID.s
+++ b/workbench/devs/AHI/Drivers/Void/VOID.s
@@ -78,5 +78,5 @@
 
 	FORM_END
 
-	.END
+	.end
 	

--- a/workbench/devs/AHI/Drivers/WASAPI/WASAPI.s
+++ b/workbench/devs/AHI/Drivers/WASAPI/WASAPI.s
@@ -22,4 +22,4 @@
 
     FORM_END
 
-    .END
+    .end

--- a/workbench/devs/AHI/Drivers/ac97/ac97.s
+++ b/workbench/devs/AHI/Drivers/ac97/ac97.s
@@ -22,5 +22,5 @@
 	FORM_END
 
 	.balign	4,0
-	.END
+	.end
 	

--- a/workbench/devs/AHI/configure
+++ b/workbench/devs/AHI/configure
@@ -3311,7 +3311,10 @@ foo:
     nop
 EOF
 
-# Try compiling using the assembler explicitly
+# Try compiling using the assembler explicitly.
+# Also try with $CC since LLVM toolchains set AS=llvm-as (an LLVM IR tool)
+# but actually assemble via clang, which supports -Wa,--defsym forwarding
+# to its integrated assembler.
 if $AS $target_asflags -Wa,--defsym,foo=1 -c conftest.s -o conftest.o >/dev/null 2>&1; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
@@ -3320,6 +3323,19 @@ printf "%s\n" "#define HAVE_AS_DEF_SYM 1" >>confdefs.h
 
   ASFWDOPT="-Wa,"
   ASDEFSYM="${ASFWDOPT}--defsym,"
+elif $CC $target_asflags -Wa,--defsym,foo=1 -x assembler-with-cpp -c conftest.s -o conftest.o >/dev/null 2>&1; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes, via CC" >&5
+printf "%s\n" "yes, via CC" >&6; }
+
+printf "%s\n" "#define HAVE_AS_DEF_SYM 1" >>confdefs.h
+
+  ASFWDOPT="-Wa,"
+  ASDEFSYM="${ASFWDOPT}--defsym,"
+elif $CC $target_asflags -DFOO=1 -x assembler-with-cpp -c conftest.s -o conftest.o >/dev/null 2>&1; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using -D preprocessor defines" >&5
+printf "%s\n" "using -D preprocessor defines" >&6; }
+  ASFWDOPT=""
+  ASDEFSYM="-D"
 else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }

--- a/workbench/devs/AHI/configure.in
+++ b/workbench/devs/AHI/configure.in
@@ -88,12 +88,24 @@ foo:
     nop
 EOF
 
-# Try compiling using the assembler explicitly
+# Try compiling using the assembler explicitly.
+# Also try with $CC since LLVM toolchains set AS=llvm-as (an LLVM IR tool)
+# but actually assemble via clang, which supports -Wa,--defsym forwarding
+# to its integrated assembler.
 if $AS $target_asflags -Wa,--defsym,foo=1 -c conftest.s -o conftest.o >/dev/null 2>&1; then
   AC_MSG_RESULT([yes])
   AC_DEFINE([HAVE_AS_DEF_SYM], [1], [Assembler needs -Wa])
   ASFWDOPT="-Wa,"
   ASDEFSYM="${ASFWDOPT}--defsym,"
+elif $CC $target_asflags -Wa,--defsym,foo=1 -x assembler-with-cpp -c conftest.s -o conftest.o >/dev/null 2>&1; then
+  AC_MSG_RESULT([yes, via CC])
+  AC_DEFINE([HAVE_AS_DEF_SYM], [1], [Assembler needs -Wa])
+  ASFWDOPT="-Wa,"
+  ASDEFSYM="${ASFWDOPT}--defsym,"
+elif $CC $target_asflags -DFOO=1 -x assembler-with-cpp -c conftest.s -o conftest.o >/dev/null 2>&1; then
+  AC_MSG_RESULT([using -D preprocessor defines])
+  ASFWDOPT=""
+  ASDEFSYM="-D"
 else
   AC_MSG_RESULT([no])
   ASDEFSYM="--defsym "


### PR DESCRIPTION
Lowercase GAS directives (.MACRO/.ENDM/.END -> .macro/.endm/.end) across all AHI driver mode files for LLVM integrated assembler compatibility. It is case-sensitive and only recognizes the lowercase forms. Since GNU assembler is case-insensitive for directives, these changes should not cause assembly errors under GNU.

In MODEFILE.s, replace GAS .ifdef/.else/.endif conditionals with #if defined()/#else/#endif preprocessor guards, as LLVM's assembler does not support -Wa,--defsym for conditional assembly in the same way as GNU as.

Update configure/configure.in with fallback detection for LLVM toolchains where AS=llvm-as cannot assemble GAS sources: try $CC (clang) with -x assembler-with-cpp first, then fall back to -D preprocessor defines if -Wa,--defsym is not supported.