### PR TITLE
arm-native/kernel: ARMv7 fixes for clang, VFP and aborts

### DIFF
--- a/arch/arm-native/kernel/intr.c
+++ b/arch/arm-native/kernel/intr.c
@@ -195,14 +195,28 @@ asm (
 
 void handle_dataabort(regs_t *regs)
 {
-    register unsigned int far;
+    register unsigned int far, dfsr;
 
-    // Read fault address register
+    // Read fault address register and data fault status register
     asm volatile("mrc p15, 0, %[far], c6, c0, 0": [far] "=r" (far) );
+    asm volatile("mrc p15, 0, %[dfsr], c5, c0, 0": [dfsr] "=r" (dfsr) );
 
     bug("[Kernel] Trap ARM Data Abort Exception\n");
     bug("[Kernel]    exception #2 (Bus Error)\n");
     bug("[Kernel]    attempt to access 0x%p from 0x%p\n", far, regs->pc);
+    /* DFSR: bits[10,3:0] = status; bit[11] = WnR (1=write, 0=read);
+     * bits[7:4] = domain. Common status codes (short descriptor):
+     *   0b00001 (0x01) - Alignment fault
+     *   0b00101 (0x05) - Translation fault, section
+     *   0b00111 (0x07) - Translation fault, page
+     *   0b01101 (0x0d) - Permission fault, section
+     *   0b01111 (0x0f) - Permission fault, page
+     *   0b00010 (0x02) - Debug event
+     *   0b01000 (0x08) - Synchronous external abort */
+    bug("[Kernel]    DFSR=0x%08x  status=0x%02x  WnR=%d\n",
+        dfsr,
+        ((dfsr >> 6) & 0x10) | (dfsr & 0x0f),
+        (dfsr >> 11) & 1);
 
     cpu_DumpRegs(regs);
 
@@ -246,9 +260,24 @@ asm (
 
 void handle_prefetchabort(regs_t *regs)
 {
+    register unsigned int ifar, ifsr;
+
+    /* Read instruction fault address and status registers */
+    asm volatile("mrc p15, 0, %[ifar], c6, c0, 2": [ifar] "=r" (ifar) );
+    asm volatile("mrc p15, 0, %[ifsr], c5, c0, 1": [ifsr] "=r" (ifsr) );
+
     bug("[Kernel] Trap ARM Prefetch Abort Exception\n");
     bug("[Kernel]    exception #3 (Address Error)\n");
-    bug("[Kernel]    at 0x%p\n", regs->pc);
+    bug("[Kernel]    at 0x%p (IFAR=0x%p)\n", regs->pc, ifar);
+    /* IFSR status codes (short descriptor):
+     *   0x05 - Translation fault, section
+     *   0x07 - Translation fault, page
+     *   0x0d - Permission fault, section
+     *   0x0f - Permission fault, page
+     *   0x08 - Synchronous external abort */
+    bug("[Kernel]    IFSR=0x%08x  status=0x%02x\n",
+        ifsr,
+        ((ifsr >> 6) & 0x10) | (ifsr & 0x0f));
 
     cpu_DumpRegs(regs);
 

--- a/arch/arm-native/kernel/kernel_cpu.c
+++ b/arch/arm-native/kernel/kernel_cpu.c
@@ -199,27 +199,36 @@ void cpu_Restore_VFP32_State(void *buffer);
 
 asm(
 "cpu_Save_VFP16_State:                      \n"
-"           vmsr    fpscr, r3               \n"
+"           vmrs    r3, fpscr               \n"
 "           str     r3, [r0, #256]          \n"
 "           vstmia  r0, {d0-d15}            \n"
 "           bx      lr                      \n"
 
+/*
+ * ARMv7 VSTMIA/VLDMIA only encode up to 16 doubles per instruction
+ * (imm8 <= 32). d16-d31 must be saved/restored with a second
+ * VSTMIA/VLDMIA targeting the high half.
+ */
 "cpu_Save_VFP32_State:                      \n"
-"           vmsr    fpscr, r3               \n"
+"           vmrs    r3, fpscr               \n"
 "           str     r3, [r0, #256]          \n"
-"           .word   0xec800b40              \n"         // vstmia  r0, {d0-d31}
+"           vstmia  r0, {d0-d15}            \n"
+"           add     r1, r0, #128            \n"
+"           vstmia  r1, {d16-d31}           \n"
 "           bx      lr                      \n"
 
 "cpu_Restore_VFP16_State:                   \n"
 "           ldr     r3, [r0, #256]          \n"
-"           vmrs    r3, fpscr               \n"
+"           vmsr    fpscr, r3               \n"
 "           vldmia  r0, {d0-d15}            \n"
 "           bx      lr                      \n"
 
 "cpu_Restore_VFP32_State:                   \n"
 "           ldr     r3, [r0, #256]          \n"
-"           vmrs    r3, fpscr               \n"
-"           .word   0xec900b20              \n"         // vldmia  r0, {d0-d31}
+"           vmsr    fpscr, r3               \n"
+"           vldmia  r0, {d0-d15}            \n"
+"           add     r1, r0, #128            \n"
+"           vldmia  r1, {d16-d31}           \n"
 "           bx      lr                      \n"
 );
 
@@ -235,10 +244,26 @@ void cpu_Probe(struct ARM_Implementation *krnARMImpl)
     asm volatile ("mrc p15, 0, %0, c0, c0, 0" : "=r" (tmp));
     if ((tmp & 0xfff0) == 0xc070 || (tmp & 0xfff0) == 0xd030)
     {
+        uint32_t mvfr0;
+
         krnARMImpl->ARMI_Family = 7;
 
-        krnARMImpl->ARMI_Save_VFP_State = &cpu_Save_VFP16_State;
-        krnARMImpl->ARMI_Restore_VFP_State = &cpu_Restore_VFP16_State;
+        /*
+         * VFPv3+ (ARMv7+) reports register file size in MVFR0[3:0]:
+         *   1 = 16 double registers (d0-d15)
+         *   2 = 32 double registers (d0-d31)
+         */
+        asm volatile ("vmrs %0, mvfr0" : "=r" (mvfr0));
+        if ((mvfr0 & 0xf) == 2)
+        {
+            krnARMImpl->ARMI_Save_VFP_State = &cpu_Save_VFP32_State;
+            krnARMImpl->ARMI_Restore_VFP_State = &cpu_Restore_VFP32_State;
+        }
+        else
+        {
+            krnARMImpl->ARMI_Save_VFP_State = &cpu_Save_VFP16_State;
+            krnARMImpl->ARMI_Restore_VFP_State = &cpu_Restore_VFP16_State;
+        }
 
 #if defined(__AROSEXEC_SMP__)
         // Read the Multiprocessor Affinity Register (MPIDR)
@@ -252,6 +277,7 @@ void cpu_Probe(struct ARM_Implementation *krnARMImpl)
     }
     else
     {
+        /* ARMv6 / VFPv2 — d0-d15 only, no MVFR0. */
         krnARMImpl->ARMI_Family = 6;
         krnARMImpl->ARMI_Save_VFP_State = &cpu_Save_VFP16_State;
         krnARMImpl->ARMI_Restore_VFP_State = &cpu_Restore_VFP16_State;

--- a/arch/arm-native/kernel/kernel_startup.c
+++ b/arch/arm-native/kernel/kernel_startup.c
@@ -39,6 +39,7 @@
 extern struct TagItem *BootMsg;
 
 void __attribute__((used)) kernel_cstart(struct TagItem *msg);
+static void __attribute__((used, noreturn, noinline)) kernel_cstart_user(void);
 
 uint32_t stack[AROS_STACKSIZE] __attribute__((used,aligned(16)));
 static uint32_t stack_super[AROS_STACKSIZE] __attribute__((used,aligned(16)));
@@ -64,9 +65,20 @@ asm (
     ".string \"Native/CORE v3 (" __DATE__ ")\"" "\n\t\n\t"
 );
 
+/*
+ * With clang's integrated assembler, TARGET_SECTION_COMMENT (//) is NOT
+ * treated as a comment — it becomes a literal part of the section name,
+ * creating ".aros.init //" as a separate section from ".aros.init".
+ */
+#if defined(__clang__)
+static uint32_t * const stack_end __attribute__((used, section(".aros.init"))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
+static uint32_t * const stack_super_end __attribute__((used, section(".aros.init"))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
+static uint32_t * const stack_fiq_end __attribute__((used, section(".aros.init"))) = &stack_fiq[1024 - sizeof(IPTR)];
+#else
 static uint32_t * const stack_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
 static uint32_t * const stack_super_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
 static uint32_t * const stack_fiq_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack_fiq[1024 - sizeof(IPTR)];
+#endif
 
 struct ARM_Implementation __arm_arosintern  __attribute__((aligned(4), section(".data"))) = {0,0,NULL,0};
 struct ExecBase *SysBase __attribute__((section(".data"))) = NULL;
@@ -305,18 +317,49 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
     D(bug("[Kernel] InitCode(RTF_SINGLETASK) ... \n"));
     InitCode(RTF_SINGLETASK, 0);
 
+    /*
+     * Switch from SVC to USER mode and continue on the USER stack.
+     *
+     * The boot entry sets USER/SYSTEM SP to stack_end (top of stack[])
+     * and SVC SP to stack_super_end (top of stack_super[]).  kernel_cstart
+     * runs in SVC mode so all its locals live on stack_super.
+     *
+     * After "cps #0x10" SP switches to the USER bank (stack[]).  The
+     * compiler does not know SP changed — any SP-relative access to
+     * kernel_cstart locals would read uninitialised stack[] memory.
+     * Place the mode switch and branch to user-mode code in a single asm
+     * block: kernel_cstart_user runs with its own frame on stack[] and
+     * accesses only globals (SysBase, KernelBase), never kernel_cstart's
+     * locals.
+     */
     D(bug("[Kernel] Dropping into USER mode ... \n"));
-    asm("cps %[mode_user]\n"
+    asm volatile(
+        "cps    %[mode_user]    \n" /* USER mode: SP = stack[] from boot */
 #if AROS_BIG_ENDIAN
-        "setend be\n"
+        "setend be              \n"
 #endif
-     : : [mode_user] "I" (CPUMODE_USER)); /* switch to user mode */
+        "b      kernel_cstart_user \n"
+        :
+        : [mode_user] "I" (CPUMODE_USER)
+    );
+    __builtin_unreachable();
+}
 
+/*
+ * User-mode continuation of kernel_cstart.
+ *
+ * Runs on stack[] (USER/SYSTEM SP set at boot), completely separate from
+ * stack_super which is reserved for SVC exception handlers.  Must only
+ * access globals — never kernel_cstart's stack-allocated locals.
+ */
+static void __attribute__((used, noreturn, noinline)) kernel_cstart_user(void)
+{
     D(bug("[Kernel] InitCode(RTF_COLDSTART) ...\n"));
     InitCode(RTF_COLDSTART, 0);
 
     /* The above should not return */
     krnPanic(KernelBase, "System Boot Failed!");
+    __builtin_unreachable();
 }
 
 DEFINESET(ARMPLATFORMS);

--- a/arch/arm-native/kernel/syscall.c
+++ b/arch/arm-native/kernel/syscall.c
@@ -50,15 +50,37 @@ void cache_clear_e(void *addr, uint32_t length, uint32_t flags)
 {
     uint32_t count = 0;
 
-    if (addr == NULL && length == 0xffffffff)
+    /*
+     * Cache line size from CTR. ARMv7+ format has [31:29]==0b100;
+     * DminLine [19:16] / IminLine [3:0] are log2 of words per line,
+     * so line size in bytes = 4 << minline. Use min(D,I) so the
+     * stride covers both caches.
+     */
+    uint32_t ctr;
+    __asm__ __volatile__("mrc p15, 0, %0, c0, c0, 1" : "=r"(ctr));
+    uint32_t line;
+    if ((ctr >> 29) == 0x4)
     {
-        count = 0x8000000;
+        uint32_t dminline = (ctr >> 16) & 0xf;
+        uint32_t iminline = ctr & 0xf;
+        uint32_t minline = dminline < iminline ? dminline : iminline;
+        line = 4U << minline;
     }
     else
     {
-        void *end_addr = (void*)(((uintptr_t)addr + length + 31) & ~31);
-        addr = (void *)((uintptr_t)addr & ~31);
-        count = (uintptr_t)(end_addr - addr) >> 5;
+        line = 32;
+    }
+    uint32_t mask = line - 1;
+
+    if (addr == NULL && length == 0xffffffff)
+    {
+        count = (uint32_t)(0x100000000ULL / line);
+    }
+    else
+    {
+        void *end_addr = (void*)(((uintptr_t)addr + length + mask) & ~(uintptr_t)mask);
+        addr = (void *)((uintptr_t)addr & ~(uintptr_t)mask);
+        count = (uintptr_t)(end_addr - addr) / line;
     }
 
     D(bug("[Kernel] CacheClearE from %p length %d count %d, flags %x\n", addr, length, count, flags));
@@ -82,11 +104,10 @@ void cache_clear_e(void *addr, uint32_t length, uint32_t flags)
             __asm__ __volatile__("mcr p15, 0, %0, c7, c6, 1"::"r"(addr));
         }
 
-        addr += 32;
+        addr += line;
     }
 
-    asm volatile ("mcr  p15, 0, %[r], c7, c10, 4" : : [r] "r" (0)); /* dsb */
-    //__asm__ __volatile__("dsb":::"memory");
+    __asm__ __volatile__("dsb":::"memory");
 }
 
 void handle_syscall(void *regs)


### PR DESCRIPTION
- intr.c: decode DFSR/IFSR status, WnR and IFAR in abort dumps
- kernel_cpu.c: fix swapped vmrs/vmsr in VFP save/restore; encode d16-d31 with two vstmia/vldmia (16-reg max per insn); pick VFP32 path from MVFR0
- kernel_startup.c: clang section attr workaround for stack_*_end; branch to user-mode continuation after cps so SP-relative locals aren't accessed across the mode switch
- syscall.c: derive cache line size from CTR DminLine/IminLine instead of hardcoding 32; use dsb mnemonic