### PR TITLE
videocore: add hardware cursor tag IDs

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
@@ -99,6 +99,10 @@
 
 #define VCTAG_GETDMACHAN        0x00060001
 
+/* HW cursor */
+#define VCTAG_SETCURSORINFO     0x00008010
+#define VCTAG_SETCURSORSTATE    0x00008011
+
 /* GPU Memory allocation flags */
 #define VCMEM_DISCARDABLE       (1 << 0)        // can be released at any time
 #define VCMEM_NORMAL            (0 << 2)        // normal allocating alias. Don't use from ARM


### PR DESCRIPTION
## Summary
- Add `VCTAG_SETCURSORINFO` (0x00008010) and `VCTAG_SETCURSORSTATE` (0x00008011) to `arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h`.
- These are the standard BCM2835 VideoCore mailbox property tag IDs for programming the hardware-cursor overlay.

Missing file from yesterdays VC4 PR