### PR TITLE
Updated usb2otg driver

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/usb2otg.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/usb2otg.h
@@ -68,6 +68,10 @@
 #define USB2OTG_HOSTPORT_PRTSPD_HIGH                    (0 << 17)
 #define USB2OTG_HOSTPORT_PRTSPD_FULL                    (1 << 17)
 #define USB2OTG_HOSTPORT_PRTSPD_LOW                     (2 << 17)
+#define USB2OTG_HOSTPORT_PRTSPD(reg)                    (((reg) >> 17) & 0x3)
+#define USB2OTG_HOSTPORT_PRTSPD_HS_VAL                  0
+#define USB2OTG_HOSTPORT_PRTSPD_FS_VAL                  1
+#define USB2OTG_HOSTPORT_PRTSPD_LS_VAL                  2
 #define USB2OTG_HOSTPORT_SC_BITS                        0x2e
 
 #define USB2OTG_HOST_CHANBASE                           (USB2OTG_BASE + 0x0500)
@@ -85,10 +89,17 @@
 #define USB2OTG_HOSTCHAR_EPDIR(x)                       (((x) & 1) << 15)
 #define USB2OTG_HOSTCHAR_ADDR(x)                        (((x) & 0x7f) << 22)
 #define USB2OTG_HOSTCHAR_EC(x)                          (((x) & 3) << 20)
+#define USB2OTG_HOSTCHAR_ODDFRAME                       (1 << 29)
 #define USB2OTG_HOSTCHAR_DISABLE                        (1 << 30)
 #define USB2OTG_HOSTCHAR_ENABLE                         (1 << 31)
 #define USB2OTG_HOSTCHAR_EPTYPE(x)                      (((x) & 3) << 18)
 #define USB2OTG_HOSTCHAR_LOWSPEED                       (1 << 17)
+
+/* HCSPLT (SPLITCTRL register) bits */
+#define USB2OTG_HCSPLT_SPLITEN                          (1U << 31)
+#define USB2OTG_HCSPLT_COMPLSPLT                        (1U << 16)
+#define USB2OTG_HCSPLT_SSPLIT                           USB2OTG_HCSPLT_SPLITEN
+#define USB2OTG_HCSPLT_CSPLIT                           (USB2OTG_HCSPLT_SPLITEN | USB2OTG_HCSPLT_COMPLSPLT)
 
 #define USB2OTG_HOSTTSIZE_PID(x)                        (((x) & 3) << 29)
 #define USB2OTG_HOSTTSIZE_PKTCNT(x)                     (((x) & 1023) << 19)
@@ -223,6 +234,27 @@
 #define USB2OTG_RESET_INTOKENQUEUEFLUSH                 (1 << 3)
 #define USB2OTG_RESET_RXFIFOFLUSH                       (1 << 4)
 #define USB2OTG_RESET_TXFIFOFLUSH                       (1 << 5)
+#define USB2OTG_RESET_AHBIDLE                           (1U << 31)
+
+/* GHWCFG2 (HARDWARE2) field accessors. */
+#define USB2OTG_HW2_ARCH(reg)                           (((reg) >> 3) & 0x3)
+#define USB2OTG_HW2_ARCH_SLAVE_ONLY                     0
+#define USB2OTG_HW2_ARCH_EXT_DMA                        1
+#define USB2OTG_HW2_ARCH_INT_DMA                        2
+#define USB2OTG_HW2_FSPHY_TYPE(reg)                     (((reg) >> 6) & 0x3)
+#define USB2OTG_HW2_FSPHY_TYPE_NONE                     0
+#define USB2OTG_HW2_FSPHY_TYPE_DEDICATED                1
+#define USB2OTG_HW2_FSPHY_TYPE_UTMI                     2
+#define USB2OTG_HW2_FSPHY_TYPE_ULPI                     3
+#define USB2OTG_HW2_HSPHY_TYPE(reg)                     (((reg) >> 8) & 0x3)
+#define USB2OTG_HW2_HSPHY_TYPE_NONE                     0
+#define USB2OTG_HW2_HSPHY_TYPE_UTMI                     1
+#define USB2OTG_HW2_HSPHY_TYPE_ULPI                     2
+#define USB2OTG_HW2_HSPHY_TYPE_BOTH                     3
+#define USB2OTG_HW2_HOSTCHANS(reg)                      ((((reg) >> 14) & 0xF) + 1)
+#define USB2OTG_HW2_NPTXQDEPTH(reg)                     (((reg) >> 22) & 0x3)
+#define USB2OTG_HW2_PTXQDEPTH(reg)                      (((reg) >> 24) & 0x3)
+#define USB2OTG_HW2_DEVTOKENS(reg)                      (((reg) >> 26) & 0x1F)
 
 /* Bits in USB2OTG_I2CCTRL */
 #define USB2OTG_I2CCTRL_READWRITEDATA                   (1 << 0)
@@ -327,6 +359,15 @@
 #define USB2OTG_INTRCHAN_BUFFERNOTAVAILABLE             (1 << 11)
 #define USB2OTG_INTRCHAN_EXCESSIVETRANSMISSION          (1 << 12)
 #define USB2OTG_INTRCHAN_FRAMELISTROLLOVER              (1 << 13)
+
+/* Common HCINT bit combinations seen by the IRQ handler. Names
+ * mirror DWC2 spec terminology so the meaning is obvious at the
+ * dispatch site. */
+#define USB2OTG_INTR_CLEAR_ALL                          (0x7ff)
+#define USB2OTG_INTR_XFC_STALL                          (USB2OTG_INTRCHAN_TRANSFERCOMPLETE | USB2OTG_INTRCHAN_STALL)
+#define USB2OTG_INTR_HALT_ACK                           (USB2OTG_INTRCHAN_HALT | USB2OTG_INTRCHAN_ACKNOWLEDGE)
+#define USB2OTG_INTR_HALT_NAK                           (USB2OTG_INTRCHAN_HALT | USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE)
+#define USB2OTG_INTR_HALT_NYET                          (USB2OTG_INTRCHAN_HALT | USB2OTG_INTRCHAN_NOTREADY)
 
 /* Bits in the power register */
 #define USB2OTG_POWER_STOPPCLOCK                        (1 << 0)

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox.conf
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox.conf
@@ -14,4 +14,5 @@ libbasetype struct MBoxBase
 unsigned int MBoxStatus(void *mb) (A0)
 volatile unsigned int *MBoxRead(void *mb, unsigned int chan) (A0, D0)
 void MBoxWrite(void *mb, unsigned int chan, void *msg) (A0, D0, A1)
+volatile unsigned int *MBoxCall(void *mb, unsigned int chan, void *msg) (A0, D0, A1)
 ##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
@@ -31,6 +31,71 @@ static int mbox_init(struct MBoxBase *MBoxBase)
     return retval;
 }
 
+volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
+    unsigned int chan, void *msg)
+{
+    unsigned int try = 0x2000000;
+    unsigned int reply;
+    ULONG length;
+    void *phys_addr;
+
+    if ((((unsigned int)msg & VCMB_CHAN_MASK) != 0) || (chan > VCMB_CHAN_MAX))
+        return (volatile unsigned int *)-1;
+
+    length = AROS_LE2LONG(((ULONG *)msg)[0]);
+    phys_addr = CachePreDMA(msg, &length, DMA_ReadFromRAM);
+
+    ObtainSemaphore(&MBoxBase->mbox_Sem);
+
+    {
+        unsigned int wtry = 0x2000000;
+        while ((MBoxStatus(mb) & VCMB_STATUS_WRITEREADY) != 0)
+        {
+            __asm__ __volatile__("dsb" ::: "memory");
+            if (--wtry == 0)
+            {
+                ReleaseSemaphore(&MBoxBase->mbox_Sem);
+                return (volatile unsigned int *)-1;
+            }
+        }
+    }
+
+    __asm__ __volatile__("dmb" ::: "memory");
+    *((volatile unsigned int *)(mb + VCMB_WRITE)) =
+        AROS_LONG2LE(((unsigned int)phys_addr | chan));
+    while (1)
+    {
+        while ((MBoxStatus(mb) & VCMB_STATUS_READREADY) != 0)
+        {
+            __asm__ __volatile__("dsb" ::: "memory");
+
+            if (try-- == 0)
+            {
+                ReleaseSemaphore(&MBoxBase->mbox_Sem);
+                return (volatile unsigned int *)-1;
+            }
+        }
+
+        __asm__ __volatile__("dmb" ::: "memory");
+        reply = AROS_LE2LONG(*((volatile unsigned int *)(mb + VCMB_READ)));
+        __asm__ __volatile__("dmb" ::: "memory");
+
+        if ((reply & VCMB_CHAN_MASK) == chan)
+        {
+            uint32_t *addr = (uint32_t *)(reply & ~VCMB_CHAN_MASK);
+            uint32_t len = AROS_LE2LONG(addr[0]);
+
+            CacheClearE(addr, len, CACRF_InvalidateD);
+
+            if ((void *)addr == phys_addr)
+            {
+                ReleaseSemaphore(&MBoxBase->mbox_Sem);
+                return (volatile unsigned int *)msg;
+            }
+        }
+    }
+}
+
 AROS_LH1(unsigned int, MBoxStatus,
                 AROS_LHA(void *, mb, A0),
                 struct MBoxBase *, MBoxBase, 1, Mbox)
@@ -126,6 +191,24 @@ AROS_LH3(void, MBoxWrite,
 
         ReleaseSemaphore(&MBoxBase->mbox_Sem);
     }
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH3(volatile unsigned int *, MBoxCall,
+                AROS_LHA(void *, mb, A0),
+                AROS_LHA(unsigned int, chan, D0),
+                AROS_LHA(void *, msg, A1),
+                struct MBoxBase *, MBoxBase, 4, Mbox)
+{
+    AROS_LIBFUNC_INIT
+
+    D(bug("[MBOX] MBoxCall(chan %d @ 0x%p, msg @ 0x%p)\n", chan, mb, msg));
+
+    if (msg == NULL)
+        return (volatile unsigned int *)-1;
+
+    return mbox_call_locked(MBoxBase, mb, chan, msg);
 
     AROS_LIBFUNC_EXIT
 }

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox_private.h
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox_private.h
@@ -14,4 +14,7 @@ struct MBoxBase {
     struct SignalSemaphore      mbox_Sem;
 };
 
+volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
+    unsigned int chan, void *msg);
+
 #endif /* MBOX_PRIVATE_H_ */

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013-2023, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
@@ -50,25 +50,54 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
             D(bug("[USB2OTG] %s: Enabling Power ..\n", __PRETTY_FUNCTION__));
             wr32le(USB2OTG_POWER, 0);
 
-#if (0)
-            D(bug("[USB2OTG] %s: Preparing Controller (non HSIC mode) ..\n", __PRETTY_FUNCTION__));
-            *((volatile unsigned int *)USB2OTG_USB) = USB2OTG_USB_MODESELECT|USB2OTG_USB_USBTRDTIM(5)|(USB2OTGBase->hd_Unit->hu_OperatingMode << 29);
-            *((volatile unsigned int *)USB2OTG_OTGCTRL) = 0;
+            /* Save firmware GUSBCFG before reset to restore PHY settings. */
+            ULONG saved_gusbcfg = rd32le(USB2OTG_USB);
 
-            otg_RegVal = *((volatile unsigned int *)USB2OTG_LPMCONFIG);
-            otg_RegVal &= ~USB2OTG_LPMCONFIG_HSICCONNECT;
-            *((volatile unsigned int *)USB2OTG_LPMCONFIG) = otg_RegVal;
+            /* Step 1: Core soft reset (wait AHB IDLE -> CSFTRST -> wait clear). */
+            bug("[USB2OTG] Init: Core soft reset\n");
+            usb2otg_wait_ahb_idle(100000, "before core soft reset");
+            wr32le(USB2OTG_RESET, USB2OTG_RESET_CORESOFT);
+            usb2otg_wait_reset_bit_clear(USB2OTG_RESET_CORESOFT, 1000000,
+                "Init: Core soft reset");
+            /* Wait for internal logic to settle after core reset */
+            {
+                volatile int i;
+                for (i = 0; i < 100000; i++)
+                    asm volatile("mov r0, r0\n");
+            }
 
-            D(bug("[USB2OTG] %s: Clearing Global NAK ..\n", __PRETTY_FUNCTION__));
-            *((volatile unsigned int *)USB2OTG_DEVCTRL) = (1 << 10) | (1 << 8);
-#endif
+            /*
+             * Step 2: Re-enable DMA + global IRQs (cleared by core reset).
+             * NPTxFEmpLvl=1 → NPTXFEMP only fires when fully drained, so
+             * OUT-arming code doesn't queue while stale data is in FIFO.
+             */
+            otg_RegVal = rd32le(USB2OTG_AHB);
+            otg_RegVal |= USB2OTG_AHB_DMAENABLE
+                        | USB2OTG_AHB_AXIBURSTLENGTH
+                        | USB2OTG_AHB_INTENABLE
+                        | USB2OTG_AHB_TRANSFEREMPTYLEVEL;  /* NPTxFEmpLvl = fully empty */
+            wr32le(USB2OTG_AHB, otg_RegVal);
+
+            /* Step 3: Restore GUSBCFG with force-host bit set. */
+            saved_gusbcfg &= ~USB2OTG_USB_FORCE_DEV_MODE;
+            saved_gusbcfg |= USB2OTG_USB_FORCE_HOST_MODE;
+            wr32le(USB2OTG_USB, saved_gusbcfg);
+            /* 25 ms for mode switch — ~30M NOPs on 1.2 GHz Cortex-A53. */
+            {
+                volatile int i;
+                for (i = 0; i < 30000000; i++)
+                    asm volatile("mov r0, r0\n");
+            }
+
+            /* Step 4: Configure HOSTCFG (FSLSPCLKSEL) after core reset. */
             otg_RegVal = rd32le(USB2OTG_HARDWARE2);
-            if (((otg_RegVal & (3 << 6) >> 6) == 2) && ((otg_RegVal & (3 << 8) >> 8) == 1))
+            if (USB2OTG_HW2_FSPHY_TYPE(otg_RegVal) == USB2OTG_HW2_FSPHY_TYPE_ULPI &&
+                USB2OTG_HW2_HSPHY_TYPE(otg_RegVal) == USB2OTG_HW2_HSPHY_TYPE_UTMI)
             {
                 otg_RegVal = rd32le(USB2OTG_USB);
                 if (otg_RegVal & USB2OTG_USB_ULPIFSLS)
                 {
-                    D(bug("[USB2OTG] %s: Host clock: 48Mhz\n", __PRETTY_FUNCTION__));
+                    bug("[USB2OTG] Host clock: 48Mhz\n");
                     otg_RegVal = rd32le(USB2OTG_HOSTCFG);
                     otg_RegVal &= ~3;
                     otg_RegVal |= 1;
@@ -76,64 +105,73 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                 }
                 else
                 {
-                    D(bug("[USB2OTG] %s: Host clock: 30-60Mhz\n", __PRETTY_FUNCTION__));
+                    bug("[USB2OTG] Host clock: 30-60Mhz (ULPI)\n");
                     otg_RegVal = rd32le(USB2OTG_HOSTCFG);
                     otg_RegVal &= ~3;
                     wr32le(USB2OTG_HOSTCFG, otg_RegVal);
                 }
             } else {
-                D(bug("[USB2OTG] %s: Host clock: 30-60Mhz\n", __PRETTY_FUNCTION__));
+                bug("[USB2OTG] Host clock: 30-60Mhz (default)\n");
                 otg_RegVal = rd32le(USB2OTG_HOSTCFG);
                 otg_RegVal &= ~3;
                 wr32le(USB2OTG_HOSTCFG, otg_RegVal);
             }
-#if 0 // Emulate FS/LS only device
-            otg_RegVal = rd32le(USB2OTG_HOSTCFG);
-            otg_RegVal |= (1 << 2);
-            wr32le(USB2OTG_HOSTCFG, otg_RegVal);
-#endif
 
-#if (0)
-            D(bug("[USB2OTG] %s: Enabling HNP...\n", __PRETTY_FUNCTION__));
-            otg_RegVal = *((volatile unsigned int *)USB2OTG_OTGCTRL);
-            otg_RegVal |= USB2OTG_OTGCTRL_HOSTSETHNPENABLE;
-            *((volatile unsigned int *)USB2OTG_OTGCTRL) = otg_RegVal;
-#endif
+            /* Step 5: HFIR = 60000 for 30-60 MHz PHY clock. */
+            {
+                ULONG hfir = rd32le(USB2OTG_HOSTFRAMEINTERV);
+                hfir &= ~0xffff;
+                hfir |= 60000;
+                wr32le(USB2OTG_HOSTFRAMEINTERV, hfir);
+            }
+
+            /*
+             * Step 6: Enable SOF + HOSTCHANNEL IRQs (GINTMSK cleared by
+             * reset). SOF drives frame scheduling; HOSTCHANNEL drives
+             * per-channel completion/error.
+             */
+            wr32le(USB2OTG_INTR, 0xffffffff); /* clear pending */
+            otg_RegVal = USB2OTG_INTRCORE_DMASTARTOFFRAME |
+                         USB2OTG_INTRCORE_HOSTCHANNEL;
+            wr32le(USB2OTG_INTRMASK, otg_RegVal);
+
+            /*
+             * BCM2835/2837 DWC OTG SPRAM layout: RXFIFO 774 DW @ 0,
+             * NPTXFIFO 256 DW @ 774, PTXFIFO 512 DW @ 1030.
+             */
+            wr32le(USB2OTG_RCVSIZE, 774);
+            wr32le(USB2OTG_NONPERIFIFOSIZE, (256 << 16) | 774);
+            wr32le(USB2OTG_PERIFIFOSIZE, (512 << 16) | (774 + 256));
+
+            usb2otg_wait_ahb_idle(100000, "before FIFO flush");
 
             D(bug("[USB2OTG] %s: Flushing Tx Fifo's...\n", __PRETTY_FUNCTION__));
-            wr32le(USB2OTG_RESET, USB2OTG_RESET_TXFIFOFLUSH | (10 << 6));
-            for (ns = 0; ns < 10000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 10ms
-            if ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH) != 0)
-                bug("[USB2OTG] %s: Tx Flush Timed-Out!\n", __PRETTY_FUNCTION__);
+            wr32le(USB2OTG_RESET, USB2OTG_RESET_TXFIFOFLUSH | (0x10 << 6));
+            usb2otg_wait_reset_bit_clear(USB2OTG_RESET_TXFIFOFLUSH, 100000,
+                "Init: Tx Flush");
 
             D(bug("[USB2OTG] %s: Flushing Rx Fifo's...\n", __PRETTY_FUNCTION__));
             wr32le(USB2OTG_RESET, USB2OTG_RESET_RXFIFOFLUSH);
-            for (ns = 0; ns < 10000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 10ms
-            if ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_RXFIFOFLUSH) != 0)
-                bug("[USB2OTG] %s: Rx Flush Timed-Out!\n", __PRETTY_FUNCTION__);
+            usb2otg_wait_reset_bit_clear(USB2OTG_RESET_RXFIFOFLUSH, 100000,
+                "Init: Rx Flush");
 
             otg_RegVal = rd32le(USB2OTG_HARDWARE2);
             D(bug("[USB2OTG] %s: Queue Depths:\n",
                         __PRETTY_FUNCTION__));
             D(bug("[USB2OTG] %s:      Periodic Transmit: 0x%0x\n",
-                        __PRETTY_FUNCTION__, ((otg_RegVal & (0x3 << 24)) >> 24)));
+                        __PRETTY_FUNCTION__, USB2OTG_HW2_PTXQDEPTH(otg_RegVal)));
             D(bug("[USB2OTG] %s:      Non-Periodic Transmit: 0x%0x\n",
-                        __PRETTY_FUNCTION__, ((otg_RegVal & (0x3 << 22)) >> 22)));
+                        __PRETTY_FUNCTION__, USB2OTG_HW2_NPTXQDEPTH(otg_RegVal)));
 
-            otg_RegVal = rd32le(USB2OTG_HARDWARE3);
-#if (0)
-            D(bug("[USB2OTG] %s:      Device Tokens: 0x%0x\n",
-                        __PRETTY_FUNCTION__, ((otg_RegVal & (0x1F << 26)) >> 26)));
-#endif
-            D(bug("[USB2OTG] %s:      FIFO: %ld bytes\n",
-                        __PRETTY_FUNCTION__, ((otg_RegVal & (0xFFFF << 16)) >> 16) << 2));
-#if (0)
-            D(bug("[USB2OTG] %s: Xfer Size: %ld\n",
-                        __PRETTY_FUNCTION__, (otg_RegVal & 0xF)));
-#endif
+            {
+                ULONG hw3 = rd32le(USB2OTG_HARDWARE3);
+                /* HW3[31:16] = total FIFO depth in DWORDs; *4 for bytes. */
+                D(bug("[USB2OTG] %s:      FIFO: %ld bytes\n",
+                            __PRETTY_FUNCTION__, ((hw3 >> 16) & 0xFFFF) << 2));
+            }
 
             otg_RegVal = rd32le(USB2OTG_HARDWARE2);
-            if ((otg_Unit->hu_HostChans = ((otg_RegVal & (0xF << 14)) >> 14) + 1) > EPSCHANS_MAX)
+            if ((otg_Unit->hu_HostChans = USB2OTG_HW2_HOSTCHANS(otg_RegVal)) > EPSCHANS_MAX)
                 otg_Unit->hu_HostChans = EPSCHANS_MAX;
 
             otg_RegVal = rd32le(USB2OTG_HOSTCFG);
@@ -142,74 +180,43 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                 D(bug("[USB2OTG] %s: Host Channels: %d\n",
                             __PRETTY_FUNCTION__, otg_Unit->hu_HostChans));
 
+                /*
+                 * Two-phase channel halt per Synopsys DWC OTG Programming
+                 * Guide: 1) disable active channels, 2) force-halt all.
+                 */
+                bug("[USB2OTG] Init: Halting %d host channels\n", otg_Unit->hu_HostChans);
+
+                /* Phase 1: Disable channels */
                 for (chan = 0; chan < otg_Unit->hu_HostChans; chan++) {
-#if (0)
-                    *((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_INTRMASK)) =
-                        (USB2OTG_INTRCHAN_STALL|USB2OTG_INTRCHAN_BABBLEERROR|USB2OTG_INTRCHAN_TRANSACTIONERROR) |
-                        (USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE|USB2OTG_INTRCHAN_ACKNOWLEDGE|USB2OTG_INTRCHAN_NOTREADY) |
-                        (USB2OTG_INTRCHAN_HALT|USB2OTG_INTRCHAN_FRAMEOVERRUN|USB2OTG_INTRCHAN_DATATOGGLEERROR);
-                    otg_RegVal = *((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_CHARBASE));
-                    D(bug("[USB2OTG] %s:      Chan #%d FIFO @ 0x%p, Characteristics: %08x -> %08x\n",
-                                __PRETTY_FUNCTION__,
-                                chan, USB2OTG_FIFOBASE + (chan * USB2OTG_FIFOSIZE), otg_RegVal, (otg_RegVal & ~USB2OTG_HOSTCHAR_ENABLE) | (USB2OTG_HOSTCHAR_DISABLE | (1 << USB2OTG_HOSTCHAR_EPDIR))
-                                ));
-                    otg_RegVal &= ~USB2OTG_HOSTCHAR_ENABLE;
-                    otg_RegVal |= USB2OTG_HOSTCHAR_DISABLE | (1 << USB2OTG_HOSTCHAR_EPDIR);
-                    *((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_CHARBASE)) = otg_RegVal;
-#endif
+                    otg_RegVal = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                    /* Clear enable, clear direction, set disable */
+                    otg_RegVal &= ~(USB2OTG_HOSTCHAR_ENABLE | USB2OTG_HOSTCHAR_EPDIR(1));
+                    otg_RegVal |= USB2OTG_HOSTCHAR_DISABLE;
+                    wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), otg_RegVal);
                 }
 
+                /* Phase 2: Force-halt all channels */
                 for (chan = 0; chan < otg_Unit->hu_HostChans; chan++) {
-#if (0)
-                    otg_RegVal = *((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_CHARBASE));
-                    otg_RegVal |= USB2OTG_HOSTCHAR_ENABLE|USB2OTG_HOSTCHAR_DISABLE|(1 << USB2OTG_HOSTCHAR_EPDIR);
-                    *((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_CHARBASE)) = otg_RegVal;
-                    for (ns = 0; ns < 100000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 100ms
-                    if ((*((volatile unsigned int *)(USB2OTG_HOST_CHANBASE + (chan * USB2OTG_HOST_CHANREGSIZE) + USB2OTG_HOSTCHAN_CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) != 0)
-                        bug("[USB2OTG] %s: Unable to clear Halt on channel #%d\n", __PRETTY_FUNCTION__, chan);
-#endif
-                }
+                    otg_RegVal = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                    otg_RegVal |= USB2OTG_HOSTCHAR_ENABLE | USB2OTG_HOSTCHAR_DISABLE;
+                    otg_RegVal &= ~USB2OTG_HOSTCHAR_EPDIR(1);
+                    wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), otg_RegVal);
 
-#if (0)
-                D(bug("[USB2OTG] %s: Enabling HOST Channel Interrupts ...\n",
-                            __PRETTY_FUNCTION__));
-                *((volatile unsigned int *)USB2OTG_HOSTINTRMASK) = (1U << otg_Unit->hu_HostChans) - 1U;
-#endif
-            }
-#if (0)
-            otg_RegVal = *((volatile unsigned int *)USB2OTG_HARDWARE2);
-
-            if (!(otg_Unit->hu_OperatingMode) || (otg_Unit->hu_OperatingMode == USB2OTG_USBDEVICEMODE))
-            {
-                D(bug("[USB2OTG] %s: Configuring USB Core DEVICE mode -:\n",
-                            __PRETTY_FUNCTION__));
-
-                if ((otg_Unit->hu_DevEPs = ((otg_RegVal & (0xF << 10)) >> 10) + 1) > EPSCHANS_MAX)
-                    otg_Unit->hu_DevEPs = EPSCHANS_MAX;
-
-                otg_RegVal = *((volatile unsigned int *)USB2OTG_HARDWARE4);
-                otg_Unit->hu_DevInEPs = ((otg_RegVal & (0xF << 26)) >> 26) + 1;
-
-                D(bug("[USB2OTG] %s:      Endpoints: %d/%d\n",
-                            __PRETTY_FUNCTION__, otg_Unit->hu_DevInEPs, otg_Unit->hu_DevEPs));
-
-                for (chan = 0; chan < otg_Unit->hu_DevEPs; chan++) {
-                    D(bug("[USB2OTG] %s:      Endpoint #%d ", __PRETTY_FUNCTION__, chan));
-                    if (chan < otg_Unit->hu_DevInEPs)
+                    /* Wait for channel to halt (ENABLE bit clears) */
                     {
-                        D(bug("IN_CTL: %08x, ", *((volatile unsigned int *)(USB2OTG_DEV_INEP_BASE + (chan * USB2OTG_DEV_EPSIZE) + USB2OTG_DEV_INEP_DIEPCTL))));
+                        int timeout = 100000;
+                        while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
+                            asm volatile("mov r0, r0\n");
+                        if (timeout == 0)
+                            bug("[USB2OTG] Init: Channel #%d halt timed out!\n", chan);
                     }
-                    D(bug("OUT_CTL: %08x\n", *((volatile unsigned int *)(USB2OTG_DEV_OUTEP_BASE + (chan * USB2OTG_DEV_EPSIZE) + USB2OTG_DEV_OUTEP_DOEPCTL))));
-                }
-            }
-#endif
 
-#if (0)
-            D(bug("[USB2OTG] %s: Pulling-Up D+ ..\n", __PRETTY_FUNCTION__));
-            otg_RegVal = *((volatile unsigned int *)USB2OTG_DEVCTRL);
-            otg_RegVal &= ~(1 << 1);
-            *((volatile unsigned int *)USB2OTG_DEVCTRL) = otg_RegVal;
-#endif
+                    /* Clear all pending interrupts on this channel */
+                    wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
+                }
+
+            }
+
 
             {
                 struct MsgPort *port = CreateMsgPort();
@@ -219,7 +226,8 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                 otg_RegVal = rd32le(USB2OTG_HOSTPORT);
                 if (!(otg_RegVal & USB2OTG_HOSTPORT_PRTPWR))
                 {
-                    D(bug("[USB2OTG] %s: Powering On Host Port ..\n", __PRETTY_FUNCTION__));
+                    bug("[USB2OTG] Init: Powering On Host Port\n");
+                    otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
                     otg_RegVal |= USB2OTG_HOSTPORT_PRTPWR;
                     wr32le(USB2OTG_HOSTPORT, otg_RegVal);
                 }
@@ -232,14 +240,14 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                 otg_RegVal = rd32le(USB2OTG_HOSTPORT);
                 if (otg_RegVal & USB2OTG_HOSTPORT_PRTCONNSTS)
                 {
-                    D(bug("[USB2OTG] %s: Reseting Host Port ..\n", __PRETTY_FUNCTION__));
+                    bug("[USB2OTG] Init: Device connected, resetting port\n");
 
                     req->tr_time.tv_secs = 0;
                     req->tr_time.tv_micro = 100000;
                     DoIO((struct IORequest *)req);
 
                     otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                    otg_RegVal &= ~(USB2OTG_HOSTPORT_PRTCONNSTS|USB2OTG_HOSTPORT_PRTENA|USB2OTG_HOSTPORT_PRTENCHNG|USB2OTG_HOSTPORT_PRTOVRCURRCHNG);
+                    otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
                     otg_RegVal |= USB2OTG_HOSTPORT_PRTRST;
                     wr32le(USB2OTG_HOSTPORT, otg_RegVal);
 
@@ -248,67 +256,38 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                     DoIO((struct IORequest *)req);
 
                     otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                    otg_RegVal &= ~(USB2OTG_HOSTPORT_PRTCONNSTS|USB2OTG_HOSTPORT_PRTENA|USB2OTG_HOSTPORT_PRTENCHNG|USB2OTG_HOSTPORT_PRTOVRCURRCHNG| USB2OTG_HOSTPORT_PRTRST);
+                    otg_RegVal &= ~(USB2OTG_HOSTPORT_SC_BITS | USB2OTG_HOSTPORT_PRTRST);
                     wr32le(USB2OTG_HOSTPORT, otg_RegVal);
-
 
                     req->tr_time.tv_secs = 0;
                     req->tr_time.tv_micro = 20000;
                     DoIO((struct IORequest *)req);
+
+                    otg_RegVal = rd32le(USB2OTG_HOSTPORT);
+
+                    /* Signal port change so hub class INT EP returns immediately. */
+                    if (otg_RegVal & USB2OTG_HOSTPORT_PRTCONNSTS)
+                    {
+                        otg_Unit->hu_HubPortChanged = TRUE;
+                        D(bug("[USB2OTG] Init: HubPortChanged set to TRUE\n"));
+                    }
+                }
+                else
+                {
+                    bug("[USB2OTG] Init: No device connected on port!\n");
                 }
 
                 CloseDevice((struct IORequest *)req);
                 DeleteIORequest((struct IORequest *)req);
                 DeleteMsgPort(port);
             }
-#if (0)
-            D(bug("[USB2OTG] %s: Configuring Interrupts ...\n",
-                        __PRETTY_FUNCTION__));
-
-            *((volatile unsigned int *)USB2OTG_INTRMASK) =
-                (USB2OTG_INTRCORE_ENUMERATIONDONE|USB2OTG_INTRCORE_USBRESET|USB2OTG_INTRCORE_USBSUSPEND) |
-                (USB2OTG_INTRCORE_INENDPOINT|USB2OTG_INTRCORE_RECEIVESTATUSLEVEL|USB2OTG_INTRCORE_SESSIONREQUEST|USB2OTG_INTRCORE_OTG|USB2OTG_INTRCORE_HOSTCHANNEL|USB2OTG_INTRCORE_PORT);
-
-            if (!(otg_Unit->hu_OperatingMode) || (otg_Unit->hu_OperatingMode == USB2OTG_USBDEVICEMODE))
-            {
-                otg_RegVal = *((volatile unsigned int *)USB2OTG_HARDWARE2);
-                if (otg_RegVal & (1 << 20))
-                {
-                    D(bug("[USB2OTG] %s: Multi-Process Interrupts ...\n",
-                        __PRETTY_FUNCTION__));
-                    for (chan = 0; chan < otg_Unit->hu_DevInEPs; chan++) {
-                        *((volatile unsigned int *)(USB2OTG_DEV_INEP_BASE + (chan * USB2OTG_DEV_EPSIZE) + USB2OTG_DEV_INEP_DIEPCTL)) = (1 << 0);
-                        *((volatile unsigned int *)(USB2OTG_DEV_INEP_BASE + (chan * USB2OTG_DEV_EPSIZE) + USB2OTG_DEV_INEP_DIEPCTL)) = 0;
-                        *((volatile unsigned int *)USB2OTG_DEVEACHINTMSK) = 0xFFFF;
-                    }
-                }
-                else
-                {
-                    *((volatile unsigned int *)USB2OTG_DEVINEPMASK) = (1 << 0);
-                    *((volatile unsigned int *)USB2OTG_DEVOUTEPMASK) = 0;
-                    *((volatile unsigned int *)USB2OTG_DEVINTRMASK) = 0xFFFF;
-                }
-            }
-
-            D(bug("[USB2OTG] %s: Enabling Global Interrupts ...\n",
-                        __PRETTY_FUNCTION__));
-            *((volatile unsigned int *)USB2OTG_AHB) = USB2OTG_AHB_INTENABLE;
-
-            D(bug("[USB2OTG] %s: Initialising NakTimeout (intr @ 0x%p) ...\n",
-                        __PRETTY_FUNCTION__, &otg_Unit->hu_NakTimeoutInt));
-
-
-            Cause(&otg_Unit->hu_NakTimeoutInt);
-#endif
+            /* Don't double-start NakTimeoutInt — creates overlapping chains. */
+            // Cause(&otg_Unit->hu_NakTimeoutInt);
         }
 
         otg_RegVal = rd32le(USB2OTG_OTGCTRL);
         D(bug("[USB2OTG] %s: OTG Control: %08x\n",
                     __PRETTY_FUNCTION__, otg_RegVal));
