### PR TITLE
exec: Fix SMP lock flag checks and missing Permit() in useralert

### DIFF
--- a/rom/exec/exec_locks.c
+++ b/rom/exec/exec_locks.c
@@ -83,9 +83,9 @@ int ExecLock__InternObtainSystemLock(struct List *systemList, ULONG mode, ULONG 
     D(bug("[Exec:Lock] %s(), List='%s' (%p), mode=%s, flags=%d\n", __func__, name, systemList, mode == SPINLOCK_MODE_WRITE ? "write":"read", flags));
     if (sysListLock)
     {
-        if (flags && LOCKF_DISABLE)
+        if (flags & LOCKF_DISABLE)
             Disable();
-        if (flags && LOCKF_FORBID)
+        if (flags & LOCKF_FORBID)
             Forbid();
 
         EXEC_SPINLOCK_LOCK(sysListLock, NULL, mode);
@@ -179,9 +179,9 @@ int ExecLock__ObtainLock(void * lock, ULONG mode, ULONG flags)
 
     if (lock)
     {
-        if (flags && LOCKF_DISABLE)
+        if (flags & LOCKF_DISABLE)
             Disable();
-        if (flags && LOCKF_FORBID)
+        if (flags & LOCKF_FORBID)
             Forbid();
 
         EXEC_SPINLOCK_LOCK(lock, NULL, mode);

--- a/rom/exec/useralert.c
+++ b/rom/exec/useralert.c
@@ -78,7 +78,7 @@ LONG Alert_AskSuspend(struct Task *task, ULONG alertNum, char * buffer, struct E
     /* Look for the library in our list */
     IntuitionBase = (struct IntuitionBase *) FindName (&SysBase->LibList, "intuition.library");
 
-    EXEC_UNLOCK_LIST(&SysBase->LibList);
+    EXEC_UNLOCK_LIST_AND_PERMIT(&SysBase->LibList);
     if (!IntuitionBase)
          return choice;
 


### PR DESCRIPTION
**exec_locks.c**: Use bitwise AND (`&`) instead of logical AND (`&&`) when testing `LOCKF_DISABLE` and `LOCKF_FORBID` flags.

The logical operator treats any non-zero flags value as true, causing every lock operation to unconditionally call both `Disable()` and `Forbid()` regardless of which flags were actually requested.

**useralert.c**: Use `EXEC_UNLOCK_LIST_AND_PERMIT` instead of `EXEC_UNLOCK_LIST`.

The corresponding `EXEC_LOCK_LIST_READ_AND_FORBID` calls `Forbid()` before acquiring the spinlock. Unlike `OpenLibrary()`/`OpenDevice()` (which intentionally keep Forbid active for the subsequent Open call and have a later `Permit()`), `Alert_AskSuspend` returns immediately after the unlock, leaving Forbid permanently active on SMP systems.

Note: `OpenLibrary()` and `OpenDevice()` correctly use `EXEC_UNLOCK_LIST` (without Permit) — their Forbid/Permit nesting is intentional and balanced by the `Permit()` at the end of each function.