### PR TITLE
Workbench: clang fixes for armhf

### DIFF
--- a/workbench/devs/AHI/configure
+++ b/workbench/devs/AHI/configure
@@ -5841,7 +5841,7 @@ printf "%s\n" "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
 
 
 
-ac_config_files="$ac_config_files Makefile AHI/Makefile AHI-Handler/Makefile AddAudioModes/Makefile Device/Makefile Docs/Makefile Drivers/Makefile Drivers/Common/Makefile.common Drivers/Device/Makefile Drivers/Filesave/Makefile Drivers/Void/Makefile Drivers/ac97/Makefile Drivers/VIA-AC97/Makefile Drivers/HDAudio/Makefile Drivers/CMI8738/Makefile Drivers/SB128/Makefile Drivers/EMU10kx/Makefile Drivers/Envy24HT/Makefile Drivers/Envy24/Makefile Drivers/Alsa/Makefile Drivers/OSS/Makefile Drivers/PulseAudio/Makefile Drivers/WASAPI/Makefile Examples/Makefile Examples/Device/PlayTest/Makefile Examples/Extras/CloneAudioModes/Makefile Examples/Low-level/PlaySineEverywhere/Makefile Examples/Low-level/Test-7.1/Makefile Examples/Low-level/ScanAudioModes/Makefile Include/Makefile"
+ac_config_files="$ac_config_files Makefile AHI/Makefile AHI-Handler/Makefile AddAudioModes/Makefile Device/Makefile Docs/Makefile Drivers/Makefile Drivers/Common/Makefile.common Drivers/Device/Makefile Drivers/Filesave/Makefile Drivers/Void/Makefile Drivers/ac97/Makefile Drivers/VIA-AC97/Makefile Drivers/HDAudio/Makefile Drivers/CMI8738/Makefile Drivers/SB128/Makefile Drivers/EMU10kx/Makefile Drivers/Envy24HT/Makefile Drivers/Envy24/Makefile Drivers/Alsa/Makefile Drivers/OSS/Makefile Drivers/PulseAudio/Makefile Drivers/WASAPI/Makefile Drivers/RPiPWM/Makefile Drivers/RPiHDMI/Makefile Examples/Makefile Examples/Device/PlayTest/Makefile Examples/Extras/CloneAudioModes/Makefile Examples/Low-level/PlaySineEverywhere/Makefile Examples/Low-level/Test-7.1/Makefile Examples/Low-level/ScanAudioModes/Makefile Include/Makefile"
 
 ac_config_commands="$ac_config_commands default"
 
@@ -6559,6 +6559,8 @@ do
     "Drivers/OSS/Makefile") CONFIG_FILES="$CONFIG_FILES Drivers/OSS/Makefile" ;;
     "Drivers/PulseAudio/Makefile") CONFIG_FILES="$CONFIG_FILES Drivers/PulseAudio/Makefile" ;;
     "Drivers/WASAPI/Makefile") CONFIG_FILES="$CONFIG_FILES Drivers/WASAPI/Makefile" ;;
+    "Drivers/RPiPWM/Makefile") CONFIG_FILES="$CONFIG_FILES Drivers/RPiPWM/Makefile" ;;
+    "Drivers/RPiHDMI/Makefile") CONFIG_FILES="$CONFIG_FILES Drivers/RPiHDMI/Makefile" ;;
     "Examples/Makefile") CONFIG_FILES="$CONFIG_FILES Examples/Makefile" ;;
     "Examples/Device/PlayTest/Makefile") CONFIG_FILES="$CONFIG_FILES Examples/Device/PlayTest/Makefile" ;;
     "Examples/Extras/CloneAudioModes/Makefile") CONFIG_FILES="$CONFIG_FILES Examples/Extras/CloneAudioModes/Makefile" ;;

