### PR TITLE
Intelgma nouveau

### DIFF
--- a/configure
+++ b/configure
@@ -19641,8 +19641,6 @@ if test "$use_libatomic" = "yes" ; then
     aros_cxx_libs="$aros_cxx_libs  -latomic"
 fi
 
-aros_target_options+="$export_newline""# Enable Nouveau Gfx Driver$export_newline""OPT_GFX_NOUVEAU               := no$export_newline"
-
 
 make_extra_commands="$make_extra_commands$export_newline""GENCTBL	:= $""(TOOLDIR)/genctbl$""(HOST_EXE_SUFFIX)$export_newline"
 

--- a/configure.in
+++ b/configure.in
@@ -4030,8 +4030,6 @@ if test "$use_libatomic" = "yes" ; then
     aros_cxx_libs="$aros_cxx_libs  -latomic"
 fi
 
-aros_target_options+="$export_newline""# Enable Nouveau Gfx Driver$export_newline""OPT_GFX_NOUVEAU               := no$export_newline"
-
 dnl --------------------------------------------------------------------
 dnl Configuration Output Section
 dnl --------------------------------------------------------------------

--- a/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
@@ -449,6 +449,31 @@ OOP_Object *METHOD(INTELG45, Root, New)
 //        { TAG_DONE, 0UL }
 //    };
 
+    MAKE_SYNC(640x480_60,  25174,
+         640,  656,  752,  800,
+         480,  490,  492,  525,
+         "GMA_LVDS:640x480");
+
+
+    //native lcd mode
+    struct TagItem sync_native[]={
+        { aHidd_Sync_PixelClock,sd->lvds_fixed.pixelclock*1000000 },
+        { aHidd_Sync_HDisp,     sd->lvds_fixed.hdisp },
+        { aHidd_Sync_HSyncStart,sd->lvds_fixed.hstart },
+        { aHidd_Sync_HSyncEnd,  sd->lvds_fixed.hend },
+        { aHidd_Sync_HTotal,    sd->lvds_fixed.htotal },
+        { aHidd_Sync_VDisp,     sd->lvds_fixed.vdisp },
+        { aHidd_Sync_VSyncStart,sd->lvds_fixed.vstart },
+        { aHidd_Sync_VSyncEnd,  sd->lvds_fixed.vend },
+        { aHidd_Sync_VTotal,    sd->lvds_fixed.vtotal },
+        { aHidd_Sync_VMin,     sd->lvds_fixed.vdisp},
+        { aHidd_Sync_VMax,     4096},
+        { aHidd_Sync_HMin,     sd->lvds_fixed.hdisp},
+        { aHidd_Sync_HMax,     4096},
+        { aHidd_Sync_Description, (IPTR)NULL },
+        { TAG_DONE, 0UL }
+    };
+
         OOP_Object *i2cBus = NULL;
 
     modetags = tags = AllocVecPooled(sd->MemPool,
@@ -479,30 +504,8 @@ OOP_Object *METHOD(INTELG45, Root, New)
                 char *description = AllocVecPooled(sd->MemPool, MAX_MODE_NAME_LEN + 1);
                 snprintf(description, MAX_MODE_NAME_LEN, "GMA_LVDS:%dx%d",
                         sd->lvds_fixed.hdisp, sd->lvds_fixed.vdisp);
+        sync_native[13].ti_Data = (IPTR)description;
 
-                //native lcd mode
-                struct TagItem sync_native[]={
-                { aHidd_Sync_PixelClock,sd->lvds_fixed.pixelclock*1000000 },
-                { aHidd_Sync_HDisp,     sd->lvds_fixed.hdisp },
-                { aHidd_Sync_HSyncStart,sd->lvds_fixed.hstart },
-                { aHidd_Sync_HSyncEnd,  sd->lvds_fixed.hend },
-                { aHidd_Sync_HTotal,    sd->lvds_fixed.htotal },
-                { aHidd_Sync_VDisp,     sd->lvds_fixed.vdisp },
-                { aHidd_Sync_VSyncStart,sd->lvds_fixed.vstart },
-                { aHidd_Sync_VSyncEnd,  sd->lvds_fixed.vend },
-                { aHidd_Sync_VTotal,    sd->lvds_fixed.vtotal },
-                { aHidd_Sync_VMin,     sd->lvds_fixed.vdisp},
-                { aHidd_Sync_VMax,     4096},
-                { aHidd_Sync_HMin,     sd->lvds_fixed.hdisp},
-                { aHidd_Sync_HMax,     4096},
-                { aHidd_Sync_Description, (IPTR)description },
-                { TAG_DONE, 0UL }};
-
-                MAKE_SYNC(640x480_60,   25174,
-         640,  656,  752,  800,
-         480,  490,  492,  525,
-         "GMA_LVDS:640x480");
-                
                 tags->ti_Tag =  aHidd_Gfx_SyncTags;
                 tags->ti_Data = (IPTR)sync_640x480_60;
                 tags++;

--- a/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
@@ -431,29 +431,10 @@ OOP_Object *METHOD(INTELG45, Root, New)
         { TAG_DONE, 0UL }
     };
 
