### PR TITLE
processor.resource/arm-native: ARMv7 cache decode and SMP probe sync

### DIFF
--- a/arch/arm-native/processor/processor_init.c
+++ b/arch/arm-native/processor/processor_init.c
@@ -16,10 +16,27 @@
 
 #define DUMPINFO(a) a
 
+#if defined(__AROSEXEC_SMP__)
+static void ProbeCPUAndSignal(struct ARMProcessorInformation *info,
+                              struct Task *parent, ULONG sigmask)
+{
+    ReadProcessorInformation(info);
+    Signal(parent, sigmask);
+}
+#endif
+
 LONG Processor_Init(struct ProcessorBase * ProcessorBase)
 {
     struct ARMProcessorInformation **sysprocs;
     unsigned int i;
+#if defined(__AROSEXEC_SMP__)
+    struct Task *me = FindTask(NULL);
+    ULONG waitmask = 0;
+    BYTE sigbits[ProcessorBase->cpucount];
+
+    for (i = 0; i < ProcessorBase->cpucount; i++)
+        sigbits[i] = -1;
+#endif
 
     D(bug("[processor.ARM] :%s()\n", __PRETTY_FUNCTION__));
 
@@ -38,11 +55,25 @@ LONG Processor_Init(struct ProcessorBase * ProcessorBase)
             void *cpuMask = KrnAllocCPUMask();
             if (cpuMask)
                 KrnGetCPUMask(i, cpuMask);
-            NewCreateTask(TASKTAG_AFFINITY      , cpuMask,
-                          TASKTAG_PRI           , -127,
-                          TASKTAG_PC            , ReadProcessorInformation,
-                          TASKTAG_ARG1          , sysprocs[i],
-                          TAG_DONE);
+
+            sigbits[i] = AllocSignal(-1);
+            if (sigbits[i] >= 0)
+            {
+                ULONG mask = 1UL << sigbits[i];
+                waitmask |= mask;
+                NewCreateTask(TASKTAG_AFFINITY      , cpuMask,
+                              TASKTAG_PRI           , -127,
+                              TASKTAG_PC            , ProbeCPUAndSignal,
+                              TASKTAG_ARG1          , sysprocs[i],
+                              TASKTAG_ARG2          , me,
+                              TASKTAG_ARG3          , mask,
+                              TAG_DONE);
+            }
+            else
+            {
+                /* Out of signals — fall back to probing on whatever CPU we land on. */
+                ReadProcessorInformation(sysprocs[i]);
+            }
         }
         else
 #else
@@ -50,6 +81,16 @@ LONG Processor_Init(struct ProcessorBase * ProcessorBase)
 #endif
             ReadProcessorInformation(sysprocs[i]);
     }
