### PR TITLE
icon/diskobj35io: Fix buffer overflow in ARGB decompression

### DIFF
--- a/workbench/libs/icon/diskobj35io.c
+++ b/workbench/libs/icon/diskobj35io.c
@@ -214,7 +214,7 @@ VOID MakeMask35(UBYTE *imgdata, UBYTE *imgmask, UBYTE transpcolor, LONG imagew, 
 /****************************************************************************************/
 void *malloc(size_t size)
 {
-    return AllocVec(size, MEMF_PUBLIC);
+    return AllocVec(size, MEMF_PUBLIC | MEMF_CLEAR);
 }
 
 void free(void *ptr)
@@ -249,7 +249,10 @@ STATIC BOOL ReadARGB35(struct DiskObject *icon, struct IFFHandle *iff, struct Fi
     argb = AllocMemIcon(icon, size, MEMF_PUBLIC, IconBase);
     if (!argb) goto fail;
  
-    zsize = AROS_BE2WORD(*((UWORD *)(src + 6))) + 1;
+    zsize = (UWORD)AROS_BE2WORD(*((UWORD *)(src + 6))) + 1;
+    if (chunksize < 10 || zsize + 10 > (ULONG)chunksize)
+        zsize = (chunksize > 10) ? (ULONG)chunksize - 10 : 0;
+    if (zsize == 0) goto fail;
     err = uncompress(argb, &size, src + 10, zsize);
     if (err != Z_OK) {
         D(bug("%s: Can't uncompress %d ARGB bytes: %s\n", __func__, zsize, zError(err)));


### PR DESCRIPTION
Two fixes:
1. malloc() uses MEMF_CLEAR to prevent uninitialized memory leaks
2. Bounds-check zsize before uncompress() — prevents heap corruption from malformed .info files

Security-relevant.