### PR TITLE
binutils 2.45 arm-aros: emit REL relocations on ARM

### DIFF
--- a/tools/crosstools/gnu/binutils-2.45-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.45-aros.diff
@@ -144,13 +144,13 @@ diff -ruN binutils-2.45/bfd/elf32-arm.c binutils-2.45.aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
-+#define elf_backend_rela_normal		1
++#define elf_backend_rela_normal		0
 +#undef  elf_backend_want_plt_sym
 +#define elf_backend_want_plt_sym	0
 +


### PR DESCRIPTION
The arm-aros target was set to emit RELA, but ld doesn't apply the addend on R_ARM_CALL / R_ARM_JUMP24 from RELA, so every cross-file BL landed 8 bytes past its target. ARM ELF uses REL by convention. Switch the arm-aros backend to match.

Tested with gcc 16.1.0