### PR TITLE
dos/InternalLoadSeg: accept VFPv4 ELF attribute

### DIFF
--- a/rom/dos/internalloadseg_elf.c
+++ b/rom/dos/internalloadseg_elf.c
@@ -921,8 +921,17 @@ static BOOL ARM_ParseAttrs(UBYTE *data, ULONG len, struct DosLibrary *DOSBase)
                                 }
                                 break;
 
+                            case ELF_FP_v4:
+                            case ELF_FP_v4_Short:
+                                /* VFPv4 is a superset of VFPv3; accept on any VFPv3-capable CPU */
+                                if (!IDosBase(DOSBase)->arm_VFP_v3)
+                                {
+                                    DATTR(bug("[ELF.ARM] VFPv4 required but missing\n"));
+                                    return FALSE;
+                                }
+                                break;
+
                             default:
-                                /* This includes VFPv4 for now */
                                 DATTR(bug("[ELF.ARM] VFP %d required -- unsupported\n", val));
                                 return FALSE;
                             }


### PR DESCRIPTION
The ARM ELF attribute parser rejected binaries tagged VFPv4 even on CPUs that report VFPv3. VFPv4 is a strict superset of VFPv3, so allow loading when arm_VFP_v3 is set.

GCC 16 emits `Tag_FP_arch: VFPv4`, LLVM 11 emits `Tag_FP_arch: VFPv3`