### PR TITLE
ARM: clang/lld code compatibility

### DIFF
--- a/arch/arm-all/include/aros-armeb/cpu-thumb2.h
+++ b/arch/arm-all/include/aros-armeb/cpu-thumb2.h
@@ -74,7 +74,9 @@ typedef	unsigned int	cpumask_t;
 #define AROS_SIG_ATOMIC_MIN     (-0x7fffffff-1)
 #define AROS_SIG_ATOMIC_MAX     0x7fffffff
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#define AROS_GET_SP ({ unsigned char *__sp; __asm__ __volatile__("mov %0, sp" : "=r"(__sp)); __sp; })
+#else
 register unsigned char* AROS_GET_SP __asm__("%sp");
 #endif
 
@@ -126,7 +128,7 @@ struct JumpVec
 #define AROS_ALIGN(x)        (((x)+AROS_WORSTALIGN-1)&-AROS_WORSTALIGN)
 
 /* Prototypes */
-extern void _aros_not_implemented ();
+extern void _aros_not_implemented (char *);
 extern void aros_not_implemented ();
 
 /* How much stack do we need ? Lots :-) */

--- a/arch/arm-all/include/aros-armeb/cpu.h
+++ b/arch/arm-all/include/aros-armeb/cpu.h
@@ -75,7 +75,9 @@ typedef	unsigned int	cpumask_t;
 #define AROS_SIG_ATOMIC_MIN     (-0x7fffffff-1)
 #define AROS_SIG_ATOMIC_MAX     0x7fffffff
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#define AROS_GET_SP ({ unsigned char *__sp; __asm__ __volatile__("mov %0, sp" : "=r"(__sp)); __sp; })
+#else
 register unsigned char* AROS_GET_SP __asm__("%sp");
 #endif
 
@@ -127,7 +129,7 @@ struct JumpVec
 #define AROS_ALIGN(x)        (((x)+AROS_WORSTALIGN-1)&-AROS_WORSTALIGN)
 
 /* Prototypes */
-extern void _aros_not_implemented ();
+extern void _aros_not_implemented (char *);
 extern void aros_not_implemented ();
 
 /* How much stack do we need ? Lots :-) */

--- a/arch/arm-all/include/aros-armel/cpu-thumb2.h
+++ b/arch/arm-all/include/aros-armel/cpu-thumb2.h
@@ -2,7 +2,7 @@
 #define AROS_ARM_CPU_H
 
 /*
-    Copyright © 2016, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 2016, The AROS Development Team. All rights reserved.
     $Id$
 
     NOTE: This file must compile *without* any other header !
@@ -74,7 +74,9 @@ typedef	unsigned int	cpumask_t;
 #define AROS_SIG_ATOMIC_MIN     (-0x7fffffff-1)
 #define AROS_SIG_ATOMIC_MAX     0x7fffffff
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#define AROS_GET_SP ({ unsigned char *__sp; __asm__ __volatile__("mov %0, sp" : "=r"(__sp)); __sp; })
+#else
 register unsigned char* AROS_GET_SP __asm__("%sp");
 #endif
 
@@ -126,7 +128,7 @@ struct JumpVec
 #define AROS_ALIGN(x)        (((x)+AROS_WORSTALIGN-1)&-AROS_WORSTALIGN)
 
 /* Prototypes */
-extern void _aros_not_implemented ();
+extern void _aros_not_implemented (char *);
 extern void aros_not_implemented ();
 
 /* How much stack do we need ? Lots :-) */

--- a/arch/arm-all/include/aros-armel/cpu.h
+++ b/arch/arm-all/include/aros-armel/cpu.h
@@ -75,7 +75,9 @@ typedef	unsigned int	cpumask_t;
 #define AROS_SIG_ATOMIC_MIN     (-0x7fffffff-1)
 #define AROS_SIG_ATOMIC_MAX     0x7fffffff
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#define AROS_GET_SP ({ unsigned char *__sp; __asm__ __volatile__("mov %0, sp" : "=r"(__sp)); __sp; })
+#else
 register unsigned char* AROS_GET_SP __asm__("%sp");
 #endif
 
@@ -127,7 +129,7 @@ struct JumpVec
 #define AROS_ALIGN(x)        (((x)+AROS_WORSTALIGN-1)&-AROS_WORSTALIGN)
 
 /* Prototypes */
-extern void _aros_not_implemented ();
+extern void _aros_not_implemented (char *);
 extern void aros_not_implemented ();
 
 /* How much stack do we need ? Lots :-) */