--- a/workbench/devs/AHI/configure.in
+++ b/workbench/devs/AHI/configure.in
@@ -368,6 +368,8 @@ AC_OUTPUT(Makefile
           Drivers/OSS/Makefile
           Drivers/PulseAudio/Makefile
           Drivers/WASAPI/Makefile
+          Drivers/RPiPWM/Makefile
+          Drivers/RPiHDMI/Makefile
           Examples/Makefile
           Examples/Device/PlayTest/Makefile
           Examples/Extras/CloneAudioModes/Makefile

--- a/workbench/devs/AHI/mmakefile.src
+++ b/workbench/devs/AHI/mmakefile.src
@@ -38,5 +38,12 @@ AHI_OPTIONS+=--with-target-cppflags="$(TARGET_CPPFLAGS)"
 TARGET_AS:=$(strip $(CC) $(TARGET_SYSROOT))
 AHI_OPTIONS+=--with-target-asflags="$(AFLAGS)"
 
+#
+# AHI configure runs AC_CHECK_TOOL for objcopy/strip and falls back to
+# ":" / bare names when the toolchain prefix doesn't match. Force the
+# values so the per-driver MODEFILE binaries (RPiPWM/RPiHDMI etc.)
+# get produced by llvm-objcopy.
+#
 %build_with_configure mmake=workbench-devs-AHI-subsystem prefix=$(EXEDIR) \
-    extraoptions="$(AHI_OPTIONS)" usecppflags=no gnuflags=no
+    extraoptions="$(AHI_OPTIONS)" usecppflags=no gnuflags=no \
+    config_env_extra="OBJCOPY=$(OBJCOPY) STRIP=$(STRIP_PLAIN)"

--- a/workbench/libs/jpeg/jfif.conf
+++ b/workbench/libs/jpeg/jfif.conf
@@ -64,8 +64,8 @@ void jpeg_stdio_dest_9e(j_compress_ptr cinfo, FILE * outfile)
 .private
 void jpeg_stdio_src_9e(j_decompress_ptr cinfo, FILE * infile)
 .private
-void jpeg_mem_dest(j_compress_ptr cinfo, unsigned char ** outbuffer, unsigned long * outsize)
-void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char * inbuffer, unsigned long insize)
+void jpeg_mem_dest(j_compress_ptr cinfo, unsigned char ** outbuffer, size_t * outsize)
+void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char * inbuffer, size_t insize)
 void jpeg_default_qtables(j_compress_ptr cinfo, boolean force_baseline)
 void jpeg_calc_jpeg_dimensions(j_compress_ptr cinfo)
 void jpeg_core_output_dimensions(j_decompress_ptr cinfo)

--- a/workbench/libs/png/mmakefile.src
+++ b/workbench/libs/png/mmakefile.src
@@ -52,6 +52,14 @@ endif
 #AFILES += \
 #	arm/filter_neon
 
+# Clang auto-defines __ARM_NEON for armv7-a+fp even with -mfpu=vfpv3-d16,
+# which makes pngpriv.h enable PNG_ARM_NEON_OPT=2 and reference the
+# arm/*_neon implementations above. Until those are wired in, force the
+# NEON path off so the link resolves.
+ifeq ($(AROS_TARGET_CPU),arm)
+USER_CPPFLAGS += -DPNG_ARM_NEON_OPT=0
+endif
+
 #MM- core-linklibs : linklibs-png
 #MM- linklibs-png : workbench-libs-png-pkgconfig
 

--- a/workbench/system/VMM/MUI/main.c
+++ b/workbench/system/VMM/MUI/main.c
@@ -104,7 +104,7 @@ if (CxBase != NULL)
 
 /**********************************************************************/
 
-int main (LONG argc, UBYTE **argv)
+int main (LONG argc, char **argv)
 
 {
 BOOL Quit;
@@ -116,7 +116,7 @@ if (!OpenLibs1 ())
   return (10);
   }
 
-ToolTypes = ArgArrayInit (argc, argv);
+ToolTypes = ArgArrayInit (argc, (UBYTE **)argv);
 
 if (ToolTypes == NULL)
   {
@@ -145,7 +145,7 @@ if (QuestionMark)
   CloseAll ();
   return (0);
   }
-          
+
 if (Quit)
   {
   if (!StopVMM ())

--- a/workbench/system/VMM/MUI/protos.h
+++ b/workbench/system/VMM/MUI/protos.h
@@ -6,7 +6,7 @@ Object *CreateTaskSelectWindow (void);
 Object *CreateMemoryPage (void);
 Object *CreateMiscPage (void);
 int HandleGUI (void);
-int main (LONG argc, UBYTE **argv);
+int main (LONG argc, char **argv);
 
 BOOL StartVMM (void);
 BOOL InstallAsCommodity (void);


### PR DESCRIPTION
- jpeg/jfif.conf: use size_t for jpeg_mem_dest/src to match libjpeg (was 'unsigned long', conflicts on 32-bit ARM where size_t is unsigned int).
- libs/png: force PNG_ARM_NEON_OPT=0 on arm — clang sets __ARM_NEON for armv7-a+fp even with vfpv3-d16, but the arm/*neon* source files are still commented out in FILES. A followup for later.
- AHI: emit Drivers/RPiPWM/Makefile and Drivers/RPiHDMI/Makefile from configure (Drivers/Makefile.in already references them); pass OBJCOPY/STRIP via config_env_extra so the subconfigure doesn't fall back to ':'. Missing in earlier commit.
- VMM/MUI: switch main() to char** argv and cast at the ArgArrayInit call site (silences clang pointer-sign warning).