-#if 0
-for(int i=0; i < 0x600 / 4; i++)
-bug("%04x: %08x\n", i * 4, rd32le(USB2OTG_OTGCTRL + i*4));
-#endif
         return (&otg_Unit->hu_Unit);
     }
 
@@ -326,6 +305,41 @@ void FNAME_DEV(CloseUnit)(struct IOUsbHWReq *ioreq, struct USB2OTGUnit *otg_Unit
 void FNAME_DEV(TermIO)(struct IOUsbHWReq *ioreq,
             LIBBASETYPEPTR USB2OTGBase)
 {
+    /*
+     * USB §9.4.5: CLEAR_FEATURE(ENDPOINT_HALT) resets device toggle to
+     * DATA0; host must mirror or every subsequent xfer hits DATATGLERR.
+     * MSC BOT reset-recovery depends on this.
+     */
+    if (ioreq->iouh_Req.io_Error == 0 &&
+        ioreq->iouh_Req.io_Command == UHCMD_CONTROLXFER &&
+        ioreq->iouh_SetupData.bmRequestType ==
+            (URTF_OUT | URTF_STANDARD | URTF_ENDPOINT) &&
+        ioreq->iouh_SetupData.bRequest == USR_CLEAR_FEATURE &&
+        AROS_LE2WORD(ioreq->iouh_SetupData.wValue) == UFS_ENDPOINT_HALT)
+    {
+        struct USB2OTGUnit *otg_Unit = USB2OTGBase->hd_Unit;
+        UWORD widx = AROS_LE2WORD(ioreq->iouh_SetupData.wIndex);
+        UBYTE ep = (UBYTE)(widx & 0x0f);
+        UBYTE dev = ioreq->iouh_DevAddr;
+
+        if (otg_Unit != NULL)
+        {
+            Disable();
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            otg_Unit->hu_PIDBits[dev & 0x7f] &= ~(3UL << (2 * ep));
+            otg_Unit->hu_NakGate[dev & 0x7f] = USB2OTG_NAK_GATE_NONE;
+            /* Also clear PING flow bit; stale PING state survives BOT
+             * Reset Recovery and re-wedges on the next CBW. */
+            otg_Unit->hu_PingBits[dev & 0x7f] &= ~(1UL << ep);
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+            Enable();
+        }
+    }
+
     ioreq->iouh_Req.io_Message.mn_Node.ln_Type = NT_FREEMSG;
 
     if (!(ioreq->iouh_Req.io_Flags & IOF_QUICK))
@@ -520,34 +534,39 @@ WORD FNAME_DEV(cmdControlXFer)(struct IOUsbHWReq *ioreq,
     D(bug("[USB2OTG] UHCMD_CONTROLXFER(unit:0x%p, ioreq:0x%p)\n",
                 otg_Unit, ioreq));
 
-#if (0)
-    if (!(ioreq->iouh_State & UHSF_OPERATIONAL))
-    {
-        return (UHIOERR_USBOFFLINE);
-    }
-#endif
 
     if (ioreq->iouh_DevAddr == otg_Unit->hu_HubAddr)
     {
+        D(bug("[USB2OTG] CTRL-RH: dev=%ld hubaddr=%ld req=%02lx val=%04lx len=%ld\n",
+            (LONG)ioreq->iouh_DevAddr,
+            (LONG)otg_Unit->hu_HubAddr,
+            (ULONG)ioreq->iouh_SetupData.bRequest,
+            (ULONG)AROS_LE2WORD(ioreq->iouh_SetupData.wValue),
+            (LONG)ioreq->iouh_Length));
         return (FNAME_ROOTHUB(cmdControlXFer)(ioreq, otg_Unit, USB2OTGBase));
     }
 
-    D(bug("[USB2OTG] UHCMD_CONTROLXFER: DevAddr #%ld\n",
-                ioreq->iouh_DevAddr));
-
-    (bug("[USB2OTG] ControlTransfer to dev %02x: %02x %02x %04x %04x %04x\n", ioreq->iouh_DevAddr,
-            ioreq->iouh_SetupData.bmRequestType, ioreq->iouh_SetupData.bRequest, AROS_LE2WORD(ioreq->iouh_SetupData.wValue),
-            AROS_LE2WORD(ioreq->iouh_SetupData.wLength), AROS_LE2WORD(ioreq->iouh_SetupData.wIndex)));
+    D(bug("[USB2OTG] CTRL-HW: dev=%ld hubaddr=%ld req=%02lx val=%04lx len=%ld\n",
+        (LONG)ioreq->iouh_DevAddr,
+        (LONG)otg_Unit->hu_HubAddr,
+        (ULONG)ioreq->iouh_SetupData.bRequest,
+        (ULONG)AROS_LE2WORD(ioreq->iouh_SetupData.wValue),
+        (LONG)ioreq->iouh_Length));
 
     ioreq->iouh_Req.io_Flags &= ~IOF_QUICK;
     ioreq->iouh_Actual = 0;
+    usb2otg_reset_retry_state(ioreq);
 
     Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
     AddTail(&otg_Unit->hu_CtrlXFerQueue, (struct Node *) ioreq);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
     Enable();
-    //FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
-
-    D(bug("[USB2OTG] UHCMD_CONTROLXFER: handled ioreq @ 0x%p\n", ioreq));
+    FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
 
     return (RC_DONTREPLY);
 }
@@ -559,12 +578,6 @@ WORD FNAME_DEV(cmdBulkXFer)(struct IOUsbHWReq *ioreq,
     D(bug("[USB2OTG] UHCMD_BULKXFER(unit:0x%p, ioreq:0x%p)\n",
                 otg_Unit, ioreq));
 
-#if (0)
-    if(!(ioreq->iouh_State & UHSF_OPERATIONAL))
-    {
-        return(UHIOERR_USBOFFLINE);
-    }
-#endif
 
     if (ioreq->iouh_Flags & UHFF_LOWSPEED)
     {
@@ -573,11 +586,33 @@ WORD FNAME_DEV(cmdBulkXFer)(struct IOUsbHWReq *ioreq,
 
     ioreq->iouh_Req.io_Flags &= ~IOF_QUICK;
     ioreq->iouh_Actual = 0;
+    usb2otg_reset_retry_state(ioreq);
 
     Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+    {
+        int chan;
+        for (chan = 0; chan < 8; chan++)
+        {
+            if (otg_Unit->hu_Channel[chan].hc_Request == ioreq &&
+                otg_Unit->hu_Channel[chan].hc_SplitCSplitPending)
+            {
+#if defined(__AROSEXEC_SMP__)
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                Enable();
+                return RC_DONTREPLY;
+            }
+        }
+    }
     AddTail(&otg_Unit->hu_BulkXFerQueue, (struct Node *) ioreq);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
     Enable();
-    //FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
+    FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
 
     D(bug("[USB2OTG] UHCMD_BULKXFER: handled ioreq @ 0x%p\n", ioreq));
 
@@ -588,25 +623,13 @@ WORD FNAME_DEV(cmdIntXFer)(struct IOUsbHWReq *ioreq,
                        struct USB2OTGUnit *otg_Unit,
                        LIBBASETYPEPTR USB2OTGBase)
 {
-    D(bug("[USB2OTG] UHCMD_INTXFER(unit:0x%p, ioreq:0x%p)\n",
-                otg_Unit, ioreq));
-
-#if (0)
-    if(!(ioreq->iouh_State & UHSF_OPERATIONAL))
-    {
-        return (UHIOERR_USBOFFLINE);
-    }
-#endif
-
     if (ioreq->iouh_DevAddr == otg_Unit->hu_HubAddr)
     {
+        D(bug("[USB2OTG] INT-RH: ep=%ld len=%ld changed=%d\n",
+            (LONG)ioreq->iouh_Endpoint, (LONG)ioreq->iouh_Length,
+            otg_Unit->hu_HubPortChanged));
         return (FNAME_ROOTHUB(cmdIntXFer)(ioreq, otg_Unit, USB2OTGBase));
     }
-
-if (ioreq->iouh_DevAddr == 4) {
-    D(bug("[USB2OTG] UHCMD_INTXFER: DevAddr #%ld\n",
-                ioreq->iouh_DevAddr));
-}
 
     ioreq->iouh_Req.io_Flags &= ~IOF_QUICK;
     ioreq->iouh_Actual = 0;
@@ -617,11 +640,19 @@ if (ioreq->iouh_DevAddr == 4) {
     ioreq->iouh_DriverPrivate1 = (APTR)((last_handled << 16) | next_to_handle);
 
     Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
     AddTail(&otg_Unit->hu_IntXFerQueue, (struct Node *) ioreq);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
     Enable();
-    //FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
+    FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
 
-    D(bug("[USB2OTG] UHCMD_INTXFER: handled ioreq @ 0x%p added=%d, next=%d\n", ioreq, last_handled, next_to_handle));
+    D(bug("[USB2OTG] INT-Q: dev=%d ep=%d len=%d interval=%d next=%d\n",
+        ioreq->iouh_DevAddr, ioreq->iouh_Endpoint,
+        ioreq->iouh_Length, ioreq->iouh_Interval, next_to_handle));
 
     return (RC_DONTREPLY);
 }
@@ -633,12 +664,6 @@ WORD FNAME_DEV(cmdIsoXFer)(struct IOUsbHWReq *ioreq,
     D(bug("[USB2OTG] UHCMD_ISOXFER(unit:0x%p, ioreq:0x%p)\n",
                 otg_Unit, ioreq));
 
-#if (0)
-    if(!(ioreq->iouh_State & UHSF_OPERATIONAL))
-    {
-        return(UHIOERR_USBOFFLINE);
-    }
-#endif
     if(ioreq->iouh_Flags & UHFF_LOWSPEED)
     {
         return(UHIOERR_BADPARAMS);
@@ -648,7 +673,13 @@ WORD FNAME_DEV(cmdIsoXFer)(struct IOUsbHWReq *ioreq,
     ioreq->iouh_Actual = 0;
 
     Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
     AddTail(&otg_Unit->hu_IsoXFerQueue, (struct Node *) ioreq);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
     Enable();
     //FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
 

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
@@ -1,9 +1,10 @@
 /*
-    Copyright (C) 2013-2019, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
 #include <aros/debug.h>
+#include <aros/atomic.h>
 
 #include <proto/exec.h>
 #include <proto/kernel.h>
@@ -79,13 +80,13 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                 );
 
                     otg_RegVal = rd32le(USB2OTG_HARDWARE2);
-                    bug("[USB2OTG] Architecture: %d - ", ((otg_RegVal & (3 << 3)) >> 3));
-                    switch (((otg_RegVal & (3 << 3)) >> 3))
+                    bug("[USB2OTG] Architecture: %d - ", USB2OTG_HW2_ARCH(otg_RegVal));
+                    switch (USB2OTG_HW2_ARCH(otg_RegVal))
                     {
-                        case 2:
+                        case USB2OTG_HW2_ARCH_INT_DMA:
                             bug("Internal DMA\n");
                             break;
-                        case 1:
+                        case USB2OTG_HW2_ARCH_EXT_DMA:
                             bug("External DMA\n");
                             break;
                         default:
@@ -114,8 +115,7 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                     PwrOnMsg[6] = AROS_LE2LONG(VCPOWER_STATE_ON | VCPOWER_STATE_WAIT);
                     PwrOnMsg[7] = 0;
 
-                    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, PwrOnMsg);
-                    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == PwrOnMsg)
+                    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, PwrOnMsg) == PwrOnMsg)
                     {
                         D(bug("[USB2OTG] Power on state: %08x\n", AROS_LE2LONG(PwrOnMsg[6])));
                         if ((AROS_LE2LONG(PwrOnMsg[6]) & 1) == 0)
@@ -128,8 +128,10 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                         {
                             bug("[USB2OTG] USB HCD does not exist\n");
 
-                            for (int i=0; i < 8; i++)
-                                bug("[USB2OTG] %08x\n", PwrOnMsg[i]);
+                            D(
+                                for (int i=0; i < 8; i++)
+                                    bug("[USB2OTG] %08x\n", PwrOnMsg[i]);
+                            )
 
                             USB2OTGBase = NULL;
                         }
@@ -183,6 +185,7 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     NewList(&USB2OTGBase->hd_Unit->hu_AbortQueue);
                                     NewList(&USB2OTGBase->hd_Unit->hu_PeriodicTDQueue);
                                     NewList(&USB2OTGBase->hd_Unit->hu_FinishedXfers);
+                                    KrnSpinInit(&USB2OTGBase->hd_Unit->hu_Lock);
 
                                     USB2OTGBase->hd_Unit->hu_PendingInt.is_Node.ln_Type = NT_INTERRUPT;
                                     USB2OTGBase->hd_Unit->hu_PendingInt.is_Node.ln_Name = "OTG2USB Pending Work Interrupt";
@@ -196,27 +199,39 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     USB2OTGBase->hd_Unit->hu_NakTimeoutInt.is_Data = USB2OTGBase->hd_Unit;
                                     USB2OTGBase->hd_Unit->hu_NakTimeoutInt.is_Code = (VOID_FUNC)FNAME_DEV(NakTimeoutInt);
 
-                                    USB2OTGBase->hd_Unit->hu_NakTimeoutMsgPort.mp_Node.ln_Type = NT_MSGPORT;
-                                    USB2OTGBase->hd_Unit->hu_NakTimeoutMsgPort.mp_Flags = PA_SOFTINT;
-                                    USB2OTGBase->hd_Unit->hu_NakTimeoutMsgPort.mp_SigTask = &USB2OTGBase->hd_Unit->hu_NakTimeoutInt;
-                                    NewList(&USB2OTGBase->hd_Unit->hu_NakTimeoutMsgPort.mp_MsgList);
-
+                                    USB2OTGBase->hd_Unit->hu_WorkerAffinity = 0;
+                                    KrnGetCPUMask(0, &USB2OTGBase->hd_Unit->hu_WorkerAffinity);
+                                    USB2OTGBase->hd_Unit->hu_WorkerTask = NewCreateTask(
+                                        TASKTAG_NAME, "USB2OTG Worker",
+                                        TASKTAG_AFFINITY, &USB2OTGBase->hd_Unit->hu_WorkerAffinity,
+                                        TASKTAG_PC, FNAME_DEV(WorkerTask),
+                                        TASKTAG_TASKMSGPORT, &USB2OTGBase->hd_Unit->hu_WorkerPort,
+                                        TASKTAG_ARG1, USB2OTGBase->hd_Unit,
+                                        TAG_DONE);
+                                    if (!USB2OTGBase->hd_Unit->hu_WorkerTask || !USB2OTGBase->hd_Unit->hu_WorkerPort)
+                                    {
+                                        bug("[USB2OTG] Failed to create CPU0 worker task\n");
+                                        return FALSE;
+                                    }
                                     CopyMem(USB2OTGBase->hd_TimerReq, &USB2OTGBase->hd_Unit->hu_NakTimeoutReq, sizeof(struct timerequest));
-                                    USB2OTGBase->hd_Unit->hu_NakTimeoutReq.tr_node.io_Message.mn_ReplyPort = &USB2OTGBase->hd_Unit->hu_NakTimeoutMsgPort;
+                                    USB2OTGBase->hd_Unit->hu_NakTimeoutReq.tr_node.io_Message.mn_ReplyPort = USB2OTGBase->hd_Unit->hu_WorkerPort;
+                                    USB2OTGBase->hd_Unit->hu_NakTimeoutReq.tr_time.tv_secs = 0;
+                                    USB2OTGBase->hd_Unit->hu_NakTimeoutReq.tr_time.tv_micro = 150 * 1000;
+                                    SendIO((APTR)&USB2OTGBase->hd_Unit->hu_NakTimeoutReq);
 
                                     USB2OTGBase->hd_Unit->hu_HubPortChanged = FALSE;
 
                                     USB2OTGBase->hd_Unit->hu_OperatingMode = (otg_OperatingMode == (USB2OTG_USBHOSTMODE|USB2OTG_USBDEVICEMODE)) ? 0 : otg_OperatingMode;
 
                                     for (i=0; i < 128; i++)
+                                    {
                                         USB2OTGBase->hd_Unit->hu_PIDBits[i] = 0;
+                                        USB2OTGBase->hd_Unit->hu_NakGate[i] = USB2OTG_NAK_GATE_NONE;
+                                    }
+                                    USB2OTGBase->hd_Unit->hu_BulkOwnerDev[0] = 0;
+                                    USB2OTGBase->hd_Unit->hu_BulkOwnerDev[1] = 0;
 
-#if (0)
-                                    D(bug("[USB2OTG] %s: Unit Mode %d\n",
-                                                __PRETTY_FUNCTION__, USB2OTGBase->hd_Unit->hu_OperatingMode));
-#endif
                                     USB2OTGBase->hd_Unit->hu_GlobalIRQHandle = KrnAddIRQHandler(IRQ_VC_USB, FNAME_DEV(GlobalIRQHandler), USB2OTGBase->hd_Unit, SysBase);
-
                                     USB2OTGBase->hd_Unit->hu_USB2OTGBase = USB2OTGBase;
 
                                     D(bug("[USB2OTG] %s: Installed Global IRQ Handler [handle @ 0x%p] for IRQ #%ld\n",
@@ -225,7 +240,6 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     otg_RegVal = rd32le(USB2OTG_USB);
                                     otg_RegVal &= ~(USB2OTG_USB_ULPIDRIVEEXTERNALVBUS|USB2OTG_USB_TSDLINEPULSEENABLE);
                                     wr32le(USB2OTG_USB, otg_RegVal);
-
                                     D(bug("[USB2OTG] %s: Reseting Controller ..\n", __PRETTY_FUNCTION__));
                                     wr32le(USB2OTG_RESET, USB2OTG_RESET_CORESOFT);
                                     for (ns = 0; ns < 10000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 10ms
@@ -238,16 +252,9 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     otg_RegVal &= ~USB2OTG_USB_MODESELECT_UTMI;
                                     wr32le(USB2OTG_USB, otg_RegVal);
 
-#if (0)
-                                    D(bug("[USB2OTG] %s: Reseting Controller ..\n", __PRETTY_FUNCTION__));
-                                    wr32le(USB2OTG_RESET, USB2OTG_RESET_CORESOFT);
-                                    for (ns = 0; ns < 10000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 10ms
-                                    if ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_CORESOFT) != 0)
-                                        bug("[USB2OTG] %s: Reset Timed-Out!\n", __PRETTY_FUNCTION__);
-#endif
-
                                     otg_RegVal = rd32le(USB2OTG_HARDWARE2);
-                                    if (((otg_RegVal & (3 << 6) >> 6) == 2) && ((otg_RegVal & (3 << 8) >> 8) == 1))
+                                    if (USB2OTG_HW2_FSPHY_TYPE(otg_RegVal) == USB2OTG_HW2_FSPHY_TYPE_ULPI &&
+                                        USB2OTG_HW2_HSPHY_TYPE(otg_RegVal) == USB2OTG_HW2_HSPHY_TYPE_UTMI)
                                     {
                                         D(bug("[USB2OTG] %s: ULPI FSLS configuration: enabled.\n", __PRETTY_FUNCTION__));
                                         otg_RegVal = rd32le(USB2OTG_USB);
@@ -272,44 +279,9 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     USB2OTGBase->hd_Unit->hu_XferSizeWidth = 11 + (otg_RegVal & 0x0f);
                                     USB2OTGBase->hd_Unit->hu_PktSizeWidth = 4 + ((otg_RegVal >> 4) & 0x07);
 
-                                    bug("[USB2OTG] %s: XferSizeWidth = %d, PktSizeWidth = %d\n", __PRETTY_FUNCTION__,
-                                        USB2OTGBase->hd_Unit->hu_XferSizeWidth, USB2OTGBase->hd_Unit->hu_PktSizeWidth);
+                                    D(bug("[USB2OTG] %s: XferSizeWidth = %d, PktSizeWidth = %d\n", __PRETTY_FUNCTION__,
+                                        USB2OTGBase->hd_Unit->hu_XferSizeWidth, USB2OTGBase->hd_Unit->hu_PktSizeWidth));
 
-#if (0)
-                                    D(bug("[USB2OTG] %s: Operating Mode: ", __PRETTY_FUNCTION__));
-                                    otg_RegVal = rd32le(USB2OTG_HARDWARE2);
-                                    switch (otg_RegVal & 7)
-                                    {
-                                        case 0:
-                                            D(bug("HNP/SRP\n"));
-                                            otg_RegVal = rd32le(USB2OTG_USB);
-                                            otg_RegVal |= (USB2OTG_USB_HNPCAPABLE|USB2OTG_USB_SRPCAPABLE);
-                                            wr32le(USB2OTG_USB, otg_RegVal);
-                                            break;
-                                        case 1:
-                                        case 3:
-                                        case 5:
-                                            D(bug("SRP\n"));
-                                            otg_RegVal = rd32le(USB2OTG_USB);
-                                            otg_RegVal &= ~USB2OTG_USB_HNPCAPABLE;
-                                            otg_RegVal |= USB2OTG_USB_SRPCAPABLE;
-                                            wr32le(USB2OTG_USB, otg_RegVal);
-                                            break;
-                                        case 2:
-                                        case 4:
-                                        case 6:
-                                            D(bug("No HNP or SRP\n"));
-                                            otg_RegVal = rd32le(USB2OTG_USB);
-                                            otg_RegVal &= ~(USB2OTG_USB_HNPCAPABLE|USB2OTG_USB_SRPCAPABLE);
-                                            wr32le(USB2OTG_USB, otg_RegVal);
-                                            break;
-                                    }
-#else
-                                    D(bug("[USB2OTG] %s: Disable HNP/SRP\n", __PRETTY_FUNCTION__));
-                                    otg_RegVal = rd32le(USB2OTG_USB);
-                                    otg_RegVal &= ~(USB2OTG_USB_HNPCAPABLE|USB2OTG_USB_SRPCAPABLE);
-                                    wr32le(USB2OTG_USB, otg_RegVal);
-#endif
 
                                     D(bug("[USB2OTG] %s: Enabling Global Interrupts ...\n", __PRETTY_FUNCTION__));
                                     otg_RegVal = rd32le(USB2OTG_INTR);
@@ -479,6 +451,18 @@ AROS_LH1(void, FNAME_DEV(BeginIO),
     ioreq->iouh_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
     ioreq->iouh_Req.io_Error                   = UHIOERR_NO_ERROR;
 
+    D(
+        if (ioreq->iouh_Req.io_Command == UHCMD_CONTROLXFER ||
+            ioreq->iouh_Req.io_Command == UHCMD_INTXFER)
+        {
+            bug("[USB2OTG:BIO] cmd=%lu dev=%ld ep=%ld len=%ld\n",
+                (ULONG)ioreq->iouh_Req.io_Command,
+                (LONG)ioreq->iouh_DevAddr,
+                (LONG)ioreq->iouh_Endpoint,
+                (LONG)ioreq->iouh_Length);
+        }
+    )
+
     if (ioreq->iouh_Req.io_Command < NSCMD_DEVICEQUERY)
     {
         switch (ioreq->iouh_Req.io_Command)
@@ -548,6 +532,11 @@ AROS_LH1(void, FNAME_DEV(BeginIO),
 
     if (ret != RC_DONTREPLY)
     {
+        D(
+            if (ioreq->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                bug("[USB2OTG:BIO] CTRL done dev=%ld ret=%ld\n",
+                    (LONG)ioreq->iouh_DevAddr, (LONG)ret);
+        )
         D(bug("[USB2OTG] %s: Terminating I/O..\n",
                     __PRETTY_FUNCTION__));
 
@@ -582,12 +571,6 @@ AROS_LH1(LONG, FNAME_DEV(AbortIO),
     /* Is it pending? */
     if (ioreq->iouh_Req.io_Message.mn_Node.ln_Type == NT_MESSAGE)
     {
-#if (0)
-        if (FNAME_DEV(cmdAbortIO)(ioreq, USB2OTGBase))
-        {
-            return(0);
-        }
-#endif
     }
     return(-1);
 
@@ -596,27 +579,42 @@ AROS_LH1(LONG, FNAME_DEV(AbortIO),
 
 void FNAME_DEV(Cause)(LIBBASETYPEPTR USB2OTGBase, struct Interrupt *interrupt)
 {
-    Cause(interrupt);
-    #if 0
-    /* this is a workaround for the original Cause() function missing tailed calls */
-    Disable();
-
-    if((interrupt->is_Node.ln_Type == NT_SOFTINT) || (interrupt->is_Node.ln_Type == NT_USER))
+#if defined(__AROSEXEC_SMP__)
+    if (USB2OTGBase && USB2OTGBase->hd_Unit && USB2OTGBase->hd_Unit->hu_WorkerTask)
     {
-        // signal tailed call
-        interrupt->is_Node.ln_Type = NT_USER;
-    } else {
-        do
+        struct USB2OTGUnit *unit = USB2OTGBase->hd_Unit;
+        ULONG sigmask = 1UL << unit->hu_WorkerPort->mp_SigBit;
+
+        if (interrupt == &unit->hu_PendingInt)
         {
-            interrupt->is_Node.ln_Type = NT_SOFTINT;
-            Forbid(); // make sure code is not interrupted by other tasks
-            Enable();
-            AROS_INTC1(interrupt->is_Code, interrupt->is_Data);
             Disable();
-            Permit();
-        } while(interrupt->is_Node.ln_Type != NT_SOFTINT);
-        interrupt->is_Node.ln_Type = NT_INTERRUPT;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            unit->hu_WorkFlags |= USB2OTG_WORK_PENDING;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&unit->hu_Lock);
+#endif
+            Enable();
+            Signal(unit->hu_WorkerTask, sigmask);
+            return;
+        }
+        if (interrupt == &unit->hu_NakTimeoutInt)
+        {
+            Disable();
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            unit->hu_WorkFlags |= USB2OTG_WORK_NAKTIMEOUT;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&unit->hu_Lock);
+#endif
+            Enable();
+            Signal(unit->hu_WorkerTask, sigmask);
+            return;
+        }
     }
-    Enable();
-    #endif
+#endif
+
+    Cause(interrupt);
 }

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013-2020, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
@@ -52,12 +52,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                     D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Set Device Address to #%ld\n", val));
                     otg_Unit->hu_HubAddr = val;
                     ioreq->iouh_Actual = len;
-#if (0) // In host mode do not set address!
-                    unsigned int otg_RegVal = rd32le(USB2OTG_DEVCFG);
-                    otg_RegVal &= ~(0x7F << 4);
-                    otg_RegVal |= ((val & 0x7F) << 4);
-                    wr32le(USB2OTG_DEVCFG, otg_RegVal);
-#endif
                     return (0);
 
                 case USR_SET_CONFIGURATION:
@@ -175,12 +169,8 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
 
                     cmdgood = FALSE;
 
-#if (0)
-                    ULONG oldval = *((volatile unsigned int *)USB2OTG_HOSTPORT) & ~(USB2OTG_HOSTPORT_PRTENCHNG|USB2OTG_HOSTPORT_PRTCONNSTS);
-                    ULONG newval = oldval;
-#else
                     unsigned int otg_RegVal;
-#endif
+
                     switch (val)
                     {
                         case UFS_PORT_ENABLE:
@@ -190,10 +180,7 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                         case UFS_PORT_SUSPEND:
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Suspending Port #%ld\n", idx));
 
-                            otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                            otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
-                            otg_RegVal |= USB2OTG_HOSTPORT_PRTSUSP;
-                            wr32le(USB2OTG_HOSTPORT, otg_RegVal);
+                            usb2otg_hostport_rmw(USB2OTG_HOSTPORT_PRTSUSP, 0);
                             cmdgood = TRUE;
 
                             break;
@@ -204,44 +191,60 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                                 struct timerequest *req = (struct timerequest *)CreateIORequest(port, sizeof(struct timerequest));
                                 OpenDevice("timer.device", UNIT_MICROHZ, (struct IORequest *) req, 0);
 
-                                D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Resetting Port #%ld\n", idx));
+                                D(bug("[USB2OTG:Hub] === PORT RESET START ===\n"));
+                                D(bug("[USB2OTG:Hub] HOSTPORT before reset=%08x\n", rd32le(USB2OTG_HOSTPORT)));
 
                                 req->tr_node.io_Command = TR_ADDREQUEST;
                                 req->tr_time.tv_secs = 0;
                                 req->tr_time.tv_micro = 10000;
                                 DoIO((struct IORequest *)req);
-                                D(bug("[USB2OTG:Hub] Pause done...\n"));
-                                D(bug("[USB2OTG:Hub] port:%08x\n", rd32le(USB2OTG_HOSTPORT)));
 
-                                otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                                otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
-                                otg_RegVal |= USB2OTG_HOSTPORT_PRTRST;
-                                wr32le(USB2OTG_HOSTPORT, otg_RegVal);
-
-                                D(bug("[USB2OTG:Hub] port:%08x\n", rd32le(USB2OTG_HOSTPORT)));
+                                D(bug("[USB2OTG:Hub] Reset: asserting PRTRST\n"));
+                                usb2otg_hostport_rmw(USB2OTG_HOSTPORT_PRTRST, 0);
+                                D(bug("[USB2OTG:Hub] Reset: asserted PRTRST, HOSTPORT now=%08x\n", rd32le(USB2OTG_HOSTPORT)));
 
                                 req->tr_time.tv_secs = 0;
                                 req->tr_time.tv_micro = 60000;
+                                D(bug("[USB2OTG:Hub] Reset: before DoIO(60ms)\n"));
                                 DoIO((struct IORequest *)req);
-                                D(bug("[USB2OTG:Hub] Pause with port reset done...\n"));
-                                D(bug("[USB2OTG:Hub] port:%08x\n", rd32le(USB2OTG_HOSTPORT)));
+                                D(bug("[USB2OTG:Hub] Reset: after DoIO(60ms)\n"));
+
+                                D(bug("[USB2OTG:Hub] Reset: deasserting PRTRST\n"));
+                                usb2otg_hostport_rmw(0, USB2OTG_HOSTPORT_PRTRST);
+                                D(bug("[USB2OTG:Hub] Reset: deasserted PRTRST, HOSTPORT now=%08x\n", rd32le(USB2OTG_HOSTPORT)));
+
+                                /* 200 ms settle after PRTRST deassert (SMSC LAN7515 on Pi 3B+). */
+                                req->tr_time.tv_secs = 0;
+                                req->tr_time.tv_micro = 200000;
+                                D(bug("[USB2OTG:Hub] Reset: before DoIO(200ms)\n"));
+                                DoIO((struct IORequest *)req);
+                                D(bug("[USB2OTG:Hub] Reset: after DoIO(200ms)\n"));
 
                                 otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                                otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
-                                otg_RegVal &= ~USB2OTG_HOSTPORT_PRTRST;
-                                wr32le(USB2OTG_HOSTPORT, otg_RegVal);
+                                D(bug("[USB2OTG:Hub] Port reset complete, HOSTPORT=%08x\n", otg_RegVal));
 
-                                D(bug("[USB2OTG:Hub] port:%08x\n", rd32le(USB2OTG_HOSTPORT)));
-
-                                req->tr_time.tv_secs = 0;
-                                req->tr_time.tv_micro = 10000;
-                                DoIO((struct IORequest *)req);
-                                D(bug("[USB2OTG:Hub] Pause after deasserting reset done...\n"));
-                                D(bug("[USB2OTG:Hub] port:%08x\n", rd32le(USB2OTG_HOSTPORT)));
+                                /*
+                                 * Synthesize a root-hub status change so the hub
+                                 * class wakes any queued INT xfer; the SW reset
+                                 * path produces no port-change IRQ on its own.
+                                 */
+                                Disable();
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+                                otg_Unit->hu_HubPortChanged = TRUE;
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                                Enable();
+                                D(bug("[USB2OTG:Hub] Reset: HubPortChanged=TRUE, causing pending INT\n"));
+                                FNAME_DEV(Cause)(USB2OTGBase, &otg_Unit->hu_PendingInt);
+                                D(bug("[USB2OTG:Hub] Reset: Cause returned, cleaning up timer\n"));
 
                                 CloseDevice((struct IORequest *)req);
                                 DeleteIORequest((struct IORequest *)req);
                                 DeleteMsgPort(port);
+                                D(bug("[USB2OTG:Hub] Reset: cleanup done, returning success\n"));
 
                                 cmdgood = TRUE;
                             }
@@ -250,10 +253,7 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                         case UFS_PORT_POWER:
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Powering Port #%ld\n", idx));
 
-                            otg_RegVal = rd32le(USB2OTG_HOSTPORT);
-                            otg_RegVal &= ~USB2OTG_HOSTPORT_SC_BITS;
-                            otg_RegVal |= USB2OTG_HOSTPORT_PRTPWR;
-                            wr32le(USB2OTG_HOSTPORT, otg_RegVal);
+                            usb2otg_hostport_rmw(USB2OTG_HOSTPORT_PRTPWR, 0);
                             cmdgood = TRUE;
 
                             break;
@@ -269,9 +269,7 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                     }
                     if (cmdgood)
                     {
-#if (0)
-                        *((volatile unsigned int *)USB2OTG_HOSTPORT) = newval;
-#endif
+                        D(bug("[USB2OTG:Hub] SET_FEATURE: returning 0 (val=%ld)\n", val));
                         return (0);
                     }
 
@@ -321,7 +319,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: USR_CLEAR_FEATURE Port #%ld Connect Change\n", idx));
 
                             newval |= USB2OTG_HOSTPORT_PRTCONNDET;
-                            otg_Unit->hu_HubPortChanged = TRUE;
                             cmdgood = TRUE;
 
                             break;
@@ -330,7 +327,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: USR_CLEAR_FEATURE Port #%ld Enable Change\n", idx));
 
                             newval |= USB2OTG_HOSTPORT_PRTENCHNG;
-                            otg_Unit->hu_HubPortChanged = TRUE;
                             cmdgood = TRUE;
 
                             break;
@@ -339,7 +335,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: USR_CLEAR_FEATURE Port #%ld Suspend Change\n", idx));
 
 //                            newval |= USB2OTG_HOSTPORT_PRTRES;
-                            otg_Unit->hu_HubPortChanged = TRUE;
                             cmdgood = TRUE;
 
                             break;
@@ -348,7 +343,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: USR_CLEAR_FEATURE Port #%ld Over-Current Change\n", idx));
 
                             newval |= USB2OTG_HOSTPORT_PRTOVRCURRCHNG;
-                            otg_Unit->hu_HubPortChanged = TRUE;
                             cmdgood = TRUE;
 
                             break;
@@ -357,7 +351,6 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                             D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: USR_CLEAR_FEATURE Port #%ld Reset Change\n", idx));
 
                             newval &= ~USB2OTG_HOSTPORT_PRTRST;
-                            otg_Unit->hu_HubPortChanged = TRUE;
                             cmdgood = TRUE;
 
                             break;
@@ -370,6 +363,30 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                     {
                         D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Port #%ld CLEAR_FEATURE %04lx->%04lx\n", idx, oldval, newval));
                         wr32le(USB2OTG_HOSTPORT, newval);
+                        ioreq->iouh_Actual = 0;
+
+                        /*
+                         * Only signal port change if HW change bits remain
+                         * after clearing this one; otherwise the hub class
+                         * spins polling.
+                         */
+                        {
+                            ULONG postval = rd32le(USB2OTG_HOSTPORT);
+                            Disable();
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+                            if (postval & (USB2OTG_HOSTPORT_PRTCONNDET |
+                                           USB2OTG_HOSTPORT_PRTENCHNG |
+                                           USB2OTG_HOSTPORT_PRTOVRCURRCHNG))
+                            {
+                                otg_Unit->hu_HubPortChanged = TRUE;
+                            }
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                            Enable();
+                        }
 
                         return (0);
                     }
@@ -401,6 +418,8 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
 
                     ULONG oldval = rd32le(USB2OTG_HOSTPORT);
 
+                    D(bug("[USB2OTG:Hub] GET_PORT_STATUS: HOSTPORT=%08x\n", oldval));
+
                     *mptr = 0;
                     if (oldval & USB2OTG_HOSTPORT_PRTPWR)        *mptr |= AROS_WORD2LE(UPSF_PORT_POWER);
                     if (oldval & USB2OTG_HOSTPORT_PRTENA)        *mptr |= AROS_WORD2LE(UPSF_PORT_ENABLE);
@@ -408,20 +427,21 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                     if (oldval & USB2OTG_HOSTPORT_PRTRST)        *mptr |= AROS_WORD2LE(UPSF_PORT_RESET);
                     if (oldval & USB2OTG_HOSTPORT_PRTSUSP)       *mptr |= AROS_WORD2LE(UPSF_PORT_SUSPEND);
 
-                    switch ((oldval >> 17) & 3)
+                    switch (USB2OTG_HOSTPORT_PRTSPD(oldval))
                     {
-                        case 0:
+                        case USB2OTG_HOSTPORT_PRTSPD_HS_VAL:
                             *mptr |= AROS_WORD2LE(UPSF_PORT_HIGH_SPEED);
                             break;
-                        case 2:
+                        case USB2OTG_HOSTPORT_PRTSPD_LS_VAL:
                             *mptr |= AROS_WORD2LE(UPSF_PORT_LOW_SPEED);
                             break;
                         default:
                             break;
                     }
 
-                    D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Port #%ld is %s\n", idx, (oldval & USB2OTG_HOSTPORT_PRTSPD_LOW) ? "LOWSPEED" : "FULLSPEED"));
-                    D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Port #%ld Status %08lx\n", idx, AROS_LE2WORD(*mptr)));
+                    D(bug("[USB2OTG:Hub] Port #%ld Status word=%04lx (%s)\n", idx, AROS_LE2WORD(*mptr),
+                        USB2OTG_HOSTPORT_PRTSPD(oldval) == USB2OTG_HOSTPORT_PRTSPD_HS_VAL ? "HIGH" :
+                        USB2OTG_HOSTPORT_PRTSPD(oldval) == USB2OTG_HOSTPORT_PRTSPD_FS_VAL ? "FULL" : "LOW"));
 
                     mptr++;
                     *mptr = 0;
@@ -429,8 +449,10 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
                     if (oldval & USB2OTG_HOSTPORT_PRTCONNDET)   *mptr |= AROS_WORD2LE(UPSF_PORT_CONNECTION);
                     if (oldval & USB2OTG_HOSTPORT_PRTRES)       *mptr |= AROS_WORD2LE(UPSF_PORT_SUSPEND|UPSF_PORT_ENABLE);
 
-                    D(bug("[USB2OTG:Hub] UHCMD_CONTROLXFER: Port #%ld Change %08lx\n", idx, AROS_LE2WORD(*mptr)));
+                    D(bug("[USB2OTG:Hub] GET_PORT_STATUS: status=%04x change=%04x\n",
+                        AROS_LE2WORD(*(mptr-1)), AROS_LE2WORD(*mptr)));
 
+                    ioreq->iouh_Actual = sizeof(struct UsbPortStatus);
                     return (0);
                 }
             }
@@ -514,38 +536,52 @@ WORD FNAME_ROOTHUB(cmdIntXFer)(struct IOUsbHWReq *ioreq,
                        struct USB2OTGUnit *otg_Unit,
                        LIBBASETYPEPTR USB2OTGBase)
 {
-    D(bug("[USB2OTG:Hub] UHCMD_INTXFER()\n"));
+    ULONG cpu = KrnGetCPUNumber();
 
+    D(bug("[USB2OTG:Hub] INTXFER: ep=%d len=%d changed=%d cpu=%lu\n",
+        ioreq->iouh_Endpoint, ioreq->iouh_Length, otg_Unit->hu_HubPortChanged, cpu));
     if ((ioreq->iouh_Endpoint != 1) || (!ioreq->iouh_Length))
     {
         return UHIOERR_STALL;
     }
 
+    /* PendingIO softint also touches these; serialize with Disable + lock. */
+    Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
     if (otg_Unit->hu_HubPortChanged)
     {
-        D(bug("[USB2OTG:Hub] UHCMD_INTXFER: Registering Immediate Portchange\n"));
+        D(bug("[USB2OTG:Hub] INTXFER: Immediate Portchange reply\n"));
 
+        /* Bit 1 = port 1 status changed (bit 0 would be hub status) */
         if (ioreq->iouh_Length == 1)
         {
-            *((UBYTE *) ioreq->iouh_Data) = 1;
+            *((UBYTE *) ioreq->iouh_Data) = 2;
             ioreq->iouh_Actual = 1;
         }
         else
         {
-            ((UBYTE *) ioreq->iouh_Data)[0] = 1;
+            ((UBYTE *) ioreq->iouh_Data)[0] = 2;
             ((UBYTE *) ioreq->iouh_Data)[1] = 0;
             ioreq->iouh_Actual = 2;
         }
         otg_Unit->hu_HubPortChanged = FALSE;
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+        Enable();
 
         return 0;
     }
 
-    D(bug("[USB2OTG:Hub] UHCMD_INTXFER: Queueing request\n"));
+    D(bug("[USB2OTG:Hub] INTXFER: Queueing request\n"));
 
     ioreq->iouh_Req.io_Flags &= ~IOF_QUICK;
-    Disable();
     AddTail(&otg_Unit->hu_IOPendingQueue, (struct Node *)ioreq);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
     Enable();
 
     return RC_DONTREPLY;
@@ -553,31 +589,45 @@ WORD FNAME_ROOTHUB(cmdIntXFer)(struct IOUsbHWReq *ioreq,
 
 void FNAME_ROOTHUB(PendingIO)(struct USB2OTGUnit *otg_Unit)
 {
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
     struct IOUsbHWReq *ioreq;
 
-    D(bug("[USB2OTG:Hub] PendingIO(0x%p)\n", otg_Unit));
-
-    if (otg_Unit->hu_HubPortChanged && otg_Unit->hu_IOPendingQueue.lh_Head->ln_Succ)
+    for (;;)
     {
-        D(bug("[USB2OTG:Hub] PendingIO: PortChange detected\n"));
         Disable();
-        ioreq = (struct IOUsbHWReq *) otg_Unit->hu_IOPendingQueue.lh_Head;
-        while (((struct Node *) ioreq)->ln_Succ)
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        if (!(otg_Unit->hu_HubPortChanged && otg_Unit->hu_IOPendingQueue.lh_Head->ln_Succ))
         {
-            Remove(&ioreq->iouh_Req.io_Message.mn_Node);
-            if (ioreq->iouh_Length == 1)
-            {
-                *((UBYTE *) ioreq->iouh_Data) = 1;
-                ioreq->iouh_Actual = 1;
-            } else {
-                ((UBYTE *) ioreq->iouh_Data)[0] = 1;
-                ((UBYTE *) ioreq->iouh_Data)[1] = 0;
-                ioreq->iouh_Actual = 2;
-            }
-            ReplyMsg(&ioreq->iouh_Req.io_Message);
-            ioreq = (struct IOUsbHWReq *) otg_Unit->hu_IOPendingQueue.lh_Head;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+            Enable();
+            break;
         }
-        otg_Unit->hu_HubPortChanged = FALSE;
+        D(bug("[USB2OTG:Hub] PendingIO: replying to queued INT because port changed\n"));
+        ioreq = (struct IOUsbHWReq *) otg_Unit->hu_IOPendingQueue.lh_Head;
+        Remove(&ioreq->iouh_Req.io_Message.mn_Node);
+        if (!otg_Unit->hu_IOPendingQueue.lh_Head->ln_Succ)
+        {
+            otg_Unit->hu_HubPortChanged = FALSE;
+        }
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
         Enable();
+
+        /* Bit 1 = port 1 status changed (bit 0 would be hub status) */
+        if (ioreq->iouh_Length == 1)
+        {
+            *((UBYTE *) ioreq->iouh_Data) = 2;
+            ioreq->iouh_Actual = 1;
+        } else {
+            ((UBYTE *) ioreq->iouh_Data)[0] = 2;
+            ((UBYTE *) ioreq->iouh_Data)[1] = 0;
+            ioreq->iouh_Actual = 2;
+        }
+        ReplyMsg(&ioreq->iouh_Req.io_Message);
     }
 }

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #include <devices/usb_hub.h>
@@ -68,7 +68,15 @@ const struct OTGHubCfg OTGRootHubCfg =
         URTF_IN|1,
         USEAF_INTERRUPT,
         LE16(8),
-        255
+        /*
+         * High-speed interrupt endpoints encode interval as 2^(bInterval-1)
+         * microframes. A value of 255 gets clamped by Poseidon to 16 and turns
+         * into 32768, which is clearly wrong for the root hub status pipe.
+         * Use 12 => 2048 microframes => 256 ms, which matches the old
+         * full-speed-style "255 ms" intent closely enough without exploding
+         * the scheduler state.
+         */
+        12
     },
 };
 

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
@@ -1,15 +1,17 @@
 #ifndef USB2OTG_INTERN_H
 #define USB2OTG_INTERN_H
 /*
-    Copyright � 2013-2019, The AROS Development Team. All rights reserved.
+    Copyright � 2013-2026, The AROS Development Team. All rights reserved.
     $Id$
 */
 
 #include LC_LIBDEFS_FILE
 
+#include <aros/debug.h>
 #include <aros/libcall.h>
 #include <aros/asmcall.h>
 #include <aros/symbolsets.h>
+#include <aros/types/spinlock_s.h>
 
 #include <exec/types.h>
 #include <exec/lists.h>
@@ -33,6 +35,8 @@
 #include <devices/newstyle.h>
 
 #include <oop/oop.h>
+
+#include <proto/kernel.h>
 
 extern IPTR __arm_periiobase;
 #define ARM_PERIIOBASE __arm_periiobase
@@ -103,6 +107,56 @@ static inline void wr8be(IPTR iobase, UBYTE value) {
     dmb();
 }
 
+/*
+ * Spin-wait for AHB master IDLE (RESET[31]). Required by DWC2 spec
+ * before any soft reset or FIFO flush.
+ */
+static inline BOOL usb2otg_wait_ahb_idle(int timeout, const char *where)
+{
+    while (!(rd32le(USB2OTG_RESET) & USB2OTG_RESET_AHBIDLE) && --timeout > 0)
+        asm volatile("mov r0, r0\n");
+    if (timeout <= 0)
+    {
+        bug("[USB2OTG] AHB IDLE wait timed out (%s)\n", where);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+/* Spin-wait for a self-clearing RESET bit (CORESOFT/TXFIFOFLUSH/RXFIFOFLUSH). */
+static inline BOOL usb2otg_wait_reset_bit_clear(ULONG bit, int timeout,
+    const char *what)
+{
+    while ((rd32le(USB2OTG_RESET) & bit) && --timeout > 0)
+        asm volatile("mov r0, r0\n");
+    if (timeout <= 0)
+    {
+        bug("[USB2OTG] %s timed out\n", what);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+/*
+ * RMW HOSTPORT with W1C status-change bits masked out, so toggling a
+ * feature doesn't accidentally acknowledge port-change events.
+ */
+static inline void usb2otg_hostport_rmw(ULONG set, ULONG clear)
+{
+    ULONG v = rd32le(USB2OTG_HOSTPORT);
+    v &= ~USB2OTG_HOSTPORT_SC_BITS;
+    v &= ~clear;
+    v |= set;
+    wr32le(USB2OTG_HOSTPORT, v);
+}
+
+/* Clear stale retry state in DriverPrivate slots at xfer-entry. */
+static inline void usb2otg_reset_retry_state(struct IOUsbHWReq *ioreq)
+{
+    ioreq->iouh_DriverPrivate1 = 0;
+    ioreq->iouh_DriverPrivate2 = 0;
+}
+
 struct USBNSDeviceQueryResult
 {
     ULONG               DevQueryFormat;
@@ -126,12 +180,48 @@ struct USB2OTGUnit
     struct List         hu_IsoXFerQueue;
     struct List         hu_BulkXFerQueue;
     struct List         hu_FinishedXfers;
+    /*
+     * Single lock for all USB internal state. DWC2 IRQ is pinned to
+     * CPU 0; this only provides cross-CPU exclusion for task-context
+     * submission. Single lock minimizes barriers on the hot IRQ path.
+     */
+    spinlock_t          hu_Lock;
 
 
     struct USB2OTGChannel {
         struct IOUsbHWReq * hc_Request;
         ULONG               hc_XferSize;
+        APTR                hc_OrigBuffer;  /* Non-NULL when bounce buffer is active (stores original unaligned ptr) */
+        ULONG               hc_BounceLen;   /* Bytes in bounce buffer for copy-back */
+        UBYTE               hc_BounceDir;   /* Direction: 0=OUT, 1=IN */
+        UBYTE               hc_WatchdogCount; /* Incremented each NakTimeout period while channel active */
+        UBYTE               hc_SplitCSplitPending; /* SSPLIT was issued and request must not be resubmitted yet */
+        UBYTE               hc_DeferCount;     /* Consecutive watchdog defers; caps total defer time */
+        struct IOUsbHWReq * hc_DiagReq;     /* Last bulk request tracked on this channel */
+        ULONG               hc_DiagStartFrame;
+        ULONG               hc_DiagLastProgressFrame;
+        ULONG               hc_DiagLastActual;
+        UWORD               hc_DiagLastIntr;
+        UBYTE               hc_DiagRequeueCount;
+        UBYTE               hc_DiagNoProgressCount;
+        UWORD               hc_BareChhltdTotal; /* cumulative bare-CHHLTD per request; absolute give-up cap */
+        ULONG               hc_StartHfnum;    /* HFNUM at last StartChannel arm; for bulk diag timing */
+        UBYTE               hc_NakParked;     /* 1 = bulk-IN parked waiting for NAK gate; SOF re-arms with quick=1 */
+        UBYTE               hc_PingPending;   /* 1 = OR in HOSTTSIZE_PING on next arm */
+        UBYTE               hc_PingState;     /* PING state machine: 0=none, 1=needs PING arm, 2=PING armed */
+        UWORD               hc_NyetCount;     /* NYET-handler hits per request; resets on new request */
+        ULONG               hc_LastSampleHfnum; /* sample snapshot for WAIT-PING/WAIT-QUIET liveness check */
+        ULONG               hc_LastSampleTsize;
+        ULONG               hc_LastSampleActual;
+        UWORD               hc_LastSampleIntr;
     }                   hu_Channel[8];
+
+/*
+ * Per-channel DMA bounce buffers for unaligned transfers. DWC2 DMA
+ * on BCM2835/2837 requires DWORD-aligned addresses. Sized to fit a
+ * typical AROS 16 KB SCSI WRITE cluster (8 chans x 16 KB = 128 KB).
+ */
+#define DMA_BOUNCE_SIZE (16 * 1024)
 
 //    struct IOUsbHWReq * hu_InProgressXFer[8];
 //    ULONG               hu_InProgressXFerSize[8];
@@ -143,6 +233,10 @@ struct USB2OTGUnit
     struct Interrupt    hu_NakTimeoutInt;
     struct timerequest  hu_NakTimeoutReq;
     struct MsgPort      hu_NakTimeoutMsgPort;
+    struct Task         *hu_WorkerTask;
+    struct MsgPort      *hu_WorkerPort;
+    cpumask_t           hu_WorkerAffinity;
+    ULONG               hu_WorkFlags;
 
     UBYTE               hu_OperatingMode;       /* HOST/DEVICE mode */
     UBYTE               hu_HubAddr;
@@ -158,6 +252,39 @@ struct USB2OTGUnit
     ULONG               hu_PktSizeWidth;
 
     ULONG               hu_PIDBits[128];        /* PID 2-bit pairs, one ULONG per device, each ULONG contains 2-bits for every endpoint */
+
+    /*
+     * Per-(device, endpoint) PING-pending state (USB 2.0 §8.5.1).
+     * Channel-local hc_PingPending doesn't survive requeue, so PING
+     * state must live on the (dev, ep) pair. 1 bit per ep, 1 ULONG
+     * per dev addr.
+     */
+    ULONG               hu_PingBits[128];
+
+    /*
+     * Per-device bulk NAK rate gate. Stores the earliest microframe
+     * (11-bit HOSTFRAMENO) at which this device's next bulk retry may
+     * arm; 0xFFFF = no gate. Mirrors FreeBSD dwc_otg's did_nak
+     * rate-check (dwc_otg.c:1215-1250). Stops NAK-storm CPU0 burn.
+     */
+    UWORD               hu_NakGate[128];
+
+    /*
+     * Per-device bulk channel binding: [0]→CHAN_BULK, [1]→CHAN_BULK2.
+     * 0 = free. Partitions two concurrent bulk devices onto a channel
+     * each so a wedged/NAK-storming device cannot block the other.
+     */
+    UBYTE               hu_BulkOwnerDev[2];
+
+/*
+ * DMA buffers — must be in heap memory so the 0xC0000000 VC bus
+ * alias maps correctly. Kernel static arrays in 0xf8XXXXXX VA do not.
+ * ULONG arrays guarantee 4-byte alignment for DMA.
+ */
+    ULONG               hu_StatusDmaBuf[4];
+    /* Cache-line aligned: per-buffer flush won't drag in adjacent data. */
+    ULONG               hu_BounceBuf[8][DMA_BOUNCE_SIZE / sizeof(ULONG)]
+                        __attribute__((aligned(64)));
 };
 
 /* PRIVATE device node */
@@ -181,6 +308,9 @@ struct USB2OTGDevice
 #define FNAME_DEV(x)            USB2OTG__Dev__ ## x
 #define FNAME_ROOTHUB(x)        USB2OTG__RootHub__ ## x
 
+#define USB2OTG_WORK_PENDING    (1U << 0)
+#define USB2OTG_WORK_NAKTIMEOUT (1U << 1)
+
 #ifdef UtilityBase
 #undef UtilityBase
 #endif
@@ -192,6 +322,133 @@ struct USB2OTGDevice
 #define	UtilityBase     USB2OTGBase->hd_UtilityBase
 
 #define KernelBase      USB2OTGBase->hd_KernelBase
+
+#define CHAN_CTRL       0
+#define CHAN_BULK       1
+#define CHAN_INT1       2
+#define CHAN_INT2       3
+#define CHAN_INT3       4
+#define CHAN_INT4       5
+#define CHAN_INT5       6
+#define CHAN_INT_LAST   CHAN_INT5
+#define CHAN_BULK2      7
+
+/*
+ * Bulk-OUT per-packet throttle (busy-wait iterations before arming).
+ * Some flash devices with tiny SRAM buffers go silent (no NYET/NAK)
+ * when overrun. Value 0 disables; ~1M iterations ≈ 1 ms per packet
+ * on Cortex-A7 @ 1.2 GHz.
+ */
+#define USB2OTG_BULK_OUT_THROTTLE_COUNT 0
+
+/*
+ * Per-transfer-type watchdog thresholds in 150 ms ticks. Channel
+ * must be active this many ticks before force-fail. Inspired by
+ * FreeBSD dwc_otg_timer_start().
+ */
+#define USB2OTG_WD_TICKS_INT_DIRECT   3   /* HS INT direct: 450 ms */
+#define USB2OTG_WD_TICKS_INT_SPLIT    6   /* LS/FS INT through TT: 900 ms */
+#define USB2OTG_WD_TICKS_CTRL         6   /* Control transfers: 900 ms */
+#define USB2OTG_WD_TICKS_BULK_DIRECT 20   /* HS bulk direct: 3 s */
+#define USB2OTG_WD_TICKS_BULK_SPLIT  10   /* LS/FS bulk through TT: 1.5 s */
+#define USB2OTG_WD_TICKS_DEFAULT      3   /* anything else */
+
+/* Bulk NAK rate gate: 8 microframes = 1 ms at HS. */
+#define USB2OTG_NAK_GATE_NONE          0xFFFFU
+#define USB2OTG_BULK_NAK_GATE_UFRAMES  8
+
+/*
+ * Flash-busy defer cap (WAIT-PING / WAIT-QUIET). Each cycle is
+ * 20 ticks × 150 ms = 3 s. Cap × 3 s = total tolerated NAK+PING-storm
+ * time. The halt path triggered when the cap hits can leave Pi 3B+
+ * in an unrecoverable CHENA+CHDIS state (neither NPTXFIFO flush nor
+ * HCLKSOFT clears it), so set high (200 × 3 s = 10 min) to tolerate
+ * cheap-stick FTL GC pauses.
+ */
+#define USB2OTG_FLASH_BUSY_DEFER_CAP   200
+
+/*
+ * Per-request retry budget shared across transient errors (XactErr,
+ * DataTglErr, BNA — USB 2.0 §8.4.6). Counter in iouh_DriverPrivate2;
+ * resets on XFERCOMPL/NAK/NYET. Matches FreeBSD dwc_otg errcnt.
+ */
+#define USB2OTG_TRANSIENT_RETRY_LIMIT  3
+
+static inline ULONG usb2otg_current_uframe(void)
+{
+    /* HFNUM[13:0] FRNUM: 14-bit microframe counter, wraps every 2.048 s. */
+    return rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff;
+}
+
+static inline BOOL usb2otg_nak_gated(struct USB2OTGUnit *u, UBYTE dev)
+{
+    UWORD gate = u->hu_NakGate[dev & 0x7f];
+    ULONG now;
+    ULONG delta;
+
+    if (gate == USB2OTG_NAK_GATE_NONE)
+        return FALSE;
+
+    now = usb2otg_current_uframe();
+    /* gate in future iff delta is within half the 14-bit wrap (~1 s). */
+    delta = (gate - now) & 0x3fff;
+    if (delta == 0 || delta >= 0x2000)
+    {
+        /* Gate reached/past — clear. */
+        D(
+            {
+                static ULONG cleared = 0;
+                if (++cleared <= 3 || (cleared & 0x3f) == 0)
+                    bug("[USB2OTG:GATE] cleared dev=%d gate=%04x now=%04lx delta=%lu (#%lu)\n",
+                        (int)dev, (unsigned)gate, (unsigned long)now,
+                        (unsigned long)delta, (unsigned long)cleared);
+            }
+        )
+        u->hu_NakGate[dev & 0x7f] = USB2OTG_NAK_GATE_NONE;
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static inline void usb2otg_nak_gate_set(struct USB2OTGUnit *u, UBYTE dev,
+    ULONG uframes)
+{
+    UWORD new_gate = (UWORD)((usb2otg_current_uframe() + uframes) & 0x3fff);
+    u->hu_NakGate[dev & 0x7f] = new_gate;
+    D(
+        if (uframes >= 100)
+        {
+            bug("[USB2OTG:GATE] set dev=%d gate=%04x uframes=%lu now=%04lx\n",
+                (int)dev, (unsigned)new_gate, (unsigned long)uframes,
+                (unsigned long)usb2otg_current_uframe());
+        }
+    )
+}
+
+static inline UBYTE usb2otg_watchdog_ticks(struct IOUsbHWReq *req)
+{
+    BOOL split;
+
+    /* ISO is intentionally absent: cmdIsoXFer queues but nothing drains. */
+    if (req == NULL)
+        return USB2OTG_WD_TICKS_DEFAULT;
+
+    split = (req->iouh_Flags & UHFF_SPLITTRANS) != 0;
+
+    switch (req->iouh_Req.io_Command)
+    {
+        case UHCMD_INTXFER:
+            return split ? USB2OTG_WD_TICKS_INT_SPLIT
+                         : USB2OTG_WD_TICKS_INT_DIRECT;
+        case UHCMD_CONTROLXFER:
+            return USB2OTG_WD_TICKS_CTRL;
+        case UHCMD_BULKXFER:
+            return split ? USB2OTG_WD_TICKS_BULK_SPLIT
+                         : USB2OTG_WD_TICKS_BULK_DIRECT;
+        default:
+            return USB2OTG_WD_TICKS_DEFAULT;
+    }
+}
 
 struct Unit             *FNAME_DEV(OpenUnit)(struct IOUsbHWReq *, LONG, struct USB2OTGDevice *);
 void                    FNAME_DEV(CloseUnit)(struct IOUsbHWReq *, struct USB2OTGUnit *, struct USB2OTGDevice *);
@@ -215,6 +472,244 @@ WORD                    FNAME_DEV(cmdIsoXFer)(struct IOUsbHWReq *, struct USB2OT
 
 void                    FNAME_DEV(Cause)(struct USB2OTGDevice *, struct Interrupt *);
 
+static inline BOOL usb2otg_diag_track_bulk_req(struct IOUsbHWReq *req)
+{
+    return req != NULL &&
+           req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+           req->iouh_Length != 0;
+}
+
+/* Enable to trace all bulk I/O (mass storage, ethernet, etc.). */
+#define USB2OTG_DEBUG_MASS_STORAGE 1
+
+static inline BOOL usb2otg_trace_bulk(int chan, struct IOUsbHWReq *req)
+{
+#if USB2OTG_DEBUG_MASS_STORAGE
+    return req != NULL &&
+           req->iouh_Req.io_Command == UHCMD_BULKXFER;
+#else
+    (void)chan; (void)req;
+    return FALSE;
+#endif
+}
+
+static inline ULONG usb2otg_diag_frame(void)
+{
+    return (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
+}
+
+/*
+ * Move req from channel slot to follow-up queue under hu_Lock, with
+ * a TOCTOU check vs the watchdog. Returns FALSE if the watchdog
+ * already took the request (caller must not touch req).
+ */
+static inline BOOL usb2otg_irq_finish_or_requeue(struct USB2OTGUnit *unit,
+    int chan, struct IOUsbHWReq *req, struct List *queue, BOOL head)
+{
+#if defined(__AROSEXEC_SMP__)
+    /* KernelBase macro resolves through USB2OTGBase; needs local visibility. */
+    struct USB2OTGDevice *USB2OTGBase = unit->hu_USB2OTGBase;
+    KrnSpinLock(&unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+    if (unit->hu_Channel[chan].hc_Request != req)
+    {
+        KrnSpinUnLock(&unit->hu_Lock);
+        return FALSE;
+    }
+#endif
+    if (head)
+        ADDHEAD(queue, (struct Node *)req);
+    else
+        ADDTAIL(queue, (struct Node *)req);
+    unit->hu_Channel[chan].hc_Request = NULL;
+    unit->hu_Channel[chan].hc_NakParked = 0;
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&unit->hu_Lock);
+#endif
+    return TRUE;
+}
+
+/* Standard diag log cadence: first 5 events, then every 64th. */
+static inline BOOL usb2otg_diag_log_rate(ULONG count)
+{
+    return count <= 5 || (count & 0x3f) == 0;
+}
+
+static inline void usb2otg_diag_bulk_assign(struct USB2OTGUnit *otg_Unit, int chan,
+    struct IOUsbHWReq *req)
+{
+    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+
+    if (!usb2otg_diag_track_bulk_req(req))
+        return;
+
+    if (hc->hc_DiagReq != req)
+    {
+        ULONG frame = usb2otg_diag_frame();
+
+        hc->hc_DiagReq = req;
+        hc->hc_DiagStartFrame = frame;
+        hc->hc_DiagLastProgressFrame = frame;
+        hc->hc_DiagLastActual = req->iouh_Actual;
+        hc->hc_DiagLastIntr = 0;
+        hc->hc_DiagRequeueCount = 0;
+        hc->hc_DiagNoProgressCount = 0;
+        hc->hc_BareChhltdTotal = 0;
+        hc->hc_NyetCount = 0;
+        hc->hc_LastSampleHfnum = 0;
+        hc->hc_LastSampleTsize = 0;
+        hc->hc_LastSampleActual = 0;
+        hc->hc_LastSampleIntr = 0;
+    }
+}
+
+static inline void usb2otg_diag_bulk_progress(struct USB2OTGUnit *otg_Unit, int chan,
+    struct IOUsbHWReq *req, ULONG intr)
+{
+    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+
+    if (!usb2otg_diag_track_bulk_req(req))
+        return;
+
+    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+    hc->hc_DiagLastIntr = (UWORD)intr;
+
+    if (req->iouh_Actual != hc->hc_DiagLastActual)
+    {
+        D(ULONG prev = hc->hc_DiagLastActual;)
+
+        hc->hc_DiagLastActual = req->iouh_Actual;
+        hc->hc_DiagLastProgressFrame = usb2otg_diag_frame();
+
+        D(
+            if (hc->hc_DiagRequeueCount >= 4 || hc->hc_DiagNoProgressCount >= 4)
+            {
+                bug("[USB2OTG:DIAG] bulk-progress chan=%d dev=%d ep=%d dir=%s %lu->%lu/%lu intr=%04x rq=%u np=%u split=%u\n",
+                    chan,
+                    (int)req->iouh_DevAddr,
+                    (int)req->iouh_Endpoint,
+                    req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+                    (unsigned long)prev,
+                    (unsigned long)req->iouh_Actual,
+                    (unsigned long)req->iouh_Length,
+                    (unsigned int)intr,
+                    (unsigned int)hc->hc_DiagRequeueCount,
+                    (unsigned int)hc->hc_DiagNoProgressCount,
+                    (unsigned int)otg_Unit->hu_Channel[chan].hc_SplitCSplitPending);
+            }
+        )
+
+        hc->hc_DiagRequeueCount = 0;
+        hc->hc_DiagNoProgressCount = 0;
+        hc->hc_BareChhltdTotal = 0;
+    }
+}
+
+static inline void usb2otg_diag_bulk_requeue(struct USB2OTGUnit *otg_Unit, int chan,
+    struct IOUsbHWReq *req, ULONG intr, const char *why)
+{
+    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+
+    if (!usb2otg_diag_track_bulk_req(req))
+        return;
+
+    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+    hc->hc_DiagLastIntr = (UWORD)intr;
+    hc->hc_DiagRequeueCount++;
+
+    if (req->iouh_Actual == hc->hc_DiagLastActual)
+        hc->hc_DiagNoProgressCount++;
+    else
+    {
+        hc->hc_DiagLastActual = req->iouh_Actual;
+        hc->hc_DiagLastProgressFrame = usb2otg_diag_frame();
+        hc->hc_DiagNoProgressCount = 0;
+    }
+
+    D(
+        if (hc->hc_DiagRequeueCount == 4 ||
+            hc->hc_DiagRequeueCount == 8 ||
+            hc->hc_DiagRequeueCount == 16)
+        {
+            ULONG frame = usb2otg_diag_frame();
+            int int_busy = 0;
+            int scan;
+
+            for (scan = CHAN_INT1; scan <= CHAN_INT_LAST; scan++)
+            {
+                if (otg_Unit->hu_Channel[scan].hc_Request != NULL)
+                    int_busy++;
+            }
+
+            bug("[USB2OTG:DIAG] bulk-requeue chan=%d dev=%d ep=%d dir=%s act=%lu/%lu intr=%04x why=%s rq=%u np=%u age=%lu bulkq=%d intbusy=%d split=%08x char=%08x tsize=%08x\n",
+                chan,
+                (int)req->iouh_DevAddr,
+                (int)req->iouh_Endpoint,
+                req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+                (unsigned long)req->iouh_Actual,
+                (unsigned long)req->iouh_Length,
+                (unsigned int)intr,
+                why,
+                (unsigned int)hc->hc_DiagRequeueCount,
+                (unsigned int)hc->hc_DiagNoProgressCount,
+                (unsigned long)((frame - hc->hc_DiagStartFrame) & 0x7ff),
+                (int)IsListEmpty(&otg_Unit->hu_BulkXFerQueue) ? 0 : 1,
+                int_busy,
+                rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)),
+                rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE)));
+        }
+    )
+}
+
+static inline void usb2otg_diag_bulk_finish(struct USB2OTGUnit *otg_Unit, int chan,
+    struct IOUsbHWReq *req)
+{
+    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+
+    if (!usb2otg_diag_track_bulk_req(req))
+        return;
+
+    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+
+    D(
+        if (req->iouh_Req.io_Error != 0 ||
+            hc->hc_DiagRequeueCount >= 4 ||
+            hc->hc_DiagNoProgressCount >= 4)
+        {
+            ULONG frame = usb2otg_diag_frame();
+
+            bug("[USB2OTG:DIAG] bulk-finish chan=%d dev=%d ep=%d dir=%s act=%lu/%lu err=%d rq=%u np=%u nyet=%u age=%lu last_intr=%04x split=%u\n",
+                chan,
+                (int)req->iouh_DevAddr,
+                (int)req->iouh_Endpoint,
+                req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+                (unsigned long)req->iouh_Actual,
+                (unsigned long)req->iouh_Length,
+                (int)req->iouh_Req.io_Error,
+                (unsigned int)hc->hc_DiagRequeueCount,
+                (unsigned int)hc->hc_DiagNoProgressCount,
+                (unsigned int)hc->hc_NyetCount,
+                (unsigned long)((frame - hc->hc_DiagStartFrame) & 0x7ff),
+                (unsigned int)hc->hc_DiagLastIntr,
+                (unsigned int)otg_Unit->hu_Channel[chan].hc_SplitCSplitPending);
+        }
+    )
+
+    hc->hc_DiagReq = NULL;
+    hc->hc_DiagStartFrame = 0;
+    hc->hc_DiagLastProgressFrame = 0;
+    hc->hc_DiagLastActual = 0;
+    hc->hc_DiagLastIntr = 0;
+    hc->hc_DiagRequeueCount = 0;
+    hc->hc_DiagNoProgressCount = 0;
+    hc->hc_NyetCount = 0;
+    hc->hc_LastSampleHfnum = 0;
+    hc->hc_LastSampleTsize = 0;
+    hc->hc_LastSampleActual = 0;
+    hc->hc_LastSampleIntr = 0;
+}
+void                    FNAME_DEV(WorkerTask)(struct USB2OTGUnit *);
+
 WORD                    FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *, struct USB2OTGUnit *, struct USB2OTGDevice *);
 WORD                    FNAME_ROOTHUB(cmdIntXFer)(struct IOUsbHWReq *, struct USB2OTGUnit *, struct USB2OTGDevice *);
 void                    FNAME_ROOTHUB(PendingIO)(struct USB2OTGUnit *);
@@ -223,18 +718,9 @@ void                    FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit,
 void                    FNAME_DEV(ScheduleCtrlTDs)(struct USB2OTGUnit *);
 void                    FNAME_DEV(ScheduleBulkTDs)(struct USB2OTGUnit *);
 void                    FNAME_DEV(ScheduleIntTDs)(struct USB2OTGUnit *);
-void                    FNAME_DEV(SetupChannel)(struct USB2OTGUnit *, int chan);
+BOOL                    FNAME_DEV(SetupChannel)(struct USB2OTGUnit *, int chan);
 void                    FNAME_DEV(StartChannel)(struct USB2OTGUnit *, int chan, int quick);
 int                     FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *, int chan);
 void                    FNAME_DEV(FinalizeChannel)(struct USB2OTGUnit *, int chan);
-
-#define CHAN_CTRL       0
-#define CHAN_BULK       1
-#define CHAN_INT1       2
-#define CHAN_INT2       3
-#define CHAN_INT3       4
-#define CHAN_ISO1       5
-#define CHAN_ISO2       6
-#define CHAN_ISO3       7
 
 #endif /* USB2OTG_INTERN_H */

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
@@ -1,9 +1,10 @@
 /*
-    Copyright (C) 2013-2019, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
 #include <aros/debug.h>
+#include <aros/atomic.h>
 
 #include <proto/exec.h>
 #include <proto/kernel.h>
@@ -11,96 +12,499 @@
 
 #include "usb2otg_intern.h"
 
+/*
+ * INT-pipe activity counters per dev addr (0..7). poll: ScheduleIntTDs
+ * assignment; nak: IRQ requeue; comp: completion. Dumped every ~3 s.
+ */
+ULONG usb2otg_int_poll_count[8];
+ULONG usb2otg_int_nak_count[8];
+ULONG usb2otg_int_comp_count[8];
+ULONG usb2otg_int_chh_count[8];      /* bare-CHHLTD silent-requeue on INT */
+ULONG usb2otg_int_chh_last_intr[8];  /* most recent intr for that path */
+ULONG usb2otg_int_chh_seen_intr[8];  /* OR of all intr values seen */
+static ULONG usb2otg_int_stats_ticks = 0;
+
+static inline BOOL usb2otg_require_cpu0(struct USB2OTGDevice *USB2OTGBase, const char *where)
+{
+#if defined(__AROSEXEC_SMP__)
+    ULONG cpu = KrnGetCPUNumber();
+    if (cpu != 0)
+    {
+        bug("[USB2OTG:SMP] %s running on CPU %u, expected CPU 0\n", where, (unsigned)cpu);
+        return FALSE;
+    }
+#else
+    (void)where;
+#endif
+    return TRUE;
+}
+
 static void DumpChannelRegs(int channel)
 {
-    (bug("Regs for channel %d\n", channel));
-    (bug("CHARBASE=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, CHARBASE))));
-    (bug("SPLITCTRL=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, SPLITCTRL))));
-    (bug("INTR=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, INTR))));
-    (bug("INTRMASK=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, INTRMASK))));
-    (bug("TRANSSIZE=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, TRANSSIZE))));
-    (bug("DMAADR=%08x\n", rd32le(USB2OTG_CHANNEL_REG(channel, DMAADDR))));
+    D(bug("Regs for channel %d: CHAR=%08x SPLIT=%08x INTR=%08x TSIZE=%08x DMA=%08x\n",
+        channel,
+        rd32le(USB2OTG_CHANNEL_REG(channel, CHARBASE)),
+        rd32le(USB2OTG_CHANNEL_REG(channel, SPLITCTRL)),
+        rd32le(USB2OTG_CHANNEL_REG(channel, INTR)),
+        rd32le(USB2OTG_CHANNEL_REG(channel, TRANSSIZE)),
+        rd32le(USB2OTG_CHANNEL_REG(channel, DMAADDR))));
 }
+
+/* Halt-sequence trace; set 1 for per-step register snapshots. */
+#define USB2OTG_HALT_TRACE 0
+
+/*
+ * 0 = drop PING-protocol, recover from NYET via DATA-retry with NAK
+ * gate. BCM2835 DWC2 in Buffer-DMA mode does not reliably issue PING
+ * tokens — channel wedges with bare-CHHLTD after every NYET. Linux
+ * dwc2 and FreeBSD dwc_otg shipped without PING for years. USB 2.0
+ * §8.5.1 says SHOULD PING after NYET; in practice all MSC tested
+ * tolerates plain NAK retry. Set to 1 if a strict-PING device appears.
+ */
+#define USB2OTG_USE_PING_FLOW 1
+
+#if USB2OTG_HALT_TRACE
+static void usb2otg_halt_snapshot(int chan, const char *label)
+{
+    bug("[USB2OTG:HALT %s] chan=%d CHAR=%08x INTR=%08x GINTS=%08x HAINT=%08x"
+        " NPTX=%08x HFIFO=%08x HPRT=%08x HFNUM=%08x GRST=%08x\n",
+        label, chan,
+        rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+        rd32le(USB2OTG_CHANNEL_REG(chan, INTR)),
+        rd32le(USB2OTG_INTR),
+        rd32le(USB2OTG_HOSTINTR),
+        rd32le(USB2OTG_NONPERIFIFOSTATUS),
+        rd32le(USB2OTG_HOSTFIFOSTATUS),
+        rd32le(USB2OTG_HOSTPORT),
+        rd32le(USB2OTG_HOSTFRAMENO),
+        rd32le(USB2OTG_RESET));
+}
+#define HALT_SNAP(chan, label) usb2otg_halt_snapshot((chan), (label))
+#else
+#define HALT_SNAP(chan, label) do { } while (0)
+#endif
+
+static void usb2otg_halt_channel_preserve_char(int chan)
+{
+    ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+
+    if (hcchar & USB2OTG_HOSTCHAR_ENABLE)
+    {
+        HALT_SNAP(chan, "entry");
+
+        hcchar |= USB2OTG_HOSTCHAR_ENABLE | USB2OTG_HOSTCHAR_DISABLE;
+        wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
+
+        HALT_SNAP(chan, "post-CHDIS");
+
+        /*
+         * Wait for halt completion (CHENA→0). Without this, async halt
+         * races a subsequent StartChannel and leaves the channel for
+         * the watchdog to clean. Halt can take a full microframe.
+         */
+        int timeout = 200000;
+        while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE)
+               && --timeout > 0)
+            asm volatile("mov r0, r0\n");
+        if (timeout <= 0)
+        {
+            HALT_SNAP(chan, "timeout-pre-flush");
+
+            bug("[USB2OTG] halt-channel timeout chan=%d CHAR=%08x INTR=%08x\n",
+                chan,
+                rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                rd32le(USB2OTG_CHANNEL_REG(chan, INTR)));
+
+            /*
+             * CHENA refuses to drop — usually a stale TX FIFO packet
+             * the device isn't ACKing. Flush ALL TX FIFOs (TxFNum=16
+             * per DWC2 spec); NPTXFIFO-only flush is insufficient on
+             * Pi 3B+ after WAIT-PING. Collateral: other non-periodic
+             * channels lose in-flight packets — acceptable on a
+             * give-up path; class drivers retry.
+             */
+            wr32le(USB2OTG_RESET, USB2OTG_RESET_TXFIFOFLUSH | (0x10 << 6));
+            {
+                int t = 10000;
+                while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH)
+                       && --t > 0)
+                    asm volatile("mov r0, r0\n");
+                if (t <= 0)
+                    HALT_SNAP(chan, "flush-self-timeout");
+            }
+
+            HALT_SNAP(chan, "post-flush");
+
+            timeout = 200000;
+            while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE)
+                   && --timeout > 0)
+                asm volatile("mov r0, r0\n");
+            if (timeout <= 0)
+            {
+                HALT_SNAP(chan, "stuck-after-flush");
+
+                bug("[USB2OTG] halt-channel still stuck after ALL-TX-FIFO flush chan=%d CHAR=%08x INTR=%08x\n",
+                    chan,
+                    rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                    rd32le(USB2OTG_CHANNEL_REG(chan, INTR)));
+            }
+            else
+            {
+                HALT_SNAP(chan, "recovered");
+                bug("[USB2OTG] halt-channel recovered after ALL-TX-FIFO flush chan=%d\n", chan);
+            }
+        }
+    }
+    else if (hcchar != 0)
+    {
+        hcchar |= USB2OTG_HOSTCHAR_DISABLE;
+        wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
+    }
+    else
+    {
+        wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), USB2OTG_HOSTCHAR_DISABLE);
+    }
+}
+
+static inline BOOL usb2otg_trace_bulk_ep2(int chan, struct IOUsbHWReq *req)
+{
+    return req != NULL &&
+           chan == 1 &&
+           req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+           req->iouh_Endpoint == 2;
+}
+
+/*
+ * Post-halt cleanup before re-arming HS bulk-OUT: NPTxFIFO flush +
+ * ~1 ms settle so any half-written OUT data clears and the device's
+ * BBB endpoint SM resyncs. Mirrors FreeBSD dwc_otg.c:765-767.
+ * Does NOT clear NPTxQ — wedge persistence escalates to HCLKSOFT.
+ */
+static inline void usb2otg_post_halt_bulk_out_settle(void)
+{
+    wr32le(USB2OTG_RESET, USB2OTG_RESET_TXFIFOFLUSH | (0 << 6));
+    {
+        int t = 10000;
+        while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH)
+               && --t > 0)
+            asm volatile("mov r0, r0\n");
+    }
+    {
+        int t = 1200000;
+        while (--t > 0)
+            asm volatile("mov r0, r0\n");
+    }
+}
+
+/*
+ * Last-resort wedge recovery via GRSTCTL.HCLKSOFT (host-clock domain
+ * soft reset). Resets all 8 channel SMs and host FIFO queue pointers;
+ * preserves port state and global AHB/USB/FIFO config.
+ * Side effect: other channels lose HW state — their requests are
+ * re-queued to the class-command queue. wedged_chan is NOT re-queued
+ * (caller finishes it with UHIOERR_TIMEOUT). Must be called holding
+ * hu_Lock; does not take it.
+ */
+static void usb2otg_escalate_hw_reset(struct USB2OTGUnit *USBUnit, int wedged_chan)
+{
+    ULONG char_before, char_after;
+    int i;
+    int t;
+    int requeued = 0;
+
+    char_before = rd32le(USB2OTG_CHANNEL_REG(wedged_chan, CHARBASE));
+    if (!(char_before & USB2OTG_HOSTCHAR_ENABLE))
+    {
+        /* Channel actually cleared since caller's last check — nothing to do. */
+        return;
+    }
+
+    bug("[USB2OTG] WEDGE-RECOVERY: escalating to HCLKSOFT chan=%d CHAR=%08x\n",
+        wedged_chan, char_before);
+
+    /* Wait for AHB master to idle before asserting reset, per DWC2 spec. */
+    t = 100000;
+    while (!(rd32le(USB2OTG_RESET) & (1UL << 31)) && --t > 0)
+        asm volatile("mov r0, r0\n");
+    if (t <= 0)
+        bug("[USB2OTG] WEDGE-RECOVERY: AHB never idled before HCLKSOFT RESET=%08x\n",
+            rd32le(USB2OTG_RESET));
+
+    /* Issue HCLKSOFT. HW auto-clears the bit when reset completes. */
+    wr32le(USB2OTG_RESET, USB2OTG_RESET_HCLKSOFT);
+
+    t = 200000;
+    while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_HCLKSOFT) && --t > 0)
+        asm volatile("mov r0, r0\n");
+
+    char_after = rd32le(USB2OTG_CHANNEL_REG(wedged_chan, CHARBASE));
+    if (char_after & USB2OTG_HOSTCHAR_ENABLE)
+    {
+        bug("[USB2OTG] WEDGE-RECOVERY: HCLKSOFT did NOT clear CHENA chan=%d CHAR=%08x — HW unrecoverable\n",
+            wedged_chan, char_after);
+        return;
+    }
+
+    bug("[USB2OTG] WEDGE-RECOVERY: HCLKSOFT cleared CHENA chan=%d (CHAR=%08x)\n",
+        wedged_chan, char_after);
+
+    /* Re-queue in-flight requests on other channels; HW state reset. */
+    for (i = 0; i < 8; i++)
+    {
+        struct IOUsbHWReq *stuck_req;
+
+        if (i == wedged_chan)
+            continue;
+
+        stuck_req = USBUnit->hu_Channel[i].hc_Request;
+        if (stuck_req == NULL)
+            continue;
+
+        USBUnit->hu_Channel[i].hc_Request = NULL;
+        USBUnit->hu_Channel[i].hc_SplitCSplitPending = 0;
+        USBUnit->hu_Channel[i].hc_WatchdogCount = 0;
+        USBUnit->hu_Channel[i].hc_DeferCount = 0;
+
+        switch (stuck_req->iouh_Req.io_Command)
+        {
+            case UHCMD_BULKXFER:
+                ADDHEAD(&USBUnit->hu_BulkXFerQueue, (struct Node *)stuck_req);
+                break;
+            case UHCMD_CONTROLXFER:
+                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, (struct Node *)stuck_req);
+                break;
+            case UHCMD_INTXFER:
+                ADDHEAD(&USBUnit->hu_IntXFerQueue, (struct Node *)stuck_req);
+                break;
+            default:
+                /* Unknown cmd — drop; class driver retries via timeout. */
+                continue;
+        }
+        requeued++;
+
+        bug("[USB2OTG] WEDGE-RECOVERY: re-queued chan=%d cmd=%lu dev=%d ep=%d dir=%s act=%lu/%lu\n",
+            i,
+            (unsigned long)stuck_req->iouh_Req.io_Command,
+            (int)stuck_req->iouh_DevAddr,
+            (int)stuck_req->iouh_Endpoint,
+            stuck_req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+            (unsigned long)stuck_req->iouh_Actual,
+            (unsigned long)stuck_req->iouh_Length);
+    }
+
+    bug("[USB2OTG] WEDGE-RECOVERY: done, %d in-flight request(s) re-queued\n", requeued);
+}
+
+/*
+ * Non-split bulk-OUT progress accounting for mid-burst halts.
+ * Reads HCTSIZ.PktCnt, advances iouh_Actual by ACKed × MaxPktSize,
+ * toggles host PID, resets transient retry budget on progress.
+ * Callers MUST gate on HCINT.CHHLTD — TSIZE only settles after halt;
+ * acting on pre-halt PktCnt over-advances Actual. No locking.
+ */
+static inline void usb2otg_bulk_out_advance_pktcnt(
+    struct USB2OTGUnit *USBUnit, int chan,
+    struct IOUsbHWReq *req, ULONG tsize_snapshot)
+{
+    struct USB2OTGChannel *hc;
+    int initial_pktcnt;
+    int remaining_pktcnt;
+    int acked_pktcnt_raw;
+    int acked_pktcnt;
+    ULONG accepted;
+    ULONG act_before;
+
+    if (req->iouh_Req.io_Command != UHCMD_BULKXFER ||
+        req->iouh_Dir != UHDIR_OUT ||
+        (req->iouh_Flags & UHFF_SPLITTRANS))
+        return;
+
+    hc = &USBUnit->hu_Channel[chan];
+
+    initial_pktcnt = (hc->hc_XferSize + req->iouh_MaxPktSize - 1)
+        / (req->iouh_MaxPktSize ? req->iouh_MaxPktSize : 1);
+    if (initial_pktcnt == 0)
+        initial_pktcnt = 1;
+
+    remaining_pktcnt = (tsize_snapshot >> 19) & 0x3FF;
+    acked_pktcnt_raw = initial_pktcnt - remaining_pktcnt;
+    if (acked_pktcnt_raw <= 0)
+        return;
+
+    /*
+     * BCM2835 over-reports PktCnt on NYET (PktCnt=0 with only some
+     * packets actually consumed). Cross-check against XferSize delta
+     * and use the smaller of the two — under-credit re-sends a
+     * duplicate (device discards by toggle); over-credit wedges BBB.
+     */
+    {
+        ULONG xfer_remaining = tsize_snapshot & 0x7FFFF;
+        ULONG bytes_from_xfersize;
+        ULONG bytes_from_pktcnt;
+        ULONG bytes_acked;
+
+        if (xfer_remaining > hc->hc_XferSize)
+            xfer_remaining = hc->hc_XferSize;  /* defensive */
+        bytes_from_xfersize = hc->hc_XferSize - xfer_remaining;
+        bytes_from_pktcnt = (ULONG)acked_pktcnt_raw * req->iouh_MaxPktSize;
+
+        bytes_acked = bytes_from_pktcnt < bytes_from_xfersize
+            ? bytes_from_pktcnt : bytes_from_xfersize;
+
+        /* Round down to whole MaxPktSize — partial packets are not ACKed. */
+        bytes_acked -= bytes_acked % req->iouh_MaxPktSize;
+
+        accepted = bytes_acked;
+        if (accepted > hc->hc_XferSize)
+            accepted = hc->hc_XferSize;
+        if (req->iouh_Actual + accepted > req->iouh_Length)
+            accepted = req->iouh_Length - req->iouh_Actual;
+
+        acked_pktcnt = accepted / req->iouh_MaxPktSize;
+    }
+
+    act_before = req->iouh_Actual;
+    req->iouh_Actual += accepted;
+    if (acked_pktcnt & 1)
+        USBUnit->hu_PIDBits[req->iouh_DevAddr] ^=
+            (USB2OTG_PID_DATA1 << (2 * req->iouh_Endpoint));
+    req->iouh_DriverPrivate2 = (APTR)0;
+
+    /* PING setup is done at NYET sites; XactErr is bus-level and must
+     * NOT trigger PING (device awaits OUT, loops on PING-NAK). */
+
+}
+
+static void usb2otg_remove_bulk_queue_duplicates(struct USB2OTGUnit *USBUnit,
+    struct IOUsbHWReq *target, int chan)
+{
+    struct IOUsbHWReq *req = NULL, *next = NULL;
+
+    ForeachNodeSafe(&USBUnit->hu_BulkXFerQueue, req, next)
+    {
+        if (req == target)
+        {
+            REMOVE(req);
+            break;
+        }
+    }
+}
+
 static LONG delayed_channel[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+static BOOL usb2otg_process_pending(struct USB2OTGUnit *otg_Unit);
+static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit);
+
+void FNAME_DEV(WorkerTask)(struct USB2OTGUnit *otg_Unit)
+{
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+    ULONG sigmask = 1UL << otg_Unit->hu_WorkerPort->mp_SigBit;
+
+    for (;;)
+    {
+        struct Message *msg;
+        ULONG flags;
+
+        Wait(sigmask);
+
+        while ((msg = GetMsg(otg_Unit->hu_WorkerPort)) != NULL)
+        {
+            if (msg == &otg_Unit->hu_NakTimeoutReq.tr_node.io_Message)
+                usb2otg_process_naktimeout(otg_Unit);
+        }
+
+        Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        flags = otg_Unit->hu_WorkFlags;
+        otg_Unit->hu_WorkFlags = 0;
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+        Enable();
+        if (flags & USB2OTG_WORK_NAKTIMEOUT)
+            usb2otg_process_naktimeout(otg_Unit);
+        if (flags & USB2OTG_WORK_PENDING)
+            usb2otg_process_pending(otg_Unit);
+    }
+}
+
 static void handle_SOF(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase, ULONG frnm_orig)
 {
     ULONG frnm = frnm_orig >> 3;
     static ULONG last_frame = 0;
     struct IOUsbHWReq *req = NULL, *next = NULL;
     struct USB2OTGDevice * USB2OTGBase = USBUnit->hu_USB2OTGBase;
+    BOOL int_scheduled = FALSE;
 
     wr32le(USB2OTG_INTR, USB2OTG_INTRCORE_DMASTARTOFFRAME);
 
     if (frnm < last_frame)
     {
         D(bug("[USB2OTG] SOF, frame wrap %d %d\n", frnm, last_frame));
-#if 0
-        bug("Ch2\n");
-        DumpChannelRegs(CHAN_INT1);
-        bug("Ch3\n");
-        DumpChannelRegs(CHAN_INT2);
-        bug("Ch4\n");
-        DumpChannelRegs(CHAN_INT3);
-        #endif
     }
 
     if (frnm != last_frame)
     {
-        #if 0
-         if (USBUnit->hu_CtrlXFerQueue.lh_Head->ln_Succ)
-    {
-        D(bug("[USB2OTG] [0x%p:PEND] Process CtrlXFer ..\n", otg_Unit));
-        FNAME_DEV(ScheduleCtrlTDs)(USBUnit);
-    }
-
-    if (USBUnit->hu_IntXFerQueue.lh_Head->ln_Succ)
-    {
-//        D(bug("[USB2OTG] [0x%p:PEND] Process IntXFer ..\n", otg_Unit));
-        FNAME_DEV(ScheduleIntTDs)(USBUnit);
-    }
-
-    if (USBUnit->hu_BulkXFerQueue.lh_Head->ln_Succ)
-    {
-        D(bug("[USB2OTG] [0x%p:PEND] Process BulkXFer ..\n", otg_Unit));
-//        FNAME_DEV(ScheduleBulkTDs)(otg_Unit);
-    }
-#endif
-        FNAME_DEV(Cause)(USB2OTGBase, &USBUnit->hu_PendingInt);
-
-        ForeachNodeSafe(&USBUnit->hu_IntXFerQueue, req, next)
         {
-            ULONG last_handled = (ULONG)req->iouh_DriverPrivate1 >> 16;
-            ULONG next_to_handle = (ULONG)req->iouh_DriverPrivate1 & 0xfff;
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            ForeachNodeSafe(&USBUnit->hu_IntXFerQueue, req, next)
+            {
+                ULONG last_handled = (ULONG)req->iouh_DriverPrivate1 >> 16;
+                ULONG next_to_handle = (ULONG)req->iouh_DriverPrivate1 & 0x7ff;
 
-            /* Is it time to handle the request? If yes, move it to Scheduled list */
-            if (frnm == next_to_handle)
-            {
-                //D(bug("[USB2OTG] schedule INT request on time, last=%d, next=%d, frnm=%d\n", last_handled, next_to_handle, frnm));
-                REMOVE(req);
-                ADDTAIL(&USBUnit->hu_IntXFerScheduled, req);
+                /* Is it time to handle the request? If yes, move it to Scheduled list */
+                if (frnm == next_to_handle)
+                {
+                    D(bug("[USB2OTG] SOF: promoting INT dev=%ld ep=%ld frnm=%ld\n",
+                        (LONG)req->iouh_DevAddr, (LONG)req->iouh_Endpoint, (LONG)frnm));
+                    REMOVE(req);
+                    ADDTAIL(&USBUnit->hu_IntXFerScheduled, req);
+                    int_scheduled = TRUE;
+                }
+                /*
+                    If the request is overdued several scenarios are possible:
+                    1. frnm is larger than "last" and "next"
+                        0......last....next...frnm....2047
+                    2. frnm is smaller than "last" and "next"
+                        0..frnm.....last....next......2047
+                    3. frnm is bigger than "next" but smaller than "last"
+                        0..next....frnm......last.....2047
+                */
+                else if (
+                    (frnm > next_to_handle && frnm > last_handled) ||
+                    (frnm < last_handled && frnm < next_to_handle) ||
+                    (frnm > next_to_handle && frnm < last_handled)
+                )
+                {
+                    D(bug("[USB2OTG] SOF: promoting INT (overdue) dev=%ld ep=%ld frnm=%ld\n",
+                        (LONG)req->iouh_DevAddr, (LONG)req->iouh_Endpoint, (LONG)frnm));
+                    REMOVE(req);
+                    ADDTAIL(&USBUnit->hu_IntXFerScheduled, req);
+                    int_scheduled = TRUE;
+                }
             }
-            /*
-                If the request is overdued several scenarios are possible:
-                1. frnm is larger than "last" and "next"
-                    0......last....next...frnm....2047
-                2. frnm is smaller than "last" and "next"
-                    0..frnm.....last....next......2047
-                3. frnm is bigger than "next" but smaller than "last"
-                    0..next....frnm......last.....2047
-            */
-            else if (
-                (frnm > next_to_handle && frnm > last_handled) ||
-                (frnm < last_handled && frnm < next_to_handle) ||
-                (frnm > next_to_handle && frnm < last_handled)
-            )
-            {
-                D(bug("[USB2OTG] overdued INT request, scheduling. last=%d, next=%d, frnm=%d\n", last_handled, next_to_handle, frnm));
-                REMOVE(req);
-                ADDTAIL(&USBUnit->hu_IntXFerScheduled, req);
-            }
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&USBUnit->hu_Lock);
+#endif
         }
 
-        /* If the Scheduled list is not empty process it now */
+        FNAME_DEV(Cause)(USB2OTGBase, &USBUnit->hu_PendingInt);
+
+        /*
+         * Schedule INT transfers directly from SOF for lowest latency.
+         * ScheduleIntTDs uses Disable/Enable, which is safe here because
+         * handle_irq sets IDNestCnt=0: Disable makes it 1, Enable makes
+         * it 0 — neither triggers KrnSti nor softint dispatch.
+         * Note: no bug() calls allowed in this path — serial output
+         * from IRQ context overflows the SVC stack.
+         */
+        /* Always try to schedule if there are requests waiting.
+         * The old code checked IsListEmpty; using only int_scheduled
+         * missed requests that were promoted in a previous SOF but
+         * couldn't be scheduled because all channels were busy. */
         if (!IsListEmpty(&USBUnit->hu_IntXFerScheduled))
             FNAME_DEV(ScheduleIntTDs)(USBUnit);
 
@@ -116,10 +520,7 @@ static void handle_SOF(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase, UL
                 {
                     delayed_channel[chan]--;
                     if (delayed_channel[chan] == 0)
-                    {
-    //                    bug("R%p ", frnm_orig);
                         FNAME_DEV(StartChannel)(USBUnit, chan, 1);
-                    }
                 }
             }
 
@@ -128,11 +529,14 @@ static void handle_SOF(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase, UL
 
 void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase)
 {
+    struct USB2OTGDevice * USB2OTGBase = USBUnit->hu_USB2OTGBase;
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return;
+
     //static ULONG last_frame = 0;
 
     //static ULONG delayed_frnm = 0;
     volatile unsigned int otg_RegVal;
-    //struct USB2OTGDevice * USB2OTGBase = USBUnit->hu_USB2OTGBase;
     ULONG frnm = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff);
 
     otg_RegVal = rd32le(USB2OTG_INTR);
@@ -142,15 +546,28 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
         handle_SOF(USBUnit, SysBase, frnm);
     }
 
+    /*
+     * W1C all host-mode core IRQ bits we don't dispatch on. GINTSTS is
+     * W1C — leaving IncompPeriodicXfer/FetchSusp latched starves
+     * non-periodic arbitration. Mask SOF/HOSTCHANNEL (self-cleared)
+     * and PORT (read by hub layer) before clearing the rest.
+     */
+    {
+        ULONG clear_mask = otg_RegVal &
+            ~(USB2OTG_INTRCORE_DMASTARTOFFRAME |
+              USB2OTG_INTRCORE_HOSTCHANNEL |
+              USB2OTG_INTRCORE_PORT);
+        if (clear_mask != 0)
+            wr32le(USB2OTG_INTR, clear_mask);
+    }
+
     frnm >>= 3;
 
     if (otg_RegVal & USB2OTG_INTRCORE_HOSTCHANNEL)
     {
         unsigned int otg_ChanVal;
         int chan;
-
         otg_ChanVal = rd32le(USB2OTG_HOSTINTR);
-
 
         //D(bug("[USB2OTG] HOSTCHANNEL %x frnm %d\n", otg_ChanVal, frnm));
 
@@ -160,335 +577,1007 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
 
             if (otg_ChanVal & (1 << chan))
             {
-                struct IOUsbHWReq * req = USBUnit->hu_Channel[chan].hc_Request;
+                struct IOUsbHWReq * req;
                 uint32_t intr = rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
-                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), intr);
 
+                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), intr);
+                /*
+                 * IRQ handler runs on CPU 0 with interrupts disabled —
+                 * no other code can preempt us here. The lock is only
+                 * needed at final completion to exclude the watchdog.
+                 */
+                req = USBUnit->hu_Channel[chan].hc_Request;
+
+                D(
+                    if (chan == CHAN_CTRL)
+                        bug("[USB2OTG:DBG] CTRL-IRQ intr=%04x dev=%d bReq=%02x wVal=%04x\n",
+                            (unsigned)intr,
+                            req ? (int)req->iouh_DevAddr : -1,
+                            req ? (unsigned)req->iouh_SetupData.bRequest : 0,
+                            req ? (unsigned)AROS_LE2WORD(req->iouh_SetupData.wValue) : 0);
+                )
+
+                if ((intr & USB2OTG_INTR_XFC_STALL) == USB2OTG_INTR_XFC_STALL)  /* XferComplete + STALL both present? */
+                    bug("[USB2OTG] IRQ: chan=%d intr=%04x BOTH XferComplete+STALL!\n",
+                        chan, intr);
 
             if (rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & 0x40000000)
             {
 
-                bug("disable bit on channel %d is set!!!\n", chan);
+                D(bug("disable bit on channel %d is set!!!\n", chan));
 
-                bug("req=%08x\n", USBUnit->hu_Channel[chan].hc_Request);
+                D(bug("req=%08x\n", req));
 
                 DumpChannelRegs(chan);
-                wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
-                bug("HOSTINTR=%08x\nHOSTINTRMASK=%08x\n", otg_ChanVal, rd32le(USB2OTG_HOSTINTRMASK));
+                /*
+                 * Do not zero HCCHAR here. QEMU's DWC2 model may still be
+                 * consuming the channel state, and clearing HCCHAR wipes MPS
+                 * and endpoint metadata underneath the emulator.
+                 */
+                D(bug("HOSTINTR=%08x\nHOSTINTRMASK=%08x\n", otg_ChanVal, rd32le(USB2OTG_HOSTINTRMASK)));
 
 
             }
 
                 if (req)
                 {
-                    //if (req->iouh_DevAddr == 4)
-                    //    bug("Interrupt %04x for request\n", intr);
-
-                    int do_split = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)) & 0x80010000;
-                    /*
-                        Channel closed with ACK but not comleted yet and split is active. Complete split now, do not continue with
-                        normal processing of this channel
-                    */
-                    if (intr == 0x22 && do_split == 0x80000000)
+                    /* do_split: SSPLIT bit, optionally with CSPLIT bit */
+                    int do_split = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)) & USB2OTG_HCSPLT_CSPLIT;
+                    /* Channel closed with ACK on active split: issue CSPLIT. */
+                    if (do_split == USB2OTG_HCSPLT_SSPLIT &&
+                        ((intr == USB2OTG_INTR_HALT_ACK) ||
+                         (req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+                          ((chan < CHAN_INT1) || (chan > CHAN_INT_LAST)) &&
+                          (intr & (0x10 | USB2OTG_INTRCHAN_HALT)))))
                     {
                         uint32_t tmp = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
                         tmp |= 1 << 16;   /* Set "do complete split" */
                         wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), tmp);
