### PR TITLE
vc4gfx: serialize shared mailbox buffer, use MBoxCall

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmapclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmapclass.c
@@ -12,6 +12,7 @@
 #include <string.h>    // memset() prototype
 
 #include "vc4gfx_hardware.h"
+#include "vc4gfx_hidd.h"
 
 #ifdef OnBitmap
 /*********  BitMap::Clear()  *************************************/
@@ -53,34 +54,52 @@ BOOL MNAME_BM(SetColors)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_SetCo
         return FALSE;
 
 #ifdef OnBitmap
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[0] = AROS_LONG2LE(5 + (msg->numColors - msg->firstColor) * 4);
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[2] = AROS_LONG2LE(VCTAG_SETPALETTE);
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[3] = AROS_LONG2LE((msg->numColors - msg->firstColor) * 4);
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[4] = AROS_LONG2LE(msg->firstColor);
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[5] = AROS_LONG2LE(msg->numColors);
-#endif
+    {
+        struct VideoCoreGfx_staticdata *xsd =
+            &((struct VideoCoreGfxBase *)cl->UserData)->vsd;
+        unsigned int *m;
+        ULONG nc = msg->numColors;
+
+        VC4_MBOX_LOCK(xsd);
+        m = xsd->vcsd_MBoxMessage;
+        m[0] = AROS_LONG2LE((8 + nc) * 4);
+        m[1] = AROS_LONG2LE(VCTAG_REQ);
+        m[2] = AROS_LONG2LE(VCTAG_SETPALETTE);
+        m[3] = AROS_LONG2LE((2 + nc) * 4);
+        m[4] = 0;
+        m[5] = AROS_LONG2LE(msg->firstColor);
+        m[6] = AROS_LONG2LE(nc);
+        for (xc_i = msg->firstColor, col_i = 0; col_i < nc; xc_i++, col_i++)
+        {
+            red   = msg->colors[col_i].red   >> 8;
+            green = msg->colors[col_i].green >> 8;
+            blue  = msg->colors[col_i].blue  >> 8;
+            data->cmap[xc_i] =
+                0x01000000 | red | (green << 8) | (blue << 16);
+            m[7 + col_i] = AROS_LONG2LE((red << 24) | (green << 16) |
+                                        (blue << 8) | 0xff);
+            msg->colors[col_i].pixval = xc_i;
+        }
+        m[7 + nc] = 0;  /* end tag */
+
+        if ((MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, m)
+                == (volatile unsigned int *)-1)
+            || (AROS_LE2LONG(m[4]) != (VCTAG_RESP + 4))
+            || (AROS_LE2LONG(m[5]) != 0))
+        {
+            VC4_MBOX_UNLOCK(xsd);
+            return FALSE;
+        }
+        VC4_MBOX_UNLOCK(xsd);
+    }
+#else
     for (xc_i = msg->firstColor, col_i = 0; col_i < msg->numColors; xc_i++, col_i++)
     {
-        red = msg->colors[col_i].red >> 8;
+        red   = msg->colors[col_i].red   >> 8;
         green = msg->colors[col_i].green >> 8;
-        blue = msg->colors[col_i].blue >> 8;
+        blue  = msg->colors[col_i].blue  >> 8;
         data->cmap[xc_i] = 0x01000000 | red | (green << 8) | (blue << 16);
-#ifdef OnBitmap
-
-        (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[6 + col_i] = AROS_LONG2LE((red << 24) | (green << 16) | (blue << 8));
-        D(bug("[VideoCoreGfx] VideoCoreGfx.BitMap::SetColors: color #%d = %08x\n", xc_i, AROS_LONG2LE(&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[6 + col_i]));
-#endif
         msg->colors[col_i].pixval = xc_i;
-    }
-#ifdef OnBitmap
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[7 + col_i ] = 0;
-    (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[7 + col_i + 1] = 0; // terminate tag
-
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage)
-    {
-        D(bug("[VideoCoreGfx] %s: Palette set [status %08x]\n", __PRETTY_FUNCTION__, AROS_LONG2LE(&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxMessage[7 + col_i]));
     }
 #endif
     return TRUE;

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hdmi.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hdmi.c
@@ -75,6 +75,9 @@ static struct DisplayMode *VC4_BuildMode(const struct VC4ModeEntry *e)
  */
 static BOOL VC4_TestRes(struct VideoCoreGfx_staticdata *xsd, ULONG w, ULONG h)
 {
+    BOOL ok;
+
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LONG2LE(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LONG2LE(VCTAG_TESTRES);
@@ -84,13 +87,11 @@ static BOOL VC4_TestRes(struct VideoCoreGfx_staticdata *xsd, ULONG w, ULONG h)
     xsd->vcsd_MBoxMessage[6] = AROS_LONG2LE(h);
     xsd->vcsd_MBoxMessage[7] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) != xsd->vcsd_MBoxMessage)
-        return FALSE;
-    if (xsd->vcsd_MBoxMessage[1] != AROS_LE2LONG(VCTAG_RESP))
-        return FALSE;
-
-    return TRUE;
+    ok = (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+              != (volatile unsigned int *)-1)
+         && (xsd->vcsd_MBoxMessage[1] == AROS_LE2LONG(VCTAG_RESP));
+    VC4_MBOX_UNLOCK(xsd);
+    return ok;
 }
 
 int FNAME_SUPPORT(HDMI_SyncGen)(struct List *modelist, OOP_Class *cl)
@@ -106,6 +107,7 @@ int FNAME_SUPPORT(HDMI_SyncGen)(struct List *modelist, OOP_Class *cl)
     /* Query the firmware for the currently-active display mode. This is the
      * resolution the HDMI link was negotiated at and serves as our default.
      */
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LONG2LE(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LONG2LE(VCTAG_GETRES);
@@ -115,28 +117,29 @@ int FNAME_SUPPORT(HDMI_SyncGen)(struct List *modelist, OOP_Class *cl)
     xsd->vcsd_MBoxMessage[6] = 0;
     xsd->vcsd_MBoxMessage[7] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if ((MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage) &&
+    if ((MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+            != (volatile unsigned int *)-1) &&
         (xsd->vcsd_MBoxMessage[1] == AROS_LE2LONG(VCTAG_RESP)))
     {
         native_w = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
         native_h = AROS_LE2LONG(xsd->vcsd_MBoxMessage[6]);
+    }
+    VC4_MBOX_UNLOCK(xsd);
 
-        xsd->vcsd_NativeWidth  = native_w;
-        xsd->vcsd_NativeHeight = native_h;
+    xsd->vcsd_NativeWidth  = native_w;
+    xsd->vcsd_NativeHeight = native_h;
 
-        if (native_w && native_h)
+    if (native_w && native_h)
+    {
+        struct VC4ModeEntry n = { native_w, native_h, 25174,
+            native_w, native_w, native_w,
+            native_h, native_h, native_h };
+        if ((hdmi_mode = VC4_BuildMode(&n)) != NULL)
         {
-            struct VC4ModeEntry n = { native_w, native_h, 25174,
-                native_w, native_w, native_w,
-                native_h, native_h, native_h };
-            if ((hdmi_mode = VC4_BuildMode(&n)) != NULL)
-            {
-                AddTail(modelist, &hdmi_mode->dm_Node);
-                hdmi_modecount++;
-                D(bug("[VideoCoreGfx] %s: native HDMI mode %dx%d\n",
-                    __PRETTY_FUNCTION__, (int)native_w, (int)native_h));
-            }
+            AddTail(modelist, &hdmi_mode->dm_Node);
+            hdmi_modecount++;
+            D(bug("[VideoCoreGfx] %s: native HDMI mode %dx%d\n",
+                __PRETTY_FUNCTION__, (int)native_w, (int)native_h));
         }
     }
 

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hidd.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hidd.h
@@ -10,8 +10,15 @@
 #include <exec/memheaderext.h>
 #include <exec/nodes.h>
 #include <exec/types.h>
+#include <proto/exec.h>
 
 #include "vc4gfx_hardware.h"
+
+/* vcsd_MBoxMessage is a single shared buffer used by every mailbox
+ * round-trip (palette, framebuffer alloc, cursor, mode set, memory).
+ * Take vcsd_GPUMemLock around every pack-write-read sequence. */
+#define VC4_MBOX_LOCK(xsd)   ObtainSemaphore(&(xsd)->vcsd_GPUMemLock)
+#define VC4_MBOX_UNLOCK(xsd) ReleaseSemaphore(&(xsd)->vcsd_GPUMemLock)
 
 #define DEBUGMODEARRAY
 //#define DEBUGPIXFMT

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
@@ -229,6 +229,7 @@ int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
      * flags] - the request value buffer is 3 u32 (size/align/flags),
      * the response writes a 1 u32 handle into the first slot.
      */
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(10 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_ALLOCMEM);
@@ -240,12 +241,18 @@ int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
     xsd->vcsd_MBoxMessage[8] = 0;
     xsd->vcsd_MBoxMessage[9] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) != xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        == (volatile unsigned int *)-1)
+    {
+        VC4_MBOX_UNLOCK(xsd);
         return FALSE;
+    }
     xsd->vcsd_CurBufHandle = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
     if (!xsd->vcsd_CurBufHandle)
+    {
+        VC4_MBOX_UNLOCK(xsd);
         return FALSE;
+    }
 
     /* LOCKMEM tag layout: [tag, value_buf_size, code, handle] - request
      * value is the handle, response overwrites it with the bus address.
@@ -259,11 +266,15 @@ int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
     xsd->vcsd_MBoxMessage[6] = 0;
     xsd->vcsd_MBoxMessage[7] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) != xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        == (volatile unsigned int *)-1)
+    {
+        VC4_MBOX_UNLOCK(xsd);
         return FALSE;
+    }
 
     xsd->vcsd_CurBufBus = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+    VC4_MBOX_UNLOCK(xsd);
     xsd->vcsd_CurVisible = FALSE;
 
     /* The firmware should hand back a GPU bus address with the alias
@@ -322,6 +333,7 @@ BOOL MNAME_GFX(SetCursorShape)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_Se
     {
         /* Hide and forget the current shape. */
         xsd->vcsd_CurVisible = FALSE;
+        VC4_MBOX_LOCK(xsd);
         xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
         xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
         xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETCURSORSTATE);
