### PR TITLE
exec/rawdofmt: Add AArch64 va_list support

### DIFF
--- a/rom/exec/rawdofmt.c
+++ b/rom/exec/rawdofmt.c
@@ -16,9 +16,15 @@
 #include "exec_intern.h"
 #include "exec_util.h"
 
-#ifdef __arm__
+#if defined(__arm__)
 
 #define is_va_list(ap) ap.__ap
+#define null_va_list(ap) va_list ap = {NULL}
+#define VA_NULL {NULL}
+
+#elif defined(__aarch64__)
+
+#define is_va_list(ap) ap.__stack
 #define null_va_list(ap) va_list ap = {NULL}
 #define VA_NULL {NULL}
 


### PR DESCRIPTION
AArch64 uses a different va_list structure than ARM32. Adds the __stack field check for AArch64, similar to ARM32's __ap field.