### PR TITLE
Make --with-portssources work with relative paths

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -520,6 +520,11 @@ LOCATION=${newlocation:-.}
 BASE=${newbase:-${destination}}
 patches_origins=${patches_origins:-.}
 
+# Ensure LOCATION, destination, and BASE are absolute paths.
+[[ "$LOCATION" != /* ]] && LOCATION="$PWD/$LOCATION"
+[[ "$destination" != /* ]] && destination="$PWD/$destination"
+[[ "$BASE" != /* ]] && BASE="$PWD/$BASE"
+
 fetchlockfile="$archive"
 fetchlock "$LOCATION" "$fetchlockfile"
 


### PR DESCRIPTION
Passing a relative path to --with-portssources failed because fetch.sh changes working directory and still tries to use the relative path from there. Now fetch.sh determines absolute paths for some args so passing relative paths is more stable.
