### PR TITLE
arm-raspi/boot: Pi3 boot fixes for clang and ARMv7

### DIFF
--- a/arch/arm-raspi/boot/boot.c
+++ b/arch/arm-raspi/boot/boot.c
@@ -87,7 +87,16 @@ asm("   .section .aros.startup      \n"
 );
 
 // The bootstrap tmp stack is re-used by the reset handler so we store it at this fixed location
+/*
+ * clang's integrated assembler does not treat TARGET_SECTION_COMMENT ("//")
+ * as a comment — it becomes part of the section name, so the variable lands
+ * in ".aros.startup //" instead of ".aros.startup".
+ */
+#if defined(__clang__)
+static __used void * tmp_stack_ptr __attribute__((used, section(".aros.startup"))) = (void *)(0x1000 - 16);
+#else
 static __used void * tmp_stack_ptr __attribute__((used, section(".aros.startup" TARGET_SECTION_COMMENT))) = (void *)(0x1000 - 16);
+#endif
 static struct TagItem *boottag;
 static unsigned long *mem_upper;
 static void *pkg_image = NULL;
@@ -209,6 +218,9 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
     if (e)
     {
         of_property_t *p = dt_find_property(e, "ranges");
+        if (p == NULL)
+            while(1) asm volatile("wfe");
+
         uint32_t *ranges = p->op_value;
         int32_t len = p->op_length;
 
@@ -244,7 +256,11 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
 #else
     kprintf("\n\n[BOOT] Little-Endian AROS %s\n", bootstrapName);
 #endif
-    kprintf("[BOOT] Booted on %s\n", dt_find_property(dt_find_node("/"), "model")->op_value);
+    {
+        of_node_t *root = dt_find_node("/");
+        of_property_t *model = root ? dt_find_property(root, "model") : NULL;
+        kprintf("[BOOT] Booted on %s\n", model ? (const char *)model->op_value : "unknown");
+    }
 
     /* first of all, store the arch for the kernel to use .. */
     boottag->ti_Tag = KRN_Platform;
@@ -265,13 +281,20 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
             kprintf("[BOOT] local_intc points to %s\n", p->op_value);
 
             e = dt_find_node(p->op_value);
-            p = dt_find_property(e, "reg");
-            uint32_t *reg = p->op_value;
+            if (e)
+                p = dt_find_property(e, "reg");
+            else
+                p = NULL;
 
-            kprintf("[BOOT] Mapping local interrupt area at %p-%p\n", AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[0]) + AROS_BE2LONG(reg[1]) - 1);
+            if (p)
+            {
+                uint32_t *reg = p->op_value;
 
-            /* Prepare mapping - device type */
-            mmu_map_section(AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[1]) < 0x100000 ? 0x100000 : AROS_BE2LONG(reg[1]), 0, 0, 3, 0);
+                kprintf("[BOOT] Mapping local interrupt area at %p-%p\n", AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[0]) + AROS_BE2LONG(reg[1]) - 1);
+
+                /* Prepare mapping - device type */
+                mmu_map_section(AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[0]), AROS_BE2LONG(reg[1]) < 0x100000 ? 0x100000 : AROS_BE2LONG(reg[1]), 0, 0, 3, 0);
+            }
         }
     }
 

--- a/arch/arm-raspi/boot/devicetree.c
+++ b/arch/arm-raspi/boot/devicetree.c
@@ -157,6 +157,26 @@ of_node_t * dt_find_node_by_phandle(uint32_t phandle)
 #define MAX_KEY_SIZE    64
 char ptrbuf[64];
 
