### PR TITLE
Wanderer: fix resource leaks and improve directory type detection

### DIFF
--- a/workbench/system/Wanderer/filesystems.c
+++ b/workbench/system/Wanderer/filesystems.c
@@ -608,8 +608,8 @@ BOOL IsOnSameDevice(CONST_STRPTR path1, CONST_STRPTR path2)
             {
                 returnValue = TRUE;
             }
+            UnLock(tlock);
         }
-        UnLock(tlock);
     }
     UnLock(slock);
 

--- a/workbench/system/Wanderer/filesystems_utilities.c
+++ b/workbench/system/Wanderer/filesystems_utilities.c
@@ -634,7 +634,7 @@ BOOL IsDirectory(CONST_STRPTR path)
 
     if (fib != NULL)
     {
-        retValue = fib->fib_DirEntryType == 2;
+        retValue = fib->fib_DirEntryType > 0;
         FreeDosObject(DOS_FIB, fib);
     }
 

--- a/workbench/system/Wanderer/wanderer.c
+++ b/workbench/system/Wanderer/wanderer.c
@@ -317,10 +317,11 @@ D(bug("[Wanderer]: %s()\n", __func__));
         // Count number of dropped elements
         WORD numberOfObjects = 0;
         struct Node *current = &currententry->dropse_Node;
-        do
+        while (current != NULL && GetSucc(current) != NULL)
         {
             numberOfObjects++;
-        } while ((current = GetSucc(current)) != NULL);
+            current = GetSucc(current);
+        }
 
         dobjects.totalObjects = numberOfObjects;
 
@@ -376,6 +377,8 @@ D(bug("[Wanderer]: %s()\n", __func__));
             }
         }
 
+        if (targetDir != copyFunc_DropEvent->drop_TargetPath)
+            FreeVec(copyFunc_DropEvent->drop_TargetPath);
         FreeVec(targetDir);
         FreeMem(copyFunc_DropEvent, sizeof(struct IconList_Drop_Event));
 


### PR DESCRIPTION
## Fix icon move on same disk copying instead of moving
 
Fixes #41 — dragging an icon to another folder on the same disk copies it instead of moving it.
 
### Root cause
 
Three bugs combined to cause incorrect behaviour during drag-and-drop file operations:
 
1. **[IsDirectory](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:623:0-641:1) only matched `ST_USERDIR` (2)** — the check `fib_DirEntryType == 2` excluded volume roots (`ST_ROOT = 1`) and linked directories (`ST_LINKDIR = 4`). When the drop target was a volume root (e.g. `SYS:`), [IsDirectory](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:623:0-641:1) returned `FALSE`, causing [GetPathPart("SYS:")](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:455:0-479:1) to produce an empty `targetDir`, which silently broke move and copy operations targeting a root volume.
 
2. **`UnLock(tlock)` outside `if (tlock)` in [IsOnSameDevice](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems.c:588:0-616:1)** — when the target path lock failed, `UnLock` was called on a null `BPTR`. While `UnLock(BNULL)` is technically safe, this was a structural correctness issue masking lock failures.
 
3. **Memory leak in `Wanderer__Func_CopyDropEntries`** — when [IsDirectory](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:623:0-641:1) returned `FALSE`, `targetDir` was set to a new [GetPathPart](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:455:0-479:1) allocation, but the original `drop_TargetPath` allocation was never freed. Additionally, the node count loop iterated one past the last real entry, including the Exec list tail sentinel in the progress display count.
 
### Changes
 
- **[filesystems_utilities.c](cci:7://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:0:0-0:0)**: Fix [IsDirectory](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems_utilities.c:623:0-641:1) to use `fib_DirEntryType > 0` (the standard AmigaDOS idiom for directory detection) instead of `== 2`.
 
- **[filesystems.c](cci:7://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems.c:0:0-0:0)**: Move `UnLock(tlock)` inside the `if (tlock)` block in [IsOnSameDevice](cci:1://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/filesystems.c:588:0-616:1).
 
- **[wanderer.c](cci:7://file:///home/reaver/aros/aros-source/workbench/system/Wanderer/wanderer.c:0:0-0:0)**:
  - Free `drop_TargetPath` when it differs from `targetDir` to fix the memory leak.
  - Fix the node count loop to stop at the last real list node instead of counting the tail sentinel.


- Move UnLock(tlock) inside the if block to prevent unlocking NULL lock
- Change IsDirectory() to check fib_DirEntryType > 0 instead of == 2 to properly detect all directory types
- Convert do-while to while loop with NULL check to prevent dereferencing invalid node
- Free drop_TargetPath only if it differs from targetDir to avoid double-free