### PR TITLE
kernel/tlsf: Add double-free detection in tlsf_freevec

### DIFF
--- a/rom/kernel/tlsf.c
+++ b/rom/kernel/tlsf.c
@@ -679,7 +679,7 @@ void tlsf_freevec(struct MemHeaderExt * mhe, APTR ptr)
     /* Double-free detection (after semaphore for SMP safety) */
     if (FREE_BLOCK(fb))
     {
-        D(nbug("[Kernel:TLSF] DOUBLE FREE! ptr=%p size=%lu\n", ptr, (unsigned long)GET_SIZE(fb)));
+        D(nbug("[Kernel:TLSF] DOUBLE FREE! ptr=%p size=%llu\n", ptr, (unsigned long long)GET_SIZE(fb)));
         if (sem_protected)
             ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
         return;

--- a/rom/kernel/tlsf.c
+++ b/rom/kernel/tlsf.c
@@ -672,8 +672,18 @@ void tlsf_freevec(struct MemHeaderExt * mhe, APTR ptr)
 
     fb = MEM_TO_BHDR(ptr);
 
-    if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+    BOOL sem_protected = !!(((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED);
+    if (sem_protected)
         ObtainSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+
+    /* Double-free detection (after semaphore for SMP safety) */
+    if (FREE_BLOCK(fb))
+    {
+        D(nbug("[Kernel:TLSF] DOUBLE FREE! ptr=%p size=%lu\n", ptr, (unsigned long)GET_SIZE(fb)));
+        if (sem_protected)
+            ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+        return;
+    }
 
     /* Mark block as free */
     SET_FREE_BLOCK(fb);
@@ -700,8 +710,10 @@ void tlsf_freevec(struct MemHeaderExt * mhe, APTR ptr)
         INSERT_FREE_BLOCK(tlsf, fb);
     }
 
-    if (((ULONG)(IPTR)mhe->mhe_MemHeader.mh_First) & MEMF_SEM_PROTECTED)
+    if (sem_protected)
         ReleaseSemaphore((struct SignalSemaphore *)mhe->mhe_MemHeader.mh_Node.ln_Name);
+
+
 }
 
 void tlsf_freemem(struct MemHeaderExt * mhe, APTR ptr, IPTR size)


### PR DESCRIPTION
- Check after ObtainSemaphore (SMP TOCTOU safe)
- !! for BOOL normalization (16-bit safe)
- Local bool avoids duplicated sem-protection condition
- nbug with [Kernel:TLSF] prefix, %lu format
- Allman-style braces matching file convention

Prevents TLSF free-list corruption from double-frees.