### PR TITLE
spinlock: gate 128-byte alignment by arch capability

### DIFF
--- a/arch/i386-all/include/aros/cpu.h
+++ b/arch/i386-all/include/aros/cpu.h
@@ -2,7 +2,7 @@
 #define AROS_I386_CPU_H
 
 /*
-    Copyright © 1995-2020, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2020, The AROS Development Team. All rights reserved.
     $Id$
 
     NOTE: This file must compile *without* any other header !
@@ -36,6 +36,10 @@ typedef  void *cpumask_t;
 #define AROS_DOUBLEALIGN           4 /* Alignment for double */
 #define AROS_WORSTALIGN            16 /* Worst case alignment */
 #define AROS_STACKALIGN           16 /* Clean stack must be aligned to this */
+
+/* Cache-line isolation for spinlocks (Intel guidance, 128 B). The allocator
+ * must honour this for any heap-allocated container that embeds spinlock_t. */
+#define AROS_SPINLOCK_ALIGN __attribute__((__aligned__(128)))
 
 #define AROS_32BIT_TYPE         int
 

--- a/arch/x86_64-all/include/aros/cpu.h
+++ b/arch/x86_64-all/include/aros/cpu.h
@@ -2,7 +2,7 @@
 #define AROS_X86_64_CPU_H
 
 /*
-    Copyright © 1995-2023, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2023, The AROS Development Team. All rights reserved.
     $Id$
 
     NOTE: This file must compile *without* any other header !
@@ -36,6 +36,10 @@ typedef  void *cpumask_t;
 #define AROS_DOUBLEALIGN           8 /* Alignment for double */
 #define AROS_WORSTALIGN           16 /* Worst case alignment */
 #define AROS_STACKALIGN           16 /* Clean stack alignment */
+
+/* Cache-line isolation for spinlocks (Intel guidance, 128 B). The allocator
+ * must honour this for any heap-allocated container that embeds spinlock_t. */
+#define AROS_SPINLOCK_ALIGN __attribute__((__aligned__(128)))
 
 /* define this if we have no support for linear varargs in the compiler */
 #define NO_LINEAR_VARARGS       1

--- a/compiler/include/aros/types/spinlock_s.h
+++ b/compiler/include/aros/types/spinlock_s.h
@@ -4,11 +4,21 @@
 #include <aros/cpu.h>
 #include <exec/types.h>
 
-/* Align spinlock_t to 128 bytes so that each lock occupies a full cache line.
- * This avoids false sharing between CPUs, since otherwise multiple locks could
- * reside in the same line and contend unnecessarily. On x86_64 the natural
- * alignment would only be 16 bytes, so the attribute enforces cache-line isolation.
+/* AROS_SPINLOCK_ALIGN is defined by <aros/cpu.h> (per-arch). Arches that
+ * want cache-line isolation between locks (e.g. x86 per Intel guidance)
+ * set it to __attribute__((__aligned__(N))); the default is empty so
+ * spinlock_t gets natural alignment. AROS_PLATFORM_SMP unconditionally
+ * embeds spinlock_t as padding in struct MsgPort and SemaphoreRequest,
+ * so any container -- including library bases like IconBase -- inherits
+ * the alignment. On arches where AllocMem cannot deliver that alignment
+ * (e.g. arm-native), an over-aligned spinlock_t makes Clang emit
+ * udf-trap checks before every field access. Keep this empty unless
+ * the arch's allocator can honour the alignment at runtime.
  */
+#ifndef AROS_SPINLOCK_ALIGN
+#define AROS_SPINLOCK_ALIGN
+#endif
+
 typedef struct {
     union
     {
@@ -25,7 +35,7 @@ typedef struct {
     // The field s_Owner is set either to task owning the lock,
     // or NULL if the lock is free/read mode or was acquired in interrupt/supervisor mode
     void * s_Owner;
-} __attribute__((__aligned__(128))) spinlock_t;
+} AROS_SPINLOCK_ALIGN spinlock_t;
 
 #define SPINLOCK_UNLOCKED               0
 #define SPINLOCKB_WRITE                 27


### PR DESCRIPTION
## Summary

Clang trusts the alignment hint and uses NEON instructions to access the struct field, which require their addresses
to be properly aligned. AROS's allocator only guarantees 16-byte alignment, so the attribute is effectively a promise the system can't keep. The result is a Data Abort the first time anything touches a `MsgPort`, `SignalSemaphore`, or any other struct that embeds a `spinlock_t`.

## What this PR does

Replace the unconditional `__attribute__((aligned(128)))` with a per-architecture macro `AROS_SPINLOCK_ALIGN`:

- `arch/i386-all/include/aros/cpu.h` defines it as `aligned(128)`
- `arch/x86_64-all/include/aros/cpu.h` defines it as `aligned(128)`
- All other architectures (ARM, etc.) get the default empty definition