### PR TITLE
kernel/tlsf: Add double-free detection

### DIFF
--- a/rom/kernel/tlsf.c
+++ b/rom/kernel/tlsf.c
@@ -356,6 +356,14 @@ void * tlsf_malloc(struct MemHeaderExt *mhe, IPTR size, ULONG *flags)
     if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
 
+    /* Double-free detection (must be after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb)) {
+        D(bug("[TLSF] DOUBLE FREE! ptr=%p size=%ld\n", ptr, (long)GET_SIZE(fb)));
+        if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
+
     /* Find the indices fl and sl for given size */
     MAPPING_SEARCH(&size, &fl, &sl);
 
@@ -562,6 +570,14 @@ void * tlsf_malloc_aligned(struct MemHeaderExt *mhe, IPTR size, IPTR align, ULON
     if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
 
+    /* Double-free detection (must be after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb)) {
+        D(bug("[TLSF] DOUBLE FREE! ptr=%p size=%ld\n", ptr, (long)GET_SIZE(fb)));
+        if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
+
     size = ROUNDUP(size);
 
     D(nbug("[Kernel:TLSF] %s(%p, %lx, %u)\n", __PRETTY_FUNCTION__, mhe, size, align));
@@ -672,8 +688,17 @@ void tlsf_freevec(struct MemHeaderExt * mhe, APTR ptr)
 
     fb = MEM_TO_BHDR(ptr);
 
+
     if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+
+    /* Double-free detection (must be after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb)) {
+        D(bug("[TLSF] DOUBLE FREE! ptr=%p size=%ld\n", ptr, (long)GET_SIZE(fb)));
+        if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
 
     /* Mark block as free */
     SET_FREE_BLOCK(fb);
@@ -738,6 +763,14 @@ void * tlsf_realloc(struct MemHeaderExt *mhe, APTR ptr, IPTR new_size)
 
     if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+
+    /* Double-free detection (must be after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb)) {
+        D(bug("[TLSF] DOUBLE FREE! ptr=%p size=%ld\n", ptr, (long)GET_SIZE(fb)));
+        if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
 
     bnext = GET_NEXT_BHDR(b, GET_SIZE(b));
 
@@ -849,6 +882,14 @@ void * tlsf_allocabs(struct MemHeaderExt * mhe, IPTR size, void * ptr)
 
     if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+
+    /* Double-free detection (must be after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb)) {
+        D(bug("[TLSF] DOUBLE FREE! ptr=%p size=%ld\n", ptr, (long)GET_SIZE(fb)));
+        if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
 
     /* Start searching here. It doesn't make sense to go through regions which are smaller */
     MAPPING_SEARCH(&region_size, &fl, &sl);


### PR DESCRIPTION
Check if a block is already free before freeing again. Prevents TLSF free-list corruption. Important on SMP where race conditions can cause double-frees.