### PR TITLE
pfs3, ram, diskfont: pad ExAll entry to AROS_PTRALIGN.

### DIFF
--- a/rom/filesys/pfs3/fs/directory.c
+++ b/rom/filesys/pfs3/fs/directory.c
@@ -1209,7 +1209,7 @@ static ULONG FillInData(struct ExAllData *buffer, LONG type,
 	}
 
 	/* check fit */
-	size = (size + 1) & 0xfffe;
+	size = (size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 	if (size > spaceleft)
 		return (0);
 
@@ -4188,7 +4188,7 @@ static ULONG FillInDDEData(struct ExAllData *buffer, LONG type,
 	}
 
 	/* check fit */
-	size = (size + 1) & 0xfffe;
+	size = (size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 	if (size > spaceleft)
 		return 0;
 

--- a/rom/filesys/ram/commands.c
+++ b/rom/filesys/ram/commands.c
@@ -1446,7 +1446,7 @@ BOOL CmdExamineAll(struct Handler *handler, struct Lock *lock,
          entry_size = struct_size + name_size;
          if(type >= ED_COMMENT)
             entry_size += comment_size;
-         entry_size = (entry_size + 1) & (~0x1);
+         entry_size = (entry_size + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
 
          pattern = control->eac_MatchString;
          if(pattern != NULL)

--- a/workbench/libs/diskfont/diskfontfunc.c
+++ b/workbench/libs/diskfont/diskfontfunc.c
@@ -109,7 +109,7 @@ STATIC struct FileEntry *ReadFileEntry(struct ExAllData *ead, struct DiskfontBas
         return NULL;
     }
     
-    strsize = (strlen(ead->ed_Name) + 1 + 1) & ~1;
+    strsize = (strlen(ead->ed_Name) + 1 + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
     size = sizeof(struct FileEntry) + strsize + fdh->NumEntries * sizeof(struct TTextAttr);
     if (fdh->ContentsID == OFCH_ID) /* Reserve extra Attr for outline fonts */
          size += sizeof(struct TTextAttr);
@@ -417,7 +417,7 @@ STATIC BOOL StreamInFileList(struct DirEntry *direntry, BPTR fh, struct Diskfont
 
         if (ok)
         {
-            int namelen = (strlen(fe2.FileName) + 1 + 1) & ~1;
+            int namelen = (strlen(fe2.FileName) + 1 + (AROS_PTRALIGN - 1)) & ~(AROS_PTRALIGN - 1);
             attrs = AllocVec(fe2.Numentries * sizeof(struct TTextAttr), MEMF_ANY|MEMF_CLEAR);
 
             ok = ok && attrs != NULL;


### PR DESCRIPTION
Pad ExAll entry size to AROS_PTRALIGN instead of 2 bytes so the next entry starts at a properly aligned address on platforms where pointers need stricter alignment than 16 bits.