### PR TITLE
ARM: LLVM toolchain support

### DIFF
--- a/configure
+++ b/configure
@@ -858,6 +858,8 @@ aros_kernel_cxx
 aros_kernel_cc
 aros_kernel_cpp
 target_llvm_version
+gcc_float_cpu
+gcc_soft_cpu
 HARDVAR
 SOFTVAR
 target_gcc_version
@@ -10624,7 +10626,7 @@ case "$target_os" in
                 android_tool_prefix="arm-linux-androideabi"
                 android_ndk_arch="arm"
                 kernel_tool_prefix="arm-linux-gnueabihf-"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *arm*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -10646,7 +10648,7 @@ case "$target_os" in
                 android_tool_prefix="arm-linux-androideabi"
                 android_ndk_arch="arm"
                 kernel_tool_prefix="arm-linux-gnueabi-"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 as_fn_error $? "\"Unknown CPU for Linux -- $target_cpu\"" "$LINENO" 5
@@ -10890,7 +10892,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
                 aros_kernel_ranlib="ranlib -arch arm"
                 kernel_tool_prefix="arm-apple-darwin10-"
                 export PATH="$aros_xcode_path/Platforms/$aros_ios_platform.platform/Developer/usr/bin:$PATH"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 as_fn_error $? "\"Unsupported target CPU for darwin hosted flavour -- $target_cpu\"" "$LINENO" 5
@@ -11111,7 +11113,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
 
                 target_cpu=arm
                 aros_target_cpu=arm
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *arm*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -11119,7 +11121,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
                 gcc_float_fpu="vfpv3"
                 gcc_soft_fpu=
                 gcc_default_fpu=
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 as_fn_error $? "\"Unknown CPU for EfikaMX $target_cpu\"" "$LINENO" 5
@@ -11159,6 +11161,13 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
 
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__"
 
+        aros_kernel_toolchain=$aros_toolchain
+        kernel_toolchain_c_compiler=$toolchain_c_compiler
+        kernel_toolchain_cxx_compiler=$toolchain_cxx_compiler
+        if test "$aros_kernel_toolchain" = "llvm"; then
+            aros_kernel_llvmwrapper=yes
+        fi
+
         case "$target_cpu" in
             *aarch64*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -11171,10 +11180,6 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
                 ;;
             *armhf*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
-                # we intentionaly leave
-                # gcc_default_cpu empty here
-                # so the correct value is loaded
-                # later.
                 if test "$aros_object_format" = "" ; then
                     aros_object_format="armelf_aros"
                 fi
@@ -11184,7 +11189,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
                 gcc_float_fpu="vfpv3-d16"
                 gcc_soft_fpu=$gcc_float_fpu
                 gcc_default_fpu="$""(GCC_FLOAT_FPU)"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
 
                 aros_isa_flags="$""(ISA_ARM_FLAGS)"
                 aros_config_cflags="$aros_config_cflags"
@@ -11208,7 +11213,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
                 gcc_float_fpu="vfpv3-d16"
                 gcc_soft_fpu=""
                 gcc_default_fpu=
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
 
                 aros_isa_flags="$""(ISA_ARM_FLAGS)"
                 aros_config_cflags="$aros_config_cflags"
@@ -11280,7 +11285,7 @@ printf "%s\n" "$darwin_sdk_path" >&6; }
         gcc_float_fpu="fpv5-sp-d16"
         gcc_soft_fpu=$gcc_float_fpu
         gcc_default_fpu="$""(GCC_FLOAT_FPU)"
-        llvm_target_cpu="Arm"
+        llvm_target_cpu="ARM"
 
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__ -Dthumb"
         ;;
@@ -11501,7 +11506,7 @@ fi
                 kernel_tool_prefix="arm-mingw32ce-"
                 aros_nominal_width=160
                 aros_nominal_height=160
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 as_fn_error $? "\"Unknown CPU for Mingw32 -- $target_cpu\"" "$LINENO" 5
@@ -12253,6 +12258,21 @@ printf "%s\n" "release" >&6; }
             x86_isa_extra="$x86_isa_extra $""(CFLAGS_NO_MS_BITFIELDS)"
             x86_64_isa_extra="$x86_64_isa_extra $""(CFLAGS_NO_MS_BITFIELDS)"
         fi
