### PR TITLE
arm-native: SMP build stubs (compile-only)

### DIFF
--- a/arch/arm-native/exec/exec_platform.h
+++ b/arch/arm-native/exec/exec_platform.h
@@ -16,15 +16,18 @@
 extern struct Hook Exec_TaskSpinLockFailHook;
 extern void Exec_TaskSpinUnlock(spinlock_t *);
 
-extern void Kernel_40_KrnSpinInit(spinlock_t *, void *);
-#define EXEC_SPINLOCK_INIT(a) Kernel_40_KrnSpinInit((a), NULL)
-extern spinlock_t *Kernel_43_KrnSpinLock(spinlock_t *, struct Hook *, ULONG, void *);
-#define EXEC_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), NULL, (b), NULL)
-#define EXECTASK_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), &Exec_TaskSpinLockFailHook, (b), NULL)
-extern void Kernel_44_KrnSpinUnLock(spinlock_t *, void *);
-#define EXEC_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL)
-#define EXECTASK_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL); \
+extern void Kernel_49_KrnSpinInit(spinlock_t *, void *);
+#define EXEC_SPINLOCK_INIT(a) Kernel_49_KrnSpinInit((a), NULL)
+extern spinlock_t *Kernel_52_KrnSpinLock(spinlock_t *, struct Hook *, ULONG, void *);
+#define EXEC_SPINLOCK_LOCK(a,b,c) Kernel_52_KrnSpinLock((a), (b), (c), NULL)
+#define EXECTASK_SPINLOCK_LOCK(a,b) Kernel_52_KrnSpinLock((a), &Exec_TaskSpinLockFailHook, (b), NULL)
+extern void Kernel_53_KrnSpinUnLock(spinlock_t *, void *);
+#define EXEC_SPINLOCK_UNLOCK(a) Kernel_53_KrnSpinUnLock((a), NULL)
+#define EXECTASK_SPINLOCK_UNLOCK(a) Kernel_53_KrnSpinUnLock((a), NULL); \
             Exec_TaskSpinUnlock((a))
+
+/* Stub: arm-native syscall-based reschedule is not yet implemented. */
+#define krnSysCallReschedTask(task, state) do { (void)(task); (void)(state); } while (0)
 
 #endif
 
@@ -206,10 +209,10 @@ struct Exec_PlatformData
         __ret;  \
     })
 #define GET_THIS_TASK           TLS_GET(ThisTask)
-#define SCHEDQUANTUM_SET(val)           (SysBase->Quantum=(val))
-#define SCHEDQUANTUM_GET                (SysBase->Quantum)
-#define SCHEDELAPSED_SET(val)           (SysBase->Elapsed=(val))
-#define SCHEDELAPSED_GET                (SysBase->Elapsed)
+#define SCHEDQUANTUM_SET(val)           TLS_SET(Quantum,(val))
+#define SCHEDQUANTUM_GET                TLS_GET(Quantum)
+#define SCHEDELAPSED_SET(val)           TLS_SET(Elapsed,(val))
+#define SCHEDELAPSED_GET                TLS_GET(Elapsed)
 #if !defined(__AROSEXEC_SMP__)
 #define SET_THIS_TASK(x)        TLS_SET(ThisTask,(x))
 #else

--- a/arch/arm-native/exec/platform_init.c
+++ b/arch/arm-native/exec/platform_init.c
@@ -39,6 +39,7 @@ int Exec_ARMCPUInit(struct ExecBase *SysBase)
     struct Task *BootTask, *CPUIdleTask;
 #if defined(__AROSEXEC_SMP__)
     int cpu, cpunum = KrnGetCPUCount();
+    void *cpuMask = NULL;
 #endif
     char *taskName;
 
@@ -62,12 +63,15 @@ int Exec_ARMCPUInit(struct ExecBase *SysBase)
     {
         taskName = AllocVec(15, MEMF_CLEAR);
         sprintf( taskName, "CPU #%02d Idle", cpu);
+        cpuMask = KrnAllocCPUMask();
+        if (cpuMask)
+            KrnGetCPUMask(cpu, cpuMask);
 #else
     taskName = "System Idle";
 #endif
         CPUIdleTask = NewCreateTask(TASKTAG_NAME   , taskName,
 #if defined(__AROSEXEC_SMP__)
-                                TASKTAG_AFFINITY   , KrnGetCPUMask(cpu),
+                                TASKTAG_AFFINITY   , cpuMask,
 #endif
                                 TASKTAG_PRI        , -127,
                                 TASKTAG_PC         , IdleTask,
@@ -113,22 +117,22 @@ void Exec_TaskSpinUnlock(spinlock_t *thisLock)
 {
     struct Task *curTask, *nxtTask;
 
-    Kernel_43_KrnSpinLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL,
+    Kernel_52_KrnSpinLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL,
                 SPINLOCK_MODE_WRITE, NULL);
     ForeachNodeSafe(&PrivExecBase(SysBase)->TaskSpinning, curTask, nxtTask)
     {
         if (GetIntETask(curTask)->iet_SpinLock == thisLock)
         {
-            Kernel_43_KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
+            Kernel_52_KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
                 SPINLOCK_MODE_WRITE, NULL);
             Disable();
             Remove(&curTask->tc_Node);
             Enqueue(&SysBase->TaskReady, &curTask->tc_Node);
-            Kernel_44_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL);
+            Kernel_53_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL);
             Enable();
         }
     }