@@ -332,8 +344,8 @@ BOOL MNAME_GFX(SetCursorShape)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_Se
         xsd->vcsd_MBoxMessage[7] = AROS_LE2LONG(0);
         xsd->vcsd_MBoxMessage[8] = AROS_LE2LONG(0);
         xsd->vcsd_MBoxMessage[9] = 0;
-        MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-        MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN);
+        MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+        VC4_MBOX_UNLOCK(xsd);
         return TRUE;
     }
 
@@ -356,6 +368,7 @@ BOOL MNAME_GFX(SetCursorShape)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_Se
     xsd->vcsd_CurHotY   = msg->yoffset;
 
     /* SETCURSORINFO: width, height, format(0), buf, hot_x, hot_y */
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(12 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETCURSORINFO);
@@ -369,13 +382,17 @@ BOOL MNAME_GFX(SetCursorShape)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_Se
     xsd->vcsd_MBoxMessage[10] = AROS_LE2LONG(xsd->vcsd_CurHotY);
     xsd->vcsd_MBoxMessage[11] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) != xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        == (volatile unsigned int *)-1)
+    {
+        VC4_MBOX_UNLOCK(xsd);
         return FALSE;
-    if (AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]) != 0)
-        return FALSE;
-
-    return TRUE;
+    }
+    {
+        BOOL ok = (AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]) == 0);
+        VC4_MBOX_UNLOCK(xsd);
+        return ok;
+    }
 }
 
 BOOL MNAME_GFX(SetCursorPos)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_SetCursorPos *msg)
