### PR TITLE
Clang: install <images/*.h> headers

### DIFF
--- a/compiler/include/mmakefile.src
+++ b/compiler/include/mmakefile.src
@@ -40,6 +40,7 @@ INCSUBDIRS :=	aros				\
 		hardware/pic			\
 		hardware/usb			\
 		hidd				\
+		images				\
 		inline			        \
 		intuition			\
 		irda				\


### PR DESCRIPTION
The ReAction image-class headers in compiler/include/images/ were missing from INCSUBDIRS and never copied to AROS_INCLUDES.