-//    struct TagItem pftags_15bpp[] = {
-//        { aHidd_PixFmt_RedShift,    17  }, /* 0 */
-//        { aHidd_PixFmt_GreenShift,  22  }, /* 1 */
-//        { aHidd_PixFmt_BlueShift,   27  }, /* 2 */
-//        { aHidd_PixFmt_AlphaShift,  0   }, /* 3 */
-//        { aHidd_PixFmt_RedMask,     0x00007c00 }, /* 4 */
-//        { aHidd_PixFmt_GreenMask,   0x000003e0 }, /* 5 */
-//        { aHidd_PixFmt_BlueMask,    0x0000001f }, /* 6 */
-//        { aHidd_PixFmt_AlphaMask,   0x00000000 }, /* 7 */
-//        { aHidd_PixFmt_ColorModel,  vHidd_ColorModel_TrueColor }, /* 8 */
-//        { aHidd_PixFmt_Depth,       15  }, /* 9 */
-//        { aHidd_PixFmt_BytesPerPixel,   2   }, /* 10 */
-//        { aHidd_PixFmt_BitsPerPixel,    15  }, /* 11 */
-//        { aHidd_PixFmt_StdPixFmt,   vHidd_StdPixFmt_RGB15_LE }, /* 12 */
-//        { aHidd_PixFmt_BitMapType,  vHidd_BitMapType_Chunky }, /* 15 */
-//        { TAG_DONE, 0UL }
-//    };
-
     MAKE_SYNC(640x480_60,  25174,
          640,  656,  752,  800,
          480,  490,  492,  525,
          "GMA_LVDS:640x480");
-
 
     //native lcd mode
     struct TagItem sync_native[]={
@@ -474,77 +455,70 @@ OOP_Object *METHOD(INTELG45, Root, New)
         { TAG_DONE, 0UL }
     };
 
-        OOP_Object *i2cBus = NULL;
+    OOP_Object *i2cBus = NULL;
 
-    modetags = tags = AllocVecPooled(sd->MemPool,
-        sizeof (struct TagItem) * (3 + SYNC_LIST_COUNT + 1));
-    poolptr = AllocVecPooled(sd->MemPool,
-        sizeof(struct TagItem) * SYNC_TAG_COUNT * SYNC_LIST_COUNT);
+    modetags = tags = AllocVecPooled(sd->MemPool, sizeof (struct TagItem) * (3 + SYNC_LIST_COUNT + 1));
+    poolptr = AllocVecPooled(sd->MemPool, sizeof(struct TagItem) * SYNC_TAG_COUNT * SYNC_LIST_COUNT);
 
-        struct TagItem i2c_attrs[] = {
-//                      { aHidd_I2C_HoldTime,           40 },
-//                      { aHidd_I2C_RiseFallTime,   40 },
-                        { TAG_DONE, 0UL }
-        };
+    struct TagItem i2c_attrs[] = {
+//        { aHidd_I2C_HoldTime,           40 },
+//        { aHidd_I2C_RiseFallTime,   40 },
+        { TAG_DONE, 0UL }
+    };
 
-        tags->ti_Tag = aHidd_Gfx_PixFmtTags;
-        tags->ti_Data = (IPTR)pftags_24bpp;
-        tags++;
+    tags->ti_Tag = aHidd_Gfx_PixFmtTags;
+    tags->ti_Data = (IPTR)pftags_24bpp;
+    tags++;
 
-        tags->ti_Tag = aHidd_Gfx_PixFmtTags;
-        tags->ti_Data = (IPTR)pftags_16bpp;
-        tags++;
+    tags->ti_Tag = aHidd_Gfx_PixFmtTags;
+    tags->ti_Data = (IPTR)pftags_16bpp;
+    tags++;
 