+
+#if defined(__AROSEXEC_SMP__)
+    if (waitmask)
+        Wait(waitmask);
+    for (i = 0; i < ProcessorBase->cpucount; i++)
+    {
+        if (sigbits[i] >= 0)
+            FreeSignal(sigbits[i]);
+    }
+#endif
 
     DUMPINFO(
     bug("[processor.ARM] Processor Details -:\n");

--- a/arch/arm-native/processor/processor_util.c
+++ b/arch/arm-native/processor/processor_util.c
@@ -6,6 +6,7 @@
 #include <aros/debug.h>
 
 #include <resources/processor.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "processor_arch_intern.h"
@@ -69,7 +70,7 @@ VOID ReadProcessorInformation(struct ARMProcessorInformation * info)
     {
         info->Family = CPUFAMILY_ARM_6;
 
-        if ((scp_reg & 0xFFF0) == 0xc070)
+        if ((scp_reg & 0xFFF0) == 0xc070 || (scp_reg & 0xFFF0) == 0xd030)
             info->Family = CPUFAMILY_ARM_7;
 
         DPROBE(bug("[processor.ARM] %s: Checking Memory Model Feature Register..\n", __PRETTY_FUNCTION__));
@@ -145,74 +146,117 @@ VOID ReadProcessorInformation(struct ARMProcessorInformation * info)
     DPROBE(bug("[processor.ARM] %s: Checking Cache Type Register..\n", __PRETTY_FUNCTION__));
     asm volatile("mrc p15, 0, %[cache_reg], c0, c0, 1" : [cache_reg] "=r" (cache_reg) );
 
-    if (scp_reg & (1 << 2))
+    if (info->Family >= CPUFAMILY_ARM_7)
     {
-        switch((cache_reg >> 18) & 0xF) {
-            case 3:
-                info->L1DataCacheSize = 4;
-                break;
-            case 4:
-                info->L1DataCacheSize = 8;
-                break;
-            case 5:
-                info->L1DataCacheSize = 16;
-                break;
-            case 6:
-                info->L1DataCacheSize = 32;
-                break;
-            case 7:
-                info->L1DataCacheSize = 64;
-                break;
-            case 8:
-                info->L1DataCacheSize = 128;
-                break;
-            case 9:
-                info->L1DataCacheSize = 256;
-                break;
-            case 10:
-                info->L1DataCacheSize = 512;
-                break;
-            case 11:
-                info->L1DataCacheSize = 1024;
-                break;
-            default:
-                info->L1DataCacheSize = 0;
-                break;
+        /*
+         * ARMv7+ CTR no longer encodes total cache size — its 18:21
+         * and 6:9 fields are now line-size descriptors (DminLine /
+         * IminLine). Total size must be derived from CCSIDR via
+         * CSSELR (write level/type, then read CCSIDR). ARMv6 still
+         * uses the old CTR-based decoding below.
+         *
+         * CCSIDR fields:
+         *   [2:0]   LineSize   (line bytes = 1 << (LineSize + 4))
+         *   [12:3]  Associativity-1
+         *   [27:13] NumSets-1
+         */
+        uint32_t ccsidr;
+        uint32_t line_bytes, assoc, sets;
+
+        if (scp_reg & (1 << 2))
+        {
+            asm volatile("mcr p15, 2, %0, c0, c0, 0" : : "r" (0));   /* CSSELR: L1 data, 0=L1, InD=0 */
+            asm volatile("isb");
+            asm volatile("mrc p15, 1, %0, c0, c0, 0" : "=r" (ccsidr));
+            line_bytes = 1 << ((ccsidr & 7) + 4);
+            assoc = ((ccsidr >> 3) & 0x3FF) + 1;
+            sets = ((ccsidr >> 13) & 0x7FFF) + 1;
+            info->L1DataCacheSize = (sets * assoc * line_bytes) >> 10; /* KiB */
+        }
+
+        if (scp_reg & (1 << 12))
+        {
+            asm volatile("mcr p15, 2, %0, c0, c0, 0" : : "r" (1));   /* CSSELR: L1, InD=1 (instruction) */
+            asm volatile("isb");
+            asm volatile("mrc p15, 1, %0, c0, c0, 0" : "=r" (ccsidr));
+            line_bytes = 1 << ((ccsidr & 7) + 4);
+            assoc = ((ccsidr >> 3) & 0x3FF) + 1;
+            sets = ((ccsidr >> 13) & 0x7FFF) + 1;
+            info->L1InstructionCacheSize = (sets * assoc * line_bytes) >> 10;
         }
     }
-    if (scp_reg & (1 << 12))
+    else
     {
-        switch((cache_reg >> 6) & 0xF) {
-            case 3:
-                info->L1InstructionCacheSize = 4;
-                break;
-            case 4:
-                info->L1InstructionCacheSize = 8;
-                break;
-            case 5:
-                info->L1InstructionCacheSize = 16;
-                break;
-            case 6:
-                info->L1InstructionCacheSize = 32;
-                break;
-            case 7:
-                info->L1InstructionCacheSize = 64;
-                break;
-            case 8:
-                info->L1InstructionCacheSize = 128;
-                break;
-            case 9:
-                info->L1InstructionCacheSize = 256;
-                break;
-            case 10:
-                info->L1InstructionCacheSize = 512;
-                break;
-            case 11:
-                info->L1InstructionCacheSize = 1024;
-                break;
-            default:
-                info->L1InstructionCacheSize = 0;
-                break;
+        /* Pre-ARMv7: CTR encodes cache size in bits 18:21 (D) / 6:9 (I) */
+        if (scp_reg & (1 << 2))
+        {
+            switch ((cache_reg >> 18) & 0xF) {
+                case 3:
+                    info->L1DataCacheSize = 4;
+                    break;
+                case 4:
+                    info->L1DataCacheSize = 8;
+                    break;
+                case 5:
+                    info->L1DataCacheSize = 16;
+                    break;
+                case 6:
+                    info->L1DataCacheSize = 32;
+                    break;
+                case 7:
+                    info->L1DataCacheSize = 64;
+                    break;
+                case 8:
+                    info->L1DataCacheSize = 128;
+                    break;
+                case 9:
+                    info->L1DataCacheSize = 256;
+                    break;
+                case 10:
+                    info->L1DataCacheSize = 512;
+                    break;
+                case 11:
+                    info->L1DataCacheSize = 1024;
+                    break;
+                default:
+                    info->L1DataCacheSize = 0;
+                    break;
+            }
+        }
+        if (scp_reg & (1 << 12))
+        {
+            switch ((cache_reg >> 6) & 0xF) {
+                case 3:
+                    info->L1InstructionCacheSize = 4;
+                    break;
+                case 4:
+                    info->L1InstructionCacheSize = 8;
+                    break;
+                case 5:
+                    info->L1InstructionCacheSize = 16;
+                    break;
+                case 6:
+                    info->L1InstructionCacheSize = 32;
+                    break;
+                case 7:
+                    info->L1InstructionCacheSize = 64;
+                    break;
+                case 8:
+                    info->L1InstructionCacheSize = 128;
+                    break;
+                case 9:
+                    info->L1InstructionCacheSize = 256;
+                    break;
+                case 10:
+                    info->L1InstructionCacheSize = 512;
+                    break;
+                case 11:
+                    info->L1InstructionCacheSize = 1024;
+                    break;
+                default:
+                    info->L1InstructionCacheSize = 0;
+                    break;
+            }
         }
     }
     D(bug("[processor.ARM] %s: .. Done\n", __PRETTY_FUNCTION__));


### PR DESCRIPTION
- processor_util.c. recognise Cortex-A53 (MIDR 0xd03x) as ARMv7. derive L1 cache sizes from CCSIDR via CSSELR on ARMv7+ instead of the obsolete CTR layout (which now encodes line-size, not total size). ARMv6 keeps the old CTR-based path.
- processor_init.c. when probing per-CPU info under SMP, wait on per-cpu signals so Processor_Init does not return before all affinity-bound probe tasks have populated their slots.