+                        USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 1;
 
-                        D(bug("[USB2OTG] Completing split transaction in interrupt. SPLITCTRL=%08x\n", tmp));
-//bug("%08x\n", rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR)));
-#if 0
-                        /* Enable channel again */
-                        tmp = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
-                        tmp |= USB2OTG_HOSTCHAR_ENABLE;
-                        wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), tmp);
-                        //asm volatile("wfe");
-#endif
-#if 0
-                        delayed_channel |= 1 << chan;
-                        delayed_frnm = frnm;
-#else
-FNAME_DEV(StartChannel)(USBUnit, chan, 1);
-#endif
+                        if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                            usb2otg_remove_bulk_queue_duplicates(USBUnit, req, chan);
+
+                        D(bug("[USB2OTG] Completing split transaction in interrupt: chan=%d intr=%04x SPLITCTRL=%08x\n",
+                              chan, intr, tmp));
+                        FNAME_DEV(StartChannel)(USBUnit, chan, 1);
                     }
-                    else if (intr == 0x42 && do_split == 0x80010000)
+                    else if ((do_split == USB2OTG_HCSPLT_CSPLIT) &&
+                             (req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                             ((chan < CHAN_INT1) || (chan > CHAN_INT_LAST)) &&
+                             (intr & USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE))
                     {
-#if 1
+                        /* Bulk CSPLIT NAK: TT not done; requeue for fresh SSPLIT. */
+                        D(
+                            if (usb2otg_trace_bulk_ep2(chan, req))
+                            {
+                                bug("[USB2OTG:TRACE] IRQ-CSPLIT-NAK-REQUEUE chan=%d intr=%04x split=%08x char=%08x tsize=%08x\n",
+                                    chan,
+                                    (unsigned int)intr,
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)),
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE)));
+                            }
+                        )
+
+                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                        usb2otg_halt_channel_preserve_char(chan);
+
+                        USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                        usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-nak");
+                        /* Helper does TOCTOU vs watchdog. */
+                        usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
+                            USB2OTG_BULK_NAK_GATE_UFRAMES);
+                        usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                            &USBUnit->hu_BulkXFerQueue, FALSE);
+                        req = NULL;
+                    }
+                    else if (intr == USB2OTG_INTR_HALT_NYET && do_split == USB2OTG_HCSPLT_CSPLIT)
+                    {
+                        /*
+                         * CHHLTD+ACK on a CSPLIT. If frame number passed
+                         * half-interval, TT cache is stale → requeue with
+                         * updated timing; otherwise re-arm/delay.
+                         */
                         ULONG last = (ULONG)req->iouh_DriverPrivate1 >> 16;
                         ULONG thresh = (last + (ULONG)req->iouh_Interval / 2) % 2047;
-//bug("0x%p ", rd32le(USB2OTG_HOSTFRAMENO));
-//bug("0x%p ", rd32le(USB2OTG_HOSTFRAMENO));
-//bug("NYET!");
-//DumpChannelRegs(chan);
-//bug("NYET! frnm=%d last=%d thresh=%d\n", frnm, last, thresh);
 
-                        if ((chan >= CHAN_INT1 && chan <= CHAN_INT3)  &&
+                        if ((chan >= CHAN_INT1 && chan <= CHAN_INT_LAST) &&
                             ((frnm > thresh && frnm > last) ||
-                            (frnm < thresh && frnm < last) ||
-                            (frnm > thresh && frnm < last)))
+                             (frnm < thresh && frnm < last) ||
+                             (frnm > thresh && frnm < last)))
                         {
                             D(bug("[USB2OTG] restarting transaction... %x, %x, %d\n", frnm, req->iouh_DriverPrivate1, req->iouh_DriverPrivate2));
 
-                            /* Disable channel */
-                            wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
+                            /* Disable channel without clearing MPS/ep metadata */
+                            usb2otg_halt_channel_preserve_char(chan);
 
-                            /* Put transfer back into queue */
-                            if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
-                                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
-                            if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
-                                ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
+                            /* Put transfer back into queue with updated timing */
                             if (req->iouh_Req.io_Command == UHCMD_INTXFER)
+                            {
+                                ULONG interval = req->iouh_Interval;
+                                if ((req->iouh_Flags & UHFF_SPLITTRANS) && interval < 2)
+                                    interval = 2;
+                                ULONG next = (frnm + interval) & 0x7ff;
+                                req->iouh_DriverPrivate1 = (APTR)((frnm << 16) | next);
                                 ADDHEAD(&USBUnit->hu_IntXFerQueue, req);
+                            }
+                            else if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
+                            else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                                ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
 
                             /* Mark channel free */
                             USBUnit->hu_Channel[chan].hc_Request = NULL;
                             req = NULL;
                         }
                         else