@@ -391,6 +408,7 @@ BOOL MNAME_GFX(SetCursorPos)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_SetC
     if (!xsd->vcsd_CurVisible)
         return TRUE;
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETCURSORSTATE);
@@ -402,8 +420,8 @@ BOOL MNAME_GFX(SetCursorPos)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_SetC
     xsd->vcsd_MBoxMessage[8] = AROS_LE2LONG(1);     /* 1 = framebuffer coords (firmware scales) */
     xsd->vcsd_MBoxMessage[9] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN);
+    MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+    VC4_MBOX_UNLOCK(xsd);
     return TRUE;
 }
 
@@ -416,6 +434,7 @@ VOID MNAME_GFX(SetCursorVisible)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_
 
     xsd->vcsd_CurVisible = msg->visible ? TRUE : FALSE;
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETCURSORSTATE);
@@ -427,8 +446,8 @@ VOID MNAME_GFX(SetCursorVisible)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_
     xsd->vcsd_MBoxMessage[8] = AROS_LE2LONG(1);     /* 1 = framebuffer coords */
     xsd->vcsd_MBoxMessage[9] = 0;
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN);
+    MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+    VC4_MBOX_UNLOCK(xsd);
 }
 
 OOP_Object *MNAME_GFX(CreateObject)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_CreateObject *msg)

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
@@ -102,10 +102,16 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
     xsd->vcsd_MBoxMessage =
         (unsigned int *)((xsd->vcsd_MBoxBuff + 0xF) & ~0x0000000F);
 
