### PR TITLE
afs/filehandles1: Fix buffer overflow in path parsing

### DIFF
--- a/rom/filesys/afs/filehandles1.c
+++ b/rom/filesys/afs/filehandles1.c
@@ -248,7 +248,7 @@ UBYTE buffer[32];
                                 return NULL;
                         }
                         pos = buffer;
-                        while ((*name != 0) && (*name != '/'))
+                        while ((*name != 0) && (*name != '/') && (pos < buffer + sizeof(buffer) - 1))
                         {
                                 *pos++ = *name++;
                         }


### PR DESCRIPTION
Add bounds check to prevent writing past buffer end when parsing path components. Names exceeding the buffer are truncated (standard AFS 30-char limit).