+        ;;
+    esac
+elif test "$aros_toolchain" = "llvm" ; then
+    case "$aros_target_cpu" in
+    *arm*)
+        # clang accepts the modern <arm arch><features> form (armv7-a+fp/+nofp)
+        if test "$gcc_default_cpu" = ""; then
+            default_arm_cpu=armv7-a
+        else
+            default_arm_cpu=$gcc_default_cpu
+        fi
+        gcc_soft_cpu="$default_arm_cpu+nofp"
+        gcc_float_cpu="$default_arm_cpu+fp"
+
+
         ;;
     esac
 fi

--- a/configure.in
+++ b/configure.in
@@ -1492,7 +1492,7 @@ case "$target_os" in
                 android_tool_prefix="arm-linux-androideabi"
                 android_ndk_arch="arm"
                 kernel_tool_prefix="arm-linux-gnueabihf-"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *arm*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -1514,7 +1514,7 @@ case "$target_os" in
                 android_tool_prefix="arm-linux-androideabi"
                 android_ndk_arch="arm"
                 kernel_tool_prefix="arm-linux-gnueabi-"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 AC_MSG_ERROR("Unknown CPU for Linux -- $target_cpu")
@@ -1764,7 +1764,7 @@ case "$target_os" in
                 aros_kernel_ranlib="ranlib -arch arm"
                 kernel_tool_prefix="arm-apple-darwin10-"
                 export PATH="$aros_xcode_path/Platforms/$aros_ios_platform.platform/Developer/usr/bin:$PATH"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 AC_MSG_ERROR("Unsupported target CPU for darwin hosted flavour -- $target_cpu")
@@ -1985,7 +1985,7 @@ case "$target_os" in
 
                 target_cpu=arm
                 aros_target_cpu=arm
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *arm*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -1993,7 +1993,7 @@ case "$target_os" in
                 gcc_float_fpu="vfpv3"
                 gcc_soft_fpu=
                 gcc_default_fpu=
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 AC_MSG_ERROR("Unknown CPU for EfikaMX $target_cpu")
@@ -2033,6 +2033,13 @@ case "$target_os" in
 
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__"
 
+        aros_kernel_toolchain=$aros_toolchain
+        kernel_toolchain_c_compiler=$toolchain_c_compiler
+        kernel_toolchain_cxx_compiler=$toolchain_cxx_compiler
+        if test "$aros_kernel_toolchain" = "llvm"; then
+            aros_kernel_llvmwrapper=yes
+        fi
+
         case "$target_cpu" in
             *aarch64*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
@@ -2045,10 +2052,6 @@ case "$target_os" in
                 ;;
             *armhf*)
                 PLATFORM_EXECSMP="#define __AROSPLATFORM_SMP__"
-                # we intentionaly leave
-                # gcc_default_cpu empty here
-                # so the correct value is loaded
-                # later.
                 if test "$aros_object_format" = "" ; then
                     aros_object_format="armelf_aros"
                 fi
@@ -2058,7 +2061,7 @@ case "$target_os" in
                 gcc_float_fpu="vfpv3-d16"
                 gcc_soft_fpu=$gcc_float_fpu
                 gcc_default_fpu="$""(GCC_FLOAT_FPU)"
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
 
                 aros_isa_flags="$""(ISA_ARM_FLAGS)"
                 aros_config_cflags="$aros_config_cflags"
@@ -2082,7 +2085,7 @@ case "$target_os" in
                 gcc_float_fpu="vfpv3-d16"
                 gcc_soft_fpu=""
                 gcc_default_fpu=
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
 
                 aros_isa_flags="$""(ISA_ARM_FLAGS)"
                 aros_config_cflags="$aros_config_cflags"
@@ -2154,7 +2157,7 @@ case "$target_os" in
         gcc_float_fpu="fpv5-sp-d16"
         gcc_soft_fpu=$gcc_float_fpu
         gcc_default_fpu="$""(GCC_FLOAT_FPU)"
-        llvm_target_cpu="Arm"
+        llvm_target_cpu="ARM"
 
         aros_target_mkdep="$aros_target_mkdep -D__GNUC__ -Dthumb"
         ;;
@@ -2260,7 +2263,7 @@ case "$target_os" in
                 kernel_tool_prefix="arm-mingw32ce-"
                 aros_nominal_width=160
                 aros_nominal_height=160
