### PR TITLE
Raspberry Pi: add BCM2835 SDHOST controller driver

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -36,7 +36,101 @@
 #define SPI0_BASE                                       (ARM_PERIIOBASE + 0x204000)
 #define BSC0_BASE                                       (ARM_PERIIOBASE + 0x205000)
 #define GPIO_PWM                                        (ARM_PERIIOBASE + 0x20C000)
+#define DMA0_BASE                                       (ARM_PERIIOBASE + 0x007000)
 #define V3D_BASE                                        (ARM_PERIIOBASE + 0xc00000)
+
+/* PWM registers */
+#define PWM_CTL                                         (GPIO_PWM + 0x00)
+#define PWM_STA                                         (GPIO_PWM + 0x04)
+#define PWM_DMAC                                        (GPIO_PWM + 0x08)
+#define PWM_RNG1                                        (GPIO_PWM + 0x10)
+#define PWM_DAT1                                        (GPIO_PWM + 0x14)
+#define PWM_FIF1                                        (GPIO_PWM + 0x18)
+#define PWM_RNG2                                        (GPIO_PWM + 0x20)
+#define PWM_DAT2                                        (GPIO_PWM + 0x24)
+
+/* PWM CTL bits */
+#define PWM_CTL_PWEN1                                   (1 << 0)
+#define PWM_CTL_MODE1                                   (1 << 1)
+#define PWM_CTL_RPTL1                                   (1 << 2)
+#define PWM_CTL_SBIT1                                   (1 << 3)
+#define PWM_CTL_POLA1                                   (1 << 4)
+#define PWM_CTL_USEF1                                   (1 << 5)
+#define PWM_CTL_CLRF1                                   (1 << 6)
+#define PWM_CTL_MSEN1                                   (1 << 7)
+#define PWM_CTL_PWEN2                                   (1 << 8)
+#define PWM_CTL_MODE2                                   (1 << 9)
+#define PWM_CTL_RPTL2                                   (1 << 10)
+#define PWM_CTL_SBIT2                                   (1 << 11)
+#define PWM_CTL_POLA2                                   (1 << 12)
+#define PWM_CTL_USEF2                                   (1 << 13)
+#define PWM_CTL_MSEN2                                   (1 << 15)
+
+/* PWM STA bits */
+#define PWM_STA_FULL1                                   (1 << 0)
+#define PWM_STA_EMPT1                                   (1 << 1)
+#define PWM_STA_WERR1                                   (1 << 2)
+#define PWM_STA_RERR1                                   (1 << 3)
+#define PWM_STA_GAPO1                                   (1 << 4)
+#define PWM_STA_GAPO2                                   (1 << 5)
+#define PWM_STA_BERR                                    (1 << 8)
+#define PWM_STA_STA1                                    (1 << 9)
+#define PWM_STA_STA2                                    (1 << 10)
+
+/* PWM DMAC bits */
+#define PWM_DMAC_ENAB                                   (1 << 31)
+#define PWM_DMAC_PANIC(x)                               (((x) & 0xFF) << 8)
+#define PWM_DMAC_DREQ(x)                                (((x) & 0xFF) << 0)
+
+/* Clock Manager PWM */
+#define CM_PWMCTL                                       (CLOCK_BASE + 0xA0)
+#define CM_PWMDIV                                       (CLOCK_BASE + 0xA4)
+#define CM_PASSWORD                                     0x5A000000
+#define CM_SRC_OSC                                      1
+#define CM_SRC_PLLD                                     6
+#define CM_BUSY                                         (1 << 7)
+#define CM_ENAB                                         (1 << 4)
+#define CM_MASH(x)                                      (((x) & 3) << 9)
+
+/* DMA controller */
+#define DMA_CH_BASE(ch)                                 (DMA0_BASE + (ch) * 0x100)
+#define DMA_CS(ch)                                      (DMA_CH_BASE(ch) + 0x00)
+#define DMA_CONBLK_AD(ch)                               (DMA_CH_BASE(ch) + 0x04)
+#define DMA_DEBUG(ch)                                   (DMA_CH_BASE(ch) + 0x20)
+#define DMA_INT_STATUS                                  (DMA0_BASE + 0xFE0)
+#define DMA_ENABLE_REG                                  (DMA0_BASE + 0xFF0)
+
+/* DMA CS bits */
+#define DMA_CS_ACTIVE                                   (1 << 0)
+#define DMA_CS_END                                      (1 << 1)
+#define DMA_CS_INT                                      (1 << 2)
+#define DMA_CS_WAIT_FOR_WRITES                          (1 << 28)
+#define DMA_CS_PANIC_PRI(x)                             (((x) & 0xF) << 20)
+#define DMA_CS_PRI(x)                                   (((x) & 0xF) << 16)
+#define DMA_CS_ABORT                                    (1 << 30)
+#define DMA_CS_RESET                                    (1 << 31)
+
+/* DMA TI (Transfer Information) bits */
+#define DMA_TI_INTEN                                    (1 << 0)
+#define DMA_TI_TDMODE                                   (1 << 1)
+#define DMA_TI_WAIT_RESP                                (1 << 3)
+#define DMA_TI_DEST_INC                                 (1 << 4)
+#define DMA_TI_DEST_WIDTH                               (1 << 5)
+#define DMA_TI_DEST_DREQ                                (1 << 6)
+#define DMA_TI_SRC_INC                                  (1 << 8)
+#define DMA_TI_SRC_WIDTH                                (1 << 9)
+#define DMA_TI_SRC_DREQ                                 (1 << 10)
+#define DMA_TI_BURST_LENGTH(x)                          (((x) & 0xF) << 12)
+#define DMA_TI_PERMAP(x)                                (((x) & 0x1F) << 16)
+#define DMA_TI_NO_WIDE_BURSTS                           (1 << 26)
+
+/* DMA 2D mode transfer length encoding */
+#define DMA_TXFR_LEN_2D(xlength, ylength)               (((ylength) << 16) | (xlength))
+/* DMA 2D mode stride encoding (both signed 16-bit) */
+#define DMA_STRIDE_2D(src_stride, dst_stride)            (((dst_stride) << 16) | ((src_stride) & 0xFFFF))
+
+/* DMA DREQ peripheral map IDs */
+#define DMA_DREQ_PWM                                    5
 
 #define SYSTIMER_CS                                     (SYSTIMER_BASE + 0x00)
 #define SYSTIMER_CLO                                    (SYSTIMER_BASE + 0x04)

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/sdhost.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/sdhost.h
@@ -1,0 +1,120 @@
+/*-
+ * Register definitions for the BCM2835 SDHOST controller.
+ * Derived from NetBSD's sys/arch/arm/broadcom/bcm2835_sdhost.c.
+ *
+ * Copyright (c) 2017 Jared McNeill <jmcneill@invisible.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * AROS port additions:
+ *     Copyright (C) 2026, The AROS Development Team.
+ */
+
+#ifndef SDHOST_H
+#define SDHOST_H
+
+/* Controller base address (caller supplies ARM_PERIIOBASE). */
+#define SDHOST_BASE                     (ARM_PERIIOBASE + 0x202000)
+
+/* Register offsets from SDHOST_BASE. */
+#define SDCMD                           0x00
+#define  SDCMD_NEW                      (1U << 15)
+#define  SDCMD_FAIL                     (1U << 14)
+#define  SDCMD_BUSY                     (1U << 11)
+#define  SDCMD_NORESP                   (1U << 10)
+#define  SDCMD_LONGRESP                 (1U <<  9)
+#define  SDCMD_WRITE                    (1U <<  7)
+#define  SDCMD_READ                     (1U <<  6)
+#define SDARG                           0x04
+#define SDTOUT                          0x08
+#define  SDTOUT_DEFAULT                 0xf00000
+#define SDCDIV                          0x0c
+#define  SDCDIV_MASK                    0x7ff
+#define SDRSP0                          0x10
+#define SDRSP1                          0x14
+#define SDRSP2                          0x18
+#define SDRSP3                          0x1c
+#define SDHSTS                          0x20
+#define  SDHSTS_BUSY                    (1U << 10)
+#define  SDHSTS_BLOCK                   (1U <<  9)
+#define  SDHSTS_SDIO                    (1U <<  8)
+#define  SDHSTS_REW_TO                  (1U <<  7)
+#define  SDHSTS_CMD_TO                  (1U <<  6)
+#define  SDHSTS_CRC16_E                 (1U <<  5)
+#define  SDHSTS_CRC7_E                  (1U <<  4)
+#define  SDHSTS_FIFO_E                  (1U <<  3)
+#define  SDHSTS_DATA                    (1U <<  0)
+#define SDVDD                           0x30
+#define  SDVDD_POWER                    (1U <<  0)
+#define SDEDM                           0x34
+#define  SDEDM_RD_FIFO_SHIFT            14
+#define  SDEDM_RD_FIFO_MASK             (0x1fU << SDEDM_RD_FIFO_SHIFT)
+#define  SDEDM_WR_FIFO_SHIFT             9
+#define  SDEDM_WR_FIFO_MASK             (0x1fU << SDEDM_WR_FIFO_SHIFT)
+#define  SDEDM_FIFO_LEVEL_SHIFT          4    /* Current FIFO occupancy, 0..16 */
+#define  SDEDM_FIFO_LEVEL_MASK          (0x1fU << SDEDM_FIFO_LEVEL_SHIFT)
+#define SDHCFG                          0x38
+#define  SDHCFG_BUSY_EN                 (1U << 10)
+#define  SDHCFG_BLOCK_EN                (1U <<  8)
+#define  SDHCFG_SDIO_EN                 (1U <<  5)
+#define  SDHCFG_DATA_EN                 (1U <<  4)
+#define  SDHCFG_SLOW                    (1U <<  3)
+#define  SDHCFG_WIDE_EXT                (1U <<  2)
+#define  SDHCFG_WIDE_INT                (1U <<  1)
+#define  SDHCFG_REL_CMD                 (1U <<  0)
+#define SDHBCT                          0x3c
+#define SDDATA                          0x40
+#define SDHBLC                          0x50
+
+/* Convenience masks composed from the bit definitions above. */
+#define SDHSTS_ERROR_MASK               (SDHSTS_CMD_TO  | \
+                                         SDHSTS_REW_TO  | \
+                                         SDHSTS_CRC16_E | \
+                                         SDHSTS_CRC7_E  | \
+                                         SDHSTS_FIFO_E)
+#define SDHSTS_W1C_MASK                 (SDHSTS_BUSY    | \
+                                         SDHSTS_BLOCK   | \
+                                         SDHSTS_SDIO    | \
+                                         SDHSTS_ERROR_MASK)
+
+/*
+ * AROS-side additions below — not part of the NetBSD reference.
+ */
+
+/* VideoCore interrupt line for the SDHOST controller. */
+#define IRQ_VC_SDHOST                   IRQ_VC_SDIO  /* GPUIRQ1 bit 24 */
+
+/* SDHOST timing derives from the VideoCore core clock. */
+#define VCCLOCK_CORE                    4
+
+/* DMA parameters chosen by the AROS driver. */
+#define SDHOST_DMA_CHANNEL              10      /* Lite channel avoids firmware-owned full channels */
+#define SDHOST_DMA_DREQ                 13      /* BCM2835 DREQ map ID for SDHOST */
+
+/* System RAM must be presented to DMA through the uncached VC alias. */
+#define SDHOST_DMA_BUS_ALIAS(x)         (0xC0000000 | (ULONG)(x))
+
+/* DMA sees peripherals through the VideoCore bus aperture. */
+#define SDHOST_SDDATA_DMA_ADDR          (BCM2835_PERIBUSBASE + 0x202000 + SDDATA)
+
+#endif /* SDHOST_H */

--- a/arch/arm-native/soc/broadcom/2708/sdcard/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/mmakefile.src
@@ -3,19 +3,30 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_INCLUDES := -I$(SRCDIR)/$(CURDIR) -I$(SRCDIR)/rom/devs/sdcard
 
+# Arasan SDHCI controller (default)
 BCM2708FILES = \
     sdcard_bcm2708init \
     sdcard_bcm2708bus \
     sdcard_bcm2708time
 
+# BCM2835 SDHOST controller (alternative — frees Arasan for WiFi)
+BCM2708SDHOSTFILES = \
+    sdcard_sdhost_init \
+    sdcard_sdhost_bus \
+    sdcard_bcm2708time
+
+# Uncomment ONE of these to select the SD controller:
+#BCM2708BUILDFILES := $(BCM2708FILES)
+BCM2708BUILDFILES := $(BCM2708SDHOSTFILES)
+
 %build_archspecific \
   mainmmake=kernel-sdcard maindir=rom/devs/sdcard \
   arch=raspi-arm modname=sdcard \
-  files="$(BCM2708FILES)"
+  files="$(BCM2708BUILDFILES)"
 
 %build_archspecific \
   mainmmake=kernel-sdcard maindir=rom/devs/sdcard \
   arch=raspi-armeb modname=sdcard \
-  files="$(BCM2708FILES)"
+  files="$(BCM2708BUILDFILES)"
 
 %common

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -21,6 +21,53 @@
 APTR            MBoxBase;
 IPTR            __arm_periiobase __attribute__((used)) = 0 ;
 