-#endif
                         {
-                            //D(bug("!!! Channel %d, Restarting CSPLIT phase! %d, %d, %d\n", chan, frnm, req->iouh_DriverPrivate1, req->iouh_DriverPrivate2));
-                            #if 0
-                            /* Enable channel again */
-                            uint32_t tmp = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
-                            tmp |= USB2OTG_HOSTCHAR_ENABLE;
-                            wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), tmp);
-                              #endif
-
-                            //intr = 2;
-        #if 1
-        if ((chan >= CHAN_INT1 && chan <= CHAN_INT3))
-        {
-         //   if (req->iouh_Flags & UHFF_LOWSPEED)
-         //       delayed_channel[chan] = 4;
-         //   else
-                FNAME_DEV(StartChannel)(USBUnit, chan, 1);
-        }
-            //delayed_channel[chan] = 8;
-        else
-                            delayed_channel[chan] = 16;
-                          //  delayed_frnm = frnm;
-#else
-                            FNAME_DEV(StartChannel)(USBUnit, chan, 1);
-#endif
+                            if (chan >= CHAN_INT1 && chan <= CHAN_INT_LAST)
+                                FNAME_DEV(StartChannel)(USBUnit, chan, 1);
+                            else
+                                delayed_channel[chan] = 16;
                         }
                     }