-//      tags->ti_Tag = aHidd_Gfx_PixFmtTags;
-//      tags->ti_Data = (IPTR)pftags_15bpp;
-//      tags++;
-
-        if( sd->pipe == PIPE_B )
-        {
-                char *description = AllocVecPooled(sd->MemPool, MAX_MODE_NAME_LEN + 1);
-                snprintf(description, MAX_MODE_NAME_LEN, "GMA_LVDS:%dx%d",
-                        sd->lvds_fixed.hdisp, sd->lvds_fixed.vdisp);
+    if( sd->pipe == PIPE_B )
+    {
+        char *description = AllocVecPooled(sd->MemPool, MAX_MODE_NAME_LEN + 1);
+        snprintf(description, MAX_MODE_NAME_LEN, "GMA_LVDS:%dx%d",
+                sd->lvds_fixed.hdisp, sd->lvds_fixed.vdisp);
         sync_native[13].ti_Data = (IPTR)description;
 
-                tags->ti_Tag =  aHidd_Gfx_SyncTags;
-                tags->ti_Data = (IPTR)sync_640x480_60;
-                tags++;
-                
-                tags->ti_Tag =  aHidd_Gfx_SyncTags;
-                tags->ti_Data = (IPTR)sync_native;
-                tags++;
-                
-        }
-        else
+        tags->ti_Tag =  aHidd_Gfx_SyncTags;
+        tags->ti_Data = (IPTR)sync_640x480_60;
+        tags++;
+
+        tags->ti_Tag =  aHidd_Gfx_SyncTags;
+        tags->ti_Data = (IPTR)sync_native;
+        tags++;
+    }
+    else
+    {
+        i2cBus = OOP_NewObject(sd->IntelI2C, NULL, i2c_attrs);
+
+        if (i2cBus)
         {
-                i2cBus = OOP_NewObject(sd->IntelI2C, NULL, i2c_attrs);
+            if (HIDD_I2C_ProbeAddress(i2cBus, 0xa0))
+            {
+                struct TagItem attrs[] = {
+                    { aHidd_I2CDevice_Driver,   (IPTR)i2cBus    },
+                    { aHidd_I2CDevice_Address,  0xa0            },
+                    { aHidd_I2CDevice_Name,     (IPTR)"Display" },
+                    { TAG_DONE,                 0UL             }
+                };
 
-                if (i2cBus)
+                D(bug("[GMA] I2C display device found\n"));
+
+                OOP_Object *i2cDev = OOP_NewObject(NULL, CLID_Hidd_I2CDevice, attrs);
+
+                if (i2cDev)
                 {
-                        if (HIDD_I2C_ProbeAddress(i2cBus, 0xa0))
-                        {
-                                struct TagItem attrs[] = {
-                                                { aHidd_I2CDevice_Driver,       (IPTR)i2cBus    },
-                                                { aHidd_I2CDevice_Address,      0xa0            },
-                                                { aHidd_I2CDevice_Name,         (IPTR)"Display" },
-                                                { TAG_DONE,                             0UL                     }
-                                };
-
-                                D(bug("[GMA] I2C display device found\n"));
-
-                                OOP_Object *i2cDev = OOP_NewObject(NULL, CLID_Hidd_I2CDevice, attrs);
-
-                                if (i2cDev)
-                                {
-                                        G45_parse_ddc(cl, &tags, poolptr, i2cDev);
-                                }
-                        }
+                    G45_parse_ddc(cl, &tags, poolptr, i2cDev);
                 }
-
+            }
         }
 
-        tags->ti_Tag = TAG_DONE;
-        tags->ti_Data = 0;
+    }
+
+    tags->ti_Tag = TAG_DONE;
+    tags->ti_Data = 0;
 
     struct TagItem mytags[] = {
         { aHidd_Gfx_ModeTags,   (IPTR)modetags  },
@@ -564,20 +538,19 @@ OOP_Object *METHOD(INTELG45, Root, New)
     o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
     if (o)
     {
-                struct g45data * gfxdata = OOP_INST_DATA(cl, o);
-                gfxdata->i2cobj = i2cBus;
+        struct g45data * gfxdata = OOP_INST_DATA(cl, o);
+        gfxdata->i2cobj = i2cBus;
         sd->GMAObject = o;
 
-                /* Create compositor object */
-                {
-                        struct TagItem comptags [] =
-                        {
-                                { aHidd_Compositor_GfxHidd, (IPTR)o },
-                                { TAG_DONE, TAG_DONE }
-                        };
-                        sd->compositor = OOP_NewObject(sd->compositorclass, NULL, comptags);
-                        /* TODO: Check if object was created, how to handle ? */
-                }
+        /* Create compositor object */
+        {
+            struct TagItem comptags [] = {
+                { aHidd_Compositor_GfxHidd, (IPTR)o },
+                { TAG_DONE, TAG_DONE }
+            };
+            sd->compositor = OOP_NewObject(sd->compositorclass, NULL, comptags);
+            /* TODO: Check if object was created, how to handle ? */
+        }
     }
 
     FreeVecPooled(sd->MemPool, modetags);

--- a/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
@@ -1001,6 +1001,16 @@ ULONG METHOD(INTELG45, Hidd_Gfx, ModeProperties)
     return len;
 }
 