+    /* Initialise the mailbox lock here, before the first MBoxWrite/Read,
+     * so every subsequent transaction (including ones triggered before
+     * InitMem runs) can take it. */
+    InitSemaphore(&xsd->vcsd_GPUMemLock);
+
     D(bug("[VideoCoreGfx] %s: VideoCore Mailbox resource @ 0x%p\n", __PRETTY_FUNCTION__, MBoxBase));
     D(bug("[VideoCoreGfx] %s: VideoCore message buffer @ 0x%p\n", __PRETTY_FUNCTION__, xsd->vcsd_MBoxMessage));
 
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_GETVCRAM);
@@ -117,10 +123,13 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
 
     xsd->vcsd_MBoxMessage[7] = 0; // terminate tag
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
     {
-        if (FNAME_SUPPORT(InitMem)((void*)AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]), AROS_LE2LONG(xsd->vcsd_MBoxMessage[6]), LIBBASE))
+        BOOL  mbox_ok   = (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+                          != (volatile unsigned int *)-1);
+        void *vc_base   = (void*)AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+        ULONG vc_length = AROS_LE2LONG(xsd->vcsd_MBoxMessage[6]);
+        VC4_MBOX_UNLOCK(xsd);
+        if (mbox_ok && FNAME_SUPPORT(InitMem)(vc_base, vc_length, LIBBASE))
         {
             D(bug("[VideoCoreGfx] VideoCore GPU Found\n"));
 

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_memory.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_memory.c
@@ -58,6 +58,7 @@ void *FNAME_SUPPORT(Alloc)(struct MemHeaderExt *mhe, IPTR size, ULONG *flags)
     if (*flags & MEMF_HWALIGNED)
         gpumemalign = 4096;
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(9 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_ALLOCMEM);
@@ -70,16 +71,19 @@ void *FNAME_SUPPORT(Alloc)(struct MemHeaderExt *mhe, IPTR size, ULONG *flags)
 
     xsd->vcsd_MBoxMessage[8] = 0; // terminate tag
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        != (volatile unsigned int *)-1)
     {
+        void *res = (void*)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[7]) & 0x3fffffff);
         D(bug("[VideoCoreGfx] %s: Allocated %d bytes, memhandle @ 0x%p\n", __PRETTY_FUNCTION__,
             AROS_LE2LONG(xsd->vcsd_MBoxMessage[4]), AROS_LE2LONG(xsd->vcsd_MBoxMessage[7])));
+        VC4_MBOX_UNLOCK(xsd);
 
         mhe->mhe_MemHeader.mh_Free -= size;
 
-        return (void*)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[7]) & 0x3fffffff);
+        return res;
     }
+    VC4_MBOX_UNLOCK(xsd);
     return NULL;
 }
 