-                llvm_target_cpu="Arm"
+                llvm_target_cpu="ARM"
                 ;;
             *)
                 AC_MSG_ERROR("Unknown CPU for Mingw32 -- $target_cpu")
@@ -2600,6 +2603,21 @@ if test "$aros_toolchain" = "gnu" ; then
             x86_isa_extra="$x86_isa_extra $""(CFLAGS_NO_MS_BITFIELDS)"
             x86_64_isa_extra="$x86_64_isa_extra $""(CFLAGS_NO_MS_BITFIELDS)"
         fi
+        ;;
+    esac
+elif test "$aros_toolchain" = "llvm" ; then
+    case "$aros_target_cpu" in
+    *arm*)
+        # clang accepts the modern <arm arch><features> form (armv7-a+fp/+nofp)
+        if test "$gcc_default_cpu" = ""; then
+            default_arm_cpu=armv7-a
+        else
+            default_arm_cpu=$gcc_default_cpu
+        fi
+        gcc_soft_cpu="$default_arm_cpu+nofp"
+        gcc_float_cpu="$default_arm_cpu+fp"
+        AC_SUBST([gcc_soft_cpu])
+        AC_SUBST([gcc_float_cpu])
         ;;
     esac
 fi

--- a/scripts/aros-clang++.in
+++ b/scripts/aros-clang++.in
@@ -1,2 +1,11 @@
 #!/bin/sh
-exec @orig_target_cxx@ @orig_target_cxx_flags@ "$@" -static
+
+# Clang++ ELF wrapper for kernel compilation — equivalent of elf-specs for GCC.
+# Calls the AROS-targeted compiler with predefines and include paths that
+# GCC would get from -specs=elf-specs.
+
+exec @orig_target_cxx@ @orig_target_cxx_flags@ \
+    -D__ELF__ \
+    -isystem @AROS_BUILDDIR@/bin/@aros_target_arch@-@aros_target_cpu@@aros_target_suffix@/AROS/Developer/include/aros/stdc \
+    -isystem @AROS_BUILDDIR@/bin/@aros_target_arch@-@aros_target_cpu@@aros_target_suffix@/AROS/Developer/include \
+    "$@" -static

--- a/scripts/aros-clang.in
+++ b/scripts/aros-clang.in
@@ -1,2 +1,11 @@
 #!/bin/sh
-exec @orig_target_cc@ @orig_target_c_flags@ "$@" -static
+
+# Clang ELF wrapper for kernel compilation — equivalent of elf-specs for GCC.
+# Calls the AROS-targeted compiler with predefines and include paths that
+# GCC would get from -specs=elf-specs.
+
+exec @orig_target_cc@ @orig_target_c_flags@ \
+    -D__ELF__ \
+    -isystem @AROS_BUILDDIR@/bin/@aros_target_arch@-@aros_target_cpu@@aros_target_suffix@/AROS/Developer/include/aros/stdc \
+    -isystem @AROS_BUILDDIR@/bin/@aros_target_arch@-@aros_target_cpu@@aros_target_suffix@/AROS/Developer/include \
+    "$@" -static

--- a/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
+++ b/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
@@ -124,13 +124,13 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic
      case llvm::Triple::FreeBSD:
 @@ -180,6 +185,11 @@
        return new DarwinARMTargetInfo(Triple, Opts);
