### PR TITLE
Shell: Don't override cli_Background if already set

### DIFF
--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -164,7 +164,7 @@ LONG interact(ShellState *ss)
             }
 
             cli->cli_CurrentInput = cli->cli_StandardInput;
-            cli->cli_Background = IsInteractive(cli->cli_CurrentInput) ? DOSFALSE : DOSTRUE;
+            if (!cli->cli_Background) cli->cli_Background = IsInteractive(cli->cli_CurrentInput) ? DOSFALSE : DOSTRUE;
 
             setInteractive(cli, ss);
         }


### PR DESCRIPTION
A shell launched with cli_Background=DOSTRUE (e.g. via RunCommand from a script) should not have its background state overridden by the IsInteractive() check.