-                    else if ((intr == 0x12 && do_split) &&
-                        (chan < CHAN_INT1 || chan > CHAN_INT3))
+                    else if (intr == USB2OTG_INTRCHAN_HALT &&
+                             do_split == USB2OTG_HCSPLT_SSPLIT &&
+                             chan >= CHAN_INT1 && chan <= CHAN_INT_LAST &&
+                             req->iouh_Req.io_Command == UHCMD_INTXFER)
                     {
-                        /* NAK response from split transaction. Restart the request from beginning */
-                      /*  D(bug("[USB2OTG] Restarting split transaction\n"));
+                        /* Bare CHHLTD on SSPLIT INT: wrong OddFrame parity;
+                         * restart, StartChannel re-predicts the frame. */
+                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                        FNAME_DEV(StartChannel)(USBUnit, chan, 1);
+                        req = NULL;
+                    }
+                    else if ((intr == USB2OTG_INTR_HALT_NAK && do_split) &&
+                        (chan < CHAN_INT1 || chan > CHAN_INT_LAST))
+                    {
+                        D(
+                            if (usb2otg_trace_bulk_ep2(chan, req))
+                            {
+                                bug("[USB2OTG:TRACE] REQUEUE-BEGIN chan=%d req=%p intr=%04x split=%08x\n",
+                                    chan, req, (unsigned int)intr,
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)));
+                            }
+                        )
+                        /* NAK on split — restart from the beginning. */
+                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                        usb2otg_halt_channel_preserve_char(chan);
 
-                        DumpChannelRegs(chan);*/
-
-                        /* Clear interrupt flags */
-                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
-
-                        /* Disable channel */
-                        if (rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & 0x80000000)
-                        {
-                            bug("Channel completed but still active. Disabling now...\n");
-                            wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0x40000000);
-                        }
-                        else
-                            wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
-
-                        /* Put transfer back into queue */
+                        /* Put transfer back into appropriate queue */
                         if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
                             ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
-                        if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                        else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                        {
+                            USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                            usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-begin-nak");
+                            D(
+                                if (usb2otg_trace_bulk_ep2(chan, req))
+                                    bug("[USB2OTG:TRACE] REQUEUE-BEGIN-BULKQ chan=%d req=%p\n", chan, req);
+                            )
                             ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
-                        if (req->iouh_Req.io_Command == UHCMD_INTXFER)
-                            ADDHEAD(&USBUnit->hu_IntXFerQueue, req);
+                        }
 
                         /* Mark channel free */
                         USBUnit->hu_Channel[chan].hc_Request = NULL;
+                        req = NULL;
+                    }
+                    else if ((intr == USB2OTG_INTRCHAN_HALT) &&
+                             (do_split == USB2OTG_HCSPLT_CSPLIT) &&
+                             (req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                             ((chan < CHAN_INT1) || (chan > CHAN_INT_LAST)))
+                    {
+                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                        usb2otg_halt_channel_preserve_char(chan);
+
+                        D(
+                            if (usb2otg_trace_bulk_ep2(chan, req))
+                                bug("[USB2OTG:TRACE] IRQ-CSPLIT-CHH-REQUEUE chan=%d req=%p\n", chan, req);
+                        )
+
+                        USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                        usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-halt");
+                        usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
+                            USB2OTG_BULK_NAK_GATE_UFRAMES);
+
+                        usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                            &USBUnit->hu_BulkXFerQueue, FALSE);
                         req = NULL;
                     }
                     else
                     {
                         int cont = 0;
 
-                        /* Ignore NAK on INT channels when reporting closed channel */
-                        //if (intr != 0x12 || (chan < CHAN_INT1 && chan > CHAN_INT3))
-                        //    D(bug("[USB2OTG] Channel %d closed. INTR=%08x\n", chan, intr));
+                        D(bug("[USB2OTG] IRQ: chan=%d intr=%04x dev=%d cmd=%d\n",
+                            chan, intr, req->iouh_DevAddr, req->iouh_Req.io_Command));
 
-                        if ((intr & 0x21) == 0x21)
+                        /*
+                         * XferCompl = success. ACK only fires for splits and
+                         * must NOT be required. ChHltd always co-fires.
+                         */
+                        if ((intr & USB2OTG_INTRCHAN_TRANSFERCOMPLETE)
+                            && !(intr & (USB2OTG_INTRCHAN_STALL |
+                                         USB2OTG_INTRCHAN_AHBERROR |
+                                         USB2OTG_INTRCHAN_TRANSACTIONERROR |
+                                         USB2OTG_INTRCHAN_BABBLEERROR |
+                                         USB2OTG_INTRCHAN_DATATOGGLEERROR |
+                                         USB2OTG_INTRCHAN_BUFFERNOTAVAILABLE)))
                         {
                             req->iouh_Req.io_Error = 0;
+                            /* Reset transient-error budget on completion. */
+                            req->iouh_DriverPrivate2 = 0;
+                            D(if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                                bug("[USB2OTG] BULK DONE: chan=%d actual=%ld/%ld\n",
+                                    chan, (LONG)req->iouh_Actual, (LONG)req->iouh_Length));
+                            D(bug("[USB2OTG] IRQ: XferComplete chan=%d, advancing\n", chan));
 
                             if (!FNAME_DEV(AdvanceChannel)(USBUnit, chan))
                             {
                                 cont = 1;
+                                D(bug("[USB2OTG] IRQ: Starting next phase chan=%d\n", chan));
                                 FNAME_DEV(StartChannel)(USBUnit, chan, 0);
                             }
                             else
                             {
-                                //CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_InvalidateD);
-                                #if 0
-                                for (int i=0; i < 1; i++)
-                                {
-
-                                    (bug("[USB2OTG] Transfer completted: %d of %d transferred at %p\n[USB2OTG]",
-                                        req->iouh_Actual, req->iouh_Length, req->iouh_Data));
-
-                                    UBYTE *ptr = req->iouh_Data;
-                                    int len = 16;
-                                    if (len > req->iouh_Length)
-                                        len = req->iouh_Length;
-
-                                    for (int i=0; i < len; i++)
-                                        (bug(" %02x", ptr[i]));
-
-                                    (bug("\n"));
-
-                                    if (*((ULONG*)req->iouh_Data) == 0xffffffff) {
-                                        bug("[USB2OTG] Have not received?\n");
-                                        while(1);
-                                    }
-                                }
-                                #endif
+                                D(bug("[USB2OTG] IRQ: Transfer fully done chan=%d actual=%d/%d\n",
+                                    chan, req->iouh_Actual, req->iouh_Length));
                             }
                         }
-                        else if (intr & 0x80)
+                        else if (intr & USB2OTG_INTRCHAN_AHBERROR)
                         {
-                            req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
-                            bug("0x80: ");
-                            DumpChannelRegs(chan);
+                            /* AHB DMA fault — terminal (FreeBSD dwc_otg). */
+                            bug("[USB2OTG] IRQ: AHBERR chan=%d dev=%d ep=%d intr=%04x\n",
+                                chan, req->iouh_DevAddr, req->iouh_Endpoint, intr);
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+                            req->iouh_Req.io_Error = UHIOERR_HOSTERROR;
                         }
-                        else if (intr & 0x08)
+                        else if ((intr & (USB2OTG_INTRCHAN_TRANSACTIONERROR |
+                                          USB2OTG_INTRCHAN_DATATOGGLEERROR |
+                                          USB2OTG_INTRCHAN_BUFFERNOTAVAILABLE))
+                                 && !(intr & (USB2OTG_INTRCHAN_STALL |
+                                              USB2OTG_INTRCHAN_BABBLEERROR)))
                         {
-                            bug("0x08: ");
-                            req->iouh_Req.io_Error = UHIOERR_STALL;
-                            DumpChannelRegs(chan);
-                        }
-                        else if (intr & 0x10)
-                        {
-                            /* In case of INT requests NAK is silently ignored. Just put the request back to the IntXferQueue */
-                            if (chan >= CHAN_INT1 && chan <= CHAN_INT3)
+                            /*
+                             * Transient errors (XactErr/DataTglErr/BNA) —
+                             * retry a few times. FreeBSD dwc_otg merges
+                             * DATATGLERR into the XactErr retry path
+                             * (dwc_otg.c:1422,1944). Halt-then-read TSIZE
+                             * for settled PktCnt.
+                             */
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+
+                            ULONG retries = (ULONG)req->iouh_DriverPrivate2;
+                            if ((req->iouh_Req.io_Command == UHCMD_CONTROLXFER ||
+                                 req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                                retries < USB2OTG_TRANSIENT_RETRY_LIMIT)
                             {
-//                                if (req->iouh_DevAddr == 4)
-//                                    bug("!NAK channel %d\n", chan);
+                                const char *why =
+                                    (intr & USB2OTG_INTRCHAN_DATATOGGLEERROR) ? "datatglerr" :
+                                    (intr & USB2OTG_INTRCHAN_BUFFERNOTAVAILABLE) ? "bna" :
+                                    "xacterr";
+                                /* HCTSIZ settled by the halt above. */
+                                ULONG tsize_snap =
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                ULONG act_before_helper = req->iouh_Actual;
+                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, why);
+                                D(bug("[USB2OTG] IRQ: %s chan=%d dev=%d intr=%04x, retry %ld/%d\n",
+                                    why, chan, req->iouh_DevAddr, intr,
+                                    retries + 1, USB2OTG_TRANSIENT_RETRY_LIMIT));
 
-                                /* Clear interrupt flags */
-                                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
+                                usb2otg_bulk_out_advance_pktcnt(USBUnit, chan, req, tsize_snap);
+                                /* retry++ after helper (helper may reset budget on progress). */
+                                req->iouh_DriverPrivate2 =
+                                    (APTR)((ULONG)req->iouh_DriverPrivate2 + 1);
 
-                                /* Disable channel */
-                                wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
+                                /*
+                                 * XactErr-with-progress on HS direct bulk OUT:
+                                 * device almost certainly flash-congested.
+                                 * Apply a 500 ms NAK gate for bus-idle time.
+                                 */
+                                if (req != NULL &&
+                                    req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+                                    req->iouh_Dir == UHDIR_OUT &&
+                                    !(req->iouh_Flags & UHFF_SPLITTRANS) &&
+                                    (req->iouh_Flags & UHFF_HIGHSPEED) &&
+                                    req->iouh_Actual > act_before_helper)
+                                {
+                                    /*
+                                     * Do NOT set PingPending: XACTERR is a
+                                     * USB 2.0 §8.4.6 bus-level error, not a
+                                     * flash-busy NYET. PING-flow on XACTERR
+                                     * wedges the channel.
+                                     */
+                                    usb2otg_nak_gate_set(USBUnit,
+                                        req->iouh_DevAddr, 4000);
+                                    usb2otg_post_halt_bulk_out_settle();
+                                }
 
-                                ADDTAIL(&USBUnit->hu_IntXFerQueue, req);
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+                                if (USBUnit->hu_Channel[chan].hc_Request != req)
+                                {
+                                    KrnSpinUnLock(&USBUnit->hu_Lock);
+                                }
+                                else
+                                {
+#endif
+                                if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                                    ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
+                                else
+                                    ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
                                 USBUnit->hu_Channel[chan].hc_Request = NULL;
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinUnLock(&USBUnit->hu_Lock);
+                                }
+#endif
                                 req = NULL;
                             }
                             else
                             {
-                                bug("0x10: ");
-                                req->iouh_Req.io_Error = UHIOERR_NAK;
-                                DumpChannelRegs(chan);
+                                req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                                bug("[USB2OTG] IRQ: TIMEOUT chan=%d dev=%d cmd=%d\n", chan, req->iouh_DevAddr, req->iouh_Req.io_Command);
                             }
                         }
-                        else if (intr & 0x100)
+                        else if (intr & USB2OTG_INTRCHAN_STALL)
                         {
-                            bug("0x100: ");
-                            req->iouh_Req.io_Error = UHIOERR_BABBLE;
-                            DumpChannelRegs(chan);
+                            /* STALL is terminal — USB "Request Error". */
+                            D(bug("[USB2OTG] IRQ: STALL chan=%d dev=%d ep=%d HOSTPORT=%08x\n",
+                                chan, req->iouh_DevAddr, req->iouh_Endpoint, rd32le(USB2OTG_HOSTPORT)));
+                            /* Clear channel state after STALL */
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+                            req->iouh_Req.io_Error = UHIOERR_STALL;
                         }
-                        else if (intr & 0x200)
+                        else if (intr & USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE)
                         {
-                            /* Frame overrun. Don't report problem, reinsert request for further processing */
-                            /* Clear interrupt flags */
-                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
+                            /* INT NAK: silently requeue so SOF re-promotes after interval. */
+                            if (chan >= CHAN_INT1 && chan <= CHAN_INT_LAST)
+                            {
+                                if (req->iouh_DevAddr < 8)
+                                    usb2otg_int_nak_count[req->iouh_DevAddr]++;
+                                /* Clear interrupt flags */
+                                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
 
-                            /* Disable channel */
-                            wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
+                                /* Disable channel */
+                                usb2otg_halt_channel_preserve_char(chan);
 
-                            /* Put transfer back into queue */
-                            if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
-                                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
-                            if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
-                                ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
+                                /* Update DP1 so SOF waits the full interval; else tight poll. */
+                                {
+                                    ULONG interval = req->iouh_Interval;
+                                    if ((req->iouh_Flags & UHFF_SPLITTRANS) && interval < 2)
+                                        interval = 2;
+                                    ULONG next = (frnm + interval) & 0x7ff;
+                                    req->iouh_DriverPrivate1 = (APTR)((frnm << 16) | next);
+                                }
+
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+                                if (USBUnit->hu_Channel[chan].hc_Request != req)
+                                {
+                                    /* Watchdog already handled this request */
+                                    KrnSpinUnLock(&USBUnit->hu_Lock);
+                                }
+                                else
+                                {
+#endif
+                                ADDTAIL(&USBUnit->hu_IntXFerQueue, req);
+                                USBUnit->hu_Channel[chan].hc_Request = NULL;
+#if defined(__AROSEXEC_SMP__)
+                                KrnSpinUnLock(&USBUnit->hu_Lock);
+                                }
+#endif
+                                req = NULL;
+                            }
+                            else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                            {
+                                if (USBUnit->hu_Channel[chan].hc_SplitCSplitPending)
+                                {
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                                    usb2otg_halt_channel_preserve_char(chan);
+                                    D(
+                                        if (usb2otg_trace_bulk_ep2(chan, req))
+                                            bug("[USB2OTG:TRACE] IRQ-CSPLIT-NAK-REQUEUE chan=%d req=%p\n", chan, req);
+                                    )
+                                    USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                                    usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "bulk-csplit-nak");
+                                    /* 1 ms gate; prevents NAK-storm pegging CPU 0. */
+                                    usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
+                                                         USB2OTG_BULK_NAK_GATE_UFRAMES);
+                                    req->iouh_DriverPrivate1 = (APTR)0;
+                                    /* NAK = forward progress → reset transient-error budget. */
+                                    req->iouh_DriverPrivate2 = (APTR)0;
+                                    usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                                        &USBUnit->hu_BulkXFerQueue, FALSE);
+                                    req = NULL;
+                                }
+                                else
+                                {
+                                /* Bulk NAK: device busy; requeue. */
+                                D(bug("[USB2OTG] BULK NAK: chan=%d dev=%d ep=%d\n",
+                                    chan, req->iouh_DevAddr, req->iouh_Endpoint));
+                                D(
+                                    if (usb2otg_trace_bulk_ep2(chan, req))
+                                        bug("[USB2OTG:TRACE] REQUEUE-BULK-NAK chan=%d req=%p\n", chan, req);
+                                )
+                                /* Snapshot HCTSIZ before halting for bulk-OUT progress. */
+                                ULONG tsize_snap =
+                                    rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                                usb2otg_halt_channel_preserve_char(chan);
+                                usb2otg_bulk_out_advance_pktcnt(USBUnit, chan, req, tsize_snap);
+                                USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "bulk-nak");
+                                usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
+                                                     USB2OTG_BULK_NAK_GATE_UFRAMES);
+                                req->iouh_DriverPrivate1 = (APTR)0;
+                                /* NAK = forward progress — reset transient-error budget */
+                                req->iouh_DriverPrivate2 = (APTR)0;
+
+                                usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                                    &USBUnit->hu_BulkXFerQueue, FALSE);
+                                req = NULL;
+                                }
+                            }
+                            else
+                            {
+                                D(bug("0x10: "));
+                                req->iouh_Req.io_Error = UHIOERR_NAK;
+                                D(DumpChannelRegs(chan));
+                            }
+                        }
+                        else if (intr & USB2OTG_INTRCHAN_BABBLEERROR)
+                        {
+                            bug("[USB2OTG] IRQ: BABBLE chan=%d dev=%d ep=%d\n",
+                                chan, req->iouh_DevAddr, req->iouh_Endpoint);
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+                            req->iouh_Req.io_Error = UHIOERR_BABBLE;
+                        }
+                        else if (intr & USB2OTG_INTRCHAN_FRAMEOVERRUN)
+                        {
+                            /* Frame overrun: requeue with updated timing. */
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+                            if (USBUnit->hu_Channel[chan].hc_Request != req)
+                            {
+                                /* Watchdog already handled this request */
+                                KrnSpinUnLock(&USBUnit->hu_Lock);
+                            }
+                            else
+                            {
+#endif
                             if (req->iouh_Req.io_Command == UHCMD_INTXFER)
+                            {
+                                ULONG interval = req->iouh_Interval;
+                                if ((req->iouh_Flags & UHFF_SPLITTRANS) && interval < 2)
+                                    interval = 2;
+                                ULONG next = (frnm + interval) & 0x7ff;
+                                req->iouh_DriverPrivate1 = (APTR)((frnm << 16) | next);
                                 ADDHEAD(&USBUnit->hu_IntXFerQueue, req);
-
-                            /* Mark channel free */
+                            }
+                            else if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
+                            else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                            {
+                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "frame-overrun");
+                                ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
+                            }
                             USBUnit->hu_Channel[chan].hc_Request = NULL;
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinUnLock(&USBUnit->hu_Lock);
+                            }
+#endif
                             req = NULL;
                         }
-                        else if (intr & 0x400)
+                        else if ((intr & USB2OTG_INTRCHAN_NOTREADY) &&
+                                 req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+                                 req->iouh_Dir == UHDIR_OUT &&
+                                 !(req->iouh_Flags & UHFF_SPLITTRANS))
                         {
-                            bug("0x400: ");
-                            req->iouh_Req.io_Error = UHIOERR_HOSTERROR;
-                            DumpChannelRegs(chan);
+                            /*
+                             * Bulk OUT NYET (HS, non-split) — USB 2.0
+                             * §8.5.1. Device ACKed this transaction but
+                             * cannot accept the next. Handle in SW
+                             * regardless of CHHLTD; HW auto-PING starves
+                             * the device's MCU.
+                             *
+                             * PktCnt over-credits on NYET (BCM2835 quirk):
+                             * cap acked at 1 packet/NYET, matches what
+                             * the bus actually conveyed. See FreeBSD
+                             * dwc_otg.c:1841-1868 (WAIT_ANE).
+                             */
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+                            USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                            {
+                                struct USB2OTGChannel *hc = &USBUnit->hu_Channel[chan];
+                                ULONG tsize_now = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                ULONG char_now  = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                int initial_pktcnt =
+                                    (hc->hc_XferSize + req->iouh_MaxPktSize - 1)
+                                        / (req->iouh_MaxPktSize ? req->iouh_MaxPktSize : 1);
+                                int remaining_pktcnt;
+                                int acked_pktcnt_raw;
+                                int acked_pktcnt;
+                                ULONG accepted;
+                                ULONG act_before;
+
+                                /* Bump per-request NYET hit count so the
+                                 * WAIT-PING dump can distinguish "HW
+                                 * absorbed NYET internally, handler never
+                                 * ran" (count==0) from "handler ran but
+                                 * progress accounting clamped to 0". */
+                                if (hc->hc_NyetCount != 0xFFFF)
+                                    hc->hc_NyetCount++;
+
+                                if (initial_pktcnt == 0)
+                                    initial_pktcnt = 1;
+                                remaining_pktcnt = (tsize_now >> 19) & 0x3FF;
+                                acked_pktcnt_raw = initial_pktcnt - remaining_pktcnt;
+                                if (acked_pktcnt_raw < 0)
+                                    acked_pktcnt_raw = 0;
+
+                                /*
+                                 * BCM2835 over-reports PktCnt on NYET —
+                                 * cross-check against XferSize delta and
+                                 * use the smaller. See helper comment for
+                                 * full rationale.
+                                 */
+                                {
+                                    ULONG xfer_remaining = tsize_now & 0x7FFFF;
+                                    ULONG bytes_from_xfersize;
+                                    ULONG bytes_from_pktcnt;
+                                    ULONG bytes_acked;
+
+                                    if (xfer_remaining > (ULONG)hc->hc_XferSize)
+                                        xfer_remaining = hc->hc_XferSize;
+                                    bytes_from_xfersize = hc->hc_XferSize - xfer_remaining;
+                                    bytes_from_pktcnt = (ULONG)acked_pktcnt_raw * req->iouh_MaxPktSize;
+
+                                    bytes_acked = bytes_from_pktcnt < bytes_from_xfersize
+                                        ? bytes_from_pktcnt : bytes_from_xfersize;
+                                    bytes_acked -= bytes_acked % req->iouh_MaxPktSize;
+
+                                    accepted = bytes_acked;
+                                    if (accepted > (ULONG)hc->hc_XferSize)
+                                        accepted = hc->hc_XferSize;
+                                    if (req->iouh_Actual + accepted > req->iouh_Length)
+                                        accepted = req->iouh_Length - req->iouh_Actual;
+
+                                    acked_pktcnt = accepted / req->iouh_MaxPktSize;
+                                }
+
+                                act_before = req->iouh_Actual;
+                                req->iouh_Actual += accepted;
+
+                                if (acked_pktcnt & 1)
+                                    USBUnit->hu_PIDBits[req->iouh_DevAddr] ^=
+                                        (USB2OTG_PID_DATA1 << (2 * req->iouh_Endpoint));
+
+                                D(
+                                    {
+                                        static ULONG nyet_diag = 0;
+                                        nyet_diag++;
+                                        if (usb2otg_diag_log_rate(nyet_diag))
+                                            bug("[USB2OTG:NYET] #%lu chan=%d dev=%d ep=%d intr=%04x"
+                                                " char=%08x tsize=%08x burst=%d init=%d rem=%d"
+                                                " ackedRaw=%d acked=%d acc=%lu act=%lu->%lu/%lu pid=%u\n",
+                                                (unsigned long)nyet_diag, chan,
+                                                (int)req->iouh_DevAddr,
+                                                (int)req->iouh_Endpoint,
+                                                (unsigned int)intr,
+                                                (unsigned int)char_now,
+                                                (unsigned int)tsize_now,
+                                                (int)hc->hc_XferSize,
+                                                initial_pktcnt, remaining_pktcnt,
+                                                acked_pktcnt_raw, acked_pktcnt,
+                                                (unsigned long)accepted,
+                                                (unsigned long)act_before,
+                                                (unsigned long)req->iouh_Actual,
+                                                (unsigned long)req->iouh_Length,
+                                                (unsigned)((USBUnit->hu_PIDBits[req->iouh_DevAddr] >>
+                                                    (2 * req->iouh_Endpoint)) & 3));
+                                    }
+                                )
+                            }
+
+                            /*
+                             * Transfer complete via NYET: device ACKed
+                             * the last packet but signalled "slow down for
+                             * the next one" — except there IS no next
+                             * packet, so we're done. Without this check,
+                             * the requeue path below would re-arm with
+                             * xfer_size=0 + DoPing=1, causing immediate
+                             * bare-CHHLTD and an infinite retry loop.
+                             */
+                            if (req->iouh_Actual >= req->iouh_Length)
+                            {
+                                /* Forward progress — clear PING state for
+                                 * this endpoint so subsequent transfers
+                                 * don't unnecessarily PING. */
+                                USBUnit->hu_Channel[chan].hc_PingPending = 0;
+                                USBUnit->hu_PingBits[req->iouh_DevAddr] &=
+                                    ~(1U << req->iouh_Endpoint);
+
+                                wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                                usb2otg_halt_channel_preserve_char(chan);
+                                USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+
+                                req->iouh_Req.io_Error = 0;
+                                req->iouh_DriverPrivate1 = (APTR)0;
+                                req->iouh_DriverPrivate2 = (APTR)0;
+
+                                usb2otg_diag_bulk_finish(USBUnit, chan, req);
+                                usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                                    &USBUnit->hu_FinishedXfers, FALSE);
+                                req = NULL;
+                                continue;
+                            }
+
+                            /* NYET is forward progress — reset retry budget */
+                            req->iouh_DriverPrivate2 = (APTR)0;
+
+                            /*
+                             * USB 2.0 §8.5.1: after NYET, OUT transactions
+                             * MUST be preceded by PING. Set BOTH the
+                             * channel flag and the per-endpoint bit —
+                             * SetupChannel clears the channel flag on
+                             * requeue, so the per-ep bit restores it.
+                             */
+#if USB2OTG_USE_PING_FLOW
+                            USBUnit->hu_Channel[chan].hc_PingPending = 1;
+                            USBUnit->hu_PingBits[req->iouh_DevAddr] |=
+                                (1U << req->iouh_Endpoint);
+#endif
+
+                            /* ~500 ms NAK gate. <= ~8000 µframes to avoid
+                             * 14-bit half-wrap aliasing. */
+                            usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
+                                                 4000);
+                            req->iouh_DriverPrivate1 = (APTR)0;
+                            usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "bulk-out-nyet");
+                            usb2otg_post_halt_bulk_out_settle();
+
+                            usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                                &USBUnit->hu_BulkXFerQueue, FALSE);
+                            req = NULL;
+                        }
+                        else if ((intr & USB2OTG_INTRCHAN_HALT) && !(intr & USB2OTG_INTRCHAN_TRANSFERCOMPLETE))
+                        {
+                            /*
+                             * Bare CHHLTD (no XferCompl, no error). In
+                             * Buffer DMA mode bulk NAK arrives this way;
+                             * for INT it's a missed microframe. Treat as
+                             * NAK with short retry. Snapshot regs before
+                             * clearing.
+                             */
+                            ULONG chhltd_tsize = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                            D(ULONG chhltd_char = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));)
+                            D(ULONG chhltd_dma = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));)
+                            D(ULONG chhltd_nptx = rd32le(USB2OTG_NONPERIFIFOSTATUS);)
+                            D(ULONG chhltd_hfnum = rd32le(USB2OTG_HOSTFRAMENO);)
+                            D(ULONG chhltd_port = rd32le(USB2OTG_HOSTPORT);)
+
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+                            if (USBUnit->hu_Channel[chan].hc_Request != req)
+                            {
+                                KrnSpinUnLock(&USBUnit->hu_Lock);
+                            }
+                            else
+                            {
+#endif
+                            if (chan >= CHAN_INT1 && chan <= CHAN_INT_LAST)
+                            {
+                                if (req->iouh_DevAddr < 8)
+                                {
+                                    usb2otg_int_chh_count[req->iouh_DevAddr]++;
+                                    usb2otg_int_chh_last_intr[req->iouh_DevAddr] = intr;
+                                    usb2otg_int_chh_seen_intr[req->iouh_DevAddr] |= intr;
+                                }
+                                ULONG interval = req->iouh_Interval;
+                                if ((req->iouh_Flags & UHFF_SPLITTRANS) && interval < 2)
+                                    interval = 2;
+                                ULONG next = (frnm + interval) & 0x7ff;
+                                req->iouh_DriverPrivate1 = (APTR)((frnm << 16) | next);
+                                ADDTAIL(&USBUnit->hu_IntXFerQueue, req);
+                            }
+                            else if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                                ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
+                            else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                            {
+                                ULONG bulk_old_actual = req->iouh_Actual;
+                                BOOL bulk_hidden_nyet = FALSE;
+
+                                /*
+                                 * PING-only completion (PingState==2):
+                                 * NAK → keep PING, install gate, retry.
+                                 * ACK/bare → clear PING, requeue for DATA.
+                                 */
+                                if (USBUnit->hu_Channel[chan].hc_PingState == 2)
+                                {
+                                    BOOL ping_nak = (intr & USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE) != 0;
+
+                                    D(
+                                        {
+                                            static ULONG ping_done_count = 0;
+                                            BOOL ping_ack = (intr & USB2OTG_INTRCHAN_ACKNOWLEDGE) != 0;
+
+                                            ping_done_count++;
+                                            if (usb2otg_diag_log_rate(ping_done_count))
+                                            {
+                                                bug("[USB2OTG:PING] DONE #%lu chan=%d dev=%d ep=%d intr=%04x %s\n",
+                                                    (unsigned long)ping_done_count,
+                                                    chan,
+                                                    (int)req->iouh_DevAddr,
+                                                    (int)req->iouh_Endpoint,
+                                                    (unsigned)intr,
+                                                    ping_nak ? "NAK" :
+                                                    ping_ack ? "ACK" : "bare");
+                                            }
+                                        }
+                                    )
+
+                                    if (ping_nak)
+                                    {
+                                        /* Flash-busy: keep PING, gate, retry. */
+                                        USBUnit->hu_Channel[chan].hc_PingState = 0;
+                                        usb2otg_nak_gate_set(USBUnit,
+                                            req->iouh_DevAddr, 4000);
+                                    }
+                                    else
+                                    {
+                                        /* ACK/bare → next arm carries DATA. */
+                                        USBUnit->hu_Channel[chan].hc_PingPending = 0;
+                                        USBUnit->hu_Channel[chan].hc_PingState = 0;
+                                        USBUnit->hu_PingBits[req->iouh_DevAddr] &=
+                                            ~(1UL << req->iouh_Endpoint);
+                                    }
+
+                                    /* PING-only carried no data; skip bare-CHHLTD bookkeeping. */
+                                    usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr,
+                                        ping_nak ? "ping-nak" : "ping-ack");
+                                    req->iouh_DriverPrivate1 = (APTR)0;
+                                    ADDTAIL(&USBUnit->hu_BulkXFerQueue, req);
+                                    goto ping_done_requeue;
+                                }
+
+                                /* Multi-packet bulk-OUT progress accounting. */
+                                usb2otg_bulk_out_advance_pktcnt(USBUnit, chan, req, chhltd_tsize);
+
+                                /*
+                                 * Hidden-NYET synthesis: HS direct bulk-OUT
+                                 * with progress but not done = device flow-
+                                 * controlled mid-burst. Some BCM2835 DWC2
+                                 * cases expose this as bare CHHLTD without
+                                 * HCINT.NYET, so next arm must set DoPing.
+                                 * Skip on XACTERR (bus-level, not flash-busy).
+                                 */
+                                if ((req->iouh_Dir == UHDIR_OUT) &&
+                                    !(req->iouh_Flags & UHFF_SPLITTRANS) &&
+                                    (req->iouh_Flags & UHFF_HIGHSPEED) &&
+                                    (req->iouh_Actual > bulk_old_actual) &&
+                                    (req->iouh_Actual < req->iouh_Length) &&
+                                    !(intr & USB2OTG_INTRCHAN_TRANSACTIONERROR))
+                                {
+#if USB2OTG_USE_PING_FLOW
+                                    USBUnit->hu_Channel[chan].hc_PingPending = 1;
+                                    USBUnit->hu_PingBits[req->iouh_DevAddr] |=
+                                        (1U << req->iouh_Endpoint);
+#endif
+                                    bulk_hidden_nyet = TRUE;
+                                }
+
+                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr,
+                                    bulk_hidden_nyet ? "bare-chhltd-hidden-nyet"
+                                                     : "bare-chhltd");
+
+                                {
+                                    struct USB2OTGChannel *hc = &USBUnit->hu_Channel[chan];
+                                    UBYTE np = hc->hc_DiagNoProgressCount;
+
+                                    /* Absolute cap: not reset by np-reset below. */
+                                    if (hc->hc_BareChhltdTotal < 0xFFFF)
+                                        hc->hc_BareChhltdTotal++;
+
+                                    D(
+                                        {
+                                            static ULONG bare_chhltd_total = 0;
+                                            bare_chhltd_total++;
+
+                                            if (np <= 3 || np == 100 || np == 200 ||
+                                                (bare_chhltd_total & 0xffff) == 0)
+                                            {
+                                                ULONG hcint_now =
+                                                    rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
+                                                ULONG hfnum_now =
+                                                    rd32le(USB2OTG_HOSTFRAMENO);
+                                                ULONG core_intr =
+                                                    rd32le(USB2OTG_INTR);
+                                                ULONG host_intr =
+                                                    rd32le(USB2OTG_HOSTINTR);
+                                                ULONG start_hfnum =
+                                                    hc->hc_StartHfnum;
+                                                LONG uframe_delta =
+                                                    (start_hfnum != 0)
+                                                        ? (LONG)((hfnum_now & 0x3fff) -
+                                                                 (start_hfnum & 0x3fff)) & 0x3fff
+                                                        : -1;
+                                                ULONG pidbits =
+                                                    (USBUnit->hu_PIDBits[req->iouh_DevAddr] >>
+                                                     (2 * req->iouh_Endpoint)) & 3;
+                                                bug("[USB2OTG:MSS] BARE-CHHLTD np=%u rq=%u total=%u nyet=%u chan=%d dev=%d ep=%d dir=%s act=%lu/%lu\n"
+                                                    "  CHAR=%08x TSIZE=%08x DMA=%08x INTR_raw=%04x HCINT_now=%08x\n"
+                                                    "  NPTXSTS=%08x HFNUM=%08x HOSTPORT=%08x\n"
+                                                    "  start_hfnum=%08x ufdelta=%d coreINTR=%08x HAINT=%08x PID=%u\n",
+                                                    (unsigned)np,
+                                                    (unsigned)hc->hc_DiagRequeueCount,
+                                                    bare_chhltd_total,
+                                                    (unsigned)hc->hc_NyetCount,
+                                                    chan,
+                                                    (int)req->iouh_DevAddr,
+                                                    (int)req->iouh_Endpoint,
+                                                    req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+                                                    (unsigned long)req->iouh_Actual,
+                                                    (unsigned long)req->iouh_Length,
+                                                    chhltd_char,
+                                                    chhltd_tsize,
+                                                    chhltd_dma,
+                                                    (unsigned int)intr,
+                                                    hcint_now,
+                                                    chhltd_nptx,
+                                                    chhltd_hfnum,
+                                                    chhltd_port,
+                                                    start_hfnum,
+                                                    uframe_delta,
+                                                    core_intr,
+                                                    host_intr,
+                                                    (unsigned)pidbits);
+                                            }
+                                        }
+                                    )
+
+                                    /*
+                                     * Idle bulk-IN and bulk-OUT in PING flow
+                                     * bypass the np-counter giveup (legit
+                                     * NAK pattern). Absolute cap still
+                                     * applies via hc_BareChhltdTotal.
+                                     */
+                                    BOOL out_ping_flow =
+                                        req->iouh_Dir == UHDIR_OUT &&
+                                        hc->hc_PingPending != 0;
+                                    /* OUT-PING: 30 × 500 ms = 15 s budget.
+                                     * Non-PING: 1500 × ~1 ms = ~1.5 s. */
+                                    ULONG total_cap = out_ping_flow ? 30 : 1500;
+                                    BOOL skip_np_giveup =
+                                        (req->iouh_Dir == UHDIR_IN &&
+                                         req->iouh_Actual == 0) ||
+                                        out_ping_flow;
+                                    if ((np >= 250 && !skip_np_giveup) ||
+                                        hc->hc_BareChhltdTotal >= total_cap)
+                                    {
+                                        bug("[USB2OTG:MSS] BARE-CHHLTD giving up after %u no-progress chan=%d dev=%d ep=%d dir=%s act=%lu/%lu\n",
+                                            (unsigned)np, chan,
+                                            (int)req->iouh_DevAddr,
+                                            (int)req->iouh_Endpoint,
+                                            req->iouh_Dir == UHDIR_IN ? "IN" : "OUT",
+                                            (unsigned long)req->iouh_Actual,
+                                            (unsigned long)req->iouh_Length);
+                                        req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                                        /* Defensive PING clear; some failure
+                                         * paths skip CLEAR_HALT, next CBW
+                                         * would re-wedge with DoPing=1. */
+                                        hc->hc_PingPending = 0;
+                                        USBUnit->hu_PingBits[req->iouh_DevAddr] &=
+                                            ~(1UL << req->iouh_Endpoint);
+                                        /* Flush NPTxFIFO so next CBW lands clean. */
+                                        if (req->iouh_Dir == UHDIR_OUT)
+                                        {
+                                            wr32le(USB2OTG_RESET,
+                                                USB2OTG_RESET_TXFIFOFLUSH | (0 << 6));
+                                            {
+                                                int timeout = 10000;
+                                                while ((rd32le(USB2OTG_RESET)
+                                                        & USB2OTG_RESET_TXFIFOFLUSH)
+                                                       && --timeout > 0)
+                                                    asm volatile("mov r0, r0\n");
+                                            }
+                                            bug("[USB2OTG:MSS] BARE-CHHLTD NP-TX-FIFO-FLUSH after giveup chan=%d dev=%d ep=%d\n",
+                                                chan,
+                                                (int)req->iouh_DevAddr,
+                                                (int)req->iouh_Endpoint);
+                                        }
+                                        /* Do NOT reset PID toggle: would desync
+                                         * a marginal device. Canonical recovery
+                                         * is BOT Reset + CLEAR_HALT, handled
+                                         * in TermIO. */
+                                        usb2otg_diag_bulk_finish(USBUnit, chan, req);
+                                        USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                                        USBUnit->hu_Channel[chan].hc_Request = NULL;
+                                        ADDTAIL(&USBUnit->hu_FinishedXfers, (struct Node *)req);
+                                    }
+                                    else
+                                    {
+                                        USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                                        if (out_ping_flow)
+                                        {
+                                            /* Bare-CHHLTD in PING flow = device
+                                             * NAK-storming PING; 500 ms gate. */
+                                            usb2otg_nak_gate_set(USBUnit,
+                                                req->iouh_DevAddr, 4000);
+                                            req->iouh_DriverPrivate1 = (APTR)0;
+                                            hc->hc_DiagNoProgressCount = 0;
+                                        }
+                                        else if (req->iouh_Dir == UHDIR_IN && req->iouh_Actual == 0 && np >= 250)
+                                        {
+                                            /* IN-idle long backoff. */
+                                            usb2otg_nak_gate_set(USBUnit,
+                                                req->iouh_DevAddr, 200);
+                                            hc->hc_DiagNoProgressCount = 0;
+                                        }
+                                        else
+                                        {
+                                            usb2otg_nak_gate_set(USBUnit,
+                                                req->iouh_DevAddr,
+                                                USB2OTG_BULK_NAK_GATE_UFRAMES);
+                                            if (bulk_hidden_nyet)
+                                                req->iouh_DriverPrivate1 = (APTR)0;
+                                        }
+                                        ADDTAIL(&USBUnit->hu_BulkXFerQueue, req);
+                                    }
+                                }
+                            }
+                          ping_done_requeue:
+                            USBUnit->hu_Channel[chan].hc_Request = NULL;
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinUnLock(&USBUnit->hu_Lock);
+                            }
+#endif
+                            req = NULL;
                         }
                         else
                         {
-                            bug("Unknown %04x: ", intr);
-                            DumpChannelRegs(chan);
+                            D(bug("[USB2OTG] IRQ: Unknown %04x chan=%d dev=%d ep=%d\n",
+                                intr, chan, req->iouh_DevAddr, req->iouh_Endpoint));
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
                         }
 
 