- 
+
      switch (os) {
 +    //  FIXME:
-+    //  Needs to be tested before inclusion!!!
++    //  Needs to be tested!!!
 +    //  New Target AROS ARMle
-+    //  case llvm::Triple::AROS:
-+    //    return new AROSTargetInfo<ARMleTargetInfo>(Triple, Opts);
++    case llvm::Triple::AROS:
++      return new AROSTargetInfo<ARMleTargetInfo>(Triple, Opts);
      case llvm::Triple::CloudABI:
        return new CloudABITargetInfo<ARMleTargetInfo>(Triple, Opts);
      case llvm::Triple::Linux:

--- a/tools/crosstools/llvm/libcxx-11.0.0.src-aros.diff
+++ b/tools/crosstools/llvm/libcxx-11.0.0.src-aros.diff
@@ -1,3 +1,60 @@
+diff -ruN libcxx-11.0.0.src/include/__config libcxx-11.0.0.src.aros/include/__config
+--- libcxx-11.0.0.src/include/__config	2020-10-07 10:10:48.000000000 +0000
++++ libcxx-11.0.0.src.aros/include/__config	2026-03-11 12:00:00.000000000 +0000
+@@ -1230,7 +1230,8 @@
+ #endif
+
+ #if defined(__BIONIC__) || defined(__CloudABI__) ||                            \
+-    defined(__Fuchsia__) || defined(__wasi__) || defined(_LIBCPP_HAS_MUSL_LIBC)
++    defined(__Fuchsia__) || defined(__wasi__) || defined(_LIBCPP_HAS_MUSL_LIBC) || \
++    defined(__AROS__)
+ #define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
+ #endif
+
+diff -ruN libcxx-11.0.0.src/include/typeinfo libcxx-11.0.0.src.aros/include/typeinfo
+--- libcxx-11.0.0.src/include/typeinfo	2020-10-07 10:10:48.000000000 +0000
++++ libcxx-11.0.0.src.aros/include/typeinfo	2026-02-27 12:00:00.000000000 +0000
+@@ -222,7 +222,7 @@
+     _LIBCPP_INLINE_VISIBILITY _LIBCPP_ALWAYS_INLINE
+     static size_t __hash(__type_name_t __v) _NOEXCEPT {
+       if (__is_type_name_unique(__v))
+-        return reinterpret_cast<size_t>(__v);
++        return static_cast<size_t>(__v);
+       return __non_unique_impl::__hash(__type_name_to_string(__v));
+     }
+   };
+diff -ruN libcxx-11.0.0.src/include/atomic libcxx-11.0.0.src.aros/include/atomic
+--- libcxx-11.0.0.src/include/atomic	2020-10-07 10:10:48.000000000 +0000
++++ libcxx-11.0.0.src.aros/include/atomic	2026-04-07 12:00:00.000000000 +0000
+@@ -2774,10 +2774,11 @@
+ typedef conditional<_LIBCPP_CONTENTION_LOCK_FREE, __cxx_contention_t, char>::type               __libcpp_signed_lock_free;
+ typedef conditional<_LIBCPP_CONTENTION_LOCK_FREE, __cxx_contention_t, unsigned char>::type      __libcpp_unsigned_lock_free;
+ #else
+-    // No signed/unsigned lock-free types
++typedef __cxx_contention_t __libcpp_signed_lock_free;
++typedef typename make_unsigned<__cxx_contention_t>::type __libcpp_unsigned_lock_free;
+ #endif
+ 
+ typedef atomic<__libcpp_signed_lock_free> atomic_signed_lock_free;
+ typedef atomic<__libcpp_unsigned_lock_free> atomic_unsigned_lock_free;
+ 
+ #define ATOMIC_FLAG_INIT {false}
+diff -ruN libcxx-11.0.0.src/cmake/config-ix.cmake libcxx-11.0.0.src.aros/cmake/config-ix.cmake
+--- libcxx-11.0.0.src/cmake/config-ix.cmake	2020-10-07 10:10:48.000000000 +0000
++++ libcxx-11.0.0.src.aros/cmake/config-ix.cmake	2026-04-07 12:00:00.000000000 +0000
+@@ -96,6 +96,12 @@
+   set(LIBCXX_HAS_RT_LIB NO)
+   set(LIBCXX_HAS_SYSTEM_LIB NO)
+   check_library_exists(atomic __atomic_fetch_add_8 "" LIBCXX_HAS_ATOMIC_LIB)
++elseif(AROS)
++  check_library_exists(pthread pthread_create "" LIBCXX_HAS_PTHREAD_LIB)
++  check_library_exists(m ccos "" LIBCXX_HAS_M_LIB)
++  set(LIBCXX_HAS_RT_LIB NO)
++  set(LIBCXX_HAS_SYSTEM_LIB NO)
++  set(LIBCXX_HAS_ATOMIC_LIB NO)
+ else()
+   check_library_exists(pthread pthread_create "" LIBCXX_HAS_PTHREAD_LIB)
+   check_library_exists(m ccos "" LIBCXX_HAS_M_LIB)
 diff -ruN libcxx-11.0.0.src/src/filesystem/filesystem_common.h libcxx-11.0.0.src.aros/src/filesystem/filesystem_common.h
 --- libcxx-11.0.0.src/src/filesystem/filesystem_common.h	2020-10-07 10:10:48.000000000 +0000
 +++ libcxx-11.0.0.src.aros/src/filesystem/filesystem_common.h	2025-07-09 01:12:21.008427636 +0000