--- a/arch/arm-native/kernel/kernel_cpu.c
+++ b/arch/arm-native/kernel/kernel_cpu.c
@@ -41,7 +41,7 @@ asm(
 "       .globl mpcore_trampoline                \n"
 "       .type mpcore_trampoline,%function       \n"
 "mpcore_trampoline:                             \n"
-"               mrs     r4, cpsr_all            \n" /* Check if in hypervisor mode */
+"               mrs     r4, cpsr                \n" /* Check if in hypervisor mode */
 "               and     r4, r4, #0x1f           \n" /* In that case try to leave it */
 "               mov     r8, #0x1a               \n"
 "               cmp     r4, r8                  \n"
@@ -86,7 +86,7 @@ asm(
 "leave_hyper:                                   \n" /* Escape hypervisor mode forever */
 "               adr     r4, mpcore_continue_boot\n"
 "               .byte   0x04,0xf3,0x2e,0xe1     \n" /* msr     ELR_hyp, r4             */
-"               mrs     r4, cpsr_all            \n"
+"               mrs     r4, cpsr                \n"
 "               and     r4, r4, #0x1f           \n"
 "               orr     r4, r4, #0x13           \n"
 "               .byte   0x04,0xf3,0x6e,0xe1     \n" /* msr     SPSR_hyp, r4            */

--- a/arch/arm-native/kernel/mmakefile.src
+++ b/arch/arm-native/kernel/mmakefile.src
@@ -75,7 +75,7 @@ kernel-raspi-armeb-quick: $(OSGENDIR)/boot/core.elf
 $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_library.o  $(KOBJSDIR)/task_resource.o
 		@$(ECHO) "Creating   $@"
 		%mkdirs_q $(OSGENDIR)/boot
-		@$(TARGET_LD) -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static -laeabi
+		@$(TARGET_LD) -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static $(TARGET_C_LIBS)
 		@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $@
 
 #MM kernel-kernel-raspi-arm : includes

--- a/arch/arm-native/kernel/spinlock.c
+++ b/arch/arm-native/kernel/spinlock.c
@@ -40,11 +40,12 @@ AROS_LH3(spinlock_t *, KrnSpinLock,
     else
     {
         asm volatile(
+                ".syntax unified                \n\t"   // GCC/binutils default in inline asm is divided; clang requires unified
                 "1:     ldrex   %0, [%2]        \n\t"   // Load the lock value, gaining exclusive access
                 "       adds    %0, %0, #1      \n\t"   // Increase the lock value and update conditional bits
                 "       wfemi                   \n\t"   // Wait for event if lock value is negative
                 "       strexpl %1, %0, [%2]    \n\t"   // Try to exclusively write the lock value to memory if positive
-                "       rsbpls  %0, %1, #0      \n\t"   // Reverse substract and update conditionals:
+                "       rsbspl  %0, %1, #0      \n\t"   // Reverse substract and update conditionals:
                                                         // - if strex write was successful, %0 contains 0. #0 - %0 clears N flag.
                                                         // - If write failed %0 contains 1. #0 - %0 sets N flag (value 0xffffffff).
                 "       bmi     1b              \n\t"   // Try again if N flag is set (because of lock value, or write failure)

--- a/arch/arm-raspi/boot/boot.c
+++ b/arch/arm-raspi/boot/boot.c
@@ -46,7 +46,7 @@ asm("   .section .aros.startup      \n"
 "       .globl bootstrap            \n"
 "       .type bootstrap,%function   \n"
 "bootstrap:                         \n"
-"       mrs     r4, cpsr_all        \n" /* Check if in hypervisor mode */
+"       mrs     r4, cpsr            \n" /* Check if in hypervisor mode */
 "       and     r4, r4, #0x1f       \n"
 "       mov     r8, #0x1a           \n"
 "       cmp     r4, r8              \n"
@@ -56,20 +56,21 @@ asm("   .section .aros.startup      \n"
 #if AROS_BIG_ENDIAN
 "       setend  be                  \n" /* Switch to big endian mode */
 #endif
-"       ldr     sp, tmp_stack_ptr   \n"
+"       mov     sp, #0x1000         \n"
+"       sub     sp, sp, #16         \n"
 "       mrc     p15,0,r4,c1,c0,2    \n" /* Enable signle and double VFP coprocessors */
 "       orr     r4, r4, #0x00f00000 \n" /* This is necessary since gcc might want to use vfp registers  */
 "       mcr     p15,0,r4,c1,c0,2    \n" /* Either as cache for general purpose regs or e.g. for division. This is the case with gcc9 */
 "       mov     r4,#0x40000000      \n"
 "       fmxr    fpexc,r4            \n" /* Enable VFP now */
-"       b       boot                \n"
+"       ldr     pc, =boot           \n"
 "leave_hyper:                       \n"
 #if AROS_BIG_ENDIAN
 "       setend  be                  \n"
 #endif
 "       adr     r4, continue_boot   \n"
 "       .byte   0x04,0xf3,0x2e,0xe1 \n" /* msr     ELR_hyp, r4  */
-"       mrs     r4, cpsr_all        \n"
+"       mrs     r4, cpsr            \n"
 "       and     r4, r4, #0x1f       \n"
 "       orr     r4, r4, #0x13       \n"
 "       .byte   0x04,0xf3,0x6e,0xe1 \n" /* msr     SPSR_hyp, r4 */

--- a/arch/arm-raspi/boot/ldscript-le.lds
+++ b/arch/arm-raspi/boot/ldscript-le.lds
@@ -1,6 +1,6 @@
 SECTIONS
 {
-    . = 0x8000;
+    . = 0x10000;
 
     __bootstrap_start = . ;
 

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 TARGETDIR       := $(GENDIR)/$(CURDIR)
 FILES           := boot mmu kprintf support vc_mb serialdebug elf devicetree \
                    bc/vars bc/font8x14 bc/screen_fb vc_fb
-USER_CFLAGS     := -ffixed-r8 -Wall $(CFLAGS_NO_BUILTIN)
+USER_CFLAGS     := -Wall $(CFLAGS_NO_BUILTIN)
 KERNEL_LDFLAGS  =
 USER_INCLUDES   := -isystem $(SRCDIR)/$(CURDIR)/include -I$(SRCDIR)/rom/openfirmware
 USER_CPPFLAGS   := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"
@@ -179,7 +179,7 @@ $(AROSDIR)/aros-armeb-raspi.img: $(TARGETDIR)/core-be.bin.o $(foreach f, $(FILES
 
 $(AROSDIR)/aros-arm-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"
-	@$(KERNEL_LD) -Map $(OSGENDIR)/boot/aros-arm-raspi.img.map --entry=bootstrap --script=$(SRCDIR)/$(CURDIR)/ldscript-le.lds $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $ $(TARGETDIR)/core.bin.o -L$(AROS_LIB) -lstdc.static -laeabi -o $(OSGENDIR)/boot/aros-arm-raspi.img.elf
+	@$(KERNEL_LD) -Map $(OSGENDIR)/boot/aros-arm-raspi.img.map --entry=bootstrap --script=$(SRCDIR)/$(CURDIR)/ldscript-le.lds $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $ $(TARGETDIR)/core.bin.o -L$(AROS_LIB) -lstdc.static $(TARGET_C_LIBS) -o $(OSGENDIR)/boot/aros-arm-raspi.img.elf
 	@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $(OSGENDIR)/boot/aros-arm-raspi.img.elf
 	@$(TARGET_OBJCOPY) -O binary $(OSGENDIR)/boot/aros-arm-raspi.img.elf $@
 
@@ -190,7 +190,7 @@ $(TARGETDIR)/core-be.bin.o: $(OSGENDIR)/boot/core.elf
 
 $(TARGETDIR)/core.bin.o: $(OSGENDIR)/boot/core.elf
 	@$(CP) $(OSGENDIR)/boot/core.elf $(TARGETDIR)/core.bin
-	@cd $(TARGETDIR) && $(KERNEL_LD) $(KERNEL_LDFLAGS) -r --format binary --oformat elf32-littlearm core.bin -o $@
+	@cd $(TARGETDIR) && $(TARGET_OBJCOPY) -I binary -O elf32-littlearm -B arm core.bin $@
 
 #MM
 distfiles-raspi-be : $(AROSDIR)/aros-armeb-raspi.img  $(AROSDIR)/$(ARM_BSP) $(AROSDIR)/config.txt


### PR DESCRIPTION
Code-side adjustments to make ARM source compilable with clang and linkable with lld. No behaviour change for GCC builds.

- arm-all/include cpu*.h: define AROS_GET_SP via inline asm under __clang__ (clang doesn't support GNU global register variables).
- arm-raspi/boot/boot.c: 'cpsr_all' -> 'cpsr'; set sp via immediate instead of PC-relative literal load (clang resolved the offset wrong); use 'ldr pc, =boot' instead of 'b boot' (avoids R_ARM_JUMP24 out-of-range in lld).
- arm-raspi/boot/ldscript-le.lds: link at 0x10000 to match QEMU's raspi2b -kernel load address.
- arm-raspi/boot/mmakefile.src: drop -ffixed-r8; use llvm-objcopy for core.bin -> elf32-littlearm (lld lacks --oformat); link compiler-rt via $(TARGET_C_LIBS).
- arm-native/kernel/spinlock.c: '.syntax unified' + 'rsbspl' (UAL).
- arm-native/kernel/kernel_cpu.c: 'cpsr_all' -> 'cpsr'.
- arm-native/kernel/mmakefile.src: $(TARGET_C_LIBS) for core.elf.