### PR TITLE
cdceth: drop global #pragma pack(2) from class header.

### DIFF
--- a/rom/usb/classes/cdceth/cdceth.class.h
+++ b/rom/usb/classes/cdceth/cdceth.class.h
@@ -26,10 +26,6 @@
 #include "cdceth.h"
 #include "dev.h"
 
-#if defined(__GNUC__)
-# pragma pack(2)
-#endif
-
 #define DDF_CONFIGURED (1<<2)  /* station address is configured */
 #define DDF_ONLINE     (1<<3)  /* device is online */
 #define DDF_OFFLINE    (1<<4)  /* device was put offline */
@@ -178,10 +174,6 @@ struct ClsDevCfg
     ULONG cdc_DefaultUnit;
     ULONG cdc_MediaType;
 };
-
-#if defined(__GNUC__)
-# pragma pack()
-#endif
 
 /* Structure of an ethernet packet - internal */
 

--- a/rom/usb/classes/cdceth/mmakefile.src
+++ b/rom/usb/classes/cdceth/mmakefile.src
@@ -2,7 +2,7 @@
 include $(SRCDIR)/config/aros.cfg
 
 USER_CPPFLAGS := -DMUIMASTER_YES_INLINE_STDARG
-USER_CPPFLAGS += -DDEBUG=1
+USER_CPPFLAGS += -DDEBUG=0
 USER_LDFLAGS := -static
 
 FILES :=    cdceth.class cdceth_encap dev debug


### PR DESCRIPTION
The pragma applied to all included system structures and produced misaligned accesses on ARM. Also set DEBUG=0 in mmakefile.