### PR TITLE
misc: ExAll padding, cdceth packing, Startup-Sequence ordering

### DIFF
--- a/rom/filesys/pfs3/fs/directory.c
+++ b/rom/filesys/pfs3/fs/directory.c
@@ -1209,7 +1209,7 @@ static ULONG FillInData(struct ExAllData *buffer, LONG type,
 	}
 
 	/* check fit */
-	size = (size + 1) & 0xfffe;
+	size = (size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 	if (size > spaceleft)
 		return (0);
 
@@ -4188,7 +4188,7 @@ static ULONG FillInDDEData(struct ExAllData *buffer, LONG type,
 	}
 
 	/* check fit */
-	size = (size + 1) & 0xfffe;
+	size = (size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 	if (size > spaceleft)
 		return 0;
 

--- a/rom/filesys/ram/commands.c
+++ b/rom/filesys/ram/commands.c
@@ -1446,7 +1446,7 @@ BOOL CmdExamineAll(struct Handler *handler, struct Lock *lock,
          entry_size = struct_size + name_size;
          if(type >= ED_COMMENT)
             entry_size += comment_size;
-         entry_size = (entry_size + 1) & (~0x1);
+         entry_size = (entry_size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 
          pattern = control->eac_MatchString;
          if(pattern != NULL)

--- a/rom/usb/classes/cdceth/cdceth.class.h
+++ b/rom/usb/classes/cdceth/cdceth.class.h
@@ -26,10 +26,6 @@
 #include "cdceth.h"
 #include "dev.h"
 
-#if defined(__GNUC__)
-# pragma pack(2)
-#endif
-
 #define DDF_CONFIGURED (1<<2)  /* station address is configured */
 #define DDF_ONLINE     (1<<3)  /* device is online */
 #define DDF_OFFLINE    (1<<4)  /* device was put offline */
@@ -178,10 +174,6 @@ struct ClsDevCfg
     ULONG cdc_DefaultUnit;
     ULONG cdc_MediaType;
 };
-
-#if defined(__GNUC__)
-# pragma pack()
-#endif
 
 /* Structure of an ethernet packet - internal */
 

--- a/rom/usb/classes/cdceth/mmakefile.src
+++ b/rom/usb/classes/cdceth/mmakefile.src
@@ -2,7 +2,7 @@
 include $(SRCDIR)/config/aros.cfg
 
 USER_CPPFLAGS := -DMUIMASTER_YES_INLINE_STDARG
-USER_CPPFLAGS += -DDEBUG=1
+USER_CPPFLAGS += -DDEBUG=0
 USER_LDFLAGS := -static
 
 FILES :=    cdceth.class cdceth_encap dev debug

--- a/workbench/libs/diskfont/diskfontfunc.c
+++ b/workbench/libs/diskfont/diskfontfunc.c
@@ -109,7 +109,7 @@ STATIC struct FileEntry *ReadFileEntry(struct ExAllData *ead, struct DiskfontBas
         return NULL;
     }
     
-    strsize = (strlen(ead->ed_Name) + 1 + 1) & ~1;
+    strsize = (strlen(ead->ed_Name) + 1 + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
     size = sizeof(struct FileEntry) + strsize + fdh->NumEntries * sizeof(struct TTextAttr);
     if (fdh->ContentsID == OFCH_ID) /* Reserve extra Attr for outline fonts */
          size += sizeof(struct TTextAttr);
@@ -417,7 +417,7 @@ STATIC BOOL StreamInFileList(struct DirEntry *direntry, BPTR fh, struct Diskfont
 
         if (ok)
         {
-            int namelen = (strlen(fe2.FileName) + 1 + 1) & ~1;
+            int namelen = (strlen(fe2.FileName) + 1 + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
             attrs = AllocVec(fe2.Numentries * sizeof(struct TTextAttr), MEMF_ANY|MEMF_CLEAR);
 
             ok = ok && attrs != NULL;

--- a/workbench/s/Startup-Sequence
+++ b/workbench/s/Startup-Sequence
@@ -1,6 +1,6 @@
-SetClock LOAD
-
 FailAt 21
+
+SetClock LOAD
 
 If NOT EXISTS "RAM:Clipboards"
     MakeDir "RAM:Clipboards"


### PR DESCRIPTION
- pfs3, ram, diskfont. pad ExAll entry size to AROS_PTRALIGN instead of 2 bytes so the next entry starts at a properly aligned address on platforms where pointers need stricter alignment than 16 bits.
- cdceth. drop the global #pragma pack(2) from the class header. it applied to all included system structures and produced misaligned accesses on ARM. set DEBUG=0 in mmakefile.
- Startup-Sequence. run FailAt before SetClock so a SetClock failure does not abort the boot.