--- a/tools/crosstools/llvm/lld-11.0.0.src-aros.diff
+++ b/tools/crosstools/llvm/lld-11.0.0.src-aros.diff
@@ -1,0 +1,17 @@
+diff -ruN lld-11.0.0.src/ELF/Driver.cpp lld-11.0.0.src.aros/ELF/Driver.cpp
+--- lld-11.0.0.src/ELF/Driver.cpp	2020-10-07 12:10:00.000000000 +0000
++++ lld-11.0.0.src.aros/ELF/Driver.cpp	2026-04-09 12:00:00.000000000 +0000
+@@ -135,9 +135,11 @@
+
+   std::pair<ELFKind, uint16_t> ret =
+       StringSwitch<std::pair<ELFKind, uint16_t>>(s)
+           .Cases("aarch64elf", "aarch64linux", "aarch64_elf64_le_vec",
+-                 {ELF64LEKind, EM_AARCH64})
+-          .Cases("armelf", "armelf_linux_eabi", {ELF32LEKind, EM_ARM})
++                 "aarch64elf_aros", {ELF64LEKind, EM_AARCH64})
++          .Cases("armelf", "armelf_linux_eabi", "armelf_aros",
++                 {ELF32LEKind, EM_ARM})
++          .Case("armelfb_aros", {ELF32BEKind, EM_ARM})
+           .Case("elf32_x86_64", {ELF32LEKind, EM_X86_64})
+           .Cases("elf32btsmip", "elf32btsmipn32", {ELF32BEKind, EM_MIPS})
+           .Cases("elf32ltsmip", "elf32ltsmipn32", {ELF32LEKind, EM_MIPS})

--- a/tools/crosstools/llvm/mmakefile.src
+++ b/tools/crosstools/llvm/mmakefile.src
@@ -44,7 +44,7 @@ $(eval -include $(SRCDIR)/tools/crosstools/$(AROS_TOOLCHAIN).cfg)
 #MM- crosstools-libunwind-quick : crosstools-libunwind-setup tools-crosstools-llvm-toolchain-quick
 
 #MM- crosstools-llvm : \
-#MM           tools-crosstools-llvm-toolchain crosstools-compiler-rt \
+#MM           tools-crosstools-llvm-toolchain crosstools-compiler-rt-fixup \
 #MM           crosstools-libunwind tools-crosstools-llvm-libcxx tools-crosstools-llvm-libcxxabi
 #MM- crosstools-llvm-quick : \
 #MM           tools-crosstools-llvm-toolchain-quick \
@@ -197,7 +197,7 @@ LLVM_CMAKEOPTIONS       +=-DLLVM_EXTERNAL_CLANG_SOURCE_DIR="$(CLANG_BUILDBASE)"
 
 LLVM_INSTALLCMD         :=$(MAKE) -j1 install/strip
 
-LLVM_TARGET_FLAGS       :=--target=$(AROS_TARGET_CPU)-unknown-aros
+LLVM_TARGET_FLAGS       :=--target=$(AROS_TARGET_CPU)-unknown-aros $(ISA_FLAGS)
 
 LLVM_CXX_CFLAGS         :=$(LLVM_TARGET_FLAGS) -fno-PIC -fno-pic -fno-PIE -fno-pie -fno-plt
 LLVM_CXX_CXXFLAGS       :=$(LLVM_CXX_CFLAGS) -nostdinc++ $(NOWARN_MISSING_FIELD_INITIALIZERS)
@@ -350,14 +350,18 @@ LLVM_COMPILER_RT_CMAKEBASE :=                                                   
   -DCOMPILER_RT_BUILD_LIBFUZZER=OFF                                                                                                     \
   -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON                                                                                                  \
   -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON                                                                                                 \
+  -DCOMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=OFF                                                                                              \
   -DBUILD_SHARED_LIBS=OFF                                                                                                               \