+/* SDHCI-specific scan-time init: set interrupt mask, clock, power, bus width */
+static void FNAME_BCMSDC(SDBusInit)(struct sdcard_Bus *bus)
+{
+    unsigned int sdcReg;
+
+    bus->sdcb_IntrMask = SDHCI_INT_BUS_POWER | SDHCI_INT_DATA_END_BIT |
+            SDHCI_INT_DATA_CRC | SDHCI_INT_DATA_TIMEOUT | SDHCI_INT_INDEX |
+            SDHCI_INT_END_BIT | SDHCI_INT_CRC | SDHCI_INT_TIMEOUT |
+            SDHCI_INT_CARD_REMOVE | SDHCI_INT_CARD_INSERT |
+            SDHCI_INT_DATA_AVAIL | SDHCI_INT_SPACE_AVAIL |
+            SDHCI_INT_DATA_END | SDHCI_INT_RESPONSE;
+
+    FNAME_SDCBUS(SetClock)(bus->sdcb_ClockMin, bus);
+    FNAME_SDCBUS(SetPowerLevel)(bus->sdcb_Power, FALSE, bus);
+
+    sdcReg = bus->sdcb_IOReadByte(SDHCI_HOST_CONTROL, bus);
+    sdcReg &= ~(SDHCI_HCTRL_8BITBUS|SDHCI_HCTRL_4BITBUS|SDHCI_HCTRL_HISPD);
+    bus->sdcb_IOWriteByte(SDHCI_HOST_CONTROL, sdcReg, bus);
+}
+
+/* SDHCI-specific post-IRQ init: enable interrupts, detect card */
+static void FNAME_BCMSDC(SDBusPostIRQInit)(struct sdcard_Bus *bus)
+{
+    if (bus->sdcb_IRQHandle)
+    {
+        bus->sdcb_IOWriteLong(SDHCI_INT_ENABLE, bus->sdcb_IntrMask, bus);
+        bus->sdcb_IOWriteLong(SDHCI_SIGNAL_ENABLE, bus->sdcb_IntrMask, bus);
+    }
+
+    /* Detect card already present at boot */
+    if (bus->sdcb_IOReadLong(SDHCI_PRESENT_STATE, bus) & SDHCI_PS_CARD_PRESENT)
+    {
+        FNAME_SDCBUS(RegisterUnit)(bus);
+    }
+}
+
+/* SDHCI-specific 4-bit bus width enable */
+static void FNAME_BCMSDC(SDSetBusWidth)(UBYTE width, struct sdcard_Bus *bus)
+{
+    UBYTE sdcHostCtrl = bus->sdcb_IOReadByte(SDHCI_HOST_CONTROL, bus);
+    if (width == 4)
+        sdcHostCtrl |= SDHCI_HCTRL_4BITBUS;
+    else
+        sdcHostCtrl &= ~SDHCI_HCTRL_4BITBUS;
+    bus->sdcb_IOWriteByte(SDHCI_HOST_CONTROL, sdcHostCtrl, bus);
+}
+
 static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
 {
     struct sdcard_Bus   *__BCM2708Bus;
@@ -112,6 +159,19 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
         __BCM2708Bus->sdcb_IOWriteWord = FNAME_BCMSDCBUS(BCMMMIOWriteWord);
         __BCM2708Bus->sdcb_IOWriteLong = FNAME_BCMSDCBUS(BCMMMIOWriteLong);
 
+        /* SDHCI controller-specific vtable */
+        __BCM2708Bus->sdcb_SoftReset = FNAME_SDCBUS(SoftReset);
+        __BCM2708Bus->sdcb_SetClock = FNAME_SDCBUS(SetClock);
+        __BCM2708Bus->sdcb_SetPowerLevel = FNAME_SDCBUS(SetPowerLevel);
+        __BCM2708Bus->sdcb_SendCmd = FNAME_SDCBUS(SendCmd);
+        __BCM2708Bus->sdcb_WaitCmd = FNAME_SDCBUS(WaitCmd);
+        __BCM2708Bus->sdcb_FinishCmd = FNAME_SDCBUS(FinishCmd);
+        __BCM2708Bus->sdcb_FinishData = FNAME_SDCBUS(FinishData);
+        __BCM2708Bus->sdcb_BusIRQHandler = (void (*)(struct sdcard_Bus *, void *))FNAME_SDCBUS(BusIRQ);
+        __BCM2708Bus->sdcb_SetBusWidth = FNAME_BCMSDC(SDSetBusWidth);
+        __BCM2708Bus->sdcb_BusInit = FNAME_BCMSDC(SDBusInit);
+        __BCM2708Bus->sdcb_BusPostIRQInit = FNAME_BCMSDC(SDBusPostIRQInit);
+
         if ((__BCM2708Bus->sdcb_BusUnits = AllocPooled(SDCardBase->sdcard_MemPool, sizeof(struct sdcard_BusUnits))) != NULL)
         {
             ObtainSemaphore(&SDCardBase->sdcard_BusSem);
@@ -126,6 +186,9 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
                             __BCM2708Bus->sdcb_BusUnits->sdcbu_UnitMax,
                             __BCM2708Bus->sdcb_BusUnits->sdcbu_UnitBase));
 