+/*
+ * Match a device tree node name against a search key.
+ * If the search key does not contain '@', the unit-address
+ * suffix in the node name is ignored (standard DT convention,
+ * e.g. "memory" matches a node named "memory@0").
+ */
+static int dt_name_cmp(const char *node_name, const char *key)
+{
+    while (*key) {
+        if (*node_name != *key)
+            return 1;
+        node_name++;
+        key++;
+    }
+    /* key exhausted: node must also end, or have '@' unit-address */
+    if (*node_name == 0 || *node_name == '@')
+        return 0;
+    return 1;
+}
+
 of_node_t * dt_find_node(char *key)
 {
     int i;
@@ -181,7 +201,7 @@ of_node_t * dt_find_node(char *key)
 
             ForeachNode(&ret->on_children, node)
             {
-                if (!strcmp(node->on_name, ptrbuf))
+                if (!dt_name_cmp(node->on_name, ptrbuf))
                 {
                     ret = node;
                     break;

--- a/arch/arm-raspi/boot/elf.c
+++ b/arch/arm-raspi/boot/elf.c
@@ -218,7 +218,13 @@ static int relocate(struct elfheader *eh, struct sheader *sh, long shrel_idx,
 
         struct symbol *symtab =
                         (struct symbol *)((unsigned long)shsymtab->addr);
-        struct relo *rel = (struct relo *)((unsigned long)shrel->addr);
+        /*
+         * ARM 32-bit ELF uses SHT_REL (8-byte entries: offset+info, no
+         * addend). The AROS-wide `relo` alias resolves to `struct rela`
+         * (12 bytes) on ARM, which strides past every other entry and
+         * reads garbage. Use `struct rel` explicitly here.
+         */
+        struct rel *rel = (struct rel *)((unsigned long)shrel->addr);
         char *section = (char *)((unsigned long)toreloc->addr);
 
         unsigned int numrel = (unsigned long)shrel->size
@@ -347,9 +353,6 @@ static int relocate(struct elfheader *eh, struct sheader *sh, long shrel_idx,
                         if (ELF_R_TYPE(rel->info) == R_ARM_MOVT_ABS)
                                 offset <<= 16;
 
-kprintf("movw/movt: offset=%08x, s=%08x, sym->value=%08x, section_orig_addr=%08x, section_addr=%08x\n", offset, s, sym->value,
-        deltas[sym->shindex], sh[sym->shindex].addr + virtoffset);
-
                         if (is_exec)
                         {
                                 /* Fix address by difference between actual address and expected address */
@@ -378,6 +381,32 @@ kprintf("movw/movt: offset=%08x, s=%08x, sym->value=%08x, section_orig_addr=%08x
                         {
                                 *p += s + virtoffset;
                         }
+                break;
+
+                case R_ARM_PREL31:
+                {
+                        /* 31-bit PC-relative, used in .ARM.exidx */
+                        intptr_t offset = AROS_LE2LONG(*p);
+                        /* Sign-extend from bit 30 */
+                        offset = (offset << 1) >> 1;
+
+                        if (is_exec)
+                        {
+                                if (shrel->info != sym->shindex)
+                                {
+                                        intptr_t expected_delta = deltas[sym->shindex] - deltas[shrel->info];
+                                        intptr_t actual_delta = sh[sym->shindex].addr - sh[shrel->info].addr;
+                                        offset += actual_delta - expected_delta;
+                                }
+                        }
+                        else
+                        {
+                                offset += s - (uint32_t)p;
+                        }
+
+                        *p &= AROS_LONG2LE(0x80000000);
+                        *p |= AROS_LONG2LE(offset & 0x7fffffff);
+                }
                 break;
 
                 case R_ARM_NONE: /* No reloc */

--- a/arch/arm-raspi/boot/support.c
+++ b/arch/arm-raspi/boot/support.c
@@ -18,7 +18,7 @@ void arm_flush_cache(uint32_t addr, uint32_t length)
                 addr += 32;
                 length -= 32;
         }
-        __asm__ __volatile__("mcr p15, 0, %0, c7, c10, 4"::"r"(addr));
+        __asm__ __volatile__("dsb":::"memory");
 }
 
 void arm_icache_invalidate(uint32_t addr, uint32_t length)
@@ -29,7 +29,7 @@ void arm_icache_invalidate(uint32_t addr, uint32_t length)
                 addr += 32;
                 length -= 32;
         }
-        __asm__ __volatile__("mcr p15, 0, %0, c7, c10, 4"::"r"(addr));
+        __asm__ __volatile__("dsb":::"memory");
 }
 
 void arm_dcache_invalidate(uint32_t addr, uint32_t length)
@@ -40,7 +40,7 @@ void arm_dcache_invalidate(uint32_t addr, uint32_t length)
                 addr += 32;
                 length -= 32;
         }
-        __asm__ __volatile__("mcr p15, 0, %0, c7, c10, 4"::"r"(addr));
+        __asm__ __volatile__("dsb":::"memory");
 }
 
 void *malloc(size_t size)

--- a/arch/arm-raspi/boot/vc_mb.c
+++ b/arch/arm-raspi/boot/vc_mb.c
@@ -35,7 +35,7 @@ volatile unsigned int *vcmb_read(uintptr_t mb, unsigned int chan)
             while ((rd32le(mb + VCMB_STATUS) & VCMB_STATUS_READREADY) != 0)
             {
                 /* Data synchronization barrier */
-                asm volatile ("mcr p15, 0, %[r], c7, c10, 4" : : [r] "r" (0) );
+                asm volatile ("dsb" ::: "memory");
 
                 if(try-- == 0)
                 {
@@ -43,12 +43,12 @@ volatile unsigned int *vcmb_read(uintptr_t mb, unsigned int chan)
                 }
             }
 
-            asm volatile ("mcr p15, #0, %[r], c7, c10, #5" : : [r] "r" (0) );
+            asm volatile ("dmb" ::: "memory");
 
             msg = rd32le(mb + VCMB_READ);
             D(kprintf("[VCMB] -> %p\n", msg));
 
-            asm volatile ("mcr p15, #0, %[r], c7, c10, #5" : : [r] "r" (0) );
+            asm volatile ("dmb" ::: "memory");
 
             if ((msg & VCMB_CHAN_MASK) == chan)
                 return (volatile unsigned int *)(msg & ~VCMB_CHAN_MASK);
@@ -66,10 +66,10 @@ void vcmb_write(uintptr_t mb, unsigned int chan, void *msg)
         while ((rd32le(mb + VCMB_STATUS) & VCMB_STATUS_WRITEREADY) != 0)
         {
                 /* Data synchronization barrier */
-                asm volatile ("mcr p15, 0, %[r], c7, c10, 4" : : [r] "r" (0) );
+                asm volatile ("dsb" ::: "memory");
         }
 
-        asm volatile ("mcr p15, #0, %[r], c7, c10, #5" : : [r] "r" (0) );
+        asm volatile ("dmb" ::: "memory");
 
         wr32le(mb + VCMB_WRITE, (uintptr_t)msg | chan);
     }


### PR DESCRIPTION
- boot.c: clang section attr workaround for tmp_stack_ptr. NULL-guard DT property/node lookups
- devicetree.c: match node names ignoring unit-address suffix
- elf.c: ARM 32-bit ELF uses SHT_REL (8-byte), not rela. Iterate with struct rel. Add R_ARM_PREL31 handling for .ARM.exidx
- support.c, vc_mb.c: replace deprecated CP15 c7,c10,4/5 mcr's with dsb/dmb mnemonics