-  -DAROS_BUILD=ON
+  -DAROS_BUILD=ON \
+  -DCOMPILER_RT_LIBRARY_INSTALL_DIR="lib/clang/$(LLVM_VERSION)/lib/aros" \
+  -DCOMPILER_RT_LIBRARY_OUTPUT_DIR="$(CROSSTOOLSDIR)/lib/clang/$(LLVM_VERSION)/lib/aros"
 
 LLVM_COMPILER_RT_CMAKEOPTIONS :=                                                                                                        \
   $(LLVM_COMPILER_RT_CMAKEBASE)                                                                                                         \
   -DCMAKE_C_COMPILER_TARGET=$(AROS_TARGET_CPU)-unknown-aros                                                                             \
   -DCMAKE_C_FLAGS="$(LLVM_TARGET_FLAGS)"                                                                                                \
   -DCMAKE_CXX_FLAGS="$(LLVM_TARGET_FLAGS)"                                                                                              \
+  -DCMAKE_ASM_FLAGS="$(LLVM_TARGET_FLAGS)"                                                                                              \
   -DCMAKE_EXE_LINKER_FLAGS="-nodefaultlibs -nostartfiles $(AROS_LIB)/startup.o -L$(AROS_LIB) -lexec -larossupport -lamiga -lautoinit -Wl,--allow-multiple-definition" \
   -DLLVM_TARGETS_TO_BUILD=$(LLVM_TARGETS)
 
@@ -366,6 +370,17 @@ LLVM_COMPILER_RT_CMAKEOPTIONS :=                                                
 %build_with_cmake mmake=crosstools-compiler-rt package=compiler-rt srcdir=$(COMPILER_RT_BUILDBASE)                                      \
     prefix="$(CROSSTOOLSDIR)" maketarget=$(LLVM_CMAKETARGET) cmakeinstallcmd="$(LLVM_INSTALLCMD)"                                       \
     extraoptions="$(LLVM_COMPILER_RT_CMAKEOPTIONS)" compiler=host usecppflags=no
+
+# Clang's driver looks for libclang_rt.builtins-armhf.a on hard-float targets,
+# but compiler-rt builds it as builtins-arm.a. Create a symlink.
+COMPILER_RT_CLANG_LIBDIR := $(CROSSTOOLSDIR)/lib/clang/$(LLVM_VERSION)/lib/aros
+
+#MM crosstools-compiler-rt-fixup : crosstools-compiler-rt
+crosstools-compiler-rt-fixup :
+	$(Q)$(IF) $(TEST) -f $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-arm.a -a \
+	    ! -e $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-armhf.a ; then \
+	    $(LN) -sf libclang_rt.builtins-arm.a $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-armhf.a ; \
+	fi
 
 ifneq ($(AROS_TARGET_CPU32),)
 LLVM_COMPILER_RT32_CMAKEOPTIONS :=                                                                                                      \
@@ -434,7 +449,8 @@ endif
 
 %fetch mmake=crosstools-llvm-lld-fetch archive=$(LLVMLLD_ARCHBASE)                                                                      \
     archive_origins=$(LLVM_REPOSITORY) suffixes="tar.xz"                                                                                \
-    location=$(PORTSSOURCEDIR) destination=$(HOSTDIR)/Ports/host/llvm-lld
+    location=$(PORTSSOURCEDIR) destination=$(HOSTDIR)/Ports/host/llvm-lld                                                              \
+    patches_specs=$(LLVMLLD_ARCHBASE)-aros.diff:$(LLVMLLD_ARCHBASE):-p1
 
 %create_patch mmake=crosstools-llvm-lld-create-patch                                                                                    \
     archive=$(LLVMLLD_ARCHBASE) suffixes="tar.xz"                                                                                       \


### PR DESCRIPTION
Build-infrastructure changes for the LLVM/clang cross-toolchain:

- crosstools/llvm: pass $(ISA_FLAGS) to compiler-rt C/asm flags; install builtins under lib/clang/<ver>/lib/aros; build atomic.c (COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=OFF) so __atomic_*/__sync_* resolve; add a -fixup target symlinking builtins-armhf.a to builtins-arm.a; wire an AROS lld patch via patches_specs; enable AROSTargetInfo<ARMleTargetInfo> in the clang patch and extend the libcxx patch (rune table, typeinfo cast, atomic lock-free typedefs, cmake/config-ix AROS branch).
- scripts/aros-clang(++).in: add -D__ELF__ and AROS isystem paths.
- configure: fix LLVM target name capitalization (Arm -> ARM); extend the ARM CPU fallback to the LLVM toolchain; enable aros_kernel_llvmwrapper for raspi when toolchain is llvm.