+    #if defined(__AROSEXEC_SMP__)
+            KrnSpinInit(&__BCM2708Bus->sdcb_Lock);
+#endif
             __BCM2708Bus->sdcb_SectorShift = 9;
 
             DINIT(bug("[SDCard--] %s: Reseting SDHCI...\n", __PRETTY_FUNCTION__));

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_bus.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_bus.c
@@ -1,0 +1,612 @@
+/*-
+ * BCM2835 SDHOST controller bus implementation.
+ * Derived from NetBSD's sys/arch/arm/broadcom/bcm2835_sdhost.c.
+ *
+ * Copyright (c) 2017 Jared McNeill <jmcneill@invisible.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * AROS port additions:
+ *     Copyright (C) 2026, The AROS Development Team.
+ */
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/utility.h>
+
+#include <hardware/mmc.h>
+#include <hardware/sdhc.h>
+#include <hardware/bcm2708.h>
+
+#include "sdcard_sdhost_intern.h"
+#include "sdcard_bus.h"
+#include "sdcard_unit.h"
+#include "timer.h"
+
+/*
+ * Stub for FNAME_SDCBUS(GetClockDiv) — referenced by the SDHCI SetClock
+ * code in sdcard_bus.c which is linked but unused when SDHOST is active.
+ */
+ULONG FNAME_SDCBUS(GetClockDiv)(ULONG speed, struct sdcard_Bus *bus)
+{
+    (void)speed; (void)bus;
+    return 0;
+}
+
+static inline void sdhost_dsb(void) { asm volatile("dsb" ::: "memory"); }
+
+/* Translate a virtual address to its bus-addressable form for the DMA
+ * engine.  On Pi 3 the kernel identity-maps low memory and adds an
+ * offset for the high kernel mapping; KrnVirtualToPhysical handles
+ * both.  The 0xC0000000 alias selects the uncached view of SDRAM. */
+static inline ULONG sdhost_bus_addr(struct sdcard_Bus *bus, APTR virt)
+{
+    struct SDCardBase *SDCardBase = bus->sdcb_DeviceBase;
+    return SDHOST_DMA_BUS_ALIAS((ULONG)(IPTR)KrnVirtualToPhysical(virt));
+}
+
+/* Fast bounce-buffer copy: 64 bytes/iteration via NEON for the bulk,
+ * then a word-aligned tail.  Both src and dst are always at least
+ * 4-byte aligned (they come from ULONG pointers), which is the only
+ * alignment vldm/vstm strictly require. */
+static inline void sdhost_neon_copy(void *dst, const void *src, ULONG bytes)
+{
+    ULONG chunks = bytes >> 6;          /* 64-byte chunks */
+    ULONG tail   = (bytes & 0x3f) >> 2; /* trailing whole words */
+    ULONG *wsrc, *wdst;
+
+    if (chunks)
+    {
+        asm volatile (
+            "1: vldm %1!, {q0-q3}    \n"
+            "   vstm %0!, {q0-q3}    \n"
+            "   subs %2, %2, #1      \n"
+            "   bne 1b               \n"
+            : "+r" (dst), "+r" (src), "+r" (chunks)
+            :
+            : "memory", "q0", "q1", "q2", "q3", "cc"
+        );
+    }
+
+    wsrc = (ULONG *)src;
+    wdst = (ULONG *)dst;
+    while (tail--)
+        *wdst++ = *wsrc++;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Wait for SDCMD_NEW to clear (NetBSD sdhost_wait_idle).                  */
+/* ---------------------------------------------------------------------- */
+
+static int sdhost_wait_cmd_idle(struct sdcard_Bus *bus, int timeout_us)
+{
+    while (timeout_us-- > 0)
+    {
+        if ((sdhost_read(bus, SDCMD) & SDCMD_NEW) == 0)
+            return 0;
+        sdcard_Udelay(1);
+    }
+    return -1;
+}
+
+/* Drain any residual FIFO data left over from a previous command. */
+static void sdhost_flush_fifo(struct sdcard_Bus *bus)
+{
+    ULONG edm = sdhost_read(bus, SDEDM);
+    ULONG level = (edm & SDEDM_FIFO_LEVEL_MASK) >> SDEDM_FIFO_LEVEL_SHIFT;
+
+    while (level > 0)
+    {
+        (void)sdhost_read(bus, SDDATA);
+        edm = sdhost_read(bus, SDEDM);
+        level = (edm & SDEDM_FIFO_LEVEL_MASK) >> SDEDM_FIFO_LEVEL_SHIFT;
+    }
+}
+
+/* Write-1-to-clear any sticky error bits before issuing a new command. */
+static void sdhost_clear_errors(struct sdcard_Bus *bus)
+{
+    ULONG hsts = sdhost_read(bus, SDHSTS);
+    if (hsts & SDHSTS_ERROR_MASK)
+        sdhost_write(bus, SDHSTS, hsts & SDHSTS_ERROR_MASK);
+}
+
+/* ---------------------------------------------------------------------- */
+/* DMA: control-block setup, kick, wait.                                   */
+/* ---------------------------------------------------------------------- */
+
+static void sdhost_dma_setup(struct sdcard_Bus *bus, APTR buf,
+                              ULONG len, BOOL is_read)
+{
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+    struct SDHostDMACB *cb = priv->dma_cb;
+    ULONG buf_bus = sdhost_bus_addr(bus, buf);
+    ULONG ti;
+    ULONG i;
+
+    /* Channel 10 is a "lite" DMA channel — 32-bit transfers only.
+     * Lite channels do not support the 128-bit WIDTH bit, so use
+     * NO_WIDE_BURSTS and a 4-beat burst length instead.  WAIT_RESP is
+     * set for both directions to keep DMA in step with peripheral DREQ
+     * pacing. */
+    if (is_read)
+    {
+        ti = DMA_TI_INTEN |
+             DMA_TI_NO_WIDE_BURSTS |
+             DMA_TI_WAIT_RESP |
+             DMA_TI_PERMAP(SDHOST_DMA_DREQ) |
+             DMA_TI_SRC_DREQ |
+             DMA_TI_DEST_INC |
+             DMA_TI_BURST_LENGTH(4);
+        cb->source_ad = AROS_LONG2LE(SDHOST_SDDATA_DMA_ADDR);
+        cb->dest_ad   = AROS_LONG2LE(buf_bus);
+    }
+    else
+    {
+        ti = DMA_TI_INTEN |
+             DMA_TI_NO_WIDE_BURSTS |
+             DMA_TI_WAIT_RESP |
+             DMA_TI_PERMAP(SDHOST_DMA_DREQ) |
+             DMA_TI_DEST_DREQ |
+             DMA_TI_SRC_INC |
+             DMA_TI_BURST_LENGTH(4);
+        cb->source_ad = AROS_LONG2LE(buf_bus);
+        cb->dest_ad   = AROS_LONG2LE(SDHOST_SDDATA_DMA_ADDR);
+    }
+
+    cb->ti        = AROS_LONG2LE(ti);
+    cb->txfr_len  = AROS_LONG2LE(len);
+    cb->stride    = 0;
+    cb->nextconbk = 0;
+
+    /* Clean+invalidate the data buffer before DMA in both directions.
+     *  - Writes: flushes dirty CPU writes to RAM so DMA reads fresh data.
+     *  - Reads:  evicts any dirty lines so they cannot be written back
+     *            over data DMA has just placed in RAM, and invalidates
+     *            stale clean lines.
+     * Without the read-side pre-flush, direct DMA into a previously
+     * dirtied user buffer corrupts the result. */
+    CacheClearE(buf, len, CACRF_ClearD);
+    /* Flush the control block to RAM. */
+    CacheClearE(cb, sizeof(*cb), CACRF_ClearD);
+    sdhost_dsb();
+
+    /* Reset DMA channel; loading a fresh CB after reset is the safest
+     * way to clear any residual ACTIVE/INT/END state. */
+    *(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL) = AROS_LONG2LE(DMA_CS_RESET);
+    sdhost_dsb();
+    for (i = 0; i < 100; i++)
+    {
+        if (!(AROS_LE2LONG(*(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL)) & DMA_CS_RESET))
+            break;
+    }
+    *(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL) =
+        AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+    *(volatile ULONG *)DMA_CONBLK_AD(SDHOST_DMA_CHANNEL) =
+        AROS_LONG2LE(SDHOST_DMA_BUS_ALIAS((ULONG)cb));
+    sdhost_dsb();
+}
+
+static inline void sdhost_dma_kick(struct sdcard_Bus *bus)
+{
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+
+    *(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL) = AROS_LONG2LE(
+        DMA_CS_WAIT_FOR_WRITES |
+        DMA_CS_PANIC_PRI(15) |
+        DMA_CS_PRI(8) |
+        DMA_CS_ACTIVE);
+    priv->dma_active = TRUE;
+}
+
+static int sdhost_dma_wait(struct sdcard_Bus *bus, ULONG timeout_us)
+{
+    volatile ULONG *dma_cs = (volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL);
+    /* Poll on 50 µs intervals — SD transfers run in the millisecond
+     * range so this is well below the minimum transfer time but
+     * 50× less CPU spin than per-microsecond polling. */
+    const ULONG poll_step = 50;
+
+    while (timeout_us > 0)
+    {
+        ULONG cs = AROS_LE2LONG(*dma_cs);
+        if (cs & DMA_CS_END)
+        {
+            *dma_cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+            sdhost_dsb();
+            return 0;
+        }
+        if (!(cs & DMA_CS_ACTIVE))
+        {
+            bug("[SDHost%02u] DMA stopped early: CS=%08x SDHSTS=%08x SDEDM=%08x\n",
+                bus->sdcb_BusNum, cs,
+                sdhost_read(bus, SDHSTS), sdhost_read(bus, SDEDM));
+            *dma_cs = AROS_LONG2LE(DMA_CS_RESET);
+            sdhost_dsb();
+            return -1;
+        }
+        sdcard_Udelay(poll_step);
+        timeout_us = (timeout_us > poll_step) ? timeout_us - poll_step : 0;
+    }
+    bug("[SDHost%02u] DMA timeout: CS=%08x SDHSTS=%08x SDEDM=%08x SDCMD=%04x\n",
+        bus->sdcb_BusNum, AROS_LE2LONG(*dma_cs),
+        sdhost_read(bus, SDHSTS), sdhost_read(bus, SDEDM),
+        sdhost_read(bus, SDCMD));
+    *dma_cs = AROS_LONG2LE(DMA_CS_RESET);
+    sdhost_dsb();
+    return -1;
+}
+
+/* ---------------------------------------------------------------------- */
+/* SoftReset — bring registers to a known state and power up.              */
+/* Mirrors NetBSD's sdhost_host_reset.                                     */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOSTBUS(SoftReset)(UBYTE mask, struct sdcard_Bus *bus)
+{
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+    ULONG edm;
+    (void)mask;
+
+    sdhost_write(bus, SDVDD,  0);
+    sdhost_write(bus, SDCMD,  0);
+    sdhost_write(bus, SDARG,  0);
+    sdhost_write(bus, SDTOUT, SDTOUT_DEFAULT);
+    sdhost_write(bus, SDCDIV, 0);
+    sdhost_write(bus, SDHSTS, sdhost_read(bus, SDHSTS));
+    sdhost_write(bus, SDHCFG, 0);
+    sdhost_write(bus, SDHBCT, 0);
+    sdhost_write(bus, SDHBLC, 0);
+
+    edm = sdhost_read(bus, SDEDM);
+    edm &= ~(SDEDM_RD_FIFO_MASK | SDEDM_WR_FIFO_MASK);
+    edm |= (4U << SDEDM_RD_FIFO_SHIFT) | (4U << SDEDM_WR_FIFO_SHIFT);
+    sdhost_write(bus, SDEDM, edm);
+
+    sdcard_Udelay(20000);
+    sdhost_write(bus, SDVDD, SDVDD_POWER);
+    sdcard_Udelay(20000);
+
+    /* Leave BUSY_EN enabled permanently — keeps the controller in a
+     * consistent state across commands and removes the need to massage
+     * SDHCFG inside SendCmd.  SLOW + WIDE_INT are required for proper
+     * 4-bit FIFO datapath; SetBusWidth ORs in WIDE_EXT when needed. */
+    priv->hcfg = SDHCFG_BUSY_EN | SDHCFG_SLOW | SDHCFG_WIDE_INT;
+    sdhost_write(bus, SDHCFG, priv->hcfg);
+    sdhost_write(bus, SDCDIV, SDCDIV_MASK);
+
+    priv->cdiv = SDCDIV_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+/* SetClock — recompute SDCDIV from core clock and requested speed.        */
+/* SDHOST stores divider minus two; actual_clock = core / (SDCDIV + 2).    */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOSTBUS(SetClock)(ULONG speed, struct sdcard_Bus *bus)
+{
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+    ULONG div;
+
+    if (speed == 0)
+    {
+        div = SDCDIV_MASK;
+    }
+    else
+    {
+        div = priv->max_clk / speed;
+        if (div < 2)
+            div = 2;
+        if ((priv->max_clk / div) > speed)
+            div++;
+        div -= 2;
+        if (div > SDCDIV_MASK)
+            div = SDCDIV_MASK;
+    }
+    sdhost_write(bus, SDCDIV, div);
+    priv->cdiv = div;
+}
+
+/* ---------------------------------------------------------------------- */
+/* SetPowerLevel — SDHOST only exposes on/off through SDVDD.               */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOSTBUS(SetPowerLevel)(ULONG supportedlvls, BOOL lowest,
+                                     struct sdcard_Bus *bus)
+{
+    (void)supportedlvls;
+    (void)lowest;
+    sdhost_write(bus, SDVDD, SDVDD_POWER);
+}
+
+/* ---------------------------------------------------------------------- */
+/* SetBusWidth — toggle SDHCFG_WIDE_EXT, always keep WIDE_INT | SLOW set.  */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOSTBUS(SetBusWidth)(UBYTE width, struct sdcard_Bus *bus)
+{
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+
+    if (width == 4)
+        priv->hcfg |= SDHCFG_WIDE_EXT;
+    else
+        priv->hcfg &= ~SDHCFG_WIDE_EXT;
+
+    sdhost_write(bus, SDHCFG, priv->hcfg);
+}
+
+/* ---------------------------------------------------------------------- */
+/* SendCmd — issue one command (with optional data transfer) and wait      */
+/* for it to complete.  Synchronous, mirrors NetBSD's sdhost_exec_command. */
+/* The full transaction happens here; WaitCmd / FinishCmd / FinishData     */
+/* become trivial stubs below.                                             */
+/* ---------------------------------------------------------------------- */
+
+ULONG FNAME_SDHOSTBUS(SendCmd)(struct TagItem *CmdTags, struct sdcard_Bus *bus)
+{
+    struct SDCardBase *SDCardBase = bus->sdcb_DeviceBase;
+    struct sdhost_private *priv = SDHOST_PRIV(bus);
+    ULONG  sdCommand   = (ULONG)GetTagData(SDCARD_TAG_CMD,      0, CmdTags);
+    ULONG  sdArgument  = (ULONG)GetTagData(SDCARD_TAG_ARG,      0, CmdTags);
+    ULONG  sdRspType   = (ULONG)GetTagData(SDCARD_TAG_RSPTYPE,  MMC_RSP_NONE, CmdTags);
+    APTR   sdData      = (APTR)(IPTR)GetTagData(SDCARD_TAG_DATA, 0, CmdTags);
+    ULONG  sdDataLen   = (ULONG)GetTagData(SDCARD_TAG_DATALEN,  0, CmdTags);
+    ULONG  sdDataFlags = (ULONG)GetTagData(SDCARD_TAG_DATAFLAGS, 0, CmdTags);
+    struct TagItem *RspTag = FindTagItem(SDCARD_TAG_RSP, CmdTags);
+    BOOL   is_read = (sdDataFlags & MMC_DATA_READ) != 0;
+    BOOL   has_data = (sdDataLen != 0);
+    BOOL   used_bounce = FALSE;
+    APTR   dma_buf;
+    ULONG  cmdval;
+    ULONG  retval = 0;
+
+    DFUNCS(bug("[SDHost%02u] %s: CMD%u arg=%08x rsptype=%x len=%u flags=%x\n",
+        bus->sdcb_BusNum, __PRETTY_FUNCTION__,
+        sdCommand, sdArgument, sdRspType, sdDataLen, sdDataFlags));
+
+    if (sdhost_wait_cmd_idle(bus, 5000) != 0)
+    {
+        D(bug("[SDHost%02u] %s: device busy before CMD%u\n",
+            bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdCommand));
+        return -1;
+    }
+
+    /* Drain any leftover data and clear sticky error bits from a previous
+     * command before driving SDHBCT/SDHBLC + DMA setup. */
+    sdhost_flush_fifo(bus);
+    sdhost_clear_errors(bus);
+
+    cmdval = SDCMD_NEW;
+    if (!(sdRspType & MMC_RSP_PRESENT))
+        cmdval |= SDCMD_NORESP;
+    if (sdRspType & MMC_RSP_136)
+        cmdval |= SDCMD_LONGRESP;
+    if (sdRspType & MMC_RSP_BUSY)
+        cmdval |= SDCMD_BUSY;
+
+    /* Program data transfer ahead of issuing the command. */
+    if (has_data)
+    {
+        ULONG sectorSize = (1U << bus->sdcb_SectorShift);
+        /* For small transfers (SCR = 8 B, SSR = 64 B, …) the controller must
+         * be told the actual transfer length, not the sector size — otherwise
+         * its FSM hangs in READDATA waiting for sectorSize bytes the card
+         * never sends. */
+        ULONG blklen = (sdDataLen > sectorSize) ? sectorSize : sdDataLen;
+        ULONG nblks  = (sdDataLen + blklen - 1) / blklen;
+
+        cmdval |= is_read ? SDCMD_READ : SDCMD_WRITE;
+        sdhost_write(bus, SDHBCT, blklen);
+        sdhost_write(bus, SDHBLC, nblks);
+
+        /* Direct DMA when the caller's buffer is 32-byte aligned and
+         * its physical address fits in the 1 GB low-memory window the
+         * 0xC0000000 bus alias covers.  Otherwise bounce through the
+         * AllocMem'd low buffer and NEON-copy in/out. */
+        {
+            ULONG phys = (ULONG)(IPTR)KrnVirtualToPhysical(sdData);
+            BOOL direct_ok = (((IPTR)sdData & 0x1f) == 0) &&
+                              (phys < 0x40000000);
+
+            if (direct_ok)
+            {
+                dma_buf = sdData;
+            }
+            else if (priv->dma_bounce && sdDataLen <= priv->dma_bounce_size)
+            {
+                dma_buf = priv->dma_bounce;
+                used_bounce = TRUE;
+                if (!is_read)
+                    sdhost_neon_copy(priv->dma_bounce, sdData, sdDataLen);
+            }
+            else
+            {
+                bug("[SDHost%02u] CMD%u %s len=%u: no DMA path available\n",
+                    bus->sdcb_BusNum, sdCommand,
+                    is_read ? "read" : "write", sdDataLen);
+                retval = -1;
+                goto done;
+            }
+        }
+
+        sdhost_dma_setup(bus, dma_buf, sdDataLen, is_read);
+
+        priv->dma_data_addr = (ULONG)sdData;
+        priv->dma_data_len  = sdDataLen;
+        priv->dma_xfer_len  = sdDataLen;
+        priv->xfer_is_dma   = TRUE;
+        priv->xfer_active   = TRUE;
+    }
+
+    /* Issue the command.  For data transfers, the DMA engine must be
+     * armed immediately after SDCMD with nothing in between: the card
+     * begins streaming into the FIFO as soon as it processes the
+     * command, and the FIFO overflows after ~2.5 µs at 50 MHz 4-bit. */
+    sdhost_write(bus, SDARG, sdArgument);
+    sdhost_write(bus, SDCMD, cmdval | (sdCommand & 0x3f));
+    if (has_data)
+        sdhost_dma_kick(bus);
+
+    /* Wait for the DMA engine to drain the FIFO. */
+    if (has_data)
+    {
+        if (sdhost_dma_wait(bus, 1000000) != 0)
+        {
+            retval = -1;
+            goto done;
+        }
+
+        if (is_read)
+        {
+            APTR dma_dest = used_bounce ? priv->dma_bounce
+                                        : (APTR)priv->dma_data_addr;
+            CacheClearE(dma_dest, sdDataLen, CACRF_ClearD);
+            if (used_bounce)
+                sdhost_neon_copy((APTR)priv->dma_data_addr,
+                                  priv->dma_bounce, sdDataLen);
+        }
+
+        priv->xfer_active = FALSE;
+    }
+
+    /* Wait for the command engine to settle. */
+    if (sdhost_wait_cmd_idle(bus, 5000) != 0)
+    {
+        D(bug("[SDHost%02u] %s: cmd idle wait failed (SDCMD=%04x)\n",
+            bus->sdcb_BusNum, __PRETTY_FUNCTION__,
+            sdhost_read(bus, SDCMD)));
+    }
+
+    if (sdhost_read(bus, SDCMD) & SDCMD_FAIL)
+    {
+        bug("[SDHost%02u] CMD%u FAIL: SDCMD=%04x SDHSTS=%08x SDEDM=%08x\n",
+            bus->sdcb_BusNum, sdCommand,
+            sdhost_read(bus, SDCMD), sdhost_read(bus, SDHSTS),
+            sdhost_read(bus, SDEDM));
+        retval = -1;
+        goto done;
+    }
+
+    /* Read response into the supplied tag.  136-bit responses get the
+     * register order reversed so the resulting array is MSB-first (rsp[0]
+     * holds bits 127..96), matching what FNAME_SDCBUS(Rsp136Unpack) and
+     * the rest of sdcard.device expect. */
+    if ((sdRspType & MMC_RSP_PRESENT) && RspTag != NULL)
+    {
+        if (sdRspType & MMC_RSP_136)
+        {
+            if (RspTag->ti_Data)
+            {
+                ULONG *rsp = (ULONG *)RspTag->ti_Data;
+                rsp[0] = sdhost_read(bus, SDRSP3);
+                rsp[1] = sdhost_read(bus, SDRSP2);
+                rsp[2] = sdhost_read(bus, SDRSP1);
+                rsp[3] = sdhost_read(bus, SDRSP0);
+            }
+        }
+        else
+        {
+            RspTag->ti_Data = sdhost_read(bus, SDRSP0);
+        }
+    }
+
+done:
+    /* On data-transfer errors leave the DMA channel and FIFO in a known
+     * good state so the higher-level CMD12 cleanup that follows can
+     * issue cleanly. */
+    if (has_data && retval != 0)
+    {
+        *(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL) = AROS_LONG2LE(DMA_CS_RESET);
+        sdhost_dsb();
+        sdhost_flush_fifo(bus);
+    }
+    /* W1C the sticky status bits so the next command sees a clean slate. */
+    sdhost_write(bus, SDHSTS, sdhost_read(bus, SDHSTS));
+    return retval;
+}
+
+/* ---------------------------------------------------------------------- */
+/* WaitCmd / FinishCmd / FinishData — no-ops; SendCmd is synchronous.      */
+/* ---------------------------------------------------------------------- */
+
+ULONG FNAME_SDHOSTBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus)
+{
+    (void)mask; (void)timeout; (void)bus;
+    return 0;
+}
+
+ULONG FNAME_SDHOSTBUS(FinishCmd)(struct TagItem *CmdTags, struct sdcard_Bus *bus)
+{
+    (void)CmdTags; (void)bus;
+    return 0;
+}
+
+ULONG FNAME_SDHOSTBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
+{
+    (void)DataTags; (void)bus;
+    return 0;
+}
+
+/* ---------------------------------------------------------------------- */
+/* IRQ handler — just clear SDHSTS so future polls see a fresh value.      */
+/* SendCmd is fully synchronous (polls in foreground), so no signalling    */
+/* is required here.                                                       */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOSTBUS(BusIRQ)(struct sdcard_Bus *bus, void *unused)
+{
+    ULONG hsts;
+    (void)unused;
+
+    hsts = sdhost_read(bus, SDHSTS);
+    if (hsts != 0)
+        sdhost_write(bus, SDHSTS, hsts);
+}
+
+/* ---------------------------------------------------------------------- */
+/* BusInit — scan-time init, called from sdcard_init.c::Scan().            */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOST(BusInit)(struct sdcard_Bus *bus)
+{
+    D(bug("[SDHost%02u] %s()\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
+
+    FNAME_SDHOSTBUS(SoftReset)(0, bus);
+    FNAME_SDHOSTBUS(SetClock)(bus->sdcb_ClockMin, bus);
+    FNAME_SDHOSTBUS(SetPowerLevel)(bus->sdcb_Power, FALSE, bus);
+    FNAME_SDHOSTBUS(SetBusWidth)(1, bus);
+}
+
+/* ---------------------------------------------------------------------- */
+/* BusPostIRQInit — register the unit.  SDHOST has no card-detect line,   */
+/* so we always assume the card is present.                                */
+/* ---------------------------------------------------------------------- */
+
+void FNAME_SDHOST(BusPostIRQInit)(struct sdcard_Bus *bus)
+{
+    D(bug("[SDHost%02u] %s()\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
+    FNAME_SDCBUS(RegisterUnit)(bus);
+}

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
@@ -1,0 +1,319 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    BCM2835 SDHOST controller initialization.
+
+    This driver uses the non-standard Broadcom SDHOST controller at
+    peripheral offset 0x202000, instead of the Arasan SDHCI controller
+    at 0x300000. The Arasan SDHCI is freed for WiFi (SDIO) use.
+
+    GPIO pin muxing:
+    - SD card signals are on GPIO 48-53
+    - ALT0 = SDHOST controller
+    - ALT3 = Arasan SDHCI controller
+    - By default, firmware routes them to Arasan (ALT3)
+    - We switch to ALT0 for SDHOST
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/mbox.h>
+#include <proto/kernel.h>
+
+#include <hardware/mmc.h>
+#include <hardware/sdhc.h>
+
+#include "sdcard_sdhost_intern.h"
+#include "sdcard_bus.h"
+#include "timer.h"
+
+#include <hardware/videocore.h>
+
+#define VCMB_PROPCHAN                   8
+
+APTR            MBoxBase;
+IPTR            __arm_periiobase __attribute__((used)) = 0;
+
+
+/* GPIO Function Select: 3 bits per pin, 10 pins per register */
+#define GPFSEL_ALT0     4   /* ALT0 function select value */
+#define GPFSEL_BITS     3   /* Bits per pin */
+#define GPFSEL_PINS     10  /* Pins per FSEL register */
+
+/*
+ * Set GPIO pin to ALT0 function (SDHOST).
+ * GPIO 48-53 are used for SDHOST:
+ *   GPIO 48 = SD_CLK
+ *   GPIO 49 = SD_CMD
+ *   GPIO 50 = SD_DATA0
+ *   GPIO 51 = SD_DATA1
+ *   GPIO 52 = SD_DATA2
+ *   GPIO 53 = SD_DATA3
+ */
+static void sdhost_gpio_init(void)
+{
+    volatile ULONG *gpfsel4 = (volatile ULONG *)GPFSEL4;
+    volatile ULONG *gpfsel5 = (volatile ULONG *)GPFSEL5;
+    ULONG val;
+
+    D(bug("[SDHost] %s: Muxing GPIO 48-53 to ALT0 (SDHOST)\n", __PRETTY_FUNCTION__));
+
+    /* GPIO 48-49: GPFSEL4, pins 8 and 9 (bits 24-26 and 27-29) */
+    val = AROS_LE2LONG(*gpfsel4);
+    val &= ~((7 << 24) | (7 << 27));           /* Clear bits for GPIO 48, 49 */
+    val |= (GPFSEL_ALT0 << 24) | (GPFSEL_ALT0 << 27);  /* Set ALT0 */
+    *gpfsel4 = AROS_LONG2LE(val);
+
+    /* GPIO 50-53: GPFSEL5, pins 0-3 (bits 0-2, 3-5, 6-8, 9-11) */
+    val = AROS_LE2LONG(*gpfsel5);
+    val &= ~((7 << 0) | (7 << 3) | (7 << 6) | (7 << 9));  /* Clear bits for GPIO 50-53 */
+    val |= (GPFSEL_ALT0 << 0) | (GPFSEL_ALT0 << 3) |
+            (GPFSEL_ALT0 << 6) | (GPFSEL_ALT0 << 9);       /* Set ALT0 */
+    *gpfsel5 = AROS_LONG2LE(val);
+
+    /*
+     * Configure pull-ups for data/cmd lines, no pull for clock.
+     * GPIO pull-up/down sequence for BCM2835/BCM2836:
+     * 1. Write control signal to GPPUD
+     * 2. Wait 150 cycles
+     * 3. Write clock to GPPUDCLK0/1
+     * 4. Wait 150 cycles
+     * 5. Clear GPPUD
+     * 6. Clear GPPUDCLK0/1
+     */
+
+    /* Pull-up for CMD and DATA lines (GPIO 49-53) */
+    *(volatile ULONG *)GPPUD = AROS_LONG2LE(2);  /* 2 = pull-up */
+    sdcard_Udelay(10);
+    *(volatile ULONG *)GPPUDCLK1 = AROS_LONG2LE(
+        (1 << (49 - 32)) | (1 << (50 - 32)) | (1 << (51 - 32)) |
+        (1 << (52 - 32)) | (1 << (53 - 32)));
+    sdcard_Udelay(10);
+    *(volatile ULONG *)GPPUD = 0;
+    *(volatile ULONG *)GPPUDCLK1 = 0;
+
+    /* No pull for CLK line (GPIO 48) */
+    *(volatile ULONG *)GPPUD = 0;  /* 0 = no pull */
+    sdcard_Udelay(10);
+    *(volatile ULONG *)GPPUDCLK1 = AROS_LONG2LE(1 << (48 - 32));
+    sdcard_Udelay(10);
+    *(volatile ULONG *)GPPUD = 0;
+    *(volatile ULONG *)GPPUDCLK1 = 0;
+}
+
+static void FNAME_SDHOST(LEDCtrl)(int lvl)
+{
+    if (lvl > 0)
+    {
+        /* Activity LED ON */
+        if (__arm_periiobase == BCM2835_PERIPHYSBASE)
+            *(volatile unsigned int *)GPCLR0 = AROS_LONG2LE(1 << 16);
+        else
+            *(volatile unsigned int *)GPSET1 = AROS_LONG2LE(1 << (47 - 32));
+    }
+    else
+    {
+        /* Activity LED OFF */
+        if (__arm_periiobase == BCM2835_PERIPHYSBASE)
+            *(volatile unsigned int *)GPSET0 = AROS_LONG2LE(1 << 16);
+        else
+            *(volatile unsigned int *)GPCLR1 = AROS_LONG2LE(1 << (47 - 32));
+    }
+}
+
+static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
+{
+    struct sdcard_Bus       *bus;
+    struct sdhost_private   *priv;
+    int                     retVal = FALSE;
+    unsigned int *MBoxMessage_ = AllocMem(8*4+16, MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + 15) & ~15);
+
+    D(bug("[SDHost] %s()\n", __PRETTY_FUNCTION__));
+
+    __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
+
+    if ((MBoxBase = OpenResource("mbox.resource")) == NULL)
+    {
+        bug("[SDHost] %s: Failed to open mbox.resource\n", __PRETTY_FUNCTION__);
+        goto sdhost_fail;
+    }
+
+    /*
+     * Query core clock rate.
+     * SDHOST uses the core clock (VCCLOCK_CORE = 4), not the SDHCI clock.
+     */
+    MBoxMessage[0] = AROS_LONG2LE(8 * 4);
+    MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
+    MBoxMessage[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);
+    MBoxMessage[3] = AROS_LONG2LE(8);
+    MBoxMessage[4] = AROS_LONG2LE(4);
+    MBoxMessage[5] = AROS_LONG2LE(VCCLOCK_CORE);
+    MBoxMessage[6] = 0;
+    MBoxMessage[7] = 0;
+
+    MBoxWrite((APTR)VCMB_BASE, VCMB_PROPCHAN, MBoxMessage);
+    if (MBoxRead((APTR)VCMB_BASE, VCMB_PROPCHAN) != MBoxMessage)
+    {
+        bug("[SDHost] %s: Failed to get core clock rate\n", __PRETTY_FUNCTION__);
+        goto sdhost_fail;
+    }
+
+    D(bug("[SDHost] %s: Core clock rate: %u Hz\n", __PRETTY_FUNCTION__,
+        AROS_LE2LONG(MBoxMessage[6])));
+
+    /* Switch GPIO pins 48-53 from Arasan SDHCI to SDHOST */
+    sdhost_gpio_init();
+
+    /* Allocate bus and private data */
+    bus = AllocPooled(SDCardBase->sdcard_MemPool, sizeof(struct sdcard_Bus));
+    priv = AllocPooled(SDCardBase->sdcard_MemPool, sizeof(struct sdhost_private));
+
+    if (bus && priv)
+    {
+        bus->sdcb_DeviceBase = SDCardBase;
+        bus->sdcb_IOBase = (APTR)SDHOST_BASE;
+        bus->sdcb_BusIRQ = IRQ_VC_SDHOST;
+
+        priv->max_clk = AROS_LE2LONG(MBoxMessage[6]);
+        priv->cdiv = 0;
+        priv->hcfg = 0;
+        priv->dma_active = FALSE;
+
+        /* Allocate DMA control block (must be 32-byte aligned) */
+        {
+            ULONG cb_alloc_size = sizeof(struct SDHostDMACB) + 31;
+            APTR cb_raw = AllocMem(cb_alloc_size, MEMF_PUBLIC | MEMF_CLEAR);
+            if (cb_raw)
+            {
+                ULONG dma_enable;
+
+                priv->dma_cb_raw = cb_raw;
+                priv->dma_cb_raw_size = cb_alloc_size;
+                priv->dma_cb = (struct SDHostDMACB *)(((IPTR)cb_raw + 31) & ~31);
+
+                /* Enable DMA channel and reset it */
+                dma_enable = AROS_LE2LONG(*(volatile ULONG *)DMA_ENABLE_REG);
+                *(volatile ULONG *)DMA_ENABLE_REG = AROS_LONG2LE(
+                    dma_enable | (1 << SDHOST_DMA_CHANNEL));
+                *(volatile ULONG *)DMA_CS(SDHOST_DMA_CHANNEL) =
+                    AROS_LONG2LE(DMA_CS_RESET);
+
+                /* Allocate cache-line-aligned bounce buffer for DMA reads.
+                 * CacheClearE on unaligned buffers corrupts adjacent memory. */
+                {
+                    /* Sized to hold one full SD_CHUNK_BLOCKS transfer
+                     * (128 sectors * 512 B = 64 KB).  Caller buffers in
+                     * high virtual memory must bounce through here. */
+                    ULONG bounce_alloc = 65536 + 31;
+                    APTR bounce_raw = AllocMem(bounce_alloc, MEMF_PUBLIC | MEMF_CLEAR);
+                    if (bounce_raw)
+                    {
+                        priv->dma_bounce_raw = bounce_raw;
+                        priv->dma_bounce = (APTR)(((IPTR)bounce_raw + 31) & ~31);
+                        priv->dma_bounce_size = 65536;
+                    }
+                    else
+                    {
+                        priv->dma_bounce = NULL;
+                        priv->dma_bounce_size = 0;
+                    }
+                }
+
+                D(bug("[SDHost] %s: DMA channel %d enabled (bounce=%p)\n",
+                    __PRETTY_FUNCTION__, SDHOST_DMA_CHANNEL, priv->dma_bounce));
+            }
+            else
+            {
+                bug("[SDHost] %s: DMA CB alloc failed — driver requires DMA\n",
+                    __PRETTY_FUNCTION__);
+                goto sdhost_fail;
+            }
+        }
+
+        bus->sdcb_Private = (IPTR)priv;
+
+        bus->sdcb_ClockMax = priv->max_clk;
+        bus->sdcb_ClockMin = 400000;  /* 400 kHz for card identification */
+
+        /* LED control (same as Arasan) */
+        bus->sdcb_LEDCtrl = (BYTE (*)(int))FNAME_SDHOST(LEDCtrl);
+
+        /*
+         * IO function pointers for generic bus code compatibility.
+         * SDHOST doesn't use these for its own operations (it uses
+         * sdhost_read/sdhost_write directly), but they're needed
+         * for any generic code that still calls through them.
+         */
+        bus->sdcb_IOReadByte = NULL;
+        bus->sdcb_IOReadWord = NULL;
+        bus->sdcb_IOReadLong = NULL;
+        bus->sdcb_IOWriteByte = NULL;
+        bus->sdcb_IOWriteWord = NULL;
+        bus->sdcb_IOWriteLong = NULL;
+
+        /* SDHOST controller-specific vtable */
+        bus->sdcb_SoftReset = FNAME_SDHOSTBUS(SoftReset);
+        bus->sdcb_SetClock = FNAME_SDHOSTBUS(SetClock);
+        bus->sdcb_SetPowerLevel = FNAME_SDHOSTBUS(SetPowerLevel);
+        bus->sdcb_SendCmd = FNAME_SDHOSTBUS(SendCmd);
+        bus->sdcb_WaitCmd = FNAME_SDHOSTBUS(WaitCmd);
+        bus->sdcb_FinishCmd = FNAME_SDHOSTBUS(FinishCmd);
+        bus->sdcb_FinishData = FNAME_SDHOSTBUS(FinishData);
+        bus->sdcb_BusIRQHandler = (void (*)(struct sdcard_Bus *, void *))FNAME_SDHOSTBUS(BusIRQ);
+        bus->sdcb_SetBusWidth = FNAME_SDHOSTBUS(SetBusWidth);
+        bus->sdcb_BusInit = FNAME_SDHOST(BusInit);
+        bus->sdcb_BusPostIRQInit = FNAME_SDHOST(BusPostIRQInit);
+
+        if ((bus->sdcb_BusUnits = AllocPooled(SDCardBase->sdcard_MemPool, sizeof(struct sdcard_BusUnits))) != NULL)
+        {
+            ObtainSemaphore(&SDCardBase->sdcard_BusSem);
+            bus->sdcb_BusUnits->sdcbu_UnitBase = SDCardBase->sdcard_TotalBusUnits;
+            bus->sdcb_BusUnits->sdcbu_UnitMax = 1;  /* One SD card slot */
+            SDCardBase->sdcard_TotalBusUnits += 1;
+            bus->sdcb_BusNum = SDCardBase->sdcard_BusCnt++;
+            ReleaseSemaphore(&SDCardBase->sdcard_BusSem);
+
+            D(bug("[SDHost] %s: Bus #%02u - 1 Unit(s) starting from %02u\n",
+                __PRETTY_FUNCTION__, bus->sdcb_BusNum,
+                bus->sdcb_BusUnits->sdcbu_UnitBase));
+
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinInit(&bus->sdcb_Lock);
+#endif
+            bus->sdcb_SectorShift = 9;
+
+            /* No capabilities register on SDHOST — hardcode */
+            bus->sdcb_Version = 0;
+            bus->sdcb_Capabilities = 0;
+            bus->sdcb_Quirks = 0;
+            bus->sdcb_Power = MMC_VDD_320_330 | MMC_VDD_330_340;
+
+            D(bug("[SDHost] %s: Core Clock: %u Hz\n", __PRETTY_FUNCTION__, priv->max_clk));
+            D(bug("[SDHost] %s: Min Clock: %u Hz\n", __PRETTY_FUNCTION__, bus->sdcb_ClockMin));
+
+            /* Initial reset */
+            FNAME_SDHOSTBUS(SoftReset)(0, bus);
+
+            /* Register bus with sdcard.device */
+            FNAME_SDC(RegisterBus)(bus, SDCardBase);
+
+            retVal = TRUE;
+        }
+        else
+        {
+            if (priv) FreePooled(SDCardBase->sdcard_MemPool, priv, sizeof(struct sdhost_private));
+            if (bus) FreePooled(SDCardBase->sdcard_MemPool, bus, sizeof(struct sdcard_Bus));
+        }
+    }
+
+sdhost_fail:
+    if (MBoxMessage_)
+        FreeMem(MBoxMessage_, 8*4+16);
+
+    return retVal;
+}
+
+ADD2INITLIB(FNAME_SDHOST(SDHostInit), SDCARD_BUSINITPRIO)

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_intern.h
@@ -1,0 +1,91 @@
+#ifndef _SDCARDSDHOST_INTERN_H
+#define _SDCARDSDHOST_INTERN_H
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    BCM2835 SDHOST controller driver internals.
+*/
+
+#include <exec/execbase.h>
+#include <exec/libraries.h>
+#include <exec/ports.h>
+#include <utility/utility.h>
+#include <exec/io.h>
+#include <exec/errors.h>
+
+#include <devices/timer.h>
+
+extern IPTR __arm_periiobase;
+#define ARM_PERIIOBASE __arm_periiobase
+#include <hardware/bcm2708.h>
+#include <hardware/sdhost.h>
+
+#include "sdcard_base.h"
+
+#define FNAME_SDHOST(x)                 SDHOST__Device__ ## x
+#define FNAME_SDHOSTBUS(x)             SDHOST__SDBus__ ## x
+
+/* DMA control block — must be 32-byte aligned */
+struct SDHostDMACB {
+    ULONG   ti;           /* Transfer Information */
+    ULONG   source_ad;    /* Source address (bus address) */
+    ULONG   dest_ad;      /* Destination address (bus address) */
+    ULONG   txfr_len;     /* Transfer length in bytes */
+    ULONG   stride;       /* 2D stride (unused) */
+    ULONG   nextconbk;    /* Next CB address (bus address), 0 = stop */
+    ULONG   reserved[2];  /* Padding to 32 bytes */
+};
+
+/* Private data stored in sdcb_Private (cast to struct sdhost_private *) */
+struct sdhost_private {
+    ULONG   max_clk;            /* Core clock rate from VideoCore */
+    ULONG   cdiv;               /* Cached SDCDIV value */
+    ULONG   hcfg;               /* Cached SDHCFG value */
+
+    /* DMA state */
+    APTR    dma_cb_raw;         /* Unaligned alloc for CB */
+    struct SDHostDMACB *dma_cb; /* 32-byte aligned control block */
+    ULONG   dma_cb_raw_size;    /* Allocation size */
+
+    /* Bounce buffer used for DMA reads into possibly mis-aligned caller buffers. */
+    APTR    dma_bounce_raw;     /* Unaligned bounce buffer alloc */
+    APTR    dma_bounce;         /* 32-byte aligned bounce buffer */
+    ULONG   dma_bounce_size;    /* Bounce buffer size */
+
+    /* Transient transfer bookkeeping (set in SendCmd). */
+    BOOL    xfer_active;
+    BOOL    xfer_is_dma;
+    BOOL    dma_active;
+    ULONG   dma_data_addr;
+    ULONG   dma_data_len;
+    ULONG   dma_xfer_len;
+};
+
+/* Accessor for bus private data */
+#define SDHOST_PRIV(bus)  ((struct sdhost_private *)(bus)->sdcb_Private)
+
+/* SDHOST register read/write — direct MMIO */
+static inline ULONG sdhost_read(struct sdcard_Bus *bus, ULONG reg)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)((ULONG)bus->sdcb_IOBase + reg));
+}
+
+static inline void sdhost_write(struct sdcard_Bus *bus, ULONG reg, ULONG val)
+{
+    *(volatile ULONG *)((ULONG)bus->sdcb_IOBase + reg) = AROS_LONG2LE(val);
+}
+
+/* Function declarations */
+void  FNAME_SDHOSTBUS(SoftReset)(UBYTE mask, struct sdcard_Bus *bus);
+void  FNAME_SDHOSTBUS(SetClock)(ULONG speed, struct sdcard_Bus *bus);
+void  FNAME_SDHOSTBUS(SetPowerLevel)(ULONG supportedlvls, BOOL lowest, struct sdcard_Bus *bus);
+ULONG FNAME_SDHOSTBUS(SendCmd)(struct TagItem *CmdTags, struct sdcard_Bus *bus);
+ULONG FNAME_SDHOSTBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus);
+ULONG FNAME_SDHOSTBUS(FinishCmd)(struct TagItem *CmdTags, struct sdcard_Bus *bus);
+ULONG FNAME_SDHOSTBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus);
+void  FNAME_SDHOSTBUS(BusIRQ)(struct sdcard_Bus *bus, void *unused);
+void  FNAME_SDHOSTBUS(SetBusWidth)(UBYTE width, struct sdcard_Bus *bus);
+void  FNAME_SDHOST(BusInit)(struct sdcard_Bus *bus);
+void  FNAME_SDHOST(BusPostIRQInit)(struct sdcard_Bus *bus);
+
+#endif /* _SDCARDSDHOST_INTERN_H */

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -173,7 +173,7 @@ distfiles-raspi-be-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 distfiles-raspi-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\ninitramfs $(ARM_BSP) 0x00800000" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x10000\ninitramfs $(ARM_BSP) 0x00800000\ndtoverlay=disable-bt\ndtoverlay=sdhost\narm_64bit=0\nhdmi_drive=2\n" > $@
 
 $(AROSDIR)/aros-armeb-raspi.img: $(TARGETDIR)/core-be.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -56,14 +56,15 @@ BOOL FNAME_SDCBUS(StartUnit)(struct sdcard_Unit *sdcUnit)
     DFUNCS(bug("[SDCard%02ld] %s()\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     /*
-     * Send CMD7 (SELECT_CARD) BEFORE capability detection.
+     * Fix #40: Send CMD7 (SELECT_CARD) BEFORE capability detection.
      * ACMD51 (SEND_SCR) and CMD6 (SWITCH_FUNC) are data transfer commands
-     * that require the card to be in Transfer state per the SD spec.
-     * Issuing them before CMD7 causes data transfer errors on some SDHCI
-     * controllers, which can leave the controller in a bad state and break
-     * subsequent reads (including partition table scanning).
+     * that require the card to be in Transfer state. On real hardware (e.g.
+     * Pi 3B), issuing these before CMD7 causes data transfer errors that
+     * can leave the SDHCI controller in a bad state, breaking subsequent
+     * reads (including partition table scanning by partition.library).
+     * QEMU's SD emulation is more permissive and doesn't enforce this.
      */
-    if ((FNAME_SDCBUS(SendCmd)(sdcStartTags, sdcUnit->sdcu_Bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
+    if ((SDCBUS_SendCmd(sdcStartTags, sdcUnit->sdcu_Bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
     {
         if (FNAME_SDCUNIT(WaitStatus)(10000, sdcUnit) == -1)
         {
@@ -91,7 +92,7 @@ BOOL FNAME_SDCBUS(StartUnit)(struct sdcard_Unit *sdcUnit)
             sdcStartTags[1].ti_Data = 1 << sdcUnit->sdcu_Bus->sdcb_SectorShift;
             sdcStartTags[2].ti_Data = MMC_RSP_R1;
             sdcStartTags[3].ti_Data = 0;
-            if ((FNAME_SDCBUS(SendCmd)(sdcStartTags, sdcUnit->sdcu_Bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
+            if ((SDCBUS_SendCmd(sdcStartTags, sdcUnit->sdcu_Bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
             {
                 D(bug("[SDCard%02ld] %s: Blocklen set to %d\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__, sdcStartTags[1].ti_Data));
             }
@@ -106,19 +107,19 @@ BOOL FNAME_SDCBUS(StartUnit)(struct sdcard_Unit *sdcUnit)
             if (sdcUnit->sdcu_Flags & AF_Card_HighSpeed)
             {
                 if (sdcUnit->sdcu_Flags & AB_Card_HighSpeed52)
-                    FNAME_SDCBUS(SetClock)(52000000, sdcUnit->sdcu_Bus);
+                    SDCBUS_SetClock(52000000, sdcUnit->sdcu_Bus);
                 else
-                    FNAME_SDCBUS(SetClock)(26000000, sdcUnit->sdcu_Bus);
+                    SDCBUS_SetClock(26000000, sdcUnit->sdcu_Bus);
             }
             else
-                FNAME_SDCBUS(SetClock)(20000000, sdcUnit->sdcu_Bus);
+                SDCBUS_SetClock(20000000, sdcUnit->sdcu_Bus);
         }
         else
         {
             if (sdcUnit->sdcu_Flags & AF_Card_HighSpeed)
-                FNAME_SDCBUS(SetClock)(50000000, sdcUnit->sdcu_Bus);
+                SDCBUS_SetClock(50000000, sdcUnit->sdcu_Bus);
             else
-                FNAME_SDCBUS(SetClock)(25000000, sdcUnit->sdcu_Bus);
+                SDCBUS_SetClock(25000000, sdcUnit->sdcu_Bus);
         }
 
         /* Enable 4-bit bus width if supported by the card */
@@ -134,20 +135,19 @@ BOOL FNAME_SDCBUS(StartUnit)(struct sdcard_Unit *sdcUnit)
             sdcStartTags[2].ti_Data = MMC_RSP_R1;
             sdcStartTags[3].ti_Data = 0;
             sdcStartTags[4].ti_Tag = TAG_DONE;
-            if ((FNAME_SDCBUS(SendCmd)(sdcStartTags, sdcUnit->sdcu_Bus) != -1) &&
-                (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
+            if ((SDCBUS_SendCmd(sdcStartTags, sdcUnit->sdcu_Bus) != -1) &&
+                (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
             {
                 sdcStartTags[0].ti_Data = SD_CMD_APP_SET_BUS_WIDTH;
                 sdcStartTags[1].ti_Data = 2; /* 4-bit mode */
                 sdcStartTags[2].ti_Data = MMC_RSP_R1;
                 sdcStartTags[3].ti_Data = 0;
-                if ((FNAME_SDCBUS(SendCmd)(sdcStartTags, sdcUnit->sdcu_Bus) != -1) &&
-                    (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
+                if ((SDCBUS_SendCmd(sdcStartTags, sdcUnit->sdcu_Bus) != -1) &&
+                    (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
                 {
-                    /* Set 4-bit mode in SDHCI HOST_CONTROL register */
-                    sdcHostCtrl = sdcUnit->sdcu_Bus->sdcb_IOReadByte(SDHCI_HOST_CONTROL, sdcUnit->sdcu_Bus);
-                    sdcHostCtrl |= SDHCI_HCTRL_4BITBUS;
-                    sdcUnit->sdcu_Bus->sdcb_IOWriteByte(SDHCI_HOST_CONTROL, sdcHostCtrl, sdcUnit->sdcu_Bus);
+                    /* Set 4-bit mode in controller — controller-specific via BusInit */
+                    if (sdcUnit->sdcu_Bus->sdcb_SetBusWidth)
+                        sdcUnit->sdcu_Bus->sdcb_SetBusWidth(4, sdcUnit->sdcu_Bus);
                     D(bug("[SDCard%02ld] %s: 4-bit bus width enabled\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
                 }
                 else
@@ -179,7 +179,7 @@ ULONG FNAME_SDCUNIT(WaitStatus)(ULONG timeout, struct sdcard_Unit *sdcUnit)
     DFUNCS(bug("[SDCard%02ld] %s()\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     do {
-        if ((FNAME_SDCBUS(SendCmd)(sdcStatusTags, sdcUnit->sdcu_Bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1) )
+        if ((SDCBUS_SendCmd(sdcStatusTags, sdcUnit->sdcu_Bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1) )
         {
             if ((sdcStatusTags[3].ti_Data & MMC_STATUS_RDY_FOR_DATA) &&
                 (sdcStatusTags[3].ti_Data & MMC_STATUS_STATE_MASK) != MMC_STATUS_STATE_PRG)
@@ -230,7 +230,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
     sdcRegTags[0].ti_Data = MMC_CMD_GO_IDLE_STATE;
     sdcRegTags[1].ti_Data = 0;
     sdcRegTags[2].ti_Data = MMC_RSP_NONE;
-    if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) == -1) || (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) == -1))
+    if ((SDCBUS_SendCmd(sdcRegTags, bus) == -1) || (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) == -1))
     {
         D(bug("[SDBus%02u] %s: Error: Card failed to go idle!\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
         return FALSE;
@@ -243,7 +243,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
     sdcRegTags[2].ti_Data = MMC_RSP_R7;
     D(bug("[SDBus%02u] %s: Querying Interface conditions [%08x] ...\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdcRegTags[1].ti_Data));
 
-    if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) != -1)  && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
+    if ((SDCBUS_SendCmd(sdcRegTags, bus) != -1)  && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
     {
         D(bug("[SDBus%02u] %s: Query Response = %08x\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdcRegTags[3].ti_Data));
         D(bug("[SDBus%02u] %s: SD2.0 Compliant Card .. publishing high-capacity support\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
@@ -260,7 +260,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
         sdcRegTags[1].ti_Data = 0;
         sdcRegTags[2].ti_Data = MMC_RSP_R1;
 
-        if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) == -1) || (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) == -1))
+        if ((SDCBUS_SendCmd(sdcRegTags, bus) == -1) || (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) == -1))
         {
             D(bug("[SDBus%02u] %s: App Command Failed\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
             return FALSE;
@@ -273,7 +273,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
         sdcRegTags[2].ti_Data = MMC_RSP_R3;
 
         D(bug("[SDBus%02u] %s: Querying Operating conditions [%08x] ...\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdcRegTags[1].ti_Data));
-        if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
+        if ((SDCBUS_SendCmd(sdcRegTags, bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
         {
             D(bug("[SDBus%02u] %s: Query Response = %08x\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdcRegTags[3].ti_Data));
             sdcard_Udelay(1000);
@@ -306,7 +306,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
             D(bug("[SDBus%02u] %s: Begin Voltage Switching..\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
         }
 
-        FNAME_SDCBUS(SetPowerLevel)(sdcCardPower, TRUE, bus);
+        SDCBUS_SetPowerLevel(sdcCardPower, TRUE, bus);
         sdcard_Udelay(2000);
 
         /* Put the "card" into identify mode*/
@@ -315,7 +315,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
         sdcRegTags[1].ti_Data = 0;
         sdcRegTags[2].ti_Data = MMC_RSP_R2;
         sdcRegTags[3].ti_Data = (IPTR)sdcRsp136;
-        if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
+        if ((SDCBUS_SendCmd(sdcRegTags, bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
         {
             if (sdcRegTags[3].ti_Data)
             {
@@ -335,7 +335,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
             sdcRegTags[1].ti_Data = 0;
             sdcRegTags[2].ti_Data = MMC_RSP_R6;
             sdcRegTags[3].ti_Data = 0;
-            if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
+            if ((SDCBUS_SendCmd(sdcRegTags, bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
             {
                 if ((sdcUnit = AllocVecPooled(LIBBASE->sdcard_MemPool, sizeof(struct sdcard_Unit))) != NULL)
                 {
@@ -356,7 +356,7 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
                     sdcRegTags[2].ti_Data = MMC_RSP_R2;
                     sdcRegTags[3].ti_Data = (IPTR)sdcRsp136;
                     D(bug("[SDBus%02u] %s: Querying Card Specific Data [%08x] ...\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, sdcRegTags[1].ti_Data));
-                    if ((FNAME_SDCBUS(SendCmd)(sdcRegTags, bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
+                    if ((SDCBUS_SendCmd(sdcRegTags, bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, bus) != -1))
                     {
                         if (FNAME_SDCUNIT(WaitStatus)(10000, sdcUnit) == -1)
                         {
@@ -866,8 +866,8 @@ ULONG FNAME_SDCBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
  *   3. DATA_AVAIL IRQ fires -> BusIRQ() calls FinishData() to do PIO transfer
  *   4. DATA_INHIBIT clears once all data is transferred
  *
- * Problem:
- *   The RESPONSE and DATA_AVAIL interrupts may arrive as separate IRQs.
+ * Problem (observed on BCM2708/Pi 3B+):
+ *   The RESPONSE and DATA_AVAIL interrupts arrive as separate IRQs.
  *   When BusIRQ() handles the RESPONSE IRQ, it acknowledges the interrupt
  *   by writing to INT_STATUS. If DATA_AVAIL is asserted in the narrow
  *   window between reading INT_STATUS and the acknowledgment write, the
@@ -878,7 +878,7 @@ ULONG FNAME_SDCBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
  *     - BusIRQ writes INT_STATUS to ack RESPONSE -> may clear DATA_AVAIL too
  *     - BusIRQ returns, no further IRQ edge generated
  *     - Result: FinishData() is never called, DATA_INHIBIT stays set,
- *       WaitCmd() spins until timeout.
+ *       WaitCmd() polls for 100 seconds before timing out.
  *
  * Fix:
  *   During the poll loop, if DATA_INHIBIT is still set and FinishData()
@@ -964,7 +964,7 @@ ULONG FNAME_SDCBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus)
         if ((bus->sdcb_BusStatus & SDHCI_INT_ERROR) == SDHCI_INT_ERROR)
             break;
 
-        if (--timeout == 0)
+        if (--timeout <= 0)
         {
             bug("[SDBus%02u] WaitCmd: TIMEOUT! PS=%08x BS=%08x DL=%p\n",
                 bus->sdcb_BusNum,
@@ -977,12 +977,12 @@ ULONG FNAME_SDCBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus)
     /*
      * Response recovery for non-bus-task callers.
      *
-     * Some SDHCI controllers clear CMD_INHIBIT as soon as the command
-     * response is received — before the interrupt is delivered to the CPU.
-     * When WaitCmd is called from a task other than the bus task, we poll
-     * PRESENT_STATE and may exit the loop before the IRQ handler has had
-     * a chance to call FinishCmd() to read the response register.
-     * The result: the caller's response tag stays 0.
+     * On QEMU (and potentially real hardware), the SDHCI controller clears
+     * CMD_INHIBIT as soon as the command response is received — before the
+     * interrupt is delivered to the CPU. When WaitCmd is called from a task
+     * other than the bus task, we poll PRESENT_STATE and may exit the loop
+     * before the IRQ handler has had a chance to call FinishCmd() to read
+     * the response register. The result: the caller's response tag stays 0.
      *
      * Fix: if RespListener is still set after the poll loop, the IRQ handler
      * hasn't processed it yet. Claim it under Disable() (to prevent a race
@@ -1091,130 +1091,131 @@ void FNAME_SDCBUS(BusIRQ)(struct sdcard_Bus *bus, void *_unused)
 
     while ((bus->sdcb_BusStatus & bus->sdcb_IntrMask) && loops < 8)
     {
-        loops++;
+    loops++;
 
-        if (!(bus->sdcb_BusStatus & SDHCI_INT_ERROR))
+    if (!(bus->sdcb_BusStatus & SDHCI_INT_ERROR))
+    {
+        DIRQ(bug("[SDBus%02u] %s: Status = %08x\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus));
+
+        if (bus->sdcb_BusStatus & (SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE))
         {
-            DIRQ(bug("[SDBus%02u] %s: Status = %08x\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus));
-
-            if (bus->sdcb_BusStatus & (SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE))
-            {
-                bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & (SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE)), bus);
+            bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & (SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE)), bus);
 
 #if defined(__AROSEXEC_SMP__)
-                KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
+            KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
 #endif
-                bus->sdcb_BusFlags &= ~AF_Bus_MediaPresent;
-                bus->sdcb_BusFlags |= AF_Bus_MediaChanged;
+            bus->sdcb_BusFlags &= ~AF_Bus_MediaPresent;
+            bus->sdcb_BusFlags |= AF_Bus_MediaChanged;
 
-                if (bus->sdcb_BusStatus & SDHCI_INT_CARD_INSERT)
-                    bus->sdcb_BusFlags |= AF_Bus_MediaPresent;
+            if (bus->sdcb_BusStatus & SDHCI_INT_CARD_INSERT)
+                bus->sdcb_BusFlags |= AF_Bus_MediaPresent;
 #if defined(__AROSEXEC_SMP__)
-                KrnSpinUnLock(&bus->sdcb_Lock);
+            KrnSpinUnLock(&bus->sdcb_Lock);
 #endif
 
-                bus->sdcb_BusStatus &= ~(SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE);
+            bus->sdcb_BusStatus &= ~(SDHCI_INT_CARD_INSERT|SDHCI_INT_CARD_REMOVE);
 
-                if (bus->sdcb_Task)
-                    Signal(bus->sdcb_Task, (1L << bus->sdcb_MediaSig));
-            }
-            if (bus->sdcb_BusStatus & SDHCI_INT_CMD_MASK)
-            {
-                struct TagItem *respListener;
-
-                bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & SDHCI_INT_CMD_MASK), bus);
-
-#if defined(__AROSEXEC_SMP__)
-                KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
-#endif
-                respListener = bus->sdcb_RespListener;
-                if ((bus->sdcb_BusStatus & SDHCI_INT_RESPONSE) && respListener)
-                    bus->sdcb_RespListener = NULL;
-                else
-                    respListener = NULL;
-#if defined(__AROSEXEC_SMP__)
-                KrnSpinUnLock(&bus->sdcb_Lock);
-#endif
-                if (respListener)
-                {
-                    if (FNAME_SDCBUS(FinishCmd)(respListener, bus) == -1)
-                        error = TRUE;
-                }
-                if (bus->sdcb_Task && (bus->sdcb_BusStatus & SDHCI_INT_RESPONSE))
-                {
-                    DIRQ(bug("Signalling task %p (%s) with signal %d\n", bus->sdcb_Task, bus->sdcb_Task->tc_Node.ln_Name, bus->sdcb_CommandSig));
-                    Signal(bus->sdcb_Task, 1L << bus->sdcb_CommandSig);
-                }
-
-                bus->sdcb_BusStatus &= ~SDHCI_INT_CMD_MASK;
-            }
-            if (bus->sdcb_BusStatus & SDHCI_INT_DATA_MASK)
-            {
-                struct TagItem *dataListener;
-
-#if defined(__AROSEXEC_SMP__)
-                KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
-#endif
-                dataListener = bus->sdcb_DataListener;
-                if ((bus->sdcb_BusStatus & (SDHCI_INT_DATA_AVAIL|SDHCI_INT_SPACE_AVAIL)) && dataListener)
-                    bus->sdcb_DataListener = NULL;
-                else
-                    dataListener = NULL;
-#if defined(__AROSEXEC_SMP__)
-                KrnSpinUnLock(&bus->sdcb_Lock);
-#endif
-                if (dataListener)
-                {
-                    if (FNAME_SDCBUS(FinishData)(dataListener, bus) == -1)
-                        error = TRUE;
-                    bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & (SDHCI_INT_DATA_AVAIL|SDHCI_INT_SPACE_AVAIL)), bus);
-                    bus->sdcb_BusStatus &= ~SDHCI_INT_DATA_MASK;
-                }
-                else
-                {
-                    bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & SDHCI_INT_DATA_MASK), bus);
-                    bus->sdcb_BusStatus &= ~SDHCI_INT_DATA_MASK;
-                }
-            }
-        }
-        else
-        {
-            bug("[SDBus%02u] %s: ERROR [Status = %08x]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus);
-            if (bus->sdcb_BusStatus & SDHCI_INT_ACMD12ERR)
-            {
-                bug("[SDBus%02u] %s:       [acmd12err = %04x    ]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_IOReadWord(SDHCI_ACMD12_ERR, bus));
-            }
-            error = TRUE;
-        }
-
-        if (error)
-        {
-            if (bus->sdcb_BusStatus & bus->sdcb_IntrMask)
-            {
-                bug("[SDBus%02u] %s: Clearing Unhandled Interrupts [%08x]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus & bus->sdcb_IntrMask);
-                bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, bus->sdcb_BusStatus & bus->sdcb_IntrMask, bus);
-                bus->sdcb_BusStatus &= ~bus->sdcb_IntrMask;
-            }
-            bug("[SDBus%02u] %s: Reseting SDHCI CMD/DATA\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__);
-
-            FNAME_SDCBUS(SoftReset)(SDHCI_RESET_CMD, bus);
-            FNAME_SDCBUS(SoftReset)(SDHCI_RESET_DATA, bus);
-
-            /*
-             * Signal the bus task so it wakes up from WaitCmd().
-             * Without this, a command timeout (no RESPONSE received)
-             * leaves the bus task stuck in Wait() indefinitely,
-             * because the success path is the only place that signals.
-             */
             if (bus->sdcb_Task)
-                Signal(bus->sdcb_Task, 1L << bus->sdcb_CommandSig);
-
-            break;  /* Don't re-read after error */
+                Signal(bus->sdcb_Task, (1L << bus->sdcb_MediaSig));
         }
+        if (bus->sdcb_BusStatus & SDHCI_INT_CMD_MASK)
+        {
+            struct TagItem *respListener;
 
-        /* Re-read INT_STATUS to catch bits that arrived during processing */
-        bus->sdcb_BusStatus = bus->sdcb_IOReadLong(SDHCI_INT_STATUS, bus);
+            bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & SDHCI_INT_CMD_MASK), bus);
+
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            respListener = bus->sdcb_RespListener;
+            if ((bus->sdcb_BusStatus & SDHCI_INT_RESPONSE) && respListener)
+                bus->sdcb_RespListener = NULL;
+            else
+                respListener = NULL;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&bus->sdcb_Lock);
+#endif
+            if (respListener)
+            {
+                if (FNAME_SDCBUS(FinishCmd)(respListener, bus) == -1)
+                    error = TRUE;
+            }
+            if (bus->sdcb_Task && (bus->sdcb_BusStatus & SDHCI_INT_RESPONSE))
+            {
+                DIRQ(bug("Signalling task %p (%s) with signal %d\n", bus->sdcb_Task, bus->sdcb_Task->tc_Node.ln_Name, bus->sdcb_CommandSig));
+                Signal(bus->sdcb_Task, 1L << bus->sdcb_CommandSig);
+            }
+
+            bus->sdcb_BusStatus &= ~SDHCI_INT_CMD_MASK;
+        }
+        if (bus->sdcb_BusStatus & SDHCI_INT_DATA_MASK)
+        {
+            struct TagItem *dataListener;
+
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            dataListener = bus->sdcb_DataListener;
+            if ((bus->sdcb_BusStatus & (SDHCI_INT_DATA_AVAIL|SDHCI_INT_SPACE_AVAIL)) && dataListener)
+                bus->sdcb_DataListener = NULL;
+            else
+                dataListener = NULL;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&bus->sdcb_Lock);
+#endif
+            if (dataListener)
+            {
+                if (FNAME_SDCBUS(FinishData)(dataListener, bus) == -1)
+                    error = TRUE;
+                bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & (SDHCI_INT_DATA_AVAIL|SDHCI_INT_SPACE_AVAIL)), bus);
+                bus->sdcb_BusStatus &= ~SDHCI_INT_DATA_MASK;
+            }
+            else
+            {
+                bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, (bus->sdcb_BusStatus & SDHCI_INT_DATA_MASK), bus);
+                bus->sdcb_BusStatus &= ~SDHCI_INT_DATA_MASK;
+            }
+        }
     }
+    else
+    {
+        bug("[SDBus%02u] %s: ERROR [Status = %08x]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus);
+        if (bus->sdcb_BusStatus & SDHCI_INT_ACMD12ERR)
+        {
+            bug("[SDBus%02u] %s:       [acmd12err = %04x    ]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_IOReadWord(SDHCI_ACMD12_ERR, bus));
+        }
+        error = TRUE;
+    }
+
+    if (error)
+    {
+        if (bus->sdcb_BusStatus & bus->sdcb_IntrMask)
+        {
+            bug("[SDBus%02u] %s: Clearing Unhandled Interrupts [%08x]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus & bus->sdcb_IntrMask);
+            bus->sdcb_IOWriteLong(SDHCI_INT_STATUS, bus->sdcb_BusStatus & bus->sdcb_IntrMask, bus);
+            bus->sdcb_BusStatus &= ~bus->sdcb_IntrMask;
+        }
+        bug("[SDBus%02u] %s: Reseting SDHCI CMD/DATA\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__);
+
+        FNAME_SDCBUS(SoftReset)(SDHCI_RESET_CMD, bus);
+        FNAME_SDCBUS(SoftReset)(SDHCI_RESET_DATA, bus);
+
+        /*
+         * Signal the bus task so it wakes up from WaitCmd().
+         * Without this, a command timeout (no RESPONSE received)
+         * leaves the bus task stuck in Wait() indefinitely,
+         * because the success path is the only place that signals.
+         */
+        if (bus->sdcb_Task)
+            Signal(bus->sdcb_Task, 1L << bus->sdcb_CommandSig);
+
+        break;  /* Don't re-read after error */
+    }
+
+    /* Re-read INT_STATUS to catch bits that arrived during processing */
+    bus->sdcb_BusStatus = bus->sdcb_IOReadLong(SDHCI_INT_STATUS, bus);
+
+    } /* end while loop */
 
     DIRQ(bug("[SDBus%02u] %s: Done.\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
 }
@@ -1233,10 +1234,6 @@ void FNAME_SDCBUS(BusTask)(struct sdcard_Bus *bus)
     DFUNCS(bug("[SDBus%02u] %s()\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
 
     bus->sdcb_Timer = sdcard_OpenTimer(LIBBASE);
-
-#if defined(__AROSEXEC_SMP__)
-    KrnSpinInit(&bus->sdcb_Lock);
-#endif
 
     /* Get the signal used for sleeping */
     bus->sdcb_Task = FindTask(0);
@@ -1262,23 +1259,18 @@ void FNAME_SDCBUS(BusTask)(struct sdcard_Bus *bus)
 
     DINIT(bug("[SDBus%02u] %s: TaskSig: %d, MediaSig: %d\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_TaskSig, bus->sdcb_MediaSig));
 
-    /* Install IRQ handler */
-    if ((bus->sdcb_IRQHandle = KrnAddIRQHandler(bus->sdcb_BusIRQ, FNAME_SDCBUS(BusIRQ), bus, NULL)) != NULL)
+    /* Install IRQ handler (controller-specific) */
+    if (bus->sdcb_BusIRQHandler)
     {
-        DINIT(bug("[SDBus%02u] %s: IRQHandle @ 0x%p for IRQ#%ld\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_IRQHandle, bus->sdcb_BusIRQ));
-
-        DINIT(bug("[SDBus%02u] %s: Masking chipset Interrupts...\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
-
-        bus->sdcb_IOWriteLong(SDHCI_INT_ENABLE, bus->sdcb_IntrMask, bus);
-        bus->sdcb_IOWriteLong(SDHCI_SIGNAL_ENABLE, bus->sdcb_IntrMask, bus);
+        if ((bus->sdcb_IRQHandle = KrnAddIRQHandler(bus->sdcb_BusIRQ, bus->sdcb_BusIRQHandler, bus, NULL)) != NULL)
+        {
+            DINIT(bug("[SDBus%02u] %s: IRQHandle @ 0x%p for IRQ#%ld\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_IRQHandle, bus->sdcb_BusIRQ));
+        }
     }
 
-    /* Fix #33: Detect card already present at boot (not just hotplug) */
-    if (bus->sdcb_IOReadLong(SDHCI_PRESENT_STATE, bus) & SDHCI_PS_CARD_PRESENT)
-    {
-        DINIT(bug("[SDBus%02u] %s: Card already present at startup\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__));
-        FNAME_SDCBUS(RegisterUnit)(bus);
-    }
+    /* Controller-specific post-IRQ init (enable interrupts, detect card) */
+    if (bus->sdcb_BusPostIRQInit)
+        bus->sdcb_BusPostIRQInit(bus);
 
     if (!startupScanDone)
     {

--- a/rom/devs/sdcard/sdcard_bus.h
+++ b/rom/devs/sdcard/sdcard_bus.h
@@ -76,6 +76,19 @@ struct sdcard_Bus
     void                                (*sdcb_IOWriteWord)(ULONG, UWORD, struct sdcard_Bus *);
     void                                (*sdcb_IOWriteLong)(ULONG, ULONG, struct sdcard_Bus *);
 
+    /* Controller-specific operations vtable */
+    void                                (*sdcb_SoftReset)(UBYTE, struct sdcard_Bus *);
+    void                                (*sdcb_SetClock)(ULONG, struct sdcard_Bus *);
+    void                                (*sdcb_SetPowerLevel)(ULONG, BOOL, struct sdcard_Bus *);
+    ULONG                               (*sdcb_SendCmd)(struct TagItem *, struct sdcard_Bus *);
+    ULONG                               (*sdcb_WaitCmd)(ULONG, ULONG, struct sdcard_Bus *);
+    ULONG                               (*sdcb_FinishCmd)(struct TagItem *, struct sdcard_Bus *);
+    ULONG                               (*sdcb_FinishData)(struct TagItem *, struct sdcard_Bus *);
+    void                                (*sdcb_BusIRQHandler)(struct sdcard_Bus *, void *);  /* IRQ handler */
+    void                                (*sdcb_SetBusWidth)(UBYTE, struct sdcard_Bus *);  /* Set bus width (1 or 4) */
+    void                                (*sdcb_BusInit)(struct sdcard_Bus *);  /* Scan-time HW init (clock, power, bus width) */
+    void                                (*sdcb_BusPostIRQInit)(struct sdcard_Bus *);  /* Post-IRQ init (enable interrupts, card detect) */
+
     /* Bus Instance Private/Internal */
     IPTR                                sdcb_Private;
 
@@ -110,5 +123,12 @@ ULONG FNAME_SDCBUS(Rsp136Unpack)(ULONG *, ULONG, const ULONG);
 
 void FNAME_SDCBUS(BusIRQ)(struct sdcard_Bus *, void *);
 void FNAME_SDCBUS(BusTask)(struct sdcard_Bus *);
+
+/* Dispatch macros: call through controller-specific vtable */
+#define SDCBUS_SendCmd(tags, bus)                ((bus)->sdcb_SendCmd((tags), (bus)))
+#define SDCBUS_WaitCmd(mask, timeout, bus)       ((bus)->sdcb_WaitCmd((mask), (timeout), (bus)))
+#define SDCBUS_SetClock(speed, bus)              ((bus)->sdcb_SetClock((speed), (bus)))
+#define SDCBUS_SetPowerLevel(lvls, lowest, bus)  ((bus)->sdcb_SetPowerLevel((lvls), (lowest), (bus)))
+#define SDCBUS_SoftReset(mask, bus)              ((bus)->sdcb_SoftReset((mask), (bus)))
 
 #endif /* _SDCARD_BUS_H */

--- a/rom/devs/sdcard/sdcard_init.c
+++ b/rom/devs/sdcard/sdcard_init.c
@@ -58,7 +58,6 @@ BOOL FNAME_SDC(RegisterBus)(struct sdcard_Bus *bus, LIBBASETYPEPTR LIBBASE)
 static int FNAME_SDC(Scan)(LIBBASETYPEPTR LIBBASE)
 {
     struct sdcard_Bus   *busCurrent;
-    unsigned int        sdcReg;
 
     DINIT(bug("[SDCard--] %s()\n", __PRETTY_FUNCTION__));
 
@@ -70,21 +69,9 @@ static int FNAME_SDC(Scan)(LIBBASETYPEPTR LIBBASE)
             if (busCurrent->sdcb_LEDCtrl)
                 busCurrent->sdcb_LEDCtrl(LED_OFF);
 
-            busCurrent->sdcb_IntrMask = SDHCI_INT_BUS_POWER | SDHCI_INT_DATA_END_BIT |
-                    SDHCI_INT_DATA_CRC | SDHCI_INT_DATA_TIMEOUT | SDHCI_INT_INDEX |
-                    SDHCI_INT_END_BIT | SDHCI_INT_CRC | SDHCI_INT_TIMEOUT |
-                    SDHCI_INT_CARD_REMOVE | SDHCI_INT_CARD_INSERT |
-                    SDHCI_INT_DATA_AVAIL | SDHCI_INT_SPACE_AVAIL |
-                    SDHCI_INT_DATA_END | SDHCI_INT_RESPONSE;
-
-            FNAME_SDCBUS(SetClock)(busCurrent->sdcb_ClockMin, busCurrent);
-
-            FNAME_SDCBUS(SetPowerLevel)(busCurrent->sdcb_Power, FALSE, busCurrent);
-
-            sdcReg = busCurrent->sdcb_IOReadByte(SDHCI_HOST_CONTROL, busCurrent);
-            DINIT(bug("[SDCard--] %s: Setting Min Buswidth... [%x -> %x]\n", __PRETTY_FUNCTION__, sdcReg, sdcReg & ~(SDHCI_HCTRL_8BITBUS|SDHCI_HCTRL_4BITBUS|SDHCI_HCTRL_HISPD)));
-            sdcReg &= ~(SDHCI_HCTRL_8BITBUS|SDHCI_HCTRL_4BITBUS|SDHCI_HCTRL_HISPD);
-            busCurrent->sdcb_IOWriteByte(SDHCI_HOST_CONTROL, sdcReg, busCurrent);
+            /* Controller-specific scan-time init (interrupts, clock, power, bus width) */
+            if (busCurrent->sdcb_BusInit)
+                busCurrent->sdcb_BusInit(busCurrent);
 
             DINIT(bug("[SDCard--] %s: Launching Bus Task...\n", __PRETTY_FUNCTION__));
 

--- a/rom/devs/sdcard/sdcard_ioops.c
+++ b/rom/devs/sdcard/sdcard_ioops.c
@@ -112,69 +112,92 @@ BOOL __used sdcard_WaitBusyTO(struct sdcard_Unit *unit, UWORD tout, BOOL irq, UB
 }
 
 /*
+ * Maximum number of sectors per SD transfer chunk.
+ * Smaller values give USB more bus time (less mouse jitter)
+ * but increase per-transfer overhead.  128 sectors = 64KB.
+ */
+#define SD_CHUNK_BLOCKS 128
+
+/*
  * 32bit Read operations
  */
 BYTE FNAME_SDCIO(ReadSector32)(struct sdcard_Unit *unit, ULONG block,
     ULONG count, APTR buffer, ULONG *act)
 {
-    struct TagItem sdcReadTags[] =
-    {
-        {SDCARD_TAG_CMD,         MMC_CMD_READ_SINGLE_BLOCK},
-        {SDCARD_TAG_ARG,         block},
-        {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
-        {SDCARD_TAG_RSP,         0},
-        {SDCARD_TAG_DATA,        (IPTR)buffer},
-        {SDCARD_TAG_DATALEN,     count * (1 << unit->sdcu_Bus->sdcb_SectorShift)},
-        {SDCARD_TAG_DATAFLAGS,   MMC_DATA_READ},
-        {TAG_DONE,            0}
-    };
+    struct sdcard_Bus *bus = unit->sdcu_Bus;
+    ULONG sectorShift = bus->sdcb_SectorShift;
+    ULONG remaining = count;
+    ULONG curBlock = block;
+    UBYTE *curBuffer = (UBYTE *)buffer;
     BYTE retVal = 0;
 
     D(bug("[SDCard%02ld] %s()\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     *act = 0;
 
-    if (count > 1)
-        sdcReadTags[0].ti_Data = MMC_CMD_READ_MULTIPLE_BLOCK;
-
-    if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
-        sdcReadTags[1].ti_Data <<= unit->sdcu_Bus->sdcb_SectorShift;
-
-    D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
-        sdcReadTags[0].ti_Data, sdcReadTags[1].ti_Data, sdcReadTags[5].ti_Data, sdcReadTags[4].ti_Data));
-
-    if (FNAME_SDCBUS(SendCmd)(sdcReadTags, unit->sdcu_Bus) != -1)
+    while (remaining > 0 && retVal == 0)
     {
-        if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) != -1)
+        ULONG chunk = (remaining > SD_CHUNK_BLOCKS) ? SD_CHUNK_BLOCKS : remaining;
+        ULONG chunkArg = curBlock;
+        struct TagItem sdcReadTags[] =
         {
-            if (count > 1)
+            {SDCARD_TAG_CMD,         (chunk > 1) ? MMC_CMD_READ_MULTIPLE_BLOCK : MMC_CMD_READ_SINGLE_BLOCK},
+            {SDCARD_TAG_ARG,         chunkArg},
+            {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
+            {SDCARD_TAG_RSP,         0},
+            {SDCARD_TAG_DATA,        (IPTR)curBuffer},
+            {SDCARD_TAG_DATALEN,     chunk << sectorShift},
+            {SDCARD_TAG_DATAFLAGS,   MMC_DATA_READ},
+            {TAG_DONE,            0}
+        };
+
+        if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
+            sdcReadTags[1].ti_Data <<= sectorShift;
+
+        D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
+            sdcReadTags[0].ti_Data, sdcReadTags[1].ti_Data, sdcReadTags[5].ti_Data, sdcReadTags[4].ti_Data));
+
+        if (SDCBUS_SendCmd(sdcReadTags, bus) != -1)
+        {
+            if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) != -1)
             {
-                DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-                sdcReadTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
-                sdcReadTags[1].ti_Data = 0;
-                sdcReadTags[2].ti_Data = MMC_RSP_R1b;
-                sdcReadTags[4].ti_Tag = TAG_DONE;
-                if (FNAME_SDCBUS(SendCmd)(sdcReadTags, unit->sdcu_Bus) == -1)
+                if (chunk > 1)
                 {
-                    bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
+                    sdcReadTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
+                    sdcReadTags[1].ti_Data = 0;
+                    sdcReadTags[2].ti_Data = MMC_RSP_R1b;
+                    sdcReadTags[4].ti_Tag = TAG_DONE;
+                    if (SDCBUS_SendCmd(sdcReadTags, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
+                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
                 }
-                if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) == -1)
-                {
-                    bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-                }
+                *act += chunk << sectorShift;
             }
-            *act = sdcReadTags[5].ti_Data;
+            else
+            {
+                bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                retVal = IOERR_ABORTED;
+            }
         }
         else
         {
-            bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+            bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
             retVal = IOERR_ABORTED;
         }
-    }
-    else
-    {
-        bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-        retVal = IOERR_ABORTED;
+
+        remaining -= chunk;
+        curBlock += chunk;
+        curBuffer += chunk << sectorShift;
+
+        /* Yield between chunks so USB gets bus time */
+        if (remaining > 0 && retVal == 0)
+            Reschedule();
     }
 
     DTRANS(bug("[SDCard%02ld] %s: %d bytes Read\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__, *act));
@@ -205,64 +228,78 @@ BYTE FNAME_SDCIO(ReadDMA32)(struct sdcard_Unit *unit, ULONG block,
 BYTE FNAME_SDCIO(ReadSector64)(struct sdcard_Unit *unit, UQUAD block,
     ULONG count, APTR buffer, ULONG *act)
 {
-    struct TagItem sdcReadTags[] =
-    {
-        {SDCARD_TAG_CMD,         MMC_CMD_READ_SINGLE_BLOCK},
-        {SDCARD_TAG_ARG,         block},
-        {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
-        {SDCARD_TAG_RSP,         0},
-        {SDCARD_TAG_DATA,        (IPTR)buffer},
-        {SDCARD_TAG_DATALEN,     count * (1 << unit->sdcu_Bus->sdcb_SectorShift)},
-        {SDCARD_TAG_DATAFLAGS,   MMC_DATA_READ},
-        {TAG_DONE,            0}
-    };
+    struct sdcard_Bus *bus = unit->sdcu_Bus;
+    ULONG sectorShift = bus->sdcb_SectorShift;
+    ULONG remaining = count;
+    UQUAD curBlock = block;
+    UBYTE *curBuffer = (UBYTE *)buffer;
     BYTE retVal = 0;
 
     D(bug("[SDCard%02ld] %s()\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     *act = 0;
 
-    if (count > 1)
-        sdcReadTags[0].ti_Data = MMC_CMD_READ_MULTIPLE_BLOCK;
-
     if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
         return IOERR_NOCMD;
 
-    D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
-        sdcReadTags[0].ti_Data, sdcReadTags[1].ti_Data, sdcReadTags[5].ti_Data, sdcReadTags[4].ti_Data));
-
-    if (FNAME_SDCBUS(SendCmd)(sdcReadTags, unit->sdcu_Bus) != -1)
+    while (remaining > 0 && retVal == 0)
     {
-        if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) != -1)
+        ULONG chunk = (remaining > SD_CHUNK_BLOCKS) ? SD_CHUNK_BLOCKS : remaining;
+        struct TagItem sdcReadTags[] =
         {
-            if (count > 1)
+            {SDCARD_TAG_CMD,         (chunk > 1) ? MMC_CMD_READ_MULTIPLE_BLOCK : MMC_CMD_READ_SINGLE_BLOCK},
+            {SDCARD_TAG_ARG,         curBlock},
+            {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
+            {SDCARD_TAG_RSP,         0},
+            {SDCARD_TAG_DATA,        (IPTR)curBuffer},
+            {SDCARD_TAG_DATALEN,     chunk << sectorShift},
+            {SDCARD_TAG_DATAFLAGS,   MMC_DATA_READ},
+            {TAG_DONE,            0}
+        };
+
+        D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
+            sdcReadTags[0].ti_Data, sdcReadTags[1].ti_Data, sdcReadTags[5].ti_Data, sdcReadTags[4].ti_Data));
+
+        if (SDCBUS_SendCmd(sdcReadTags, bus) != -1)
+        {
+            if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) != -1)
             {
-                DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-                sdcReadTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
-                sdcReadTags[1].ti_Data = 0;
-                sdcReadTags[2].ti_Data = MMC_RSP_R1b;
-                sdcReadTags[4].ti_Tag = TAG_DONE;
-                if (FNAME_SDCBUS(SendCmd)(sdcReadTags, unit->sdcu_Bus) == -1)
+                if (chunk > 1)
                 {
-                    bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
+                    sdcReadTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
+                    sdcReadTags[1].ti_Data = 0;
+                    sdcReadTags[2].ti_Data = MMC_RSP_R1b;
+                    sdcReadTags[4].ti_Tag = TAG_DONE;
+                    if (SDCBUS_SendCmd(sdcReadTags, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
+                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
                 }
-                if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) == -1)
-                {
-                    bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-                }
+                *act += chunk << sectorShift;
             }
-            *act = sdcReadTags[5].ti_Data;
+            else
+            {
+                bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                retVal = IOERR_ABORTED;
+            }
         }
         else
         {
-            bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+            bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
             retVal = IOERR_ABORTED;
         }
-    }
-    else
-    {
-        bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-        retVal = IOERR_ABORTED;
+
+        remaining -= chunk;
+        curBlock += chunk;
+        curBuffer += chunk << sectorShift;
+
+        if (remaining > 0 && retVal == 0)
+            Reschedule();
     }
 
     DTRANS(bug("[SDCard%02ld] %s: %d bytes Read\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__, *act));
@@ -292,64 +329,79 @@ BYTE FNAME_SDCIO(ReadDMA64)(struct sdcard_Unit *unit, UQUAD block,
 BYTE FNAME_SDCIO(WriteSector32)(struct sdcard_Unit *unit, ULONG block,
     ULONG count, APTR buffer, ULONG *act)
 {
-    struct TagItem sdcWriteTags[] =
-    {
-        {SDCARD_TAG_CMD,         MMC_CMD_WRITE_SINGLE_BLOCK},
-        {SDCARD_TAG_ARG,         block},
-        {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
-        {SDCARD_TAG_RSP,         0},
-        {SDCARD_TAG_DATA,        (IPTR)buffer},
-        {SDCARD_TAG_DATALEN,     count * (1 << unit->sdcu_Bus->sdcb_SectorShift)},
-        {SDCARD_TAG_DATAFLAGS,   MMC_DATA_WRITE},
-        {TAG_DONE,            0}
-    };
+    struct sdcard_Bus *bus = unit->sdcu_Bus;
+    ULONG sectorShift = bus->sdcb_SectorShift;
+    ULONG remaining = count;
+    ULONG curBlock = block;
+    UBYTE *curBuffer = (UBYTE *)buffer;
     BYTE retVal = 0;
 
     D(bug("[SDCard%02ld] %s()\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     *act = 0;
 
-    if (count > 1)
-        sdcWriteTags[0].ti_Data = MMC_CMD_WRITE_MULTIPLE_BLOCK;
-
-    if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
-        sdcWriteTags[1].ti_Data <<= unit->sdcu_Bus->sdcb_SectorShift;
-
-    D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
-        sdcWriteTags[0].ti_Data, sdcWriteTags[1].ti_Data, sdcWriteTags[5].ti_Data, sdcWriteTags[4].ti_Data));
-
-    if (FNAME_SDCBUS(SendCmd)(sdcWriteTags, unit->sdcu_Bus) != -1)
+    while (remaining > 0 && retVal == 0)
     {
-        if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) != -1)
+        ULONG chunk = (remaining > SD_CHUNK_BLOCKS) ? SD_CHUNK_BLOCKS : remaining;
+        ULONG chunkArg = curBlock;
+        struct TagItem sdcWriteTags[] =
         {
-            if (count > 1)
+            {SDCARD_TAG_CMD,         (chunk > 1) ? MMC_CMD_WRITE_MULTIPLE_BLOCK : MMC_CMD_WRITE_SINGLE_BLOCK},
+            {SDCARD_TAG_ARG,         chunkArg},
+            {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
+            {SDCARD_TAG_RSP,         0},
+            {SDCARD_TAG_DATA,        (IPTR)curBuffer},
+            {SDCARD_TAG_DATALEN,     chunk << sectorShift},
+            {SDCARD_TAG_DATAFLAGS,   MMC_DATA_WRITE},
+            {TAG_DONE,            0}
+        };
+
+        if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
+            sdcWriteTags[1].ti_Data <<= sectorShift;
+
+        D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
+            sdcWriteTags[0].ti_Data, sdcWriteTags[1].ti_Data, sdcWriteTags[5].ti_Data, sdcWriteTags[4].ti_Data));
+
+        if (SDCBUS_SendCmd(sdcWriteTags, bus) != -1)
+        {
+            if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) != -1)
             {
-                DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-                sdcWriteTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
-                sdcWriteTags[1].ti_Data = 0;
-                sdcWriteTags[2].ti_Data = MMC_RSP_R1b;
-                sdcWriteTags[4].ti_Tag = TAG_DONE;
-                if (FNAME_SDCBUS(SendCmd)(sdcWriteTags, unit->sdcu_Bus) == -1)
+                if (chunk > 1)
                 {
-                    bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
+                    sdcWriteTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
+                    sdcWriteTags[1].ti_Data = 0;
+                    sdcWriteTags[2].ti_Data = MMC_RSP_R1b;
+                    sdcWriteTags[4].ti_Tag = TAG_DONE;
+                    if (SDCBUS_SendCmd(sdcWriteTags, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
+                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
                 }
-                if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) == -1)
-                {
-                    bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-                }
+                *act += chunk << sectorShift;
             }
-            *act = sdcWriteTags[5].ti_Data;
+            else
+            {
+                bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                retVal = IOERR_ABORTED;
+            }
         }
         else
         {
-            bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+            bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
             retVal = IOERR_ABORTED;
         }
-    }
-    else
-    {
-        bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-        retVal = IOERR_ABORTED;
+
+        remaining -= chunk;
+        curBlock += chunk;
+        curBuffer += chunk << sectorShift;
+
+        if (remaining > 0 && retVal == 0)
+            Reschedule();
     }
 
     DTRANS(bug("[SDCard%02ld] %s: %d bytes Written\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__, *act));
@@ -379,64 +431,78 @@ BYTE FNAME_SDCIO(WriteDMA32)(struct sdcard_Unit *unit, ULONG block,
 BYTE FNAME_SDCIO(WriteSector64)(struct sdcard_Unit *unit, UQUAD block,
     ULONG count, APTR buffer, ULONG *act)
 {
-    struct TagItem sdcWriteTags[] =
-    {
-        {SDCARD_TAG_CMD,         MMC_CMD_WRITE_SINGLE_BLOCK},
-        {SDCARD_TAG_ARG,         (IPTR)block},  /* truncates UQUAD to 32-bit; safe for SD/SDHC block addressing (<2TB) */
-        {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
-        {SDCARD_TAG_RSP,         0},
-        {SDCARD_TAG_DATA,        (IPTR)buffer},
-        {SDCARD_TAG_DATALEN,     count * (1 << unit->sdcu_Bus->sdcb_SectorShift)},
-        {SDCARD_TAG_DATAFLAGS,   MMC_DATA_WRITE},
-        {TAG_DONE,            0}
-    };
+    struct sdcard_Bus *bus = unit->sdcu_Bus;
+    ULONG sectorShift = bus->sdcb_SectorShift;
+    ULONG remaining = count;
+    UQUAD curBlock = block;
+    UBYTE *curBuffer = (UBYTE *)buffer;
     BYTE retVal = 0;
 
     D(bug("[SDCard%02ld] %s()\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 
     *act = 0;
 
-    if (count > 1)
-        sdcWriteTags[0].ti_Data = MMC_CMD_WRITE_MULTIPLE_BLOCK;
-
     if (!(unit->sdcu_Flags & AF_Card_HighCapacity))
         return IOERR_NOCMD;
 
-    D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
-        sdcWriteTags[0].ti_Data, sdcWriteTags[1].ti_Data, sdcWriteTags[5].ti_Data, sdcWriteTags[4].ti_Data));
-
-    if (FNAME_SDCBUS(SendCmd)(sdcWriteTags, unit->sdcu_Bus) != -1)
+    while (remaining > 0 && retVal == 0)
     {
-        if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) != -1)
+        ULONG chunk = (remaining > SD_CHUNK_BLOCKS) ? SD_CHUNK_BLOCKS : remaining;
+        struct TagItem sdcWriteTags[] =
         {
-            if (count > 1)
+            {SDCARD_TAG_CMD,         (chunk > 1) ? MMC_CMD_WRITE_MULTIPLE_BLOCK : MMC_CMD_WRITE_SINGLE_BLOCK},
+            {SDCARD_TAG_ARG,         curBlock},
+            {SDCARD_TAG_RSPTYPE,     MMC_RSP_R1},
+            {SDCARD_TAG_RSP,         0},
+            {SDCARD_TAG_DATA,        (IPTR)curBuffer},
+            {SDCARD_TAG_DATALEN,     chunk << sectorShift},
+            {SDCARD_TAG_DATAFLAGS,   MMC_DATA_WRITE},
+            {TAG_DONE,            0}
+        };
+
+        D(bug("[SDCard%02ld] %s: Sending CMD %d, block %08x, len %d [buffer @ 0x%p]\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__,
+            sdcWriteTags[0].ti_Data, sdcWriteTags[1].ti_Data, sdcWriteTags[5].ti_Data, sdcWriteTags[4].ti_Data));
+
+        if (SDCBUS_SendCmd(sdcWriteTags, bus) != -1)
+        {
+            if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) != -1)
             {
-                DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-                sdcWriteTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
-                sdcWriteTags[1].ti_Data = 0;
-                sdcWriteTags[2].ti_Data = MMC_RSP_R1b;
-                sdcWriteTags[4].ti_Tag = TAG_DONE;
-                if (FNAME_SDCBUS(SendCmd)(sdcWriteTags, unit->sdcu_Bus) == -1)
+                if (chunk > 1)
                 {
-                    bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    DTRANS(bug("[SDCard%02ld] %s: Finishing transaction ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__));
+                    sdcWriteTags[0].ti_Data = MMC_CMD_STOP_TRANSMISSION;
+                    sdcWriteTags[1].ti_Data = 0;
+                    sdcWriteTags[2].ti_Data = MMC_RSP_R1b;
+                    sdcWriteTags[4].ti_Tag = TAG_DONE;
+                    if (SDCBUS_SendCmd(sdcWriteTags, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
+                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    {
+                        bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                    }
                 }
-                if (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, unit->sdcu_Bus) == -1)
-                {
-                    bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-                }
+                *act += chunk << sectorShift;
             }
-            *act = sdcWriteTags[5].ti_Data;
+            else
+            {
+                bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                retVal = IOERR_ABORTED;
+            }
         }
         else
         {
-            bug("[SDCard%02ld] %s: Transfer error\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+            bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
             retVal = IOERR_ABORTED;
         }
-    }
-    else
-    {
-        bug("[SDCard%02ld] %s: Error ..\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
-        retVal = IOERR_ABORTED;
+
+        remaining -= chunk;
+        curBlock += chunk;
+        curBuffer += chunk << sectorShift;
+
+        if (remaining > 0 && retVal == 0)
+            Reschedule();
     }
 
     DTRANS(bug("[SDCard%02ld] %s: %d bytes Written\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__, *act));

--- a/rom/devs/sdcard/sdcard_mmcunit.c
+++ b/rom/devs/sdcard/sdcard_mmcunit.c
@@ -27,9 +27,9 @@ ULONG FNAME_SDCUNIT(MMCSwitch)(UBYTE offset, UBYTE value, struct sdcard_Unit *sd
 
     sdcSwitchTags[1].ti_Data = (MMC_SWITCH_WRITE_BYTE << 24) | (offset << 16) | (value << 8);
 
-    if ((retVal = FNAME_SDCBUS(SendCmd)(sdcSwitchTags, sdcUnit->sdcu_Bus)) != -1)
+    if ((retVal = SDCBUS_SendCmd(sdcSwitchTags, sdcUnit->sdcu_Bus)) != -1)
     {
-        if ((retVal = FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus)) != -1)
+        if ((retVal = SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus)) != -1)
         {
             /* Wait for units ready status */
             FNAME_SDCUNIT(WaitStatus)(1000, sdcUnit);
@@ -60,7 +60,7 @@ ULONG FNAME_SDCUNIT(MMCChangeFrequency)(struct sdcard_Unit *sdcUnit)
         return 0;
 
     D(bug("[SDCard%02ld] %s: Querying Ext_CSD ... \n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-    if ((FNAME_SDCBUS(SendCmd)(sdcChFreqTags, sdcUnit->sdcu_Bus) == -1) || (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) == -1))
+    if ((SDCBUS_SendCmd(sdcChFreqTags, sdcUnit->sdcu_Bus) == -1) || (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) == -1))
     {
         D(bug("[SDCard%02ld] %s: Query Failed\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
         return 0;
@@ -77,7 +77,7 @@ ULONG FNAME_SDCUNIT(MMCChangeFrequency)(struct sdcard_Unit *sdcUnit)
         return -1;
     }
 
-    if ((FNAME_SDCBUS(SendCmd)(sdcChFreqTags, sdcUnit->sdcu_Bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
+    if ((SDCBUS_SendCmd(sdcChFreqTags, sdcUnit->sdcu_Bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) != -1))
     {
         if (sdcRespBuf[0xB9])
         {

--- a/rom/devs/sdcard/sdcard_sdscunit.c
+++ b/rom/devs/sdcard/sdcard_sdscunit.c
@@ -33,9 +33,9 @@ ULONG FNAME_SDCUNIT(SDSCSwitch)(BOOL test, int group, UBYTE value, APTR buf, str
     sdcSwitchTags[1].ti_Data &= ~(0xF << (group * 4));
     sdcSwitchTags[1].ti_Data |= value << (group * 4);
 
-    if ((retVal = FNAME_SDCBUS(SendCmd)(sdcSwitchTags, sdcUnit->sdcu_Bus)) != -1)
+    if ((retVal = SDCBUS_SendCmd(sdcSwitchTags, sdcUnit->sdcu_Bus)) != -1)
     {
-        retVal = FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus);
+        retVal = SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus);
     }
     return retVal;
 }
@@ -67,7 +67,7 @@ ULONG FNAME_SDCUNIT(SDSCChangeFrequency)(struct sdcard_Unit *sdcUnit)
         sdcChFreqTags[2].ti_Data = MMC_RSP_R1;
         sdcChFreqTags[4].ti_Tag = TAG_DONE;
 
-        if ((FNAME_SDCBUS(SendCmd)(sdcChFreqTags, sdcUnit->sdcu_Bus) == -1) || (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) == -1))
+        if ((SDCBUS_SendCmd(sdcChFreqTags, sdcUnit->sdcu_Bus) == -1) || (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 1000, sdcUnit->sdcu_Bus) == -1))
         {
             D(bug("[SDCard%02ld] %s: App Command Failed\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
             return -1;
@@ -80,7 +80,7 @@ ULONG FNAME_SDCUNIT(SDSCChangeFrequency)(struct sdcard_Unit *sdcUnit)
         sdcChFreqTags[4].ti_Tag = SDCARD_TAG_DATA;
 
         D(bug("[SDCard%02ld] %s: Querying SCR Register ... \n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
-        if ((FNAME_SDCBUS(SendCmd)(sdcChFreqTags, sdcUnit->sdcu_Bus) != -1) && (FNAME_SDCBUS(WaitCmd)(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 10000, sdcUnit->sdcu_Bus) != -1))
+        if ((SDCBUS_SendCmd(sdcChFreqTags, sdcUnit->sdcu_Bus) != -1) && (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 10000, sdcUnit->sdcu_Bus) != -1))
         {
             D(bug("[SDCard%02ld] %s: Query Response = %08x\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__, sdcChFreqTags[3].ti_Data));
             break;

--- a/rom/devs/sdcard/timer.c
+++ b/rom/devs/sdcard/timer.c
@@ -27,8 +27,9 @@ struct IORequest *sdcard_OpenTimer(LIBBASETYPEPTR LIBBASE)
         if (NULL != io)
         {
             /*
-             * UNIT_MICROHZ gives us microsecond resolution at best,
-             * so sub-microsecond delays will be rounded up.
+             * ok. ECLOCK does not have too great resolution, either.
+             * we will have to sacrifice our performance a little bit, meaning, the 400ns will turn into (worst case) 2us.
+             * hopefully we won't have to call that TOO often...
              */
             if (0 == OpenDevice("timer.device", UNIT_MICROHZ, io, 0))
             {


### PR DESCRIPTION
Adds support for the BCM2835 SDHOST controller, the secondary SD interface on Raspberry Pi. This enables SD card access on Pi models where SDHOST is the primary SD path. This driver is a prerequisite for WiFi support and is required for the USB driver to function correctly.

Changes:

- `sdcard.device`: abstract bus operations behind a controller vtable so multiple controller backends can coexist.
- `arch/arm-native`: add BCM2835 DMA, PWM and Clock Manager register definitions.
- `arch/arm-native`: add the SDHOST controller driver (init, bus ops, internal header).
- `arch/arm-raspi`: extend the generated `config.txt` to enable SDHOST at boot.