-                        /* If there is no transfer continuation on that channel then free it and reply the msg */
-                        if (cont == 0)
+                        /* req==NULL means already requeued (NAK/frame-overrun/split-NYET). */
+                        if (cont == 0 && req != NULL)
                         {
-                            USBUnit->hu_Channel[chan].hc_Request = NULL;
-                            if (req) ADDTAIL(&USBUnit->hu_FinishedXfers, (struct Node *)req);//FNAME_DEV(TermIO)(req, USB2OTGBase);
+                            usb2otg_diag_bulk_finish(USBUnit, chan, req);
+                            usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
+                                &USBUnit->hu_FinishedXfers, FALSE);
                         }
                     }
                 }
 //intr...
             }
         }
-    }
-#if 0
-    if (delayed_frnm != frnm)
-    {
-        int chan;
-        for (chan=0; chan < 8; chan++)
+
+        /* Trigger PendingInt so FinishedXfers run on IRQ return. */
         {
-            if (delayed_channel & (1 << chan))
-            {
-                FNAME_DEV(StartChannel)(USBUnit, chan);
-            }
-        }
-        delayed_channel = 0;
-    }
-#endif
-    {
-        ULONG reg, msk;
-
-
-        reg = rd32le(USB2OTG_OTGINTR);
-
-        if (reg)
-        {
-//            bug("leaving interrupt with OTGINTR active: %08x\n", reg);
-        }
-
-        reg = rd32le(USB2OTG_INTR);
-        msk = rd32le(USB2OTG_INTRMASK);
-
-        if (reg & msk)
-        {
-//            bug("leaving interrupt with INTR active: %08x %08x %08\n", reg, msk, reg&msk);
-        }
-
-        for (int i=0; i < 8; i++)
-        {
-            if (reg & (1 << i))
-            {
-                //bug("HOSTCHAN: ")
-            }
+            /* IRQ context — no lock needed, nothing can preempt */
+            if (!IsListEmpty(&USBUnit->hu_FinishedXfers))
+                FNAME_DEV(Cause)(USBUnit->hu_USB2OTGBase, &USBUnit->hu_PendingInt);
         }
     }
 }
 
 
-AROS_INTH1(FNAME_DEV(PendingInt), struct USB2OTGUnit *, otg_Unit)
+static BOOL usb2otg_process_pending(struct USB2OTGUnit *otg_Unit)
 {
-    AROS_INTFUNC_INIT
-
-    //struct USB2OTGDevice * USB2OTGBase = otg_Unit->hu_USB2OTGBase;
-    //D(bug("[USB2OTG] [0x%p:PEND] Pending Work Interupt\n", otg_Unit));
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
 
     /* **************** PROCESS DONE TRANSFERS **************** */
 
@@ -498,105 +1587,714 @@ AROS_INTH1(FNAME_DEV(PendingInt), struct USB2OTGUnit *, otg_Unit)
 
     struct IOUsbHWReq * req = NULL;
 
-    while((req = (struct IOUsbHWReq *)REMHEAD(&otg_Unit->hu_FinishedXfers)))
+    for (;;)
     {
+        Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        req = (struct IOUsbHWReq *)REMHEAD(&otg_Unit->hu_FinishedXfers);
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+        Enable();
+        if (!req)
+            break;
         FNAME_DEV(TermIO)(req, otg_Unit->hu_USB2OTGBase);
     }
 
-    if (otg_Unit->hu_CtrlXFerQueue.lh_Head->ln_Succ)
-    {
-        D(bug("[USB2OTG] [0x%p:PEND] Process CtrlXFer ..\n", otg_Unit));
+    if (!IsListEmpty(&otg_Unit->hu_CtrlXFerQueue))
         FNAME_DEV(ScheduleCtrlTDs)(otg_Unit);
-    }
 
-    if (otg_Unit->hu_IntXFerQueue.lh_Head->ln_Succ)
-    {
-//        D(bug("[USB2OTG] [0x%p:PEND] Process IntXFer ..\n", otg_Unit));
+    if (!IsListEmpty(&otg_Unit->hu_IntXFerScheduled))
         FNAME_DEV(ScheduleIntTDs)(otg_Unit);
-    }
 
-    if (otg_Unit->hu_BulkXFerQueue.lh_Head->ln_Succ)
-    {
-        D(bug("[USB2OTG] [0x%p:PEND] Process BulkXFer ..\n", otg_Unit));
-//        FNAME_DEV(ScheduleBulkTDs)(otg_Unit);
-    }
+    if (!IsListEmpty(&otg_Unit->hu_BulkXFerQueue))
+        FNAME_DEV(ScheduleBulkTDs)(otg_Unit);
 
     //D(bug("[USB2OTG] [0x%p:PEND] finished\n", otg_Unit));
 
     return FALSE;
+}
+
+AROS_INTH1(FNAME_DEV(PendingInt), struct USB2OTGUnit *, otg_Unit)
+{
+    AROS_INTFUNC_INIT
+
+    struct USB2OTGDevice * USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return FALSE;
+
+    return usb2otg_process_pending(otg_Unit);
 
     AROS_INTFUNC_EXIT
+}
+
+static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
+{
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+
+    /*
+     * Channel watchdog: detect stuck channels (lost completion IRQ,
+     * lost split, DWC2 wedge). CHENA=0 with hc_Request set → force
+     * timeout; CHENA=1 too long → halt+fail with HCLKSOFT escalation.
+     */
+#if 1
+    BOOL watchdog_finished = FALSE;
+
+    {
+        int chan;
+        struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+
+        for (chan = 0; chan < 8; chan++)
+        {
+            struct IOUsbHWReq *req;
+
+            Disable();
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            req = otg_Unit->hu_Channel[chan].hc_Request;
+            if (req == NULL)
+            {
+#if defined(__AROSEXEC_SMP__)
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                Enable();
+                otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                continue;
+            }
+            /* Parked-NAK channel idles for the gate; not stuck. */
+            if (otg_Unit->hu_Channel[chan].hc_NakParked)
+            {
+#if defined(__AROSEXEC_SMP__)
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                Enable();
+                otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                continue;
+            }
+
+            ULONG charbase = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+
+            if (!(charbase & USB2OTG_HOSTCHAR_ENABLE))
+            {
+                uint32_t intr = rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
+
+                /*
+                 * Lost-IRQ recovery: CHENA=0 + XFERCOMPL + no errors =
+                 * HW completed, IRQ not yet processed. Run the normal
+                 * AdvanceChannel path; applies to all channel types.
+                 */
+                if ((intr & USB2OTG_INTRCHAN_TRANSFERCOMPLETE) &&
+                    !(intr & (USB2OTG_INTRCHAN_STALL |
+                              USB2OTG_INTRCHAN_TRANSACTIONERROR |
+                              USB2OTG_INTRCHAN_BABBLEERROR)))
+                {
+                    D(bug("[USB2OTG] Watchdog: chan=%d lost IRQ, completing normally for dev=%d ep=%d intr=%04x\n",
+                        chan, req->iouh_DevAddr, req->iouh_Endpoint, intr));
+
+                    wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                    req->iouh_Req.io_Error = 0;
+
+                    if (FNAME_DEV(AdvanceChannel)(otg_Unit, chan))
+                    {
+                        otg_Unit->hu_Channel[chan].hc_Request = NULL;
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                        ADDTAIL(&otg_Unit->hu_FinishedXfers, (struct Node *)req);
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                        watchdog_finished = TRUE;
+                    }
+                    else
+                    {
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                        FNAME_DEV(StartChannel)(otg_Unit, chan, 0);
+                    }
+                }
+                else if (intr == USB2OTG_INTR_HALT_ACK &&
+                         (rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)) & USB2OTG_HCSPLT_CSPLIT) == USB2OTG_HCSPLT_SSPLIT)
+                {
+                    /* Lost-IRQ recovery: SSPLIT ACKed, arm CSPLIT. */
+                    D(bug("[USB2OTG] Watchdog: chan=%d lost IRQ split-ACK, arming CSPLIT for dev=%d ep=%d intr=%04x\n",
+                        chan, req->iouh_DevAddr, req->iouh_Endpoint, intr));
+                    uint32_t tmp = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                    tmp |= 1 << 16;
+                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), tmp);
+                    otg_Unit->hu_Channel[chan].hc_SplitCSplitPending = 1;
+                    wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                    otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+#if defined(__AROSEXEC_SMP__)
+                    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                    Enable();
+                    FNAME_DEV(StartChannel)(otg_Unit, chan, 1);
+                }
+                else
+                {
+                    /* CHENA=0 with unrecognized INTR — wait for IRQ to catch up. */
+                    UBYTE wd_thresh_off = usb2otg_watchdog_ticks(req);
+                    otg_Unit->hu_Channel[chan].hc_WatchdogCount++;
+                    if (otg_Unit->hu_Channel[chan].hc_WatchdogCount < wd_thresh_off)
+                    {
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                    }
+                    else if (chan >= CHAN_INT1 && chan <= CHAN_INT_LAST &&
+                             (intr & (0x10 | 0x40)) /* NAK or NYET */)
+                    {
+                        /* INT NAK missed by IRQ — requeue, don't time out. */
+                        ULONG frnm = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
+                        ULONG interval = req->iouh_Interval;
+                        ULONG next = (frnm + interval) & 0x7ff;
+
+                        wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+
+                        req->iouh_DriverPrivate1 = (APTR)((frnm << 16) | next);
+                        ADDHEAD(&otg_Unit->hu_IntXFerQueue, req);
+                        otg_Unit->hu_Channel[chan].hc_Request = NULL;
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                    }
+                    else if (intr == 0 &&
+                             otg_Unit->hu_Channel[chan].hc_WatchdogCount < 16)
+                    {
+                        /*
+                         * INTR=0 + CHENA=0 + hc_Request set = IRQ cleared
+                         * INTR but not yet updated hc_Request. Transient,
+                         * not stuck. Wait up to 16 ticks (2.4 s).
+                         */
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount++;
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                    }
+                    else
+                    {
+                        {
+                            ULONG hcchar  = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                            ULONG hcsplt  = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                            ULONG hctsiz  = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                            ULONG hfnum   = rd32le(USB2OTG_HOSTFRAMENO);
+                            ULONG started = otg_Unit->hu_Channel[chan].hc_StartHfnum;
+
+                            bug("[USB2OTG] Watchdog: chan=%d stuck (CHENA=0), forcing timeout for dev=%d ep=%d intr=%04x\n",
+                                chan, req->iouh_DevAddr, req->iouh_Endpoint, intr);
+                            bug("[USB2OTG:STUCK] HCCHAR=%08lx HCSPLT=%08lx HCTSIZ=%08lx HFNUM=%08lx (armed@%08lx)\n",
+                                (ULONG)hcchar, (ULONG)hcsplt, (ULONG)hctsiz,
+                                (ULONG)hfnum, (ULONG)started);
+                            bug("[USB2OTG:STUCK] req: cmd=%d flags=%08lx mps=%u dev=%u ep=%u dir=%u splithub=%u splitport=%u csplit_pending=%u\n",
+                                (int)req->iouh_Req.io_Command,
+                                (ULONG)req->iouh_Flags,
+                                (unsigned)req->iouh_MaxPktSize,
+                                (unsigned)req->iouh_DevAddr,
+                                (unsigned)req->iouh_Endpoint,
+                                (unsigned)req->iouh_Dir,
+                                (unsigned)req->iouh_SplitHubAddr,
+                                (unsigned)req->iouh_SplitHubPort,
+                                (unsigned)otg_Unit->hu_Channel[chan].hc_SplitCSplitPending);
+
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+
+                            req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                            usb2otg_diag_bulk_finish(otg_Unit, chan, req);
+                            otg_Unit->hu_Channel[chan].hc_Request = NULL;
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                            ADDTAIL(&otg_Unit->hu_FinishedXfers, (struct Node *)req);
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                            Enable();
+                            watchdog_finished = TRUE;
+                        }
+                    }
+                }
+            }
+            else
+            {
+#if defined(__AROSEXEC_SMP__)
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                Enable();
+                otg_Unit->hu_Channel[chan].hc_WatchdogCount++;
+                /* WD threshold per-transfer-type — see usb2otg_watchdog_ticks(). */
+                {
+                UBYTE wd_thresh = usb2otg_watchdog_ticks(req);
+                if (otg_Unit->hu_Channel[chan].hc_WatchdogCount >= wd_thresh)
+                {
+                    ULONG w_char = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                    ULONG w_intr = rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
+                    ULONG w_split = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                    ULONG w_tsize = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+
+                    if (w_intr & (USB2OTG_INTRCHAN_TRANSFERCOMPLETE |
+                                  USB2OTG_INTRCHAN_HALT))
+                    {
+                        /* Completion bits latched, IRQ behind — defer 16 ticks. */
+                        if (otg_Unit->hu_Channel[chan].hc_DeferCount < 16)
+                        {
+                            otg_Unit->hu_Channel[chan].hc_DeferCount++;
+                            /* Log only at streak start to avoid UART flood. */
+                            D(
+                                if (usb2otg_trace_bulk_ep2(chan, req) &&
+                                    otg_Unit->hu_Channel[chan].hc_DeferCount == 1)
+                                {
+                                    bug("[USB2OTG:TRACE] WATCHDOG-COMPLETION-DEFER chan=%d intr=%04x split=%08x char=%08x tsize=%08x\n",
+                                        chan, (unsigned int)w_intr, w_split, w_char, w_tsize);
+                                }
+                            )
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                            continue;
+                        }
+
+                        bug("[USB2OTG] Watchdog: chan=%d COMPLETION-DEFER cap hit (defer=%u) — giving up\n",
+                            chan,
+                            (unsigned)otg_Unit->hu_Channel[chan].hc_DeferCount);
+                        otg_Unit->hu_Channel[chan].hc_DeferCount = 0;
+                        /* fall through to active-too-long halt+fail */
+                    }
+
+                    if ((req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                        (req->iouh_Flags & UHFF_SPLITTRANS) &&
+                        (w_split & USB2OTG_HCSPLT_SPLITEN) &&
+                        (w_intr & USB2OTG_INTRCHAN_NEGATIVEACKNOWLEDGE))
+                    {
+                        if ((w_split & USB2OTG_HCSPLT_COMPLSPLT) == 0)
+                        {
+                            ULONG tmp = w_split | USB2OTG_HCSPLT_COMPLSPLT;
+
+                            wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), tmp);
+                            otg_Unit->hu_Channel[chan].hc_SplitCSplitPending = 1;
+
+                            D(
+                                if (usb2otg_trace_bulk_ep2(chan, req))
+                                {
+                                    bug("[USB2OTG:TRACE] WATCHDOG-PROMOTE chan=%d intr=%04x split=%08x -> %08x char=%08x tsize=%08x\n",
+                                        chan, (unsigned int)w_intr, w_split, tmp, w_char, w_tsize);
+                                }
+                            )
+
+                            FNAME_DEV(StartChannel)(otg_Unit, chan, 1);
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                            continue;
+                        }
+
+                        /* CSPLIT+NAK = TT busy; defer up to 16 ticks. */
+                        if (otg_Unit->hu_Channel[chan].hc_DeferCount < 16)
+                        {
+                            otg_Unit->hu_Channel[chan].hc_DeferCount++;
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+
+                            /* Log only at streak start (avoid UART flood). */
+                            D(
+                                if (usb2otg_trace_bulk_ep2(chan, req) &&
+                                    otg_Unit->hu_Channel[chan].hc_DeferCount == 1)
+                                {
+                                    bug("[USB2OTG:TRACE] WATCHDOG-DEFER-CSPLIT chan=%d intr=%04x split=%08x char=%08x tsize=%08x\n",
+                                        chan, (unsigned int)w_intr, w_split, w_char, w_tsize);
+                                }
+                            )
+                            continue;
+                        }
+
+                        bug("[USB2OTG] Watchdog: chan=%d CSPLIT-DEFER cap hit dev=%d ep=%d — TT not responding, failing transfer\n",
+                            chan, req->iouh_DevAddr, req->iouh_Endpoint);
+                        otg_Unit->hu_Channel[chan].hc_DeferCount = 0;
+                        /* fall through to active-too-long halt+fail */
+                    }
+
+                    /*
+                     * Direct bulk OUT in PING/NAK flow control (USB 2.0
+                     * §11.17.1): TSIZE.DoPing=1 + INTR.NAK=1 = device
+                     * flash-busy, host must keep polling. Defer up to
+                     * USB2OTG_FLASH_BUSY_DEFER_CAP (~10 min).
+                     */
+                    if ((req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                        (req->iouh_Dir == UHDIR_OUT) &&
+                        !(req->iouh_Flags & UHFF_SPLITTRANS) &&
+                        (w_tsize & USB2OTG_HOSTTSIZE_PING) &&
+                        !(w_intr & (USB2OTG_INTRCHAN_STALL |
+                                    USB2OTG_INTRCHAN_TRANSACTIONERROR |
+                                    USB2OTG_INTRCHAN_BABBLEERROR |
+                                    USB2OTG_INTRCHAN_AHBERROR)))
+                    {
+                        /* HW auto-PING active, no errors — defer. */
+                        if (otg_Unit->hu_Channel[chan].hc_DeferCount < USB2OTG_FLASH_BUSY_DEFER_CAP)
+                        {
+                            otg_Unit->hu_Channel[chan].hc_DeferCount++;
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+
+                            D(
+                                {
+                                    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+                                    UWORD nd = hc->hc_DeferCount;
+                                    int dump_now;
+
+                                    dump_now = (nd == 1 || nd == 2 || nd == 5 ||
+                                                nd == 10 || nd == 20 || nd == 40 ||
+                                                nd == 80 || nd == 160 ||
+                                                (nd > 160 && (nd % 80) == 0));
+
+                                    if (dump_now)
+                                    {
+                                        ULONG d_char  = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                        ULONG d_intr  = rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
+                                        ULONG d_tsize = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                        ULONG d_dmaa  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
+                                        ULONG d_nptx  = rd32le(USB2OTG_NONPERIFIFOSTATUS);
+                                        ULONG d_corei = rd32le(USB2OTG_INTR);
+                                        ULONG d_haint = rd32le(USB2OTG_HOSTINTR);
+                                        ULONG d_hfnum = rd32le(USB2OTG_HOSTFRAMENO);
+                                        LONG hfd = (LONG)((d_hfnum & 0x3fff) -
+                                                          (hc->hc_LastSampleHfnum & 0x3fff));
+                                        if (hfd < 0)
+                                            hfd += 0x4000;
+                                        {
+                                            UWORD  intr_chg = (UWORD)d_intr ^ hc->hc_LastSampleIntr;
+                                            ULONG  tsize_chg = d_tsize ^ hc->hc_LastSampleTsize;
+                                            LONG   actual_chg = (LONG)req->iouh_Actual -
+                                                                (LONG)hc->hc_LastSampleActual;
+                                            bug("[USB2OTG] WAIT-PING chan=%d defer=%u dev=%d ep=%d nyet=%u"
+                                                " CHAR=%08lx INTR=%04lx TSIZE=%08lx DMAA=%08lx NPTX=%08lx"
+                                                " coreINTR=%08lx HAINT=%08lx HFNUM=%08lx hfd=%ld"
+                                                " act=%lu/%lu d[intr^=%04x tsize^=%08lx act+=%ld]\n",
+                                                chan, (unsigned)nd,
+                                                (int)req->iouh_DevAddr,
+                                                (int)req->iouh_Endpoint,
+                                                (unsigned)hc->hc_NyetCount,
+                                                (unsigned long)d_char,
+                                                (unsigned long)d_intr,
+                                                (unsigned long)d_tsize,
+                                                (unsigned long)d_dmaa,
+                                                (unsigned long)d_nptx,
+                                                (unsigned long)d_corei,
+                                                (unsigned long)d_haint,
+                                                (unsigned long)d_hfnum,
+                                                (long)hfd,
+                                                (unsigned long)req->iouh_Actual,
+                                                (unsigned long)req->iouh_Length,
+                                                (unsigned)intr_chg,
+                                                (unsigned long)tsize_chg,
+                                                (long)actual_chg);
+                                        }
+
+                                        hc->hc_LastSampleHfnum  = d_hfnum;
+                                        hc->hc_LastSampleIntr   = (UWORD)d_intr;
+                                        hc->hc_LastSampleTsize  = d_tsize;
+                                        hc->hc_LastSampleActual = req->iouh_Actual;
+                                    }
+                                }
+                            )
+
+                            /*
+                             * Halt between defer cycles. HW auto-PING at
+                             * SOF rate starves device MCU; SW halt+rearm
+                             * with 500 ms NAK gate per cycle gives the
+                             * device bus-idle time. Mirrors FreeBSD
+                             * dwc_otg host_data_tx SM.
+                             */
+                            Disable();
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+                            if (otg_Unit->hu_Channel[chan].hc_Request != req)
+                            {
+                                KrnSpinUnLock(&otg_Unit->hu_Lock);
+                                Enable();
+                                continue;
+                            }
+#endif
+                            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+                            usb2otg_halt_channel_preserve_char(chan);
+                            otg_Unit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+
+                            /* 500 ms NAK gate; PingBits stays set so
+                             * SetupChannel re-arms with DoPing=1 next cycle. */
+                            usb2otg_nak_gate_set(otg_Unit, req->iouh_DevAddr,
+                                                 4000);
+
+                            ADDTAIL(&otg_Unit->hu_BulkXFerQueue, req);
+                            otg_Unit->hu_Channel[chan].hc_Request = NULL;
+#if defined(__AROSEXEC_SMP__)
+                            KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                            Enable();
+                            continue;
+                        }
+
+                        /* Cap hit → fall through to active-too-long for TIMEOUT. */
+                        bug("[USB2OTG] Watchdog: chan=%d WAIT-PING cap hit dev=%d ep=%d — surfacing UHIOERR_TIMEOUT\n",
+                            chan, req->iouh_DevAddr, req->iouh_Endpoint);
+                        otg_Unit->hu_Channel[chan].hc_DeferCount = 0;
+                        /* fall through to active-too-long halt+fail */
+                    }
+
+                    /*
+                     * Direct bulk OUT silent mid-data-phase (CHENA=1, INTR=0,
+                     * DoPing=0, Actual>0). Aborting violates MSC BOT §6.6.1
+                     * and wedges the device. Defer up to FLASH_BUSY_DEFER_CAP
+                     * (or forever — see cap branch below).
+                     */
+                    if ((req->iouh_Req.io_Command == UHCMD_BULKXFER) &&
+                        (req->iouh_Dir == UHDIR_OUT) &&
+                        !(req->iouh_Flags & UHFF_SPLITTRANS) &&
+                        (w_char & USB2OTG_HOSTCHAR_ENABLE) &&
+                        ((w_intr & USB2OTG_INTR_CLEAR_ALL) == 0) &&
+                        !(w_tsize & USB2OTG_HOSTTSIZE_PING) &&
+                        (req->iouh_Actual > 0))
+                    {
+                        if (otg_Unit->hu_Channel[chan].hc_DeferCount < USB2OTG_FLASH_BUSY_DEFER_CAP)
+                        {
+                            otg_Unit->hu_Channel[chan].hc_DeferCount++;
+                            otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                            D(
+                                {
+                                    struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
+                                    UWORD nd = hc->hc_DeferCount;
+                                    int dump_now;
+
+                                    /* Same cadence as WAIT-PING — see comment there. */
+                                    dump_now = (nd == 1 || nd == 2 || nd == 5 ||
+                                                nd == 10 || nd == 20 || nd == 40 ||
+                                                nd == 80 || nd == 160 ||
+                                                (nd > 160 && (nd % 80) == 0));
+
+                                    if (dump_now)
+                                    {
+                                        ULONG d_char  = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                        ULONG d_intr  = rd32le(USB2OTG_CHANNEL_REG(chan, INTR));
+                                        ULONG d_tsize = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                        ULONG d_dmaa  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
+                                        ULONG d_nptx  = rd32le(USB2OTG_NONPERIFIFOSTATUS);
+                                        ULONG d_hfnum = rd32le(USB2OTG_HOSTFRAMENO);
+                                        LONG hfd = (LONG)((d_hfnum & 0x3fff) -
+                                                          (hc->hc_LastSampleHfnum & 0x3fff));
+                                        if (hfd < 0)
+                                            hfd += 0x4000;
+                                        {
+                                            UWORD  intr_chg = (UWORD)d_intr ^ hc->hc_LastSampleIntr;
+                                            ULONG  tsize_chg = d_tsize ^ hc->hc_LastSampleTsize;
+                                            LONG   actual_chg = (LONG)req->iouh_Actual -
+                                                                (LONG)hc->hc_LastSampleActual;
+                                            bug("[USB2OTG] WAIT-QUIET chan=%d defer=%u dev=%d ep=%d nyet=%u"
+                                                " CHAR=%08lx INTR=%04lx TSIZE=%08lx DMAA=%08lx NPTX=%08lx"
+                                                " HFNUM=%08lx hfd=%ld act=%lu/%lu"
+                                                " d[intr^=%04x tsize^=%08lx act+=%ld]\n",
+                                                chan, (unsigned)nd,
+                                                (int)req->iouh_DevAddr,
+                                                (int)req->iouh_Endpoint,
+                                                (unsigned)hc->hc_NyetCount,
+                                                (unsigned long)d_char,
+                                                (unsigned long)d_intr,
+                                                (unsigned long)d_tsize,
+                                                (unsigned long)d_dmaa,
+                                                (unsigned long)d_nptx,
+                                                (unsigned long)d_hfnum,
+                                                (long)hfd,
+                                                (unsigned long)req->iouh_Actual,
+                                                (unsigned long)req->iouh_Length,
+                                                (unsigned)intr_chg,
+                                                (unsigned long)tsize_chg,
+                                                (long)actual_chg);
+                                        }
+
+                                        hc->hc_LastSampleHfnum  = d_hfnum;
+                                        hc->hc_LastSampleIntr   = (UWORD)d_intr;
+                                        hc->hc_LastSampleTsize  = d_tsize;
+                                        hc->hc_LastSampleActual = req->iouh_Actual;
+                                    }
+                                }
+                            )
+                            continue;
+                        }
+
+                        /* Cap reached: never give up mid-data-phase. */
+                        otg_Unit->hu_Channel[chan].hc_DeferCount = 0;
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                        continue;
+                    }
+
+                    {
+                        static ULONG wd_count = 0;
+                        wd_count++;
+                        if (usb2otg_diag_log_rate(wd_count))
+                        {
+                            /* Extended wedge dump for post-mortem. */
+                            ULONG w_dmaa  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
+                            ULONG w_nptx  = rd32le(USB2OTG_NONPERIFIFOSTATUS);
+                            ULONG w_corei = rd32le(USB2OTG_INTR);
+                            ULONG w_haint = rd32le(USB2OTG_HOSTINTR);
+                            ULONG w_hfnum = rd32le(USB2OTG_HOSTFRAMENO);
+                            bug("[USB2OTG] Watchdog: chan=%d active too long dev=%d ep=%d (#%lu)\n"
+                                "  CHAR=%08x INTR=%04x SPLIT=%08x TSIZE=%08x\n"
+                                "  DMAA=%08x NPTX=%08x coreINTR=%08x HAINT=%08x HFNUM=%08x\n",
+                                chan, req->iouh_DevAddr, req->iouh_Endpoint,
+                                (unsigned long)wd_count,
+                                w_char, w_intr, w_split, w_tsize,
+                                w_dmaa, w_nptx, w_corei, w_haint, w_hfnum);
+                        }
+                    }
+
+                    /*
+                     * Claim before halting so the halt-triggered IRQ on
+                     * another CPU sees hc_Request=NULL and skips. Halt
+                     * stays in the lock to prevent reassignment racing.
+                     */
+                    Disable();
+#if defined(__AROSEXEC_SMP__)
+                    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+                    if (otg_Unit->hu_Channel[chan].hc_Request != req)
+                    {
+#if defined(__AROSEXEC_SMP__)
+                        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                        Enable();
+                        otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+                        continue;
+                    }
+
+                    /* Claim now — IRQ path will read hc_Request == NULL and skip */
+                    otg_Unit->hu_Channel[chan].hc_Request = NULL;
+                    otg_Unit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+                    otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
+
+                    /* Fresh TSIZE for advance_pktcnt; w_tsize above may be stale. */
+                    ULONG wd_tsize = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+
+                    usb2otg_halt_channel_preserve_char(chan);
+                    {
+                        /* Belt-and-braces second halt wait (~200 µs). */
+                        int timeout = 200000;
+                        while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
+                            asm volatile("mov r0, r0\n");
+                    }
+
+                    /* If CHENA still stuck after full flush → escalate to HCLKSOFT. */
+                    if (rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE))
+                        & USB2OTG_HOSTCHAR_ENABLE)
+                    {
+                        usb2otg_escalate_hw_reset(otg_Unit, chan);
+                    }
+
+                    wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
+
+                    /* Update Actual so class driver sees accurate progress. */
+                    usb2otg_bulk_out_advance_pktcnt(otg_Unit, chan, req, wd_tsize);
+
+                    /* Defensive PING clear; recovery sometimes hangs. */
+                    otg_Unit->hu_Channel[chan].hc_PingPending = 0;
+                    otg_Unit->hu_PingBits[req->iouh_DevAddr] &=
+                        ~(1UL << req->iouh_Endpoint);
+
+                    /*
+                     * Wedged split INT-IN with INTR=0 ≈ device behind TT
+                     * unplugged. Poke root-hub port-change so Poseidon
+                     * re-walks the tree.
+                     */
+                    if ((req->iouh_Req.io_Command == UHCMD_INTXFER) &&
+                        (req->iouh_Dir == UHDIR_IN) &&
+                        (req->iouh_Flags & UHFF_SPLITTRANS) &&
+                        (w_intr == 0))
+                    {
+                        otg_Unit->hu_HubPortChanged = TRUE;
+                    }
+
+                    req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                    usb2otg_diag_bulk_finish(otg_Unit, chan, req);
+                    ADDTAIL(&otg_Unit->hu_FinishedXfers, (struct Node *)req);
+#if defined(__AROSEXEC_SMP__)
+                    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+                    Enable();
+                    watchdog_finished = TRUE;
+                }
+                } /* wd_thresh scope */
+            }
+        }
+    }
+
+    if (watchdog_finished)
+        FNAME_DEV(Cause)(otg_Unit->hu_USB2OTGBase, &otg_Unit->hu_PendingInt);
+#endif
+
+    FNAME_ROOTHUB(PendingIO)(otg_Unit);
+
+    /* Safety net: promote overdue INT transfers SOF may have missed. */
+    {
+        struct IOUsbHWReq *req = NULL, *next = NULL;
+        ULONG frnm = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
+        BOOL promoted = FALSE;
+        int q_count = 0, s_count = 0, f_count = 0;
+
+        Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        ForeachNodeSafe(&otg_Unit->hu_IntXFerQueue, req, next)
+        {
+            ULONG last_handled = (ULONG)req->iouh_DriverPrivate1 >> 16;
+            ULONG next_to_handle = (ULONG)req->iouh_DriverPrivate1 & 0xfff;
+
+            q_count++;
+
+            if (frnm == next_to_handle ||
+                (frnm > next_to_handle && frnm > last_handled) ||
+                (frnm < last_handled && frnm < next_to_handle) ||
+                (frnm > next_to_handle && frnm < last_handled))
+            {
+                REMOVE(req);
+                ADDTAIL(&otg_Unit->hu_IntXFerScheduled, req);
+                promoted = TRUE;
+                q_count--;
+            }
+        }
+
+        ForeachNode(&otg_Unit->hu_IntXFerScheduled, req)
+            s_count++;
+        ForeachNode(&otg_Unit->hu_FinishedXfers, req)
+            f_count++;
+
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+        Enable();
+
+        if (promoted)
+            FNAME_DEV(ScheduleIntTDs)(otg_Unit);
+    }
+
+    otg_Unit->hu_NakTimeoutReq.tr_time.tv_secs = 0;
+    otg_Unit->hu_NakTimeoutReq.tr_time.tv_micro = 150 * 1000;
+    SendIO((APTR) &otg_Unit->hu_NakTimeoutReq);
+
+    return FALSE;
 }
 
 AROS_INTH1(FNAME_DEV(NakTimeoutInt), struct USB2OTGUnit *, otg_Unit)
 {
     AROS_INTFUNC_INIT
 
-   // struct IOUsbHWReq *ioreq;
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
 
-   D(bug("[USB2OTG] [0x%p:NAK] NakTimeout Interupt\n", otg_Unit));
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return FALSE;
 
-//    ULONG framecnt;
-//    uhciUpdateFrameCounter(hc);
-//    framecnt = hc->hc_FrameCounter;
-#if (0)
-    ioreq = (struct IOUsbHWReq *) otg_Unit->hu_TDQueue.lh_Head;
-    while(((struct Node *) ioreq)->ln_Succ)
-    {
-        if(ioreq->iouh_Flags & UHFF_NAKTIMEOUT)
-        {
-/*            uqh = (struct UhciQH *) ioreq->iouh_DriverPrivate1;
-            if(uqh)
-            {
-                KPRINTF(1, ("Examining IOReq=%p with UQH=%p\n", ioreq, uqh));
-                devadrep = (ioreq->iouh_DevAddr<<5) + ioreq->iouh_Endpoint + ((ioreq->iouh_Dir == UHDIR_IN) ? 0x10 : 0);
-                linkelem = READMEM32_LE(&uqh->uqh_Element);
-                if(linkelem & UHCI_TERMINATE)
-                {
-                    KPRINTF(1, ("UQH terminated %08lx\n", linkelem));
-                    if(framecnt > unit->hu_NakTimeoutFrame[devadrep])
-                    {
-                        // give the thing the chance to exit gracefully
-                        KPRINTF(20, ("Terminated? NAK timeout %ld > %ld, IOReq=%p\n", framecnt, unit->hu_NakTimeoutFrame[devadrep], ioreq));
-                        causeint = TRUE;
-                    }
-                } else {
-                    utd = (struct UhciTD *) (((IPTR)linkelem & UHCI_PTRMASK) - hc->hc_PCIVirtualAdjust - 16); // struct UhciTD starts 16 before physical TD
-                    ctrlstatus = READMEM32_LE(&utd->utd_CtrlStatus);
-                    if(ctrlstatus & UTCF_ACTIVE)
-                    {
-                        if(framecnt > unit->hu_NakTimeoutFrame[devadrep])
-                        {
-                            // give the thing the chance to exit gracefully
-                            KPRINTF(20, ("NAK timeout %ld > %ld, IOReq=%p\n", framecnt, unit->hu_NakTimeoutFrame[devadrep], ioreq));
-                            ctrlstatus &= ~UTCF_ACTIVE;
-                            WRITEMEM32_LE(&utd->utd_CtrlStatus, ctrlstatus);
-                            causeint = TRUE;
-                        }
-                    } else {
-                        if(framecnt > unit->hu_NakTimeoutFrame[devadrep])
-                        {
-                            // give the thing the chance to exit gracefully
-                            KPRINTF(20, ("Terminated? NAK timeout %ld > %ld, IOReq=%p\n", framecnt, unit->hu_NakTimeoutFrame[devadrep], ioreq));
-                            causeint = TRUE;
-                        }
-                    }
-                }
-            }*/
-        }
-        ioreq = (struct IOUsbHWReq *) ((struct Node *) ioreq)->ln_Succ;
-    }
-
-//    uhciCheckPortStatusChange(hc);
-#endif
-    FNAME_ROOTHUB(PendingIO)(otg_Unit);
-
-    otg_Unit->hu_NakTimeoutReq.tr_time.tv_micro = 150 * 1000;
-    SendIO((APTR) &otg_Unit->hu_NakTimeoutReq);
-
-    D(bug("[USB2OTG] [0x%p:NAK] processed\n", otg_Unit));
-
-    return FALSE;
+    return usb2otg_process_naktimeout(otg_Unit);
 
     AROS_INTFUNC_EXIT
 }

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013-2019, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
@@ -10,6 +10,254 @@
 #include <proto/utility.h>
 
 #include "usb2otg_intern.h"