+VOID METHOD(INTELG45, Hidd_Gfx, NominalDimensions)
+{
+    if (msg->width)
+        *(msg->width) = 1024;
+    if (msg->height)
+        *(msg->height) = 768;
+    if (msg->depth)
+        *(msg->depth) = 24;
+}
+
 static const struct OOP_MethodDescr INTELG45_Root_descr[] =
 {
     {(OOP_MethodFunc)INTELG45__Root__New, moRoot_New},
@@ -1013,15 +1023,16 @@ static const struct OOP_MethodDescr INTELG45_Root_descr[] =
 static const struct OOP_MethodDescr INTELG45_Hidd_Gfx_descr[] =
 {
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__CopyBox         , moHidd_Gfx_CopyBox         },
-    {(OOP_MethodFunc)INTELG45__Hidd_Gfx__CreateObject       , moHidd_Gfx_CreateObject       },
+    {(OOP_MethodFunc)INTELG45__Hidd_Gfx__CreateObject    , moHidd_Gfx_CreateObject    },
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__SetCursorVisible, moHidd_Gfx_SetCursorVisible},
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__SetCursorPos    , moHidd_Gfx_SetCursorPos    },
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__SetCursorShape  , moHidd_Gfx_SetCursorShape  },
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__ShowViewPorts   , moHidd_Gfx_ShowViewPorts   },
     {(OOP_MethodFunc)INTELG45__Hidd_Gfx__ModeProperties  , moHidd_Gfx_ModeProperties  },
+    {(OOP_MethodFunc)INTELG45__Hidd_Gfx__NominalDimensions, moHidd_Gfx_NominalDimensions    },
     {NULL, 0}
 };
