### PR TITLE
usb/poseidon: fix buffer overflows, NULL derefs, integer overflows and error path issues

### DIFF
--- a/rom/usb/classes/arosx/arosx.class.c
+++ b/rom/usb/classes/arosx/arosx.class.c
@@ -403,7 +403,7 @@ struct AROSXClassController *AROSXClass_CreateController(LIBBASETYPEPTR arosxb, 
         }
     }
 
-    AROSXClass_DestroyController(arosxb, arosxc);
+    FreeVec(arosxc);
 
     return NULL;
 

--- a/rom/usb/classes/arosx/arosx.class.config.gui.c
+++ b/rom/usb/classes/arosx/arosx.class.config.gui.c
@@ -53,6 +53,15 @@ AROS_UFH0(void, nGUITask)
             mybug(-1,("[AROSXClass GUI] arosx.library openened\n"));
 
             arosx_eventport = CreateMsgPort();
+            if(!arosx_eventport)
+            {
+                CloseLibrary(AROSXBase);
+                FreeVec(gui);
+                Forbid();
+                arosxc->GUITask = NULL;
+                --arosxb->Library.lib_OpenCnt;
+                return;
+            }
             arosx_eventhook = AROSX_AddEventHandler(arosx_eventport, (((1<<arosxc->id))<<28));
             /*
                 Set to listen every controller

--- a/rom/usb/classes/arosx/arosx.library.c
+++ b/rom/usb/classes/arosx/arosx.library.c
@@ -146,25 +146,25 @@ AROS_LH2(struct AROSX_EventHook *, AROSX_AddEventHandler,
             ObtainSemaphore(&arosxb->arosxc_lock);
 
             arosxc = arosxb->arosxc_0;
-            if( (((msgmask>>28) & 1) && (arosxc->status.connected)) ) {
+            if( arosxc && (((msgmask>>28) & 1) && (arosxc->status.connected)) ) {
                 AROSXClass_SendEvent(arosxb, ((1<<28) | ((arosxc->controller_type)<<20) | AROSX_EHMF_CONNECT), (APTR)1, (APTR)2);
                 mybug(-1, ("Sent connect event for 0\n"));
             }
 
             arosxc = arosxb->arosxc_1;
-            if( (((msgmask>>28) & 2) && (arosxc->status.connected)) ) {
+            if( arosxc && (((msgmask>>28) & 2) && (arosxc->status.connected)) ) {
                 AROSXClass_SendEvent(arosxb, ((2<<28) | ((arosxc->controller_type)<<20) | AROSX_EHMF_CONNECT), (APTR)1, (APTR)2);
                 mybug(-1, ("Sent connect event for 1\n"));
             }
 
             arosxc = arosxb->arosxc_2;
-            if( (((msgmask>>28) & 4) && (arosxc->status.connected)) ) {
+            if( arosxc && (((msgmask>>28) & 4) && (arosxc->status.connected)) ) {
                 AROSXClass_SendEvent(arosxb, ((4<<28) | ((arosxc->controller_type)<<20) | AROSX_EHMF_CONNECT), (APTR)1, (APTR)2);
                 mybug(-1, ("Sent connect event for 2\n"));
             }
 
             arosxc = arosxb->arosxc_3;
-            if( (((msgmask>>28) & 8) && (arosxc->status.connected)) ) {
+            if( arosxc && (((msgmask>>28) & 8) && (arosxc->status.connected)) ) {
                 AROSXClass_SendEvent(arosxb, ((8<<28) | ((arosxc->controller_type)<<20) | AROSX_EHMF_CONNECT), (APTR)1, (APTR)2);
                 mybug(-1, ("Sent connect event for 3\n"));
             }

--- a/rom/usb/classes/hid/hid.class.c
+++ b/rom/usb/classes/hid/hid.class.c
@@ -2918,11 +2918,16 @@ BOOL nParseReport(struct NepClassHid *nch, struct NepHidReport *nhr)
                                                 nhi->nhi_LogicalMin = nch->nch_HidGlobal.nhg_LogicalMin;
                                                 nhi->nhi_LogicalMax = nch->nch_HidGlobal.nhg_LogicalMax;
 
+                                                if((nhi->nhi_LogicalMin > nhi->nhi_LogicalMax) || ((nhi->nhi_LogicalMax - nhi->nhi_LogicalMin) > 65535))
+                                                {
+                                                    KPRINTF(10, ("Invalid HID logical range %ld..%ld, capping\n", nhi->nhi_LogicalMin, nhi->nhi_LogicalMax));
+                                                    nhi->nhi_LogicalMax = nhi->nhi_LogicalMin;
+                                                }
                                                 nhi->nhi_MapSize = (nhi->nhi_LogicalMax - nhi->nhi_LogicalMin)+1;
                                                 nhi->nhi_UsageMap = psdAllocVec(sizeof(ULONG) * nhi->nhi_MapSize);
                                                 nhi->nhi_ActionMap = psdAllocVec(sizeof(struct List) * nhi->nhi_MapSize);
+                                                if(nhi->nhi_Count > 65535) nhi->nhi_Count = 1;
                                                 nhi->nhi_Buffer = psdAllocVec(2 * sizeof(LONG) * nhi->nhi_Count);
-                                                nhi->nhi_OldBuffer = &nhi->nhi_Buffer[nhi->nhi_Count];
                                                 nhi->nhi_PhysicalMin = nch->nch_HidGlobal.nhg_PhysicalMin;
                                                 nhi->nhi_PhysicalMax = nch->nch_HidGlobal.nhg_PhysicalMax;
                                                 nhi->nhi_UnitExp = nch->nch_HidGlobal.nhg_UnitExp;
@@ -2941,6 +2946,7 @@ BOOL nParseReport(struct NepClassHid *nch, struct NepHidReport *nhr)
                                                     break;
                                                 }
 
+                                                nhi->nhi_OldBuffer = &nhi->nhi_Buffer[nhi->nhi_Count];
                                                 nhi->nhi_Usage = nhi->nhi_DesignIndex = nhi->nhi_StringIndex = HID_PARAM_UNDEF;
                                                 NewList(&nhi->nhi_ActionList);
 

--- a/rom/usb/classes/hid/hid.gui.c
+++ b/rom/usb/classes/hid/hid.gui.c
@@ -211,7 +211,7 @@ AROS_UFH0(void, GM_UNIQUENAME(nGUITask))
     for(count = 0; count < 128; count++)
     {
         struct InputEvent ie;
-        UBYTE buf[16];
+        UBYTE buf[80];
         UBYTE buf2[80];
         LONG actual;
         BOOL printable;

--- a/rom/usb/classes/hub/hub.class.c
+++ b/rom/usb/classes/hub/hub.class.c
@@ -366,7 +366,10 @@ AROS_LH2(IPTR, usbDoMethodA,
                     } else {
                         Permit();
                     }
-                    DeleteMsgPort(nhm.nhm_Msg.mn_ReplyPort);
+                    if(nhm.nhm_Msg.mn_ReplyPort)
+                    {
+                        DeleteMsgPort(nhm.nhm_Msg.mn_ReplyPort);
+                    }
                 }
                 CloseLibrary(ps);
             }

--- a/rom/usb/classes/hubss/hubss_class.c
+++ b/rom/usb/classes/hubss/hubss_class.c
@@ -328,7 +328,10 @@ AROS_LH2(IPTR, usbDoMethodA, AROS_LHA(ULONG, methodid, D0), AROS_LHA(IPTR *, met
                     } else {
                         Permit();
                     }
-                    DeleteMsgPort(nhm.nhm_Msg.mn_ReplyPort);
+                    if(nhm.nhm_Msg.mn_ReplyPort)
+                    {
+                        DeleteMsgPort(nhm.nhm_Msg.mn_ReplyPort);
+                    }
                 }
                 CloseLibrary(ps);
             }

--- a/rom/usb/classes/ptp/ptp.class.c
+++ b/rom/usb/classes/ptp/ptp.class.c
@@ -260,7 +260,7 @@ struct NepClassPTP * usbForceInterfaceBinding(struct NepPTPBase *nh, struct PsdI
             FreeVec(nch->nch_CDC);
             FreeVec(nch);
             CloseLibrary(ps);
-            return(nch);
+            return(NULL);
         }
         CloseLibrary(ps);
     }

--- a/rom/usb/classes/rndis/if_urndis.c
+++ b/rom/usb/classes/rndis/if_urndis.c
@@ -198,8 +198,9 @@ urndis_ctrl_handle_query(struct NepClassEth *ncp,
         return letoh32(msg->rm_status);
     }
 
-    if (letoh32(msg->rm_infobuflen) + letoh32(msg->rm_infobufoffset) +
-        RNDIS_HEADER_OFFSET > letoh32(msg->rm_len)) {
+    if (letoh32(msg->rm_infobuflen) > letoh32(msg->rm_len) ||
+        letoh32(msg->rm_infobufoffset) > letoh32(msg->rm_len) - letoh32(msg->rm_infobuflen) ||
+        RNDIS_HEADER_OFFSET > letoh32(msg->rm_len) - letoh32(msg->rm_infobuflen) - letoh32(msg->rm_infobufoffset)) {
         bug("%s: ctrl message error: invalid query info "
             "len/offset/end_position(%d/%d/%d) -> "
             "go out of buffer limit %d\n",

--- a/rom/usb/pciusb/pciusb_arospci.c
+++ b/rom/usb/pciusb/pciusb_arospci.c
@@ -263,36 +263,44 @@ BOOL pciInit(struct PCIDevice *hd)
                     char *usb_chipset = "UHCI";
                     int usb_min = -1, usb_maj = 1;
 
-                    hc->hc_Node.ln_Name = AllocVec(16 + 34, MEMF_CLEAR);
+                    hc->hc_Node.ln_Name = AllocVec(32, MEMF_CLEAR);
                     hc->hc_Node.ln_Pri = hc->hc_HCIType;
-                    sprintf(hc->hc_Node.ln_Name, "pciusb.device/%u", (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
-                    usbc_tags[0].ti_Data = (IPTR)hc->hc_Node.ln_Name;
+                    if(hc->hc_Node.ln_Name) {
+                        char hw_name[64];
+                        int pos;
 
-                    usbc_tags[1].ti_Data = (IPTR)&hc->hc_Node.ln_Name[16];
-                    switch (hc->hc_HCIType) {
-                    case HCITYPE_OHCI: {
-                        usb_chipset = "OHCI";
-                        usb_min = 1;
-                        break;
+                        sprintf(hc->hc_Node.ln_Name, "pciusb.device/%u", (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
+                        usbc_tags[0].ti_Data = (IPTR)hc->hc_Node.ln_Name;
+
+                        switch (hc->hc_HCIType) {
+                        case HCITYPE_OHCI: {
+                            usb_chipset = "OHCI";
+                            usb_min = 1;
+                            break;
+                        }
+
+                        case HCITYPE_EHCI: {
+                            usb_chipset = "EHCI";
+                            usb_maj = 2;
+                            usb_min = 0;
+                            break;
+                        }
+
+                        }
+
+                        pos = sprintf(hw_name, "PCI USB %d.", usb_maj);
+                        if (usb_min < 0)
+                            pos += sprintf(hw_name + pos, "x");
+                        else
+                            pos += sprintf(hw_name + pos, "%d", usb_min);
+                        pos += sprintf(hw_name + pos, " %s Host controller", usb_chipset);
+
+                        usbc_tags[1].ti_Data = (IPTR)AllocVec(pos + 1, MEMF_CLEAR);
+                        if(usbc_tags[1].ti_Data)
+                            memcpy((char *)usbc_tags[1].ti_Data, hw_name, pos + 1);
+
+                        HW_AddDriver(root, usbContrClass, usbc_tags);
                     }
-
-                    case HCITYPE_EHCI: {
-                        usb_chipset = "EHCI";
-                        usb_maj = 2;
-                        usb_min = 0;
-                        break;
-                    }
-
-                    }
-
-                    sprintf((char *)usbc_tags[1].ti_Data, "PCI USB %u.",  usb_maj);
-                    if (usb_min < 0)
-                        sprintf((char *)(usbc_tags[1].ti_Data + 10), "x");
-                    else
-                        sprintf((char *)(usbc_tags[1].ti_Data + 10), "%u", usb_min);
-                    sprintf((char *)(usbc_tags[1].ti_Data + 11), " %s Host controller",  usb_chipset);
-
-                    HW_AddDriver(root, usbContrClass, usbc_tags);
                 }
                 hc->hc_Unit = hu;
                 Enqueue(&hu->hu_Controllers, &hc->hc_Node);

--- a/rom/usb/pcixhci/pcixhci_arospci.c
+++ b/rom/usb/pcixhci/pcixhci_arospci.c
@@ -238,12 +238,15 @@ BOOL pciInit(struct PCIDevice *hd)
                     };
                     int name_len = sizeof(strPcixhciDevicePrefix) - 1 + 10 + 1;
                     hc->hc_Node.ln_Name = AllocVec(name_len, MEMF_CLEAR);
-                    hc->hc_Node.ln_Pri = HCITYPE_XHCI;
-                    sprintf(hc->hc_Node.ln_Name, strPcixhciDeviceFormat,
-                            (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
-                    usbc_tags[0].ti_Data = (IPTR)hc->hc_Node.ln_Name;
-                    pciusbWarn("PCI", "Instantiating xHCI controller class for '%s'\n", hc->hc_Node.ln_Name);
-                    HW_AddDriver(root, hd->hd_USBXHCIControllerClass, usbc_tags);
+                    if(hc->hc_Node.ln_Name)
+                    {
+                        hc->hc_Node.ln_Pri = HCITYPE_XHCI;
+                        sprintf(hc->hc_Node.ln_Name, strPcixhciDeviceFormat,
+                                (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
+                        usbc_tags[0].ti_Data = (IPTR)hc->hc_Node.ln_Name;
+                        pciusbWarn("PCI", "Instantiating xHCI controller class for '%s'\n", hc->hc_Node.ln_Name);
+                        HW_AddDriver(root, hd->hd_USBXHCIControllerClass, usbc_tags);
+                    }
                 }
                 hc->hc_Unit = hu;
                 Enqueue(&hu->hu_Controllers, &hc->hc_Node);

--- a/rom/usb/pcixhci/xhci_controllerclass.c
+++ b/rom/usb/pcixhci/xhci_controllerclass.c
@@ -501,12 +501,14 @@ OOP_Object *XHCIController__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot
         char name_buf[64];
         char *hardware_name = NULL;
 
-        sprintf(name_buf, strHardwareNamePrefixFmt, hc->hc_USBVersionMajor);
+        int pos;
+
+        pos = sprintf(name_buf, strHardwareNamePrefixFmt, hc->hc_USBVersionMajor);
         if(hc->hc_USBVersionMinor == 0xFF)
-            sprintf(name_buf + 10, strHardwareNameMinorUnknown);
+            pos += sprintf(name_buf + pos, strHardwareNameMinorUnknown);
         else
-            sprintf(name_buf + 10, strHardwareNameMinorFmt, hc->hc_USBVersionMinor);
-        sprintf(name_buf + 11, strHardwareNameSuffix);
+            pos += sprintf(name_buf + pos, strHardwareNameMinorFmt, hc->hc_USBVersionMinor);
+        sprintf(name_buf + pos, strHardwareNameSuffix);
 
         hardware_name = AllocVec(strlen(name_buf) + 1, MEMF_CLEAR);
         if(hardware_name != NULL) {

--- a/rom/usb/shellapps/PencamTool.c
+++ b/rom/usb/shellapps/PencamTool.c
@@ -624,6 +624,11 @@ APTR TransferImage(struct NepClassPencam *nch, struct PCImageHeader *pcih)
     UBYTE *imgbuf;
     UBYTE *newimgbuf;
 
+    if(pcih->pcih_ImgSize < 64)
+    {
+        Printf("Image size too small (%ld bytes).\n", pcih->pcih_ImgSize);
+        return(NULL);
+    }
     rawbuf = psdAllocVec(pcih->pcih_ImgSize);
     if(!rawbuf)
     {
@@ -644,6 +649,12 @@ APTR TransferImage(struct NepClassPencam *nch, struct PCImageHeader *pcih)
     }
     if(!ioerr)
     {
+        if(((ULONG) pcih->pcih_ImgWidth > 4096) || ((ULONG) pcih->pcih_ImgHeight > 4096))
+        {
+            Printf("Image dimensions too large (%ldx%ld).\n", (LONG) pcih->pcih_ImgWidth, (LONG) pcih->pcih_ImgHeight);
+            psdFreeVec(rawbuf);
+            return(NULL);
+        }
         imgbuf = psdAllocVec((ULONG) pcih->pcih_ImgWidth * (ULONG) pcih->pcih_ImgHeight * 3);
         if(imgbuf)
         {

--- a/rom/usb/trident/ActionClass.c
+++ b/rom/usb/trident/ActionClass.c
@@ -3771,7 +3771,8 @@ IPTR Action_SaveErrors(struct IClass *cl, Object *obj, Msg msg)
     {
         if(MUI_AslRequest(aslreq, TAG_END))
         {
-            strcpy(path, aslreq->fr_Drawer);
+            strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
             AddPart(path, aslreq->fr_File, 256);
             if((fh = Open(path, MODE_NEWFILE)))
             {
@@ -3821,7 +3822,8 @@ IPTR Action_SaveDeviceList(struct IClass *cl, Object *obj, Msg msg)
     {
         if(MUI_AslRequest(aslreq, TAG_END))
         {
-            strcpy(path, aslreq->fr_Drawer);
+            strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
             AddPart(path, aslreq->fr_File, 256);
             if((fh = Open(path, MODE_NEWFILE)))
             {
@@ -3857,7 +3859,8 @@ IPTR Action_LoadPrefs(struct IClass *cl, Object *obj, Msg msg)
     {
         if(MUI_AslRequest(aslreq, TAG_END))
         {
-            strcpy(path, aslreq->fr_Drawer);
+            strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
             AddPart(path, aslreq->fr_File, 256);
             if(psdLoadCfgFromDisk(path))
             {
@@ -3887,7 +3890,8 @@ IPTR Action_SavePrefsAs(struct IClass *cl, Object *obj, Msg msg)
     {
         if(MUI_AslRequest(aslreq, TAG_END))
         {
-            strcpy(path, aslreq->fr_Drawer);
+            strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
             AddPart(path, aslreq->fr_File, 256);
             InternalCreateConfigGUI(data);
             if(psdSaveCfgToDisk(path, FALSE))
@@ -4993,7 +4997,8 @@ IPTR Action_Cfg_Export(struct IClass *cl, Object *obj, Msg msg)
         {
             if(MUI_AslRequest(aslreq, TAG_END))
             {
-                strcpy(path, aslreq->fr_Drawer);
+                strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+                path[sizeof(path) - 1] = '\0';
                 AddPart(path, aslreq->fr_File, 256);
                 fh = Open(path, MODE_NEWFILE);
                 if(fh)
@@ -5039,7 +5044,8 @@ IPTR Action_Cfg_Import(struct IClass *cl, Object *obj, Msg msg)
     {
         if(MUI_AslRequest(aslreq, TAG_END))
         {
-            strcpy(path, aslreq->fr_Drawer);
+            strncpy(path, aslreq->fr_Drawer, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
             AddPart(path, aslreq->fr_File, 256);
             fh = Open(path, MODE_OLDFILE);
             if(fh)


### PR DESCRIPTION
## Summary

Comprehensive bug fixes for the Poseidon USB stack, found during an audit of the standalone OS 3.x extraction at [poseidon-usb](https://github.com/midwan/poseidon-usb). All fixes are upstream-applicable and affect only `rom/usb/` code.

### Commit 1 — Buffer overflows and use-after-free
- **hid.gui.c**: enlarge `buf[16]` → `buf[80]` for `nNumToStr` strings that can reach 25+ chars
- **ptp.class.c**: fix use-after-free — return `NULL` instead of freed `nch` pointer
- **ActionClass.c**: replace 6 unbounded `strcpy` calls with length-checked `strncpy`

### Commit 2 — Integer overflow and bounds check vulnerabilities
- **hid.class.c**: validate HID LogicalMin/LogicalMax range (cap delta at 65535) to prevent enormous `MapSize` allocations; cap `Count` at 65535; move `OldBuffer` pointer computation after `NULL` check on `Buffer`
- **if_urndis.c**: rewrite overflow-prone addition-based bounds check to subtraction-based individual field validation
- **PencamTool.c**: reject `ImgSize < 64` to prevent underflow in `(ImgSize-64)` subtraction; add 4096×4096 dimension cap against integer overflow in `width*height*3`

### Commit 3 — NULL pointer dereferences and error path cleanup
- **arosx.class.c**: `CreateController` error path called `DestroyController` which frees from unset slot pointers — use `FreeVec(arosxc)` directly
- **arosx.library.c**: add `NULL` guards on all 4 controller slot accesses in `AROSX_AddEventHandler`
- **arosx.class.config.gui.c**: add `NULL` check for `CreateMsgPort()` with proper `Forbid`/`GUITask=NULL` cleanup on early-return
- **hub.class.c, hubss_class.c**: guard `DeleteMsgPort()` with `NULL` check
- **pcixhci_arospci.c**: `NULL` guard around `sprintf`/`HW_AddDriver` after `AllocVec`

### Commit 4 — Buffer sizing and hard-coded sprintf offsets
- **pciusb_arospci.c**: replace packed shared buffer with separate allocations; use `pos += sprintf()` instead of hard-coded offsets; add `NULL` checks
- **xhci_controllerclass.c**: replace hard-coded offsets (10, 11) with dynamic `pos += sprintf()` to handle variable-length USB version strings

#### Test plan
- [ ] Verify AROS builds cleanly with these changes
- [ ] Spot-check USB device enumeration still works on AROS