+
+static inline BOOL usb2otg_require_cpu0(struct USB2OTGDevice *USB2OTGBase, const char *where)
+{
+#if defined(__AROSEXEC_SMP__)
+    ULONG cpu = KrnGetCPUNumber();
+    if (cpu != 0)
+    {
+        bug("[USB2OTG:SMP] %s running on CPU %u, expected CPU 0\n", where, (unsigned)cpu);
+        return FALSE;
+    }
+#else
+    (void)where;
+#endif
+    return TRUE;
+}
+
+/* Forward decls — helpers defined further down in this file */
+static int usb2otg_endpoint_in_flight(struct USB2OTGUnit *otg_Unit,
+    struct IOUsbHWReq *candidate);
+static int usb2otg_tt_in_flight(struct USB2OTGUnit *otg_Unit,
+    struct IOUsbHWReq *candidate);
+
+/* TRUE if dev_addr has un-gated bulk work queued (for channel reclaim). */
+static BOOL usb2otg_dev_has_ready_bulk(struct USB2OTGUnit *otg_Unit,
+    UBYTE dev_addr)
+{
+    struct IOUsbHWReq *req;
+
+    if (dev_addr == 0)
+        return FALSE;
+    if (usb2otg_nak_gated(otg_Unit, dev_addr))
+        return FALSE;
+
+    ForeachNode(&otg_Unit->hu_BulkXFerQueue, req)
+    {
+        if (req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+            req->iouh_DevAddr == dev_addr)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+/* TRUE if any device != skip_dev has ready bulk work (fairness). */
+static BOOL usb2otg_other_dev_has_ready_bulk(struct USB2OTGUnit *otg_Unit,
+    UBYTE skip_dev)
+{
+    struct IOUsbHWReq *req;
+
+    ForeachNode(&otg_Unit->hu_BulkXFerQueue, req)
+    {
+        if (req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+            req->iouh_DevAddr != skip_dev &&
+            !usb2otg_nak_gated(otg_Unit, req->iouh_DevAddr))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+/*
+ * Find/claim a bulk channel for req. Prefer one already owned by
+ * req's device; otherwise steal from an idle owner with no ready work.
+ * Returns -1 if nothing usable. Caller holds hu_Lock.
+ */
+static int usb2otg_claim_bulk_channel(struct USB2OTGUnit *otg_Unit,
+    struct IOUsbHWReq *req)
+{
+    static const UBYTE bulk_chans[2] = { CHAN_BULK, CHAN_BULK2 };
+    BOOL other_waiting;
+    int max_chans_per_dev;
+    int own_busy = 0;
+    int own_idle_chan = -1;
+    int i;
+
+    /* Fairness cap: contention → 1 channel/dev; alone → both allowed. */
+    other_waiting = usb2otg_other_dev_has_ready_bulk(otg_Unit,
+                                                     req->iouh_DevAddr);
+    max_chans_per_dev = other_waiting ? 1 : 2;
+
+    /* Inventory: how many channels does req's device currently hold? */
+    for (i = 0; i < 2; i++)
+    {
+        int chan = bulk_chans[i];
+        if (otg_Unit->hu_BulkOwnerDev[i] != req->iouh_DevAddr)
+            continue;
+        if (otg_Unit->hu_Channel[chan].hc_Request != NULL)
+            own_busy++;
+        else if (own_idle_chan < 0)
+            own_idle_chan = chan;
+    }
+
+    /* Sticky locality: reuse own idle channel if within cap. */
+    if (own_idle_chan >= 0 && own_busy + 1 <= max_chans_per_dev)
+        return own_idle_chan;
+
+    /* Already at cap on busy channels alone — no room for more. */
+    if (own_busy >= max_chans_per_dev)
+        return -1;
+
+    /* Pass 2: claim unowned, or steal from owner who already has another busy. */
+    for (i = 0; i < 2; i++)
+    {
+        int chan = bulk_chans[i];
+        UBYTE owner = otg_Unit->hu_BulkOwnerDev[i];
+
+        if (otg_Unit->hu_Channel[chan].hc_Request != NULL)
+            continue;
+        if (owner == req->iouh_DevAddr)
+            continue;  /* handled in inventory pass */
+
+        if (owner != 0 && usb2otg_dev_has_ready_bulk(otg_Unit, owner))
+        {
+            /* Owner has queued work — only steal if they already hold another busy chan. */
+            int j;
+            int owner_busy = 0;
+            for (j = 0; j < 2; j++)
+            {
+                if (otg_Unit->hu_BulkOwnerDev[j] == owner &&
+                    otg_Unit->hu_Channel[bulk_chans[j]].hc_Request != NULL)
+                    owner_busy++;
+            }
+            if (owner_busy < 1)
+                continue;
+        }
+
+        otg_Unit->hu_BulkOwnerDev[i] = req->iouh_DevAddr;
+        return chan;
+    }
+
+    return -1;
+}
+
+/*
+ * Walk bulk queue, return first request passing NAK-gate / TT / EP /
+ * retry filters that can claim a channel. Caller holds hu_Lock.
+ */
+static struct IOUsbHWReq *usb2otg_find_schedulable_bulk_req(
+    struct USB2OTGUnit *otg_Unit, int *out_chan)
+{
+    struct IOUsbHWReq *req, *next;
+
+    ForeachNodeSafe(&otg_Unit->hu_BulkXFerQueue, req, next)
+    {
+        int chan;
+        ULONG delay;
+        BOOL already_armed = FALSE;
+        int scan;
+
+        if (req->iouh_Req.io_Command != UHCMD_BULKXFER)
+            continue;
+
+        /* Defensive: skip if req is already armed on a channel. */
+        for (scan = 0; scan < 8; scan++)
+        {
+            if (otg_Unit->hu_Channel[scan].hc_Request == req)
+            {
+                already_armed = TRUE;
+                break;
+            }
+        }
+        if (already_armed)
+            continue;
+
+        if (usb2otg_nak_gated(otg_Unit, req->iouh_DevAddr))
+            continue;
+        if (usb2otg_tt_in_flight(otg_Unit, req))
+            continue;
+        if (usb2otg_endpoint_in_flight(otg_Unit, req))
+            continue;
+
+        /* Legacy per-request retry-delay counter (call-count, not wall time). */
+        delay = (ULONG)req->iouh_DriverPrivate1;
+        if (delay > 0)
+        {
+            req->iouh_DriverPrivate1 = (APTR)(delay - 1);
+            continue;
+        }
+
+        chan = usb2otg_claim_bulk_channel(otg_Unit, req);
+        if (chan < 0)
+            continue;
+
+        *out_chan = chan;
+        return req;
+    }
+
+    *out_chan = -1;
+    return NULL;
+}
+
+/*
+ * 1 if another channel already holds same (Dev,EP,Dir) — arming a
+ * second would NYET forever on shared TT endpoint state.
+ */
+static int usb2otg_endpoint_in_flight(struct USB2OTGUnit *otg_Unit,
+    struct IOUsbHWReq *candidate)
+{
+    int scan;
+    for (scan = 0; scan < 8; scan++)
+    {
+        struct IOUsbHWReq *active = otg_Unit->hu_Channel[scan].hc_Request;
+        if (active != NULL && active != candidate &&
+            active->iouh_DevAddr == candidate->iouh_DevAddr &&
+            active->iouh_Endpoint == candidate->iouh_Endpoint &&
+            active->iouh_Dir == candidate->iouh_Dir)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * 1 if another async split is already active on the same TT
+ * (SplitHubAddr+Port). Serializes async SSPLITs so two LS/FS devices
+ * don't over-subscribe TT budget (NYET storm). Periodic candidates
+ * bypass (USB 2.0 §11.18 separate periodic budget).
+ */
+static int usb2otg_tt_in_flight(struct USB2OTGUnit *otg_Unit,
+    struct IOUsbHWReq *candidate)
+{
+    int scan;
+
+    if (!(candidate->iouh_Flags & UHFF_SPLITTRANS))
+        return 0;
+
+    /* Periodic candidates have their own TT budget — don't block them. */
+    if (candidate->iouh_Req.io_Command == UHCMD_INTXFER ||
+        candidate->iouh_Req.io_Command == UHCMD_ISOXFER)
+        return 0;
+
+    for (scan = 0; scan < 8; scan++)
+    {
+        struct IOUsbHWReq *active = otg_Unit->hu_Channel[scan].hc_Request;
+        if (active != NULL && active != candidate &&
+            (active->iouh_Flags & UHFF_SPLITTRANS) &&
+            active->iouh_SplitHubAddr == candidate->iouh_SplitHubAddr &&
+            active->iouh_SplitHubPort == candidate->iouh_SplitHubPort &&
+            (active->iouh_Req.io_Command == UHCMD_CONTROLXFER ||
+             active->iouh_Req.io_Command == UHCMD_BULKXFER))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+
+/* DMA buffers live in USB2OTGUnit (heap), not static — see intern.h. */
 
 #if DEBUG
 static void DumpChannelRegs(int channel)
@@ -23,9 +271,32 @@ static void DumpChannelRegs(int channel)
 }
 #endif
 
-/* Prepare Channel for transfer */
-void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
+static void usb2otg_finish_setup_error(struct USB2OTGUnit *otg_Unit, int chan,
+    struct IOUsbHWReq *req, BYTE error)
 {
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+
+    Disable();
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+    req->iouh_Req.io_Error = error;
+    otg_Unit->hu_Channel[chan].hc_Request = NULL;
+    otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
+    otg_Unit->hu_Channel[chan].hc_SplitCSplitPending = 0;
+    ADDTAIL(&otg_Unit->hu_FinishedXfers, (struct Node *)req);
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&otg_Unit->hu_Lock);
+#endif
+    Enable();
+
+    FNAME_DEV(Cause)(otg_Unit->hu_USB2OTGBase, &otg_Unit->hu_PendingInt);
+}
+
+/* Prepare Channel for transfer */
+BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
+{
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
     struct IOUsbHWReq *req = NULL;
     uint8_t direction = 0;
     ULONG xfer_size = 0;
@@ -35,23 +306,33 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
     int pid = 0;
 
     if (chan < 0 || chan > 7)
-        return;
+        return FALSE;
 
+    /* Caller just assigned hc_Request — no lock needed to read it */
     req = otg_Unit->hu_Channel[chan].hc_Request;
 
     D(bug("[USB2OTG] %s(%p, %d)\n", __PRETTY_FUNCTION__, otg_Unit, chan));
 
     if (req == NULL)
-        return;
+        return FALSE;
 
-    req->iouh_Actual = 0;
+    /* Fresh request: clear watchdog defer counter. */
+    otg_Unit->hu_Channel[chan].hc_DeferCount = 0;
 
     /*
-        In case of control transfer setup the buffers for request, flush necessary caches and
-        determine correct direction
-    */
+     * Inherit PING state from per-EP bitmap (channel-local flag does
+     * not survive requeue; USB 2.0 §8.5.1).
+     */
+    otg_Unit->hu_Channel[chan].hc_PingPending =
+        (otg_Unit->hu_PingBits[req->iouh_DevAddr] >> req->iouh_Endpoint) & 1;
+    otg_Unit->hu_Channel[chan].hc_PingState =
+        otg_Unit->hu_Channel[chan].hc_PingPending ? 1 : 0;
+
+    /* Control xfer: set up SETUP packet buffers, flush caches, direction. */
     if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
     {
+        req->iouh_Actual = 0;
+
         /* Direction is out, setup packet goes always to the device */
         direction = 0;
 
@@ -83,21 +364,76 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         /* Data direction as requested */
         if (req->iouh_Dir == UHDIR_IN) direction = 1; else direction = 0;
 
-        /* Buffer points to the actual data, maximal length */
-        buffer = req->iouh_Data;
-        xfer_size = req->iouh_Length;
+        if (req->iouh_Actual > req->iouh_Length)
+        {
+            bug("[USB2OTG] Refusing to resume chan=%d dev=%d ep=%d cmd=%lu with actual=%lu > len=%lu\n",
+                chan,
+                (int)req->iouh_DevAddr,
+                (int)req->iouh_Endpoint,
+                (unsigned long)req->iouh_Req.io_Command,
+                (unsigned long)req->iouh_Actual,
+                (unsigned long)req->iouh_Length);
+            usb2otg_finish_setup_error(otg_Unit, chan, req, UHIOERR_HOSTERROR);
+            return FALSE;
+        }
+
+        /* Resume non-control transfers from the current request offset. */
+        buffer = req->iouh_Data ? (APTR)((IPTR)req->iouh_Data + req->iouh_Actual) : NULL;
+        xfer_size = req->iouh_Length - req->iouh_Actual;
 
         /* Flush caches */
-        if (req->iouh_Data != NULL && req->iouh_Length != 0)
+        if (buffer != NULL && xfer_size != 0)
         {
             if (direction)
-                CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_InvalidateD);
+                CacheClearE(buffer, xfer_size, CACRF_InvalidateD);
             else
-                CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_ClearD);
+                CacheClearE(buffer, xfer_size, CACRF_ClearD);
+            /* DSB so cache maintenance is visible before DWC2 reads RAM. */
+            asm volatile("dsb sy" ::: "memory");
         }
+
+        /* Alignment diagnostic (64 B cache line on A7). */
+        D(
+            if (buffer != NULL && xfer_size != 0 && req->iouh_Req.io_Command == UHCMD_BULKXFER)
+            {
+                static ULONG align_count = 0;
+                align_count++;
+                if (align_count <= 5 || (align_count & 0xff) == 0)
+                    bug("[USB2OTG:DMA] setup chan=%d dev=%d ep=%d dir=%s buf=%p (mod64=%lu) size=%lu\n",
+                        chan, (int)req->iouh_DevAddr, (int)req->iouh_Endpoint,
+                        direction ? "IN" : "OUT", buffer,
+                        (unsigned long)((IPTR)buffer & 0x3F),
+                        (unsigned long)xfer_size);
+            }
+        )
 
         /* Get pid */
         pid = (otg_Unit->hu_PIDBits[req->iouh_DevAddr] >> (2 * req->iouh_Endpoint)) & 3;
+    }
+
+    /* Flush non-periodic TX FIFO before programming the channel */
+    if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+    {
+        wr32le(USB2OTG_RESET, USB2OTG_RESET_TXFIFOFLUSH | (0 << 6));
+        /* Wait for hardware to clear the flush bit */
+        {
+            int timeout = 100000;
+            while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH) && --timeout > 0)
+                asm volatile("mov r0, r0\n");
+        }
+    }
+
+    if (req->iouh_MaxPktSize == 0)
+    {
+        bug("[USB2OTG] Refusing to start chan=%d dev=%d ep=%d cmd=%lu with MaxPktSize=0 len=%lu flags=%04x\n",
+            chan,
+            (int)req->iouh_DevAddr,
+            (int)req->iouh_Endpoint,
+            (unsigned long)req->iouh_Req.io_Command,
+            (unsigned long)req->iouh_Length,
+            (unsigned int)req->iouh_Flags);
+        usb2otg_finish_setup_error(otg_Unit, chan, req, UHIOERR_HOSTERROR);
+        return FALSE;
     }
 
     /* Prepare HOSTCHAR register */
@@ -124,7 +460,11 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             reg |= USB2OTG_HOSTCHAR_EPTYPE(USB2OTG_TYPE_ISO);
             break;
         default:
-            return;
+            bug("[USB2OTG] Refusing to start chan=%d dev=%d ep=%d with unsupported cmd=%lu\n",
+                chan, (int)req->iouh_DevAddr, (int)req->iouh_Endpoint,
+                (unsigned long)req->iouh_Req.io_Command);
+            usb2otg_finish_setup_error(otg_Unit, chan, req, UHIOERR_HOSTERROR);
+            return FALSE;
     }
 
     /* If split transaction requested limit transfer size to max packet size or 188 bytes, whichever is less */
@@ -136,11 +476,27 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         else
             reg |= USB2OTG_HOSTCHAR_EC(1);
 
-        wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL),
-                (1 << 31) |     /* Split enable */
-                (3 << 14) |     /* Split position: 3 == ALL, 2 == Begin, 0 == Mid, 1 == END */
-                ((req->iouh_SplitHubAddr & 0x7f) << 7) |
-                ((req->iouh_SplitHubPort & 0x0f)));
+        {
+            ULONG splitpos;
+
+            /*
+             * splitpos per USB 2.0 §11.18: 0=CSPLIT (after SSPLIT ACK),
+             * 3=ALL (periodic), 2=BEGIN (async — must advance via IRQ).
+             */
+            if (otg_Unit->hu_Channel[chan].hc_SplitCSplitPending)
+                splitpos = 0; /* CSPLIT */
+            else if (req->iouh_Req.io_Command == UHCMD_INTXFER ||
+                     req->iouh_Req.io_Command == UHCMD_ISOXFER)
+                splitpos = 3; /* ALL */
+            else
+                splitpos = 2; /* BEGIN */
+
+            wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL),
+                    (1 << 31) |
+                    (splitpos << 14) |
+                    ((req->iouh_SplitHubAddr & 0x7f) << 7) |
+                    ((req->iouh_SplitHubPort & 0x0f)));
+        }
 
         if (xfer_size > req->iouh_MaxPktSize)
             xfer_size = req->iouh_MaxPktSize;
@@ -154,9 +510,21 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         reg |= USB2OTG_HOSTCHAR_EC(1);
 
         wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), 0);
+
+        /*
+         * Bulk OUT: full multi-packet burst. hu_PingBits tracks PING
+         * state across requeues; WAIT-PING/WAIT-QUIET defer is
+         * unbounded, so DWC2 auto-PING during a long burst is safe.
+         */
     }
 
     wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), reg);
+
+    /* Large unaligned buffers must be chunked through the bounce buffer.
+     * Alignment criterion is 64 bytes (cache line) so per-buffer cache
+     * flush doesn't drag in adjacent unrelated data on line boundaries. */
+    if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size > DMA_BOUNCE_SIZE)
+        xfer_size = DMA_BOUNCE_SIZE;
 
     /* Get packet count and adjust this and the transfer size */
     if (xfer_size > (1 << (otg_Unit->hu_XferSizeWidth - 1)))
@@ -169,40 +537,224 @@ void FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         xfer_size = pkt_count * req->iouh_MaxPktSize;
     }
 
-    /* Setup the size, PID, packet count and length */
-    wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE),
-        USB2OTG_HOSTTSIZE_PID(pid) |
-        USB2OTG_HOSTTSIZE_PKTCNT(pkt_count) |
-        USB2OTG_HOSTTSIZE_SIZE(xfer_size));
+    /*
+     * Setup the size, PID, packet count and length. OR in DoPing bit
+     * if the NYET handler set hc_PingPending — per USB 2.0 §8.5.1 we
+     * must PING after NYET until the device ACKs. HW auto-DoPing gets
+     * cleared when we re-program HCTSIZ, so we have to re-apply it
+     * explicitly on behalf of the software state machine.
+     */
+    {
+        ULONG tsize = USB2OTG_HOSTTSIZE_PID(pid) |
+                      USB2OTG_HOSTTSIZE_PKTCNT(pkt_count) |
+                      USB2OTG_HOSTTSIZE_SIZE(xfer_size);
+        if (otg_Unit->hu_Channel[chan].hc_PingPending)
+        {
+            /* HW-driven PING+DATA combined arm. HW issues PING first;
+             * on ACK it follows with the OUT data tokens; on NAK/NYET
+             * it halts and we re-arm via the requeue path. Letting HW
+             * drive the PING flow is what works on BCM2835 — software-
+             * driven PING-only arms (XferSize=0) result in bare CHHLTD
+             * with no token on the bus (verified empirically on Pi 3B+).
+             */
+            tsize |= USB2OTG_HOSTTSIZE_PING;
+            D(
+                {
+                    static ULONG ping_arm_count = 0;
+                    ping_arm_count++;
+                    if (ping_arm_count <= 3 || (ping_arm_count & 0x3f) == 0)
+                        bug("[USB2OTG:PING] ARM #%lu chan=%d dev=%d ep=%d TSIZE=%08x\n",
+                            (unsigned long)ping_arm_count, chan,
+                            (int)req->iouh_DevAddr, (int)req->iouh_Endpoint, tsize);
+                }
+            )
+        }
+        wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE), tsize);
+    }
 
     otg_Unit->hu_Channel[chan].hc_XferSize = xfer_size;
 
-    /* Set the bus address of transferred data (use L2 uncached from AHB's point of view!) */
-    wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), 0xc0000000 | (ULONG)buffer);
+    /*
+     * DMA alignment: route any non-cache-line-aligned (64 B) buffer
+     * through the aligned bounce buffer. DWC2 itself only requires
+     * DWORD alignment, but the per-buffer cache flush operates on
+     * full cache lines — a misaligned buffer would drag adjacent
+     * unrelated bytes across the flush, which is harmless for OUT
+     * but a real cache-pollution risk for IN.
+     */
+    otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
+    {
+        APTR dma_buf = buffer;
+        if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size <= DMA_BOUNCE_SIZE)
+        {
+            otg_Unit->hu_Channel[chan].hc_OrigBuffer = buffer;
+            otg_Unit->hu_Channel[chan].hc_BounceLen = xfer_size;
+            otg_Unit->hu_Channel[chan].hc_BounceDir = direction;
+
+            if (direction)
+                CacheClearE(otg_Unit->hu_BounceBuf[chan], xfer_size, CACRF_InvalidateD);
+            else
+            {
+                CopyMem(buffer, otg_Unit->hu_BounceBuf[chan], xfer_size);
+                CacheClearE(otg_Unit->hu_BounceBuf[chan], xfer_size, CACRF_ClearD);
+            }
+
+            dma_buf = (APTR)otg_Unit->hu_BounceBuf[chan];
+            D(bug("[USB2OTG] Setup: bounce align %p -> %p (%d bytes)\n", buffer, dma_buf, xfer_size));
+        }
+        wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), 0xc0000000 | (ULONG)dma_buf);
+    }
+
+    /* Dump SETUP data and DMA info for control transfers to help debug STALL/XactErr */
+    if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+    {
+        UBYTE *p = (UBYTE *)buffer;
+        D(bug("[USB2OTG] Setup: dev=%d buf=%p dma=%08x data=[%02x %02x %02x %02x %02x %02x %02x %02x]\n",
+            req->iouh_DevAddr, buffer,
+            0xc0000000 | (ULONG)buffer,
+            p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]));
+        D(bug("[USB2OTG] Setup: CHAR=%08x TSIZE=%08x pid=%d mps=%d len=%d data=%p\n",
+            rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+            rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE)),
+            pid, req->iouh_MaxPktSize, req->iouh_Length, req->iouh_Data));
+    }
+
+    return TRUE;
 }
 
