### PR TITLE
intuition/pointerclass: Fix NULL return on allocation failure

### DIFF
--- a/rom/intuition/pointerclass.c
+++ b/rom/intuition/pointerclass.c
@@ -174,6 +174,15 @@ IPTR PointerClass__OM_NEW(Class *cl, Object *o, struct opSet *msg)
         }
     }
 
+    /*
+     * BOOPSI convention: DoSuperMethodA returns the new object in o.
+     * If we never called it (no matching bitmap type), o still holds
+     * the class pointer passed as the second argument. Detect this
+     * and return NULL to indicate allocation failure.
+     */
+    if ((IPTR)o == (IPTR)cl)
+        return (IPTR)NULL;
+
     return (IPTR)o;
 }
 


### PR DESCRIPTION
OM_NEW must return NULL if no bitmap type matched and DoSuperMethodA was never called. Without this check, the unmodified 'o' parameter (which holds the Class pointer) is returned as if it were a valid object, causing crashes when the caller tries to use it.

Detected during AArch64 port but affects all architectures.