### PR TITLE
AHI/RPi: bugfix: slave spawn race and DMA tail encoding

### DIFF
--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
@@ -184,17 +184,21 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         /*
          * Start slave task.
-         * On SMP, Forbid() only prevents task switching on the local CPU,
-         * so the new process can start on another CPU immediately.
-         * We set tc_UserData with a memory barrier so the slave can
-         * busy-wait on it safely.
+         *
+         * The slave runs at higher priority than the caller and busy-waits
+         * for tc_UserData. Forbid()/Permit() guarantees we set tc_UserData
+         * before the slave can be scheduled — required on UP, where the
+         * slave would otherwise preempt us mid-CreateNewProc and spin
+         * forever.
          */
+        Forbid();
         dd->slavetask = CreateNewProc(proctags);
 
         if (dd->slavetask != NULL) {
             dd->slavetask->pr_Task.tc_UserData = AudioCtrl;
             __sync_synchronize();
         }
+        Permit();
 
         if (dd->slavetask != NULL) {
             /* Wait for slave to allocate its signal and pre-fill buffers */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
@@ -108,21 +108,23 @@ void Slave(struct ExecBase *SysBase)
         /*
          * Pre-fill both DMA buffers with silent IEC958 subframes.
          * Silence still needs valid Z/M/W preambles and channel status bits.
+         * Encode the full DMA buffer width so the MAI never sees zero
+         * (invalid) subframes in the tail.
          */
         ULONG i;
 
-        for (i = 0; i < AudioCtrl->ahiac_BuffSamples * 2; i++)
+        for (i = 0; i < dd->dmabuf_samples * 2; i++)
             ((WORD *) dd->mixbuffer)[i] = 0;
 
         convert_mix_to_iec958((WORD *) dd->mixbuffer,
                               dd->dmabuf[0],
-                              AudioCtrl->ahiac_BuffSamples,
+                              dd->dmabuf_samples,
                               dd->channel_status_l,
                               dd->channel_status_r,
                               &dd->frame_counter);
         convert_mix_to_iec958((WORD *) dd->mixbuffer,
                               dd->dmabuf[1],
-                              AudioCtrl->ahiac_BuffSamples,
+                              dd->dmabuf_samples,
                               dd->channel_status_l,
                               dd->channel_status_r,
                               &dd->frame_counter);
@@ -152,6 +154,25 @@ void Slave(struct ExecBase *SysBase)
                 CallHookPkt(AudioCtrl->ahiac_MixerFunc, AudioCtrl, dd->mixbuffer);
 
                 /*
+                 * The mixer only writes ahiac_BuffSamples frames, but the
+                 * DMA buffer is sized for dmabuf_samples (MaxBuffSamples).
+                 * Zero the tail so the IEC958 encode produces silent (but
+                 * still valid) subframes there — leaving stale zero ULONGs
+                 * in the DMA buffer produces invalid subframes that put
+                 * the MAI into an error state.
+                 */
+                {
+                    ULONG mixed = AudioCtrl->ahiac_BuffSamples;
+                    if (mixed < dd->dmabuf_samples) {
+                        WORD *tail = (WORD *) dd->mixbuffer + mixed * 2;
+                        ULONG n = (dd->dmabuf_samples - mixed) * 2;
+                        ULONG i;
+                        for (i = 0; i < n; i++)
+                            tail[i] = 0;
+                    }
+                }
+
+                /*
                  * Convert mixed audio to SPDIF subframes and write
                  * to the DMA buffer that is NOT currently being read.
                  *
@@ -174,10 +195,12 @@ void Slave(struct ExecBase *SysBase)
                     /*
                      * Encode fully-formed IEC958 subframes in software.
                      * The MAI consumes L/R subframe pairs from the DMA buffer.
+                     * Encode the full DMA buffer width (dmabuf_samples), not
+                     * just BuffSamples — the tail was padded with silence above.
                      */
                     convert_mix_to_iec958((WORD *) dd->mixbuffer,
                                           dd->dmabuf[fillbuf],
-                                          AudioCtrl->ahiac_BuffSamples,
+                                          dd->dmabuf_samples,
                                           dd->channel_status_l,
                                           dd->channel_status_r,
                                           &dd->frame_counter);

--- a/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-main.c
+++ b/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-main.c
@@ -201,17 +201,21 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         /*
          * Start slave task.
-         * On SMP, Forbid() only prevents task switching on the local CPU,
-         * so the new process can start on another CPU immediately.
-         * We set tc_UserData with a memory barrier so the slave can
-         * busy-wait on it safely.
+         *
+         * The slave runs at higher priority than the caller and busy-waits
+         * for tc_UserData. Forbid()/Permit() guarantees we set tc_UserData
+         * before the slave can be scheduled — required on UP, where the
+         * slave would otherwise preempt us mid-CreateNewProc and spin
+         * forever.
          */
+        Forbid();
         dd->slavetask = CreateNewProc(proctags);
 
         if (dd->slavetask != NULL) {
             dd->slavetask->pr_Task.tc_UserData = AudioCtrl;
             __sync_synchronize();
         }
+        Permit();
 
         if (dd->slavetask != NULL) {
             /* Wait for slave to allocate its signal and pre-fill buffers */


### PR DESCRIPTION
Forbid/Permit around CreateNewProc so tc_UserData is published before the higher-priority slave runs. Encode dmabuf_samples (not BuffSamples) so the DMA tail carries silent IEC958 subframes.