-/* Advance the status of channel, adjust iouh_Actual, PID etc */
+/*
+ * Advance channel state after an XFERCOMPL: update iouh_Actual, toggle
+ * PID, finalise direction. Returns 1 (done) when the IOReq is fully
+ * complete and the caller should put it on FinishedXfers; returns 0
+ * (more) when this was an intermediate phase and the caller must
+ * StartChannel again.
+ */
 int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
 {
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
     uint8_t direction = 0;
     ULONG xfer_size = 0;
     ULONG pkt_count = 0;
     APTR buffer = NULL;
     ULONG reg = 0;
-    int channel_ready = 1;
+    int done = 1;
 
-    struct IOUsbHWReq *req = otg_Unit->hu_Channel[chan].hc_Request;
+    struct IOUsbHWReq *req;
+    ULONG phase_actual;
+    APTR completed_buf = NULL;
+    UBYTE completed_dir = 0;
+    int last_pid;
+
+    /* Caller holds lock or is in IRQ context — no lock needed */
+    req = otg_Unit->hu_Channel[chan].hc_Request;
 
     D(bug("[USB2OTG] %s(%p, %d)\n", __PRETTY_FUNCTION__, otg_Unit, chan));
 
+    /* TRANSSIZE.SIZE decrements only on IN; OUT keeps the requested size. */
+    phase_actual = req->iouh_Actual;
+    int remaining = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE)) & 0x7FFFF;
+    int txsize;
+
     /*
-        Determine number of packets involved in last transfer. If it is even, toggle
-        the PID (the OTG was toggling it itself)
-    */
-    int txsize = otg_Unit->hu_Channel[chan].hc_XferSize;
-    int last_pid = (otg_Unit->hu_PIDBits[req->iouh_DevAddr] >> (2 * req->iouh_Endpoint)) & 3;
+     * Direction of just-completed phase: SETUP is always OUT, data/
+     * status follow bmRequestType, bulk/int/iso use iouh_Dir.
+     * Bulk-IN ZLPs decrement PktCnt without moving SIZE — must not
+     * use the old "SIZE decremented => IN" heuristic.
+     */
+    {
+        int is_in;
+        if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+        {
+            int cur_pid = (otg_Unit->hu_PIDBits[req->iouh_DevAddr] >>
+                           (2 * req->iouh_Endpoint)) & 3;
+            if (cur_pid == USB2OTG_PID_SETUP)
+                is_in = 0;
+            else
+                is_in = (req->iouh_SetupData.bmRequestType & URTF_IN) ? 1 : 0;
+        }
+        else
+        {
+            is_in = (req->iouh_Dir == UHDIR_IN) ? 1 : 0;
+        }
+
+        if (is_in)
+        {
+            if (remaining > otg_Unit->hu_Channel[chan].hc_XferSize)
+                txsize = 0; /* Defensive — should never happen */
+            else
+                txsize = otg_Unit->hu_Channel[chan].hc_XferSize - remaining;
+        }
+        else
+        {
+            /* OUT: hardware does not decrement SIZE */
+            txsize = otg_Unit->hu_Channel[chan].hc_XferSize;
+        }
+    }
+    last_pid = (otg_Unit->hu_PIDBits[req->iouh_DevAddr] >> (2 * req->iouh_Endpoint)) & 3;
+
+    if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+    {
+        if (last_pid == USB2OTG_PID_SETUP)
+        {
+            completed_buf = &req->iouh_SetupData;
+            completed_dir = 0;
+        }
+        else
+        {
+            completed_buf = req->iouh_Data ? (APTR)((IPTR)req->iouh_Data + phase_actual) : NULL;
+            completed_dir = (req->iouh_SetupData.bmRequestType & URTF_IN) ? 1 : 0;
+        }
+    }
+    else
+    {
+        completed_buf = req->iouh_Data ? (APTR)((IPTR)req->iouh_Data + phase_actual) : NULL;
+        completed_dir = (req->iouh_Dir == UHDIR_IN) ? 1 : 0;
+    }
+
+    /* DMA bounce copy-back for IN if previous phase used bounce. */
+    if (otg_Unit->hu_Channel[chan].hc_OrigBuffer != NULL)
+    {
+        if (otg_Unit->hu_Channel[chan].hc_BounceDir == 1 && txsize > 0)
+        {
+            ULONG copylen = txsize;
+            if (copylen > otg_Unit->hu_Channel[chan].hc_BounceLen)
+                copylen = otg_Unit->hu_Channel[chan].hc_BounceLen;
+            CacheClearE(otg_Unit->hu_BounceBuf[chan], copylen, CACRF_InvalidateD);
+            CopyMem(otg_Unit->hu_BounceBuf[chan], otg_Unit->hu_Channel[chan].hc_OrigBuffer, copylen);
+            D(bug("[USB2OTG] Advance: bounce copy-back %p <- %p (%d bytes)\n",
+                otg_Unit->hu_Channel[chan].hc_OrigBuffer, otg_Unit->hu_BounceBuf[chan], copylen));
+        }
+        otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
+    }
+    else if (completed_dir && completed_buf != NULL)
+    {
+        /*
+         * Post-DMA invalidate for direct transfers; ARM speculative
+         * prefetch can refill stale lines during the split-CSPLIT gap.
+         * Cover ≥1 MaxPktSize so a following IN doesn't read stale.
+         */
+        ULONG inval_len = txsize > 0 ? txsize : req->iouh_MaxPktSize;
+        CacheClearE(completed_buf, inval_len, CACRF_InvalidateD);
+    }
+
     int pid = 0;
-    int pktcnt = (txsize + req->iouh_MaxPktSize - 1) / req->iouh_MaxPktSize;
+
+    /* Packets from PktCnt delta; txsize/MPS misses ZLPs (no PID toggle). */
+    int initial_pktcnt =
+        (otg_Unit->hu_Channel[chan].hc_XferSize + req->iouh_MaxPktSize - 1)
+            / req->iouh_MaxPktSize;
+    if (initial_pktcnt == 0)
+        initial_pktcnt = 1;
+    int remaining_pktcnt =
+        (rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE)) >> 19) & 0x3FF;
+    int pktcnt = initial_pktcnt - remaining_pktcnt;
+    if (pktcnt < 0)
+        pktcnt = 0;
+
+    D(bug("[USB2OTG] Advance: chan=%d dev=%d requested=%d actual=%d remaining=%d last_pid=%d len=%d actual_done=%d\n",
+        chan, req->iouh_DevAddr, otg_Unit->hu_Channel[chan].hc_XferSize, txsize, remaining,
+        last_pid, req->iouh_Length, req->iouh_Actual));
+
     if (pktcnt & 1)
     {
         /* Toggle PID */
@@ -211,6 +763,12 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
     /* Update the transferred size unless it was control channel in setup phase */
     req->iouh_Actual += txsize;
     req->iouh_Req.io_Error = 0;
+    usb2otg_diag_bulk_progress(otg_Unit, chan, req, USB2OTG_INTRCHAN_TRANSFERCOMPLETE);
+
+    /* OUT ACKed → PING phase done; clear channel + per-EP bits. */
+    otg_Unit->hu_Channel[chan].hc_PingPending = 0;
+    otg_Unit->hu_PingBits[req->iouh_DevAddr] &=
+        ~(1U << req->iouh_Endpoint);
 
     /* If it was CTRL channel in setup phase reset PID and iouh_Actual */
     if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
@@ -219,6 +777,7 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
 
         if (last_pid == USB2OTG_PID_SETUP)
         {
+            D(bug("[USB2OTG] AdvanceChannel: SETUP phase done, transitioning to DATA phase (dir=%d)\n", direction));
             req->iouh_Actual = 0;
             otg_Unit->hu_PIDBits[req->iouh_DevAddr] &= ~(3 << (2 * req->iouh_Endpoint));
             otg_Unit->hu_PIDBits[req->iouh_DevAddr] |= (USB2OTG_PID_DATA1 << (2 * req->iouh_Endpoint));
@@ -230,9 +789,6 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         if (req->iouh_Dir == UHDIR_IN) direction = 1; else direction = 0;
     }
 
-    D(bug("[USB2OTG] Last transfer completed. Chan=%d, last pid=%d, last xfer size=%d, %08x\n", chan, last_pid, txsize,
-        rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE))));
-
     /* Get new PID for transfer */
     pid = (otg_Unit->hu_PIDBits[req->iouh_DevAddr] >> (2 * req->iouh_Endpoint)) & 3;
 
@@ -240,23 +796,42 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
     buffer = (APTR)((IPTR)req->iouh_Data + req->iouh_Actual);
     xfer_size = req->iouh_Length - req->iouh_Actual;
 
+    /*
+     * Short-packet (incl. ZLP) on IN terminates the transfer per USB
+     * spec. Gate on iouh_Dir, not txsize>0 (OUT never decrements SIZE).
+     */
+    if (xfer_size > 0 &&
+        req->iouh_Dir == UHDIR_IN &&
+        req->iouh_Req.io_Command != UHCMD_CONTROLXFER &&
+        txsize < otg_Unit->hu_Channel[chan].hc_XferSize)
+    {
+        xfer_size = 0;
+    }
+
+    /* CTRL STATUS/ACK done: txsize==0 past SETUP → transfer complete. */
+    if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER &&
+        txsize == 0 && last_pid != USB2OTG_PID_SETUP)
+    {
+        return 1;
+    }
+
+    D(bug("[USB2OTG] AdvanceChannel: next phase: pid=%d dir=%d buf=%p xfer_size=%d\n",
+        pid, direction, buffer, xfer_size));
+
     /* If there is still anything to transmit, do it now */
     if (xfer_size != 0 && buffer != NULL)
     {
-        channel_ready = 0;
+        done = 0;
 
-        D(bug("[USB2OTG] Channel %d not ready yet\n", chan));
+        D(bug("[USB2OTG] AdvanceChannel: DATA phase buf=%p size=%d\n", buffer, xfer_size));
     }
     else
     {
-        /*
-            Nothing to transmit now. If this was CTRL message, issue ACK transfer. But only if last transfer was
-            not empty one (which would indicate ACK issued)
-        */
+        /* Nothing to transmit — issue CTRL ACK phase unless last was empty. */
         if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER && txsize != 0)
         {
-            channel_ready = 0;
-            buffer = NULL;
+            done = 0;
+            buffer = (APTR)otg_Unit->hu_StatusDmaBuf;
             xfer_size = 0;
             pkt_count = 1;
 
@@ -268,14 +843,61 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             else
                 direction = 0;
 
-            D(bug("[USB2OTG] Channel %d not ready yet - ACK phase\n", chan));
+            D(bug("[USB2OTG] AdvanceChannel: ACK phase dir=%d\n", direction));
         }
     }
 
-    if (!channel_ready)
+    if (!done)
     {
         D(bug("[USB2OTG] Req %p on channel %d continuing with transfer: buf=%p len=%d, act=%d, pid=%d\n",
                                         req, chan, buffer, xfer_size, req->iouh_Actual, pid));
+
+        /*
+         * Halt before reprogramming (DWC2 spec). For non-split bulk
+         * OUT also force a state-machine reset by zeroing HCCHAR —
+         * without it, channel scheduler state drifts after N packets
+         * and the device goes silent mid-transfer.
+         */
+        {
+            ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+            BOOL force_state_reset = (req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+                                      req->iouh_Dir == UHDIR_OUT &&
+                                      !(req->iouh_Flags & UHFF_SPLITTRANS));
+            if (hcchar & USB2OTG_HOSTCHAR_ENABLE)
+            {
+                hcchar |= USB2OTG_HOSTCHAR_DISABLE;
+                wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
+                /* ~200 µs budget — matches halt_channel_preserve_char. */
+                int timeout = 200000;
+                while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
+                    asm volatile("mov r0, r0\n");
+                if (timeout <= 0)
+                    bug("[USB2OTG] AdvanceChannel halt timeout chan=%d CHAR=%08x INTR=%08x\n",
+                        chan,
+                        rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                        rd32le(USB2OTG_CHANNEL_REG(chan, INTR)));
+            }
+            else if (force_state_reset)
+            {
+                /* Force state-machine reset by zeroing HCCHAR. */
+                wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
+            }
+            wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
+        }
+
+        if (req->iouh_MaxPktSize == 0)
+        {
+            bug("[USB2OTG] Refusing to continue chan=%d dev=%d ep=%d cmd=%lu with MaxPktSize=0 act=%lu len=%lu flags=%04x\n",
+                chan,
+                (int)req->iouh_DevAddr,
+                (int)req->iouh_Endpoint,
+                (unsigned long)req->iouh_Req.io_Command,
+                (unsigned long)req->iouh_Actual,
+                (unsigned long)req->iouh_Length,
+                (unsigned int)req->iouh_Flags);
+            req->iouh_Req.io_Error = UHIOERR_HOSTERROR;
+            return 1;
+        }
 
         /* Prepare HOSTCHAR register */
         reg = USB2OTG_HOSTCHAR_ADDR(req->iouh_DevAddr) |
@@ -301,6 +923,7 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
                 reg |= USB2OTG_HOSTCHAR_EPTYPE(USB2OTG_TYPE_ISO);
                 break;
             default:
+                req->iouh_Req.io_Error = UHIOERR_HOSTERROR;
                 return 1;
         }
 
@@ -313,11 +936,23 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             else
                 reg |= USB2OTG_HOSTCHAR_EC(1);
 
-            wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL),
-                    (1 << 31) |     /* Split enable */
-                    (3 << 14) |     /* Split position: 3 == ALL, 2 == Begin, 0 == Mid, 1 == END */
-                    ((req->iouh_SplitHubAddr & 0x7f) << 7) |
-                    ((req->iouh_SplitHubPort & 0x0f)));
+            {
+                ULONG splitpos;
+
+                if (otg_Unit->hu_Channel[chan].hc_SplitCSplitPending)
+                    splitpos = 0; /* CSPLIT */
+                else if (req->iouh_Req.io_Command == UHCMD_INTXFER ||
+                         req->iouh_Req.io_Command == UHCMD_ISOXFER)
+                    splitpos = 3; /* ALL */
+                else
+                    splitpos = 2; /* BEGIN */
+
+                wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL),
+                        (1 << 31) |
+                        (splitpos << 14) |
+                        ((req->iouh_SplitHubAddr & 0x7f) << 7) |
+                        ((req->iouh_SplitHubPort & 0x0f)));
+            }
 
             if (xfer_size > req->iouh_MaxPktSize)
                 xfer_size = req->iouh_MaxPktSize;
@@ -331,11 +966,18 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             reg |= USB2OTG_HOSTCHAR_EC(1);
 
             wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), 0);
+
+            /* Bulk-OUT multi-packet burst — see SetupChannel for
+             * the rationale behind removing the per-packet clamp. */
         }
 
         wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), reg);
 
-        /* Get packet count and adjust this and the transfer size */
+        /* Get packet count and adjust this and the transfer size.
+         * 64-byte cache-line alignment criterion — see SetupChannel. */
+        if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size > DMA_BOUNCE_SIZE)
+            xfer_size = DMA_BOUNCE_SIZE;
+
         if (xfer_size > (1 << (otg_Unit->hu_XferSizeWidth - 1)))
             xfer_size = 1 << (otg_Unit->hu_XferSizeWidth - 1);
 
@@ -350,19 +992,101 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             xfer_size = pkt_count * req->iouh_MaxPktSize;
         }
 
-        /* Setup the size, PID, packet count and length */
-        wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE),
-            USB2OTG_HOSTTSIZE_PID(pid) |
-            USB2OTG_HOSTTSIZE_PKTCNT(pkt_count) |
-            USB2OTG_HOSTTSIZE_SIZE(xfer_size));
+        /* Size/PID/PktCnt; OR in DoPing if NYET handler set PingPending. */
+        {
+            ULONG tsize = USB2OTG_HOSTTSIZE_PID(pid) |
+                          USB2OTG_HOSTTSIZE_PKTCNT(pkt_count) |
+                          USB2OTG_HOSTTSIZE_SIZE(xfer_size);
+            if (otg_Unit->hu_Channel[chan].hc_PingPending)
+            {
+                tsize |= USB2OTG_HOSTTSIZE_PING;
+                D(
+                    {
+                        static ULONG ping_adv_count = 0;
+                        ping_adv_count++;
+                        if (ping_adv_count <= 3 || (ping_adv_count & 0x3f) == 0)
+                            bug("[USB2OTG:PING] ADV #%lu chan=%d dev=%d ep=%d TSIZE=%08x\n",
+                                (unsigned long)ping_adv_count, chan,
+                                (int)req->iouh_DevAddr, (int)req->iouh_Endpoint, tsize);
+                    }
+                )
+            }
+            wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE), tsize);
+        }
 
         otg_Unit->hu_Channel[chan].hc_XferSize = xfer_size;
 
-        /* Set the bus address of transferred data (use L2 uncached from AHB's point of view!) */
-        wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), 0xc0000000 | (ULONG)buffer);
+        /*
+         * Misaligned buffer → bounce. Aligned direct DMA needs per-arm
+         * cache flush — speculative prefetch refills stale lines
+         * between continuation arms, controller sends garbage.
+         */
+        otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
+        {
+            APTR dma_buf = buffer;
+            if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size <= DMA_BOUNCE_SIZE)
+            {
+                otg_Unit->hu_Channel[chan].hc_OrigBuffer = buffer;
+                otg_Unit->hu_Channel[chan].hc_BounceLen = xfer_size;
+                otg_Unit->hu_Channel[chan].hc_BounceDir = direction;
+                dma_buf = (APTR)otg_Unit->hu_BounceBuf[chan];
+
+                if (direction == 0)
+                {
+                    /* OUT: copy data to aligned bounce buffer before DMA */
+                    CopyMem(buffer, otg_Unit->hu_BounceBuf[chan], xfer_size);
+                    CacheClearE(otg_Unit->hu_BounceBuf[chan], xfer_size, CACRF_ClearD);
+                }
+                else
+                {
+                    /* IN: invalidate bounce buffer, copy-back happens after transfer */
+                    CacheClearE(otg_Unit->hu_BounceBuf[chan], xfer_size, CACRF_InvalidateD);
+                }
+                D(bug("[USB2OTG] Advance: bounce align %p -> %p (%d bytes, dir=%d)\n",
+                    buffer, dma_buf, xfer_size, direction));
+            }
+            else if (buffer != NULL && xfer_size > 0)
+            {
+                /* Aligned direct DMA — flush cache per arm. */
+                if (direction == 0)
+                    CacheClearE(buffer, xfer_size, CACRF_ClearD);
+                else
+                    CacheClearE(buffer, xfer_size, CACRF_InvalidateD);
+            }
+            /* DSB so cache maint is visible before DMA. */
+            asm volatile("dsb sy" ::: "memory");
+
+            /* Advance-arm alignment diagnostic. */
+            D(
+                if (buffer != NULL && xfer_size > 0 && req->iouh_Req.io_Command == UHCMD_BULKXFER)
+                {
+                    static ULONG adv_align_count = 0;
+                    adv_align_count++;
+                    if (adv_align_count <= 5 || (adv_align_count & 0xff) == 0)
+                        bug("[USB2OTG:DMA] advance chan=%d dev=%d ep=%d dir=%s buf=%p (mod64=%lu) size=%lu actual=%lu\n",
+                            chan, (int)req->iouh_DevAddr, (int)req->iouh_Endpoint,
+                            direction ? "IN" : "OUT", buffer,
+                            (unsigned long)((IPTR)buffer & 0x3F),
+                            (unsigned long)xfer_size,
+                            (unsigned long)req->iouh_Actual);
+                }
+            )
+            wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), 0xc0000000 | (ULONG)dma_buf);
+        }
+
+        /* Log phase transitions for control transfers */
+        if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+        {
+            D(bug("[USB2OTG] Advance: dev=%d dir=%d pid=%d xfer=%d buf=%p dma=%08x\n",
+                req->iouh_DevAddr, direction, pid, xfer_size, buffer,
+                0xc0000000 | (ULONG)buffer));
+            D(bug("[USB2OTG] Advance: CHAR=%08x TSIZE=%08x\n",
+                rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)),
+                rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE))));
+        }
     }
 
-    return channel_ready;
+    return done;
 }
 
 /* Start Channel */
@@ -370,19 +1094,29 @@ void FNAME_DEV(StartChannel)(struct USB2OTGUnit *otg_Unit, int chan, int quick)
 {
     ULONG tmp = 0;
 
+    if (!usb2otg_require_cpu0(otg_Unit->hu_USB2OTGBase, __PRETTY_FUNCTION__))
+        return;
+
     if (quick == 0)
     {
         if (chan < 0 || chan > 7)
             return;
 
-        /* Enable interrupts for this channel */
+        /*
+         * Enable HALT/XFERCOMPL/NYET/XactErr/DTERR. Intentionally NOT
+         * ACK/NAK — they fire before CHHLTD on splits and break the
+         * CSPLIT state machine.
+         */
         tmp = rd32le(USB2OTG_CHANNEL_REG(chan, INTRMASK));
-        tmp |= USB2OTG_INTRCHAN_HALT | USB2OTG_INTRCHAN_TRANSFERCOMPLETE;
+        tmp |= USB2OTG_INTRCHAN_HALT
+             | USB2OTG_INTRCHAN_TRANSFERCOMPLETE
+             | USB2OTG_INTRCHAN_NOTREADY              /* NYET */
+             | USB2OTG_INTRCHAN_TRANSACTIONERROR      /* XactErr */
+             | USB2OTG_INTRCHAN_DATATOGGLEERROR;      /* DTERR */
         wr32le(USB2OTG_CHANNEL_REG(chan, INTRMASK), tmp);
         wr32le(USB2OTG_CHANNEL_REG(chan, INTR), 0x7ff);
 
-        /* Enable interrupt for this channel */
-        wr32le(USB2OTG_HOSTINTR, 1 << chan);
+        /* Enable channel IRQ; HAINT is RO, cleared via per-channel INTR. */
         tmp = rd32le(USB2OTG_HOSTINTRMASK);
         tmp |= 1 << chan;
         wr32le(USB2OTG_HOSTINTRMASK, tmp);
@@ -394,98 +1128,311 @@ void FNAME_DEV(StartChannel)(struct USB2OTGUnit *otg_Unit, int chan, int quick)
 
     /* Finally enable the channel and thus start transaction */
     tmp = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+
+    /*
+     * Split-periodic channels: set OddFrm to match the frame parity
+     * SSPLIT will fire in. Predict via HFNUM.FRREM (PHY clocks left,
+     * HFIR=60000/ms) — if <20 % remains, target the next frame.
+     * Non-split must not have OddFrm set.
+     */
+    {
+        ULONG eptype = (tmp >> 18) & 3;
+        ULONG splitctrl = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+
+        if ((eptype == USB2OTG_TYPE_INT || eptype == USB2OTG_TYPE_ISO) &&
+            (splitctrl & (1 << 31)))
+        {
+            ULONG hfnum = rd32le(USB2OTG_HOSTFRAMENO);
+            ULONG frame = (hfnum >> 3) & 0x7ff;         /* bits [13:3] */
+            ULONG frrem = (hfnum >> 16) & 0xffff;       /* PHY clocks left */
+            ULONG frint = rd32le(USB2OTG_HOSTFRAMEINTERV) & 0xffff;
+
+            /* <20 % frame left → land in the next frame. */
+            if (frint > 0 && frrem < frint / 5)
+                frame++;
+
+            if (frame & 1)
+                tmp |= (1 << 29);   /* HCCHAR.OddFrm */
+            else
+                tmp &= ~(1 << 29);
+        }
+    }
+
+    /* Force EC=1 for non-split bulk/CTRL: EC=0 halts BCM2835 instantly. */
+    {
+        ULONG eptype = (tmp >> 18) & 3;
+        ULONG splitctrl = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+        if (!(splitctrl & (1U << 31)) &&
+            (eptype == USB2OTG_TYPE_BULK || eptype == USB2OTG_TYPE_CTRL))
+        {
+            tmp = (tmp & ~USB2OTG_HOSTCHAR_EC(3)) | USB2OTG_HOSTCHAR_EC(1);
+        }
+    }
+
+    /*
+     * Clear stale CHDIS before arming. BCM2835 DWC2 doesn't auto-clear
+     * CHDIS after halt; re-arming with CHENA=1+CHDIS=1 cancels the
+     * transaction immediately. Quick re-arm paths need this clear.
+     */
+    tmp &= ~USB2OTG_HOSTCHAR_DISABLE;
     tmp |= USB2OTG_HOSTCHAR_ENABLE;
+
     if (tmp & 0x40000000)
-        bug("writing Disable bit!!!\n");
+        D(bug("writing Disable bit!!!\n"));
+
+    /* Snapshot HFNUM for bare-CHHLTD diag (bulk only). */
+    {
+        struct IOUsbHWReq *diag_req = otg_Unit->hu_Channel[chan].hc_Request;
+        if (diag_req != NULL && diag_req->iouh_Req.io_Command == UHCMD_BULKXFER)
+        {
+            otg_Unit->hu_Channel[chan].hc_StartHfnum = rd32le(USB2OTG_HOSTFRAMENO);
+        }
+    }
+
+    /*
+     * NPTxFIFO drain gate for non-split bulk OUT. Mirrors FreeBSD
+     * dwc_otg.c:765-767 NPTxFEmpty gate. Without it, sustained
+     * bulk-OUT eventually wedges with WAIT-QUIET.
+     */
+    {
+        struct IOUsbHWReq *arm_req = otg_Unit->hu_Channel[chan].hc_Request;
+        BOOL is_bulk_out = (arm_req != NULL &&
+                            arm_req->iouh_Req.io_Command == UHCMD_BULKXFER &&
+                            arm_req->iouh_Dir == UHDIR_OUT &&
+                            !(arm_req->iouh_Flags & UHFF_SPLITTRANS));
+
+        if (is_bulk_out)
+        {
+            /* NPTxFIFO size in dwords from HNPTXFSIZ[31:16]. */
+            ULONG nptxfsiz = rd32le(USB2OTG_NONPERIFIFOSIZE);
+            ULONG fifo_dwords = (nptxfsiz >> 16) & 0xFFFF;
+            int timeout = 200000; /* ~200 µs */
+            ULONG nptxsts;
+
+            do {
+                nptxsts = rd32le(USB2OTG_NONPERIFIFOSTATUS);
+                /* NPTxFSpcAvail==fifo_dwords → FIFO empty; QSpcAvail==8 → q empty. */
+                if (((nptxsts & 0xFFFF) >= fifo_dwords) &&
+                    (((nptxsts >> 16) & 0xFF) >= 8))
+                    break;
+            } while (--timeout > 0);
+
+            if (timeout <= 0)
+            {
+                bug("[USB2OTG] NPTxFIFO drain timeout chan=%d NPTXSTS=%08x (need fifo>=%04x qspc>=08)\n",
+                    chan, nptxsts, (unsigned)fifo_dwords);
+                /* Proceed anyway — better to try than to stall arming. */
+            }
+
+#if USB2OTG_BULK_OUT_THROTTLE_COUNT > 0
+            {
+                int t = USB2OTG_BULK_OUT_THROTTLE_COUNT;
+                while (--t > 0)
+                    asm volatile("mov r0, r0\n");
+            }
+#endif
+        }
+    }
+
     wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), tmp);
 }
 
 /*
-    Scheduling control transfers is splitted into at least two phases:
-    1. Setup phase, where ioreq->iouh_SetupData is sent
-    2. Optional data phase
-    3. ACK phase where either host or device respond with an ACK.
-
-    Scheduling the transfer has to be splitted into these phases in the code, it is not possible
-    to let OTG to join the transfers. Therefore, the function first disables the interrupts for
-    the selected channel and enables them only for the last stage.
-*/
+ * Control transfer phases (SETUP, optional DATA, ACK) — DWC2 cannot
+ * join them, so the IRQ handler advances phase-by-phase.
+ */
 void FNAME_DEV(ScheduleCtrlTDs)(struct USB2OTGUnit *otg_Unit)
 {
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
     struct IOUsbHWReq *req = NULL;
+
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return;
 
     D(bug("[USB2OTG] %s(%p)\n", __PRETTY_FUNCTION__, otg_Unit));
 
+    D(
+        if (!IsListEmpty(&otg_Unit->hu_CtrlXFerQueue))
+            bug("[USB2OTG:SCHED] CtrlTDs: queue non-empty, chan_req=%p\n",
+                otg_Unit->hu_Channel[CHAN_CTRL].hc_Request);
+    )
+
     /* First try to get head of the transfer queue */
     Disable();
+    KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
     req = (struct IOUsbHWReq *)REMHEAD(&otg_Unit->hu_CtrlXFerQueue);
 
     /* If there was any request in the queue, try to put it into InProgress slot */
     if (req)
     {
+        /* Check retry delay — DriverPrivate1 counts down microframes between retries */
+            ULONG delay = (ULONG)req->iouh_DriverPrivate1;
+            if (delay > 0)
+            {
+                req->iouh_DriverPrivate1 = (APTR)(delay - 1);
+                ADDTAIL(&otg_Unit->hu_CtrlXFerQueue, req);
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+                Enable();
+                return;
+            }
+
         /* Channel slot empty? If yes store the request there. Otherwise put it back to the queue */
         if (otg_Unit->hu_Channel[CHAN_CTRL].hc_Request == NULL) {
+            /* Defer if another channel is mid-split to the same TT. */
+            if (usb2otg_tt_in_flight(otg_Unit, req))
+            {
+                ADDHEAD(&otg_Unit->hu_CtrlXFerQueue, req);
+                KrnSpinUnLock(&otg_Unit->hu_Lock);
+                Enable();
+                return;
+            }
             otg_Unit->hu_Channel[CHAN_CTRL].hc_Request = req;
         } else {
-            ADDHEAD(&otg_Unit, req);
+            ADDHEAD(&otg_Unit->hu_CtrlXFerQueue, req);
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
             Enable();
             return;
         }
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
         Enable();
 
-        FNAME_DEV(SetupChannel)(otg_Unit, CHAN_CTRL);
+        D(bug("[USB2OTG:SCHED] CTRL-START: dev=%ld req=%02lx len=%ld\n",
+            (LONG)req->iouh_DevAddr, (ULONG)req->iouh_SetupData.bRequest,
+            (LONG)req->iouh_Length));
 
-        FNAME_DEV(StartChannel)(otg_Unit, CHAN_CTRL, 0);
+        D(bug("[USB2OTG:DBG] CTRL-ARM dev=%d ep=%d bReq=%02x wVal=%04x wIdx=%04x len=%lu\n",
+            (int)req->iouh_DevAddr,
+            (int)req->iouh_Endpoint,
+            (unsigned)req->iouh_SetupData.bRequest,
+            (unsigned)AROS_LE2WORD(req->iouh_SetupData.wValue),
+            (unsigned)AROS_LE2WORD(req->iouh_SetupData.wIndex),
+            (unsigned long)req->iouh_Length));
+        if (FNAME_DEV(SetupChannel)(otg_Unit, CHAN_CTRL))
+            FNAME_DEV(StartChannel)(otg_Unit, CHAN_CTRL, 0);
     }
     else
     {
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
         Enable();
     }
 }
 
 /*
-    Schedule INT transfers, but only those from the Schedule list. The IntXferQueue is
-    maintained by SOF interrupt handler
-*/
+ * Schedule bulk. CHAN_BULK/CHAN_BULK2 are partitioned per-device
+ * (usb2otg_claim_bulk_channel) so MSC + ethernet cannot block each
+ * other.
+ */
+void FNAME_DEV(ScheduleBulkTDs)(struct USB2OTGUnit *otg_Unit)
+{
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+    int slot;
+
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return;
+
+    D(bug("[USB2OTG] %s(%p)\n", __PRETTY_FUNCTION__, otg_Unit));
+
+    /* At most two bulk channels → iterate at most twice. */
+    for (slot = 0; slot < 2; slot++)
+    {
+        struct IOUsbHWReq *req;
+        int chan = -1;
+
+        Disable();
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+
+        req = usb2otg_find_schedulable_bulk_req(otg_Unit, &chan);
+
+        if (req == NULL || chan < 0)
+        {
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
+            Enable();
+            return;  /* Nothing schedulable this pass */
+        }
+
+        REMOVE(req);
+        otg_Unit->hu_Channel[chan].hc_Request = req;
+        usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+
+        KrnSpinUnLock(&otg_Unit->hu_Lock);
+        Enable();
+
+        if (FNAME_DEV(SetupChannel)(otg_Unit, chan))
+            FNAME_DEV(StartChannel)(otg_Unit, chan, 0);
+    }
+}
+
+/* Schedule INT transfers from Scheduled list (SOF maintains IntXferQueue). */
 void FNAME_DEV(ScheduleIntTDs)(struct USB2OTGUnit *otg_Unit)
 {
+    struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
     int chan = 0;
+
+    if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
+        return;
 
     ULONG frnm = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
 
     /* Check if any of INT channels is free */
-    for (chan = CHAN_INT1; chan <= CHAN_INT3; chan++)
+    for (chan = CHAN_INT1; chan <= CHAN_INT_LAST; chan++)
     {
         struct IOUsbHWReq *req = NULL;
 
         /* If channel is in use unlock Enable() and continue checking, otherwise stay in Disable() state for a while */
         Disable();
+        KrnSpinLock(&otg_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
         if (otg_Unit->hu_Channel[chan].hc_Request != NULL)
         {
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
             Enable();
             continue;
         }
-
-        /* First try to get head of the int schedule queue */
-        req = (struct IOUsbHWReq *)REMHEAD(&otg_Unit->hu_IntXFerScheduled);
+        /* Pick first INT req not already in flight (shared TT state). */
+        {
+            struct IOUsbHWReq *candidate, *cnext;
+            req = NULL;
+            ForeachNodeSafe(&otg_Unit->hu_IntXFerScheduled, candidate, cnext)
+            {
+                if (!usb2otg_endpoint_in_flight(otg_Unit, candidate) &&
+                    !usb2otg_tt_in_flight(otg_Unit, candidate))
+                {
+                    REMOVE(candidate);
+                    req = candidate;
+                    break;
+                }
+            }
+        }
 
         if (req)
         {
             /* Channel was free and there is request available. Assign the request to given channel now */
             otg_Unit->hu_Channel[chan].hc_Request = req;
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
             Enable();
 
+            D(bug("[USB2OTG] ScheduleIntTD: chan=%d dev=%ld ep=%ld len=%ld\n",
+                chan, (LONG)req->iouh_DevAddr, (LONG)req->iouh_Endpoint, (LONG)req->iouh_Length));
+
+            ULONG interval = req->iouh_Interval;
+            /* 2-frame clamp only for non-periodic split; INT keeps interval=1. */
+            if ((req->iouh_Flags & UHFF_SPLITTRANS) &&
+                req->iouh_Req.io_Command != UHCMD_INTXFER &&
+                interval < 2)
+                interval = 2;
+
             ULONG last_handled = frnm;
-            ULONG next_to_handle = (last_handled + req->iouh_Interval) & 0x7ff;
+            ULONG next_to_handle = (last_handled + interval) & 0x7ff;
             req->iouh_DriverPrivate1 = (APTR)((last_handled << 16) | next_to_handle);
 
-            FNAME_DEV(SetupChannel)(otg_Unit, chan);
+            if (!FNAME_DEV(SetupChannel)(otg_Unit, chan))
+                continue;
 
             FNAME_DEV(StartChannel)(otg_Unit, chan, 0);
         }
         else
         {
             /* No more requests in the queue, return */
+            KrnSpinUnLock(&otg_Unit->hu_Lock);
             Enable();
             return;
         }


### PR DESCRIPTION
Brings the usb2otg driver to a usable state. Tested on Pi 3 and 3B+.

Works:
 - mouse and keyboard
 - ethernet
 - reading from mass storage devices

Missing / known issues:
 - ISO transfers (USB audio and video)
 - writing to mass storage devices is very unstable
 - no dynamic channel allocation - limited to one mouse, one keyboard, one USB stick, and ethernet simultaneously
 - hot-plug is flaky