-#define NUM_INTELG45_Hidd_Gfx_METHODS 7
+#define NUM_INTELG45_Hidd_Gfx_METHODS 8
 
 const struct OOP_InterfaceDescr INTELG45_ifdescr[] =
 {

--- a/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_hiddclass.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 1995-2019, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0

--- a/workbench/devs/monitors/IntelGMA/intelgma_init.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_init.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2010-2017, The AROS Development Team. All rights reserved.
+    Copyright (C) 2010-2026, The AROS Development Team. All rights reserved.
 */
 
 #include <aros/debug.h>

--- a/workbench/devs/monitors/IntelGMA/intelgma_init.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_init.c
@@ -229,6 +229,13 @@ AROS_UFH3(void, Enumerator,
         /*-------- DO NOT CHANGE/REMOVE -------------*/
         bug("\003\n"); /* Tell vga text mode debug output to die */
         /*-------- DO NOT CHANGE/REMOVE -------------*/
+        /*
+            Explanation:
+            Debug output writes to frame buffer. The same framebuffer gets mapped to first memory header below and
+            structures (like command ring or bitmaps) get allocated from it. If debug continues to output, it
+            actually overwrites allocated structures and memory manager MemChunks. First signs are Allocate failing
+            with 'Sanity check failed'.
+        */
 
         switch (MGCC & G45_MGCC_GMS_MASK)
         {

--- a/workbench/devs/monitors/IntelGMA/intelgma_init.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_init.c
@@ -494,7 +494,8 @@ int G45_Init(struct g45staticdata *sd)
 
                 if (sd->PCIDevice)
                 {
-                    D(bug("[GMA] Found supported gfx card\n\003"));
+                    D(bug("[GMA] Found supported gfx card\n"));
+                    D(bug("\003"));
 
                     sd->mid_CopyMemBox8     = OOP_GetMethodID((STRPTR)CLID_Hidd_BitMap, moHidd_BitMap_CopyMemBox8);
                     sd->mid_CopyMemBox16    = OOP_GetMethodID((STRPTR)CLID_Hidd_BitMap, moHidd_BitMap_CopyMemBox16);

--- a/workbench/devs/monitors/IntelGMA/intelgma_support.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_support.c
@@ -152,6 +152,9 @@ void UpdateCursor(struct g45staticdata *sd)
 
 void SetCursorPosition(struct g45staticdata *sd, LONG x, LONG y)
 {
+    if (sd->VisibleBitmap == NULL)
+        return;
+
     LONG width = (sd->VisibleBitmap->state->htotal & 0x0000ffff);
     LONG height = (sd->VisibleBitmap->state->vtotal & 0x0000ffff);
 

--- a/workbench/devs/monitors/IntelGMA/intelgma_support.c
+++ b/workbench/devs/monitors/IntelGMA/intelgma_support.c
@@ -150,18 +150,18 @@ void UpdateCursor(struct g45staticdata *sd)
     writel(sd->CursorBase, sd->Card.MMIO + (sd->pipe == PIPE_A ? G45_CURABASE : G45_CURBBASE));
 }
 
-void SetCursorPosition(struct g45staticdata *sd,LONG x,LONG y)
+void SetCursorPosition(struct g45staticdata *sd, LONG x, LONG y)
 {
-        LONG width = (sd->VisibleBitmap->state->htotal & 0x0000ffff);
+    LONG width = (sd->VisibleBitmap->state->htotal & 0x0000ffff);
     LONG height = (sd->VisibleBitmap->state->vtotal & 0x0000ffff);
-        
-        if(x<0)x=0;
-        if(y<0)y=0;
-        if(x>width)x = width;  // Grue eats you,if pointer is outside of the screen.
-        if(y>height)y = height;
-        
-        writel(((ULONG)x << G45_CURPOS_XSHIFT) | ((ULONG)y << G45_CURPOS_YSHIFT),
-                        sd->Card.MMIO + (sd->pipe == PIPE_A ?G45_CURAPOS:G45_CURBPOS));
+
+    if (x < 0) x=0;
+    if (y < 0) y=0;
+    if (x > width) x = width;  // Grue eats you,if pointer is outside of the screen.
+    if (y > height) y = height;
+
+    writel(((ULONG)x << G45_CURPOS_XSHIFT) | ((ULONG)y << G45_CURPOS_YSHIFT),
+                    sd->Card.MMIO + (sd->pipe == PIPE_A ?G45_CURAPOS:G45_CURBPOS));
     UpdateCursor(sd);
 }
 

--- a/workbench/hidds/nouveau/mmakefile.src
+++ b/workbench/hidds/nouveau/mmakefile.src
@@ -13,9 +13,9 @@ include $(SRCDIR)/$(CURDIR)/drm/sources.drm.mak
 # which fails to build on architectures due to because of missing
 # Wbinvd() implementation.
 
-#MM- workbench-hidds-nouveau : hidd-nouveau-$(OPT_GFX_NOUVEAU)-$(AROS_TARGET_CPU)
-#MM- hidd-nouveau-yes-i386 : hidd-nouveau
-#MM- hidd-nouveau-yes-x86_64 : hidd-nouveau
+#MM- workbench-hidds-nouveau : hidd-nouveau-$(AROS_TARGET_CPU)
+#MM- hidd-nouveau-i386 : hidd-nouveau
+#MM- hidd-nouveau-x86_64 : hidd-nouveau
 #MM hidd-nouveau : hidd-i2c hidd-agp hidd-gallium
 
 GALLIUM_NOUVEAU_SOURCES := \

--- a/workbench/hidds/nouveau/mmakefile.src
+++ b/workbench/hidds/nouveau/mmakefile.src
@@ -48,11 +48,14 @@ XF86_NOUVEAU_SOURCES = \
 DRM_PATH = $(SRCDIR)/$(CURDIR)/drm/
 XF86_NOUVEAU_PATH = $(SRCDIR)/$(CURDIR)/xf86-video-nouveau/
 
+#FIXME
+#            nouveau_galliumclass \
+#            $(addprefix $(GALLIUM_PATH)/drivers/nouveau/, $(GALLIUM_NOUVEAU_C_SOURCES:.c=)) \
+
 NOUVEAU_HIDD_C_SOURCES := \
             nouveau_hiddclass \
             nouveau_init \
             nouveau_bitmapclass \
-            nouveau_galliumclass \
             nouveau_accel \
             nouveau_i2cclass \
             arosc_emul \
@@ -61,7 +64,6 @@ NOUVEAU_HIDD_C_SOURCES := \
             $(addprefix $(DRM_PATH),$(AROS_DRM_NVIDIA_SOURCES))         \
             $(addprefix $(DRM_PATH),$(AROS_LIBDRM_CORE_SOURCES))        \
             $(addprefix $(DRM_PATH),$(AROS_LIBDRM_NVIDIA_SOURCES))      \
-            $(addprefix $(GALLIUM_PATH)/drivers/nouveau/, $(GALLIUM_NOUVEAU_C_SOURCES:.c=)) \
             $(addprefix $(XF86_NOUVEAU_PATH), $(XF86_NOUVEAU_SOURCES))  \
 
 NOUVEAU_HIDD_CXX_SOURCES := \

--- a/workbench/hidds/nouveau/mmakefile.src
+++ b/workbench/hidds/nouveau/mmakefile.src
@@ -66,8 +66,8 @@ NOUVEAU_HIDD_C_SOURCES := \
             $(addprefix $(DRM_PATH),$(AROS_LIBDRM_NVIDIA_SOURCES))      \
             $(addprefix $(XF86_NOUVEAU_PATH), $(XF86_NOUVEAU_SOURCES))  \
 
-NOUVEAU_HIDD_CXX_SOURCES := \
-            $(addprefix $(GALLIUM_PATH)/drivers/nouveau/, $(GALLIUM_NOUVEAU_CXX_SOURCES:.cpp=))
+#NOUVEAU_HIDD_CXX_SOURCES := \
+#            $(addprefix $(GALLIUM_PATH)/drivers/nouveau/, $(GALLIUM_NOUVEAU_CXX_SOURCES:.cpp=))
 
 USER_INCLUDES += \
             -I$(DRM_PATH)/drm \
@@ -79,7 +79,7 @@ USER_INCLUDES += \
             -iquote $(GALLIUM_PATH)/include \
             -iquote $(GALLIUM_PATH)/auxiliary \
             -iquote $(top_srcdir)/src/mesa \
-            -iquote $(GENDIR)/workbench/libs/mesa/src/compiler/nir \
+            -iquote $(GENDIR)/workbench/libs/mesa/20.0.8/src/compiler/nir \
             -I$(DRM_PATH)/libdrm \
             -I$(DRM_PATH)/libdrm/nouveau \
             -I$(XF86_NOUVEAU_PATH)

--- a/workbench/hidds/nouveau/mmakefile.src
+++ b/workbench/hidds/nouveau/mmakefile.src
@@ -76,6 +76,8 @@ USER_INCLUDES += \
             -iquote $(GALLIUM_PATH)/drivers/nouveau \
             -iquote $(GALLIUM_PATH)/include \
             -iquote $(GALLIUM_PATH)/auxiliary \
+            -iquote $(top_srcdir)/src/mesa \
+            -iquote $(GENDIR)/workbench/libs/mesa/src/compiler/nir \
             -I$(DRM_PATH)/libdrm \
             -I$(DRM_PATH)/libdrm/nouveau \
             -I$(XF86_NOUVEAU_PATH)
@@ -86,12 +88,10 @@ USER_CFLAGS += $(NOWARN_FLAGS) -std=gnu99
 
 USER_LDFLAGS += \
   -L$(top_libdir) \
-  -lgalliumauxiliary -lmesautil \
+  -lgalliumauxiliary -lcompiler -lmesautil \
   -lhiddstubs -lstdcio -lstdc
   
- %build_module mmake=hidd-nouveau \
-     modname=nouveau modtype=hidd \
-     files="$(NOUVEAU_HIDD_C_SOURCES)" \
-     cxxfiles="$(NOUVEAU_HIDD_CXX_SOURCES)" \
+ %build_module mmake=hidd-nouveau modname=nouveau modtype=hidd \
+     files="$(NOUVEAU_HIDD_C_SOURCES)" cxxfiles="$(NOUVEAU_HIDD_CXX_SOURCES)" \
      uselibs=""
 

--- a/workbench/hidds/nouveau/nouveau.conf
+++ b/workbench/hidds/nouveau/nouveau.conf
@@ -83,25 +83,6 @@ GetBits
 
 ##begin class
 ##begin config
-basename        NouveauGallium
-type            hidd
-classptr_field  sd.galliumclass
-classid         CLID_Hidd_Gallium_Nouveau
-superclass      CLID_Hidd_Gallium
-classdatatype   struct HIDDGalliumNouveauData
-##end config
-##begin methodlist
-.interface Root
-New
-Get
-.interface Hidd_Gallium
-CreatePipeScreen
-DisplayResource
-##end methodlist
-##end class
-
-##begin class
-##begin config
 basename        Compositor
 type            hidd
 classptr_field  sd.compositorclass
@@ -119,4 +100,3 @@ BitMapPositionChanged
 ValidateBitMapPositionChange
 ##end methodlist
 ##end class
-

--- a/workbench/hidds/nouveau/nouveau.conf
+++ b/workbench/hidds/nouveau/nouveau.conf
@@ -26,6 +26,7 @@ SetCursorPos
 SetCursorShape
 ModeProperties
 ShowViewPorts
+NominalDimensions
 ##end methodlist
 
 ##begin class

--- a/workbench/hidds/nouveau/nouveau_accel.c
+++ b/workbench/hidds/nouveau/nouveau_accel.c
@@ -25,6 +25,7 @@
 #include "nouveau_class.h"
 #include <proto/oop.h>
 #include <proto/exec.h>
+#include <stdlib.h>
 
 #undef HiddBitMapAttrBase
 #define HiddBitMapAttrBase  (SD(cl)->bitMapAttrBase)
@@ -1118,19 +1119,17 @@ VOID HIDDNouveauBitMapDrawSolidLine(struct HIDDNouveauBitMapData * bmdata,
         /*
             Horizontal line drawing code.
         */
-        IPTR addr = map + (bmdata->pitch * y1) + (x1 * bmdata->bytesperpixel);
-    
         for(i = x1; i != x2; i++)
-        {    
+        {
             /* Pixel inside ? */
             if ((!doclip) || (!POINT_OUTSIDE_CLIP(gc, i, y1)))
             {
+                IPTR addr = map + (bmdata->pitch * y1) + (i * bmdata->bytesperpixel);
                 if (bmdata->bytesperpixel == 2)
                     writew(fg, (APTR)addr);
                 else
                     writel(fg, (APTR)addr);
             }
-            addr += bmdata->bytesperpixel;
         }
     }
     else if (x1 == x2)
@@ -1138,19 +1137,17 @@ VOID HIDDNouveauBitMapDrawSolidLine(struct HIDDNouveauBitMapData * bmdata,
         /*
             Vertical line drawing code.
         */
-        IPTR addr = map + (bmdata->pitch * y1) + (x1 * bmdata->bytesperpixel);
-    
         for(i = y1; i != y2; i++)
-        {    
+        {
             /* Pixel inside ? */
             if (!doclip || !POINT_OUTSIDE_CLIP(gc, x1, i ))
             {
+                IPTR addr = map + (bmdata->pitch * i) + (x1 * bmdata->bytesperpixel);
                 if (bmdata->bytesperpixel == 2)
                     writew(fg, (APTR)addr);
                 else
                     writel(fg, (APTR)addr);
             }
-            addr += bmdata->pitch;
         }
     }
     else
@@ -1159,9 +1156,8 @@ VOID HIDDNouveauBitMapDrawSolidLine(struct HIDDNouveauBitMapData * bmdata,
             Generic line drawing code.
         */
         WORD dx, dy, x, y, incrE, incrNE, d, s1, s2, t;
-        IPTR addr;
         
-        /* Restore original coordinates - important for non-straight lines as 
+        /* Restore original coordinates - important for non-straight lines as
            normalization might have switched them */
         x1 = destX1;
         y1 = destY1;
@@ -1197,11 +1193,11 @@ VOID HIDDNouveauBitMapDrawSolidLine(struct HIDDNouveauBitMapData * bmdata,
         x = x1; y = y1;
         
         for(i = 0; i <= dx; i++)
-        {    
+        {
             /* Pixel inside ? */
             if (!doclip || !POINT_OUTSIDE_CLIP(gc, x, y ))
             {
-                addr = map + (x * bmdata->bytesperpixel) + (bmdata->pitch * y);
+                IPTR addr = map + (x * bmdata->bytesperpixel) + (bmdata->pitch * y);
                 if (bmdata->bytesperpixel == 2)
                     writew(fg, (APTR)addr);
                 else

--- a/workbench/hidds/nouveau/nouveau_hiddclass.c
+++ b/workbench/hidds/nouveau/nouveau_hiddclass.c
@@ -907,4 +907,12 @@ ULONG METHOD(Nouveau, Hidd_Gfx, ModeProperties)
     return len;
 }
 
-
+VOID METHOD(Nouveau, Hidd_Gfx, NominalDimensions)
+{
+    if (msg->width)
+        *(msg->width) = 1024;
+    if (msg->height)
+        *(msg->height) = 768;
+    if (msg->depth)
+        *(msg->depth) = 24;
+}

--- a/workbench/hidds/nouveau/nouveau_hiddclass.c
+++ b/workbench/hidds/nouveau/nouveau_hiddclass.c
@@ -626,6 +626,7 @@ OOP_Object * METHOD(Nouveau, Hidd_Gfx, CreateObject)
     else if (SD(cl)->basegallium && (msg->cl == SD(cl)->basegallium))
     {
         /* Create the gallium 3d driver object .. */
+        // FIXME
         object = OOP_NewObject(NULL, CLID_Hidd_Gallium_Nouveau, msg->attrList);
     }
     else if (SD(cl)->basei2c && (msg->cl == SD(cl)->basei2c))

--- a/workbench/hidds/nouveau/nouveau_intern.h
+++ b/workbench/hidds/nouveau/nouveau_intern.h
@@ -10,7 +10,7 @@
 #include <hidd/i2c.h>
 #include <hidd/gallium.h>
 
-#include "util/u_simple_screen.h"
+// #include "util/u_simple_screen.h"
 #include "nouveau/nouveau_drmif.h"
 #include "nouveau/nouveau_bo.h"
 #include "nouveau/nouveau_channel.h"
@@ -114,7 +114,7 @@ struct HIDDNouveauI2CData
 
 struct HIDDGalliumNouveauData
 {
-    struct pipe_winsys nouveau_winsys;
+    // struct pipe_winsys nouveau_winsys;
     OOP_Object *nouveau_obj;
 };
 

--- a/workbench/hidds/nouveau/xf86-video-nouveau/nv30_shaders.c
+++ b/workbench/hidds/nouveau/xf86-video-nouveau/nv30_shaders.c
@@ -23,6 +23,26 @@
 #include "nv30_shaders.h"
 #include "nv04_pushbuf.h"
 
+/*******************************************************************************
+ * NV40/G70 vertex shaders
+ */
+
+nv_shader_t nv40_vp_exa_render;
+nv_shader_t nv40_vp_video;
+
+/*******************************************************************************
+ * NV30/NV40/G70 fragment shaders
+ */
+
+nv_shader_t nv30_fp_pass_col0;
+nv_shader_t nv30_fp_pass_tex0;
+nv_shader_t nv30_fp_composite_mask;
+nv_shader_t nv30_fp_composite_mask_sa_ca;
+nv_shader_t nv30_fp_composite_mask_ca;
+nv_shader_t nv30_fp_yv12_bicubic;
+nv_shader_t nv30_fp_yv12_bilinear;
+nv_shader_t nv40_fp_yv12_bicubic;
+
 void NV30_UploadFragProg(NVPtr pNv, nv_shader_t *shader, int *hw_offset)
 {
 	uint32_t data, i;

--- a/workbench/hidds/nouveau/xf86-video-nouveau/nv30_shaders.h
+++ b/workbench/hidds/nouveau/xf86-video-nouveau/nv30_shaders.h
@@ -53,20 +53,20 @@ Bool NV30_LoadFragProg(ScrnInfoPtr pScrn, nv_shader_t *shader);
  * NV40/G70 vertex shaders
  */
 
-nv_shader_t nv40_vp_exa_render;
-nv_shader_t nv40_vp_video;
+extern nv_shader_t nv40_vp_exa_render;
+extern nv_shader_t nv40_vp_video;
 
 /*******************************************************************************
  * NV30/NV40/G70 fragment shaders
  */
 
-nv_shader_t nv30_fp_pass_col0;
-nv_shader_t nv30_fp_pass_tex0;
-nv_shader_t nv30_fp_composite_mask;
-nv_shader_t nv30_fp_composite_mask_sa_ca;
-nv_shader_t nv30_fp_composite_mask_ca;
-nv_shader_t nv30_fp_yv12_bicubic;
-nv_shader_t nv30_fp_yv12_bilinear;
-nv_shader_t nv40_fp_yv12_bicubic;
+extern nv_shader_t nv30_fp_pass_col0;
+extern nv_shader_t nv30_fp_pass_tex0;
+extern nv_shader_t nv30_fp_composite_mask;
+extern nv_shader_t nv30_fp_composite_mask_sa_ca;
+extern nv_shader_t nv30_fp_composite_mask_ca;
+extern nv_shader_t nv30_fp_yv12_bicubic;
+extern nv_shader_t nv30_fp_yv12_bilinear;
+extern nv_shader_t nv40_fp_yv12_bicubic;
 
 #endif


### PR DESCRIPTION
1) Fix boot time issues with IntelGMA - driver tested to work (2D and 3D) on Dell Lattitude D520
2) Restore build of current nouveau sources (only 2D) - tested on several NV50/NVC0 cards

3D in nouveau is currently disabled as it requires updated drm driver and updated libdrm.