@@ -93,6 +97,7 @@ void *FNAME_SUPPORT(LockMem)(struct MemHeaderExt *mhe, void *memhandle)
 
     D(bug("[VideoCoreGfx] %s(memhandle @ 0x%p)\n", __PRETTY_FUNCTION__, memhandle));
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_LOCKMEM);
@@ -103,12 +108,15 @@ void *FNAME_SUPPORT(LockMem)(struct MemHeaderExt *mhe, void *memhandle)
 
     xsd->vcsd_MBoxMessage[6] = 0; // terminate tag
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        != (volatile unsigned int *)-1)
     {
+        void *res = (void*)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]) & 0x3fffffff);
         D(bug("[VideoCoreGfx] %s: Memory locked @ 0x%p\n", __PRETTY_FUNCTION__, AROS_LE2LONG(xsd->vcsd_MBoxMessage[5])));
-        return (void*)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]) & 0x3fffffff);
+        VC4_MBOX_UNLOCK(xsd);
+        return res;
     }
+    VC4_MBOX_UNLOCK(xsd);
     return NULL;
 }
 
@@ -121,6 +129,7 @@ void *FNAME_SUPPORT(UnLockMem)(struct MemHeaderExt *mhe, void *memhandle)
 
     D(bug("[VideoCoreGfx] %s(memhandle @ 0x%p)\n", __PRETTY_FUNCTION__, memhandle));
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_UNLOCKMEM);
@@ -131,12 +140,15 @@ void *FNAME_SUPPORT(UnLockMem)(struct MemHeaderExt *mhe, void *memhandle)
 
     xsd->vcsd_MBoxMessage[6] = 0; // terminate tag
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        != (volatile unsigned int *)-1)
     {
+        void *res = (void*)AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
         D(bug("[VideoCoreGfx] %s: Memory unlocked [status %08x]\n", __PRETTY_FUNCTION__, AROS_LE2LONG(xsd->vcsd_MBoxMessage[5])));
-        return (void*)AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+        VC4_MBOX_UNLOCK(xsd);
+        return res;
     }
+    VC4_MBOX_UNLOCK(xsd);
     return NULL;
 }
 
@@ -154,6 +166,7 @@ void FNAME_SUPPORT(Free)(struct MemHeaderExt *mhe, APTR  memhandle, IPTR size)
 
     D(bug("[VideoCoreGfx] %s(memhandle @ 0x%p)\n", __PRETTY_FUNCTION__, memhandle));
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_FREEMEM);
@@ -164,13 +177,15 @@ void FNAME_SUPPORT(Free)(struct MemHeaderExt *mhe, APTR  memhandle, IPTR size)
 
     xsd->vcsd_MBoxMessage[6] = 0; // terminate tag
 