-    Kernel_44_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL);
+    Kernel_53_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL);
 }
 
 int Exec_ARMCPUSMPInit(struct ExecBase *SysBase)

--- a/arch/arm-native/kernel/kernel_ipi.h
+++ b/arch/arm-native/kernel/kernel_ipi.h
@@ -1,7 +1,7 @@
 #ifndef KERNEL_IPI_H_
 #define KERNEL_IPI_H_
 /*
-    Copyright © 2015, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 2015, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -19,4 +19,23 @@
 #define IPI_ADDTASK	        0x101
 #define IPI_REMTASK	        0x102
 #define IPI_REBOOT	        0x10F
+
+#include <utility/hooks.h>
+
+#define IPI_CALL_HOOK_MAX_ARGS  5
+
+struct IPIHook
+{
+    struct Hook ih_Hook;
+    IPTR        ih_Args[IPI_CALL_HOOK_MAX_ARGS];
+};
+
+/* Stub: arm-native IPI hook dispatch is not yet implemented. */
+static inline int core_DoCallIPI(struct Hook *hook, void *cpu_mask, int async,
+                                 int nargs, IPTR *args, APTR _KB)
+{
+    (void)hook; (void)cpu_mask; (void)async;
+    (void)nargs; (void)args; (void)_KB;
+    return 0;
+}
 #endif

--- a/arch/arm-native/kernel/kernel_scheduler.c
+++ b/arch/arm-native/kernel/kernel_scheduler.c
@@ -67,7 +67,7 @@ BOOL core_Schedule(void)
             for (nexttask = (struct Task *)GetHead(&SysBase->TaskReady); nexttask != NULL; nexttask = (struct Task *)GetSucc(nexttask))
             {
 #if defined(__AROSEXEC_SMP__)
-                if ((GetIntETask(nexttask)->iet_CpuAffinity  & cpumask) == cpumask)
+                if (((IPTR)GetIntETask(nexttask)->iet_CpuAffinity & cpumask) == cpumask)
                 {
 #endif
                     if (nexttask->tc_Node.ln_Pri <= task->tc_Node.ln_Pri)
@@ -179,7 +179,7 @@ struct Task *core_Dispatch(void)
     for (newtask = (struct Task *)GetHead(&SysBase->TaskReady); newtask != NULL; newtask = (struct Task *)GetSucc(newtask))
     {
 #if defined(__AROSEXEC_SMP__)
-        if ((GetIntETask(newtask)->iet_CpuAffinity & cpumask) == cpumask)
+        if (((IPTR)GetIntETask(newtask)->iet_CpuAffinity & cpumask) == cpumask)
         {
 #endif
             Remove(&newtask->tc_Node);
@@ -205,7 +205,7 @@ struct Task *core_Dispatch(void)
             SysBase->DispCount++;
             IDNESTCOUNT_SET(newtask->tc_IDNestCnt);
             SET_THIS_TASK(newtask);
-            SysBase->Elapsed = SysBase->Quantum;
+            SCHEDELAPSED_SET(SCHEDQUANTUM_GET);
             FLAG_SCHEDQUANTUM_CLEAR;
 
             /* Check the stack of the task we are about to launch. */

--- a/arch/arm-native/kernel/tls.h
+++ b/arch/arm-native/kernel/tls.h
@@ -9,6 +9,8 @@ typedef struct tls
     ULONG               ScheduleFlags;
     BYTE                IDNestCnt;
     BYTE                TDNestCnt;
+    UWORD               Quantum;
+    UWORD               Elapsed;
 } tls_t;
 
 #define TLSSF_Quantum   (1 << 0)

--- a/arch/arm-native/processor/processor_init.c
+++ b/arch/arm-native/processor/processor_init.c
@@ -35,7 +35,10 @@ LONG Processor_Init(struct ProcessorBase * ProcessorBase)
 #if defined(__AROSEXEC_SMP__)
         if (i > 0)
         {
-            NewCreateTask(TASKTAG_AFFINITY      , KrnGetCPUMask(i)              },
+            void *cpuMask = KrnAllocCPUMask();
+            if (cpuMask)
+                KrnGetCPUMask(i, cpuMask);
+            NewCreateTask(TASKTAG_AFFINITY      , cpuMask,
                           TASKTAG_PRI           , -127,
                           TASKTAG_PC            , ReadProcessorInformation,
                           TASKTAG_ARG1          , sysprocs[i],


### PR DESCRIPTION
Minimum changes to compile arm-native under SMP variant with the LLVM toolchain. Does not include runtime SMP.

- exec/exec_platform.h: route SCHEDQUANTUM/SCHEDELAPSED through TLS; EXEC_SPINLOCK_LOCK now 3-arg matching all-pc; update Kernel_NN_KrnSpin* LVOs (49/52/53); no-op krnSysCallReschedTask.
- kernel/tls.h: add Quantum/Elapsed UWORD fields.
- kernel/kernel_ipi.h: minimal IPIHook struct + inline no-op core_DoCallIPI so signal.c links.
- kernel/kernel_scheduler.c: SCHEDELAPSED_SET(SCHEDQUANTUM_GET); IPTR-cast iet_CpuAffinity for the bitmask test.
- exec/platform_init.c, processor/processor_init.c: adapt to the 2-arg KrnGetCPUMask API; update Kernel_NN_KrnSpin* references; fix a stray '}' in processor_init that was latent in non-SMP.