### PR TITLE
Fix StackSnoop on 64-bit architectures

### DIFF
--- a/workbench/c/StackSnoop.c
+++ b/workbench/c/StackSnoop.c
@@ -109,10 +109,20 @@ static int out (const UBYTE * fmt, ...)
 static void CheckTaskStack(struct Task *task)
 {
     UBYTE *startcheck, *endcheck;
-    LONG stacksize, stackinc, unusedstack = 0;
+    SIPTR stacksize, stackinc, unusedstack = 0;
     
-    stacksize = (LONG)( ((UBYTE *)task->tc_SPUpper) - ((UBYTE *)task->tc_SPLower) );
-      
+    stacksize = ((UBYTE *)task->tc_SPUpper) - ((UBYTE *)task->tc_SPLower);
+
+    if (!(task->tc_Flags & TF_STACKCHK))
+    {
+        out("Task %p (%25s) Stack Size =%6id (no stackcheck)\n",
+                    task,
+                    task->tc_Node.ln_Name ?
+                            (const char *)task->tc_Node.ln_Name : "<NONAME>",
+                    stacksize);
+        return;
+    }
+
 #if AROS_STACK_GROWS_DOWNWARDS
     startcheck = (UBYTE *)task->tc_SPLower;
     endcheck = ((UBYTE *)task->tc_SPUpper) - 1;
@@ -129,7 +139,7 @@ static void CheckTaskStack(struct Task *task)
         unusedstack++;
     }
     
-    out("Task %p (%25s) Stack Size =%6ld, Left =%6ld, Used %s%6ld%s\n",
+    out("Task %p (%25s) Stack Size =%6id, Left =%6id, Used %s%6id%s\n",
                 task,
                 task->tc_Node.ln_Name ?
                         (const char *)task->tc_Node.ln_Name : "<NONAME>",


### PR DESCRIPTION
**Fix StackSnoop on 64-bit architectures**

`C:StackSnoop` produced nonsense output on x86_64: negative stack sizes and "Needs more stack!" for every task. Fixes #79.

**Changes in [workbench/c/StackSnoop.c](cci:7://file://wsl.localhost/Ubuntu-24.04/home/reaver/aros/aros-source/workbench/c/StackSnoop.c:0:0-0:0):**

- **Fix 64-bit truncation:** `stacksize`, `stackinc`, and `unusedstack` were `LONG` (32-bit). On x86_64, the pointer subtraction `SPUpper - SPLower` was truncated by an explicit `(LONG)` cast, producing negative or wrapped values. Changed types to `SIPTR` and removed the cast.
- **Fix format specifiers:** Changed `%ld` to `%id` in `VNewRawDoFmt` calls to correctly format pointer-width integers.
- **Guard against missing stack fill:** The `0xE1` sentinel scan only works for tasks created with `TF_STACKCHK`. Tasks without this flag had unfilled stacks, so the scan always reported 0 bytes free, triggering false "Needs more stack!" warnings. Added a `TF_STACKCHK` check — tasks without the flag now print "(no stackcheck)" instead of misleading usage data.


<img width="733" height="514" alt="image" src="https://github.com/user-attachments/assets/1a69cc48-3528-409e-b495-13ea6a566284" />