-    MBoxWrite((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if (MBoxRead((void*)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        != (volatile unsigned int *)-1)
     {
-        mhe->mhe_MemHeader.mh_Free += size;
-
         D(bug("[VideoCoreGfx] %s: Memory freed [status %08x]\n", __PRETTY_FUNCTION__, AROS_LE2LONG(xsd->vcsd_MBoxMessage[5])));
+        VC4_MBOX_UNLOCK(xsd);
+        mhe->mhe_MemHeader.mh_Free += size;
+        return;
     }
+    VC4_MBOX_UNLOCK(xsd);
 }
 
 void *mh_AllocAbs(struct MemHeaderExt *mhe, IPTR size, APTR  mem)
@@ -201,7 +216,9 @@ int FNAME_SUPPORT(InitMem)(void *memstart, int memlength, struct VideoCoreGfxBas
     struct VideoCoreGfx_staticdata *xsd = &LIBBASE->vsd;
 //    struct MemChunk *mc = memstart;
 
-    InitSemaphore(&xsd->vcsd_GPUMemLock);
+    /* vcsd_GPUMemLock is initialised earlier in FNAME_SUPPORT(Init)
+     * (vc4gfx_init.c) so that the very first MBoxWrite/Read can take
+     * it. */
 
     D(bug("[VideoCoreGfx] VideoCore GPU Memory @ 0x%p [%dKB]\n", memstart, memlength >> 10));
 

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_onbitmap.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_onbitmap.c
@@ -66,6 +66,10 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
     APTR fb_ptr = NULL;
     ULONG fb_pitch = 0;
 
+    /* Hold the mailbox lock across the whole multi-transaction sequence
+     * (FBFREE -> batched mode/depth/pixfmt/FBALLOC -> GETPITCH). */
+    VC4_MBOX_LOCK(xsd);
+
     /* Free any previous framebuffer the firmware was holding. */
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(6 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
@@ -73,8 +77,7 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
     xsd->vcsd_MBoxMessage[3] = 0;
     xsd->vcsd_MBoxMessage[4] = 0;
     xsd->vcsd_MBoxMessage[5] = 0;
-    MBoxWrite((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    MBoxRead((void *)VCMB_BASE, VCMB_PROPCHAN);
+    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
 
     /* SETRES + SETVRES + SETDEPTH + SETPIXFMT + FBALLOC, all in one
      * batch. SETPIXFMT pins the channel order to RGB so the layout
@@ -115,11 +118,12 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
     xsd->vcsd_MBoxMessage[25] = 0;
     xsd->vcsd_MBoxMessage[0]  = AROS_LE2LONG(26 << 2);
 
-    MBoxWrite((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if ((MBoxRead((void *)VCMB_BASE, VCMB_PROPCHAN) != xsd->vcsd_MBoxMessage)
+    if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+            == (volatile unsigned int *)-1)
         || (xsd->vcsd_MBoxMessage[1] != AROS_LE2LONG(VCTAG_RESP))
         || (xsd->vcsd_MBoxMessage[22] != AROS_LE2LONG(VCTAG_RESP + 8)))
     {
+        VC4_MBOX_UNLOCK(xsd);
         return FALSE;
     }
     fb_ptr = (APTR)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[23]) & 0x3fffffff);
@@ -136,8 +140,8 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
     xsd->vcsd_MBoxMessage[5] = 0;
     xsd->vcsd_MBoxMessage[6] = 0;
 
-    MBoxWrite((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    if ((MBoxRead((void *)VCMB_BASE, VCMB_PROPCHAN) == xsd->vcsd_MBoxMessage)
+    if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+            != (volatile unsigned int *)-1)
         && (xsd->vcsd_MBoxMessage[4] == AROS_LE2LONG(VCTAG_RESP + 4)))
     {
         fb_pitch = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
@@ -148,6 +152,7 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
         fb_pitch = aligned_width * bytesperpix;
     }
 
+    VC4_MBOX_UNLOCK(xsd);
     *fb_ptr_out   = fb_ptr;
     *fb_pitch_out = fb_pitch;
     return TRUE;
@@ -161,6 +166,7 @@ static VOID vc4_restore_cursor(struct VideoCoreGfx_staticdata *xsd)
     if (!xsd->vcsd_CurBuf || !xsd->vcsd_CurWidth || !xsd->vcsd_CurHeight)
         return;
 
+    VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(12 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETCURSORINFO);
@@ -173,8 +179,7 @@ static VOID vc4_restore_cursor(struct VideoCoreGfx_staticdata *xsd)
     xsd->vcsd_MBoxMessage[9] = AROS_LE2LONG(xsd->vcsd_CurHotX);
     xsd->vcsd_MBoxMessage[10] = AROS_LE2LONG(xsd->vcsd_CurHotY);
     xsd->vcsd_MBoxMessage[11] = 0;
-    MBoxWrite((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    MBoxRead((void *)VCMB_BASE, VCMB_PROPCHAN);
+    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
 
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
@@ -186,8 +191,8 @@ static VOID vc4_restore_cursor(struct VideoCoreGfx_staticdata *xsd)
     xsd->vcsd_MBoxMessage[7] = AROS_LE2LONG((ULONG)xsd->vcsd_CurY);
     xsd->vcsd_MBoxMessage[8] = AROS_LE2LONG(0);
     xsd->vcsd_MBoxMessage[9] = 0;
-    MBoxWrite((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-    MBoxRead((void *)VCMB_BASE, VCMB_PROPCHAN);
+    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+    VC4_MBOX_UNLOCK(xsd);
 }
 
 /*********** BitMap::New() *************************************/


### PR DESCRIPTION
The single per-device property buffer was used concurrently across methods, letting one transaction clobber another. Take the existing semaphore around each one and switch to atomic MBoxCall for MBoxRead/MBoxWrite pairs. Also fix the SETPALETTE header size formula.