### PR TITLE
arm: preserve dirty data on partial-line invalidates

### DIFF
--- a/arch/arm-native/kernel/syscall.c
+++ b/arch/arm-native/kernel/syscall.c
@@ -72,15 +72,37 @@ void cache_clear_e(void *addr, uint32_t length, uint32_t flags)
     }
     uint32_t mask = line - 1;
 
+    /*
+     * Pure DCIMVAC on a range whose start or end is not cache-line
+     * aligned would silently drop dirty bytes outside the caller's
+     * range -- the partial head/tail lines also cover unrelated
+     * heap, and any writeback pending there is lost. Promote those
+     * edge lines to clean+invalidate (DCCIMVAC).
+     */
+    uintptr_t head_line = (uintptr_t)-1;
+    uintptr_t tail_line = (uintptr_t)-1;
+
     if (addr == NULL && length == 0xffffffff)
     {
         count = (uint32_t)(0x100000000ULL / line);
     }
     else
     {
-        void *end_addr = (void*)(((uintptr_t)addr + length + mask) & ~(uintptr_t)mask);
-        addr = (void *)((uintptr_t)addr & ~(uintptr_t)mask);
-        count = (uintptr_t)(end_addr - addr) / line;
+        uintptr_t orig_start = (uintptr_t)addr;
+        uintptr_t orig_end = orig_start + length;
+        uintptr_t aligned_start = orig_start & ~(uintptr_t)mask;
+        uintptr_t aligned_end = (orig_end + mask) & ~(uintptr_t)mask;
+
+        if ((flags & CACRF_InvalidateD) && !(flags & CACRF_ClearD))
+        {
+            if (orig_start & mask)
+                head_line = aligned_start;
+            if (orig_end & mask)
+                tail_line = aligned_end - line;
+        }
+
+        addr = (void *)aligned_start;
+        count = (aligned_end - aligned_start) / line;
     }
 
     D(bug("[Kernel] CacheClearE from %p length %d count %d, flags %x\n", addr, length, count, flags));
@@ -101,7 +123,10 @@ void cache_clear_e(void *addr, uint32_t length, uint32_t flags)
         }
         if (flags & CACRF_InvalidateD)
         {
-            __asm__ __volatile__("mcr p15, 0, %0, c7, c6, 1"::"r"(addr));
+            if ((uintptr_t)addr == head_line || (uintptr_t)addr == tail_line)
+                __asm__ __volatile__("mcr p15, 0, %0, c7, c14, 1"::"r"(addr));
+            else
+                __asm__ __volatile__("mcr p15, 0, %0, c7, c6, 1"::"r"(addr));
         }
 
         addr += line;

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
@@ -340,16 +340,16 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         buffer = &req->iouh_SetupData;
         xfer_size = 8;
 
-        /* Flush caches for setup and actual data */
+        /* Flush caches for setup data. The control data stage is armed
+         * separately by AdvanceChannel(), which does its own cache
+         * maintenance against the bounce or direct DMA target -- doing
+         * it here on the caller's iouh_Data would only force redundant
+         * work on a buffer we don't yet know the alignment-routing of. */
         CacheClearE(buffer, xfer_size, CACRF_ClearD);
-        if (req->iouh_Data != NULL && req->iouh_Length != 0)
+        if (req->iouh_Data != NULL && req->iouh_Length != 0
+            && !(req->iouh_SetupData.bmRequestType & URTF_IN))
         {
-            /* Determine data direction from request type, direction is of no use here */
-            if (req->iouh_SetupData.bmRequestType & URTF_IN) {
-                CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_InvalidateD);
-            }
-            else
-                CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_ClearD);
+            CacheClearE(req->iouh_Data, req->iouh_Length, CACRF_ClearD);
         }
 
         /* Set toggle bit to SETUP */
@@ -381,16 +381,10 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         buffer = req->iouh_Data ? (APTR)((IPTR)req->iouh_Data + req->iouh_Actual) : NULL;
         xfer_size = req->iouh_Length - req->iouh_Actual;
 
-        /* Flush caches */
-        if (buffer != NULL && xfer_size != 0)
-        {
-            if (direction)
-                CacheClearE(buffer, xfer_size, CACRF_InvalidateD);
-            else
-                CacheClearE(buffer, xfer_size, CACRF_ClearD);
-            /* DSB so cache maintenance is visible before DWC2 reads RAM. */
-            asm volatile("dsb sy" ::: "memory");
-        }
+        /* Cache flush is deferred until after the bounce-vs-direct
+         * decision below, mirroring AdvanceChannel(). For IN, flushing
+         * the caller buffer before that decision can corrupt adjacent
+         * heap on partial cache lines when the buffer is misaligned. */
 
         /* Alignment diagnostic (64 B cache line on A7). */
         D(
@@ -602,6 +596,17 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             dma_buf = (APTR)otg_Unit->hu_BounceBuf[chan];
             D(bug("[USB2OTG] Setup: bounce align %p -> %p (%d bytes)\n", buffer, dma_buf, xfer_size));
         }
+        else if (buffer != NULL && xfer_size != 0
+                 && req->iouh_Req.io_Command != UHCMD_CONTROLXFER)
+        {
+            /* Aligned direct DMA -- arm-time cache flush. Control data
+             * stage is flushed by AdvanceChannel() when it arms. */
+            if (direction)
+                CacheClearE(buffer, xfer_size, CACRF_InvalidateD);
+            else
+                CacheClearE(buffer, xfer_size, CACRF_ClearD);
+        }
+        asm volatile("dsb sy" ::: "memory");
         wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), 0xc0000000 | (ULONG)dma_buf);
     }
 


### PR DESCRIPTION
Promote partial head/tail lines of a DCIMVAC range to DCCIMVAC so neighbouring dirty bytes are written back before invalidate.

Defer the USB2OTG bulk-stage flush until after the bounce-vs-direct routing decision, since that decides which buffer needs maintenance.