### PR TITLE
expansion/makedosnode: Use AROS_STACKSIZE instead of 4000

### DIFF
--- a/rom/expansion/makedosnode.c
+++ b/rom/expansion/makedosnode.c
@@ -154,7 +154,7 @@
 
     /* Now that we have the pointers, fill it all */
     CopyMem(de_pp, de, desize);
-        
+
     bs1 = MKBADDR(s1);
     bs2 = MKBADDR(s2);
     
@@ -183,7 +183,7 @@
     dn->dn_Type = DLT_DEVICE;
     dn->dn_Name = bs1;
     dn->dn_Priority = 10;
-    dn->dn_StackSize = 4000;
+    dn->dn_StackSize = AROS_STACKSIZE;
 
 #if __WORDSIZE > 32
     /*


### PR DESCRIPTION
4000 bytes is insufficient for 64-bit architectures where pointers and stack frames are larger. AROS_STACKSIZE is the platform-appropriate default.