### PR TITLE
rom/exec: missing includes and rvalue-safe SCHEDELAPSED

### DIFF
--- a/rom/exec/intserver_vblank.c
+++ b/rom/exec/intserver_vblank.c
@@ -22,10 +22,16 @@ AROS_INTH3(VBlankServer, struct List *, intList, intMask, custom)
     D(bug("[Exec] %s()\n", __func__));
 
     /* Check if it is time for the running task to be switched away */
-    if (!SCHEDELAPSED_GET || (--SCHEDELAPSED_GET == 0))
     {
-        FLAG_SCHEDQUANTUM_SET;
-        FLAG_SCHEDSWITCH_SET;
+        UWORD current = SCHEDELAPSED_GET;
+        if (current)
+            SCHEDELAPSED_SET(--current);
+
+        if (current == 0)
+        {
+            FLAG_SCHEDQUANTUM_SET;
+            FLAG_SCHEDSWITCH_SET;
+        }
     }
 
     /* Chain to the generic routine */

--- a/rom/exec/service.c
+++ b/rom/exec/service.c
@@ -10,6 +10,7 @@
 #include <aros/libcall.h>
 #include <proto/exec.h>
 
+#include "etask.h"
 #include "exec_intern.h"
 #include "exec_util.h"
 #include "exec_debug.h"

--- a/rom/exec/signal.c
+++ b/rom/exec/signal.c
@@ -15,8 +15,10 @@
 #include "exec_intern.h"
 
 #if defined(__AROSEXEC_SMP__)
+#include <aros/atomic.h>
 #include <utility/hooks.h>
 
+#include "etask.h"
 #include "kernel_ipi.h"
 
 AROS_UFH3(IPTR, signal_hook,

--- a/rom/exec/wait.c
+++ b/rom/exec/wait.c
@@ -7,6 +7,7 @@
 #define DEBUG 0
 #include <aros/debug.h>
 
+#include <aros/atomic.h>
 #include <exec/execbase.h>
 #include <aros/libcall.h>
 #include <proto/exec.h>


### PR DESCRIPTION
- signal.c, service.c: include "etask.h" — both used IntETask / GetIntETask without it; clang treats IntETask as int-returning and '->iet_CpuAffinity' fails to compile.
- wait.c: include <aros/atomic.h> for __AROS_ATOMIC_AND_L (was silently falling through to an undefined link symbol).
- intserver_vblank.c: replace '--SCHEDELAPSED_GET' with read-local-then-SET (matches arch/all-pc; works for both lvalue and rvalue SCHEDELAPSED_GET implementations).