### PR TITLE
hidd/vc4gfx: DMA/NEON 2D acceleration, offscreen bitmaps and page flipping

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/mmakefile.src
@@ -1,17 +1,21 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+#MM hidd-vc4gfx : includes hidd-gallium kernel-dma-bcm2708-includes
+
 USER_LDFLAGS := -static
 
 FILES	:=	\
 	vc4gfx_init \
 	vc4gfx_hiddclass \
+	vc4gfx_dma \
 	vc4gfx_memory \
 	vc4gfx_sdtv \
 	vc4gfx_hdmi \
 	vc4gfx_hardware \
 	vc4gfx_pixfmts \
-	vc4gfx_onbitmap
+	vc4gfx_onbitmap \
+	vc4gfx_offbitmap
 
 %build_module mmake=hidd-vc4gfx \
   modname=vc4gfx modtype=hidd \

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx.conf
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx.conf
@@ -20,6 +20,7 @@ Dispose
 Get
 .interface Hidd_Gfx
 CreateObject
+CopyBox
 SetCursorShape
 SetCursorPos
 SetCursorVisible
@@ -44,5 +45,37 @@ Get
 Set
 .interface Hidd_BitMap
 SetColors
+Clear
+FillRect
+PutImage
+GetImage
+BlitColorExpansion
+PutTemplate
+##end methodlist
+##end class
+
+
+##begin class
+##begin config
+basename VideoCoreGfxOffBM
+type hidd
+classptr_field vsd.vcsd_VideoCoreGfxOffBMClass
+superclass CLID_Hidd_ChunkyBM
+classdatatype struct BitmapData
+##end config
+
+##begin methodlist
+.interface Root
+New
+Dispose
+Get
+.interface Hidd_BitMap
+SetColors
+Clear
+FillRect
+PutImage
+GetImage
+BlitColorExpansion
+PutTemplate
 ##end methodlist
 ##end class

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmap.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmap.h
@@ -15,10 +15,14 @@
 
 enum {
     aoHidd_VideoCoreGfxBitMap_Drawable,
+    aoHidd_VideoCoreGfxBitMap_BackDrawable,    /* [G..] back page phys addr, 0 = no flipping */
+    aoHidd_VideoCoreGfxBitMap_Flip,            /* [.S.] set TRUE to flip front/back page */
     num_Hidd_VideoCoreGfxBitMap_Attrs
 };
 
 #define aHidd_VideoCoreGfxBitMap_Drawable	(HiddVideoCoreGfxBitMapAttrBase + aoHidd_VideoCoreGfxBitMap_Drawable)
+#define aHidd_VideoCoreGfxBitMap_BackDrawable	(HiddVideoCoreGfxBitMapAttrBase + aoHidd_VideoCoreGfxBitMap_BackDrawable)
+#define aHidd_VideoCoreGfxBitMap_Flip	(HiddVideoCoreGfxBitMapAttrBase + aoHidd_VideoCoreGfxBitMap_Flip)
 
 /* This structure is used for both onscreen and offscreen bitmaps !! */
 
@@ -39,11 +43,14 @@ struct BitmapData {
 	UBYTE               *VideoData;             /* Pointing to video data */
 	ULONG               width;                  /* Width of bitmap */
 	ULONG               height;                 /* Height of bitmap */
+	ULONG               bytesperrow;            /* Pitch in bytes (matches BitMap super) */
 	UBYTE               bytesperpix;
 	ULONG               cmap[16];               /* ColorMap */
 	BYTE                bpp;                    /* 8 -> chunky; planar otherwise */
 	BYTE                disp;                   /* !=0 - displayable */
 	struct MouseData    *mouse;
+	ULONG               gpuhandle;              /* Offscreen: firmware mem handle (0 = RAM-backed) */
+	ULONG               dispwidth;              /* Mode width (width is 16px-aligned) */
 };
 
 #endif /* _VIDEOCOREGFX_BITMAP_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmapclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_bitmapclass.c
@@ -6,31 +6,222 @@
 #define DEBUG 0
 #include <aros/debug.h>
 
+#include <proto/exec.h>
 #include <proto/mbox.h>
 
 #include <exec/alerts.h>
-#include <string.h>    // memset() prototype
+#include <aros/macros.h>
+#include <string.h>
 
 #include "vc4gfx_hardware.h"
 #include "vc4gfx_hidd.h"
 
-#ifdef OnBitmap
+#include "vc4gfx_neon.h"
+
+/* Shared by the onscreen (FB) and offscreen (GPU) bitmap classes: both have
+ * uncached physical pixels in data->VideoData. RAM-backed offscreen bitmaps
+ * leave VideoData NULL and fall through to ChunkyBM.
+ */
+
 /*********  BitMap::Clear()  *************************************/
 VOID MNAME_BM(Clear)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_Clear *msg)
 {
-    //struct BitmapData *data = OOP_INST_DATA(cl, o);
-    IPTR                width, height;
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
 
-    D(bug("[VideoCoreGfx] VideoCoreGfx.BitMap::Clear()\n"));
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow)
+    {
+        HIDDT_Pixel bg = GC_BG(msg->gc);
+        ULONG width_bytes = data->width * 4;
+        ULONG y;
 
-    /* Get width & height from bitmap */
-
-    OOP_GetAttr(o, aHidd_BitMap_Width,  &width);
-    OOP_GetAttr(o, aHidd_BitMap_Height, &height);
-
-//#warning "TODO: Implement HW accelerated bitmap clear"
+        /* NEON, not DMA: fills only write, and NEON writes to the uncached
+         * FB are already fast (the DMA win is for reads). DMA fill needs a
+         * non-incrementing 2D source, which wedges the channel on BCM2835. */
+        for (y = 0; y < data->height; y++)
+            neon_fillline(data->VideoData + y * data->bytesperrow, bg, width_bytes);
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
 }
-#endif
+
+/*********  BitMap::FillRect()  *************************************/
+VOID MNAME_BM(FillRect)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_DrawRect *msg)
+{
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow &&
+        GC_DRMD(msg->gc) == vHidd_GC_DrawMode_Copy)
+    {
+        HIDDT_Pixel fg = GC_FG(msg->gc);
+        ULONG width = msg->maxX - msg->minX + 1;
+        ULONG height = msg->maxY - msg->minY + 1;
+        ULONG width_bytes = width * 4;
+        UBYTE *dst = data->VideoData + msg->minY * data->bytesperrow + msg->minX * 4;
+        ULONG y;
+
+        /* NEON fill — see Clear(): fills are write-only and DMA fill
+         * hangs on real hardware (non-incrementing 2D source). */
+        for (y = 0; y < height; y++)
+            neon_fillline(dst + y * data->bytesperrow, fg, width_bytes);
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
+}
+
+/*********  BitMap::PutImage()  *************************************/
+VOID MNAME_BM(PutImage)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_PutImage *msg)
+{
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow &&
+        (msg->pixFmt == vHidd_StdPixFmt_Native || msg->pixFmt == vHidd_StdPixFmt_Native32))
+    {
+        UBYTE *src = msg->pixels;
+        UBYTE *dst = data->VideoData + msg->y * data->bytesperrow + msg->x * 4;
+        ULONG copy_width = msg->width * 4;
+        WORD y;
+
+        /* No page flip here (see Gfx::CopyBox): a full-frame PutImage is
+         * indistinguishable from mixed desktop rendering, and flipping
+         * corrupts read-modify-write / cached-pointer rendering. Flipping
+         * lives only on the gallium full-screen path. */
+
+        if ((copy_width * msg->height) >= VC4_DMA_PUT_THRESHOLD &&
+            vc4_dma_put(XSD(cl), src, msg->modulo, (ULONG)(IPTR)dst,
+                        data->bytesperrow, copy_width, msg->height))
+            return;
+
+        for (y = 0; y < msg->height; y++)
+        {
+            neon_copyline(dst, src, copy_width);
+            src += msg->modulo;
+            dst += data->bytesperrow;
+        }
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
+}
+
+/*********  BitMap::PutTemplate()  ***********************************/
+VOID MNAME_BM(PutTemplate)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_PutTemplate *msg)
+{
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow &&
+        GC_DRMD(msg->gc) == vHidd_GC_DrawMode_Copy &&
+        GC_COLEXP(msg->gc) == vHidd_GC_ColExp_Opaque &&
+        !msg->inverttemplate)
+    {
+        HIDDT_Pixel fg = GC_FG(msg->gc);
+        HIDDT_Pixel bg = GC_BG(msg->gc);
+        UBYTE *dst = data->VideoData + msg->y * data->bytesperrow + msg->x * 4;
+        ULONG row_bytes = msg->width * sizeof(ULONG);
+        ULONG *expanded = AllocVec(row_bytes, MEMF_PUBLIC);
+        const UBYTE *mask_row = msg->masktemplate;
+        WORD y;
+        ULONG x;
+
+        if (!expanded)
+        {
+            OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+            return;
+        }
+
+        for (y = 0; y < msg->height; y++)
+        {
+            ULONG bit = msg->srcx;
+            for (x = 0; x < msg->width; x++, bit++)
+            {
+                UBYTE byte = mask_row[bit >> 3];
+                expanded[x] = (byte & (0x80 >> (bit & 7))) ? 0xFFFFFFFF : 0;
+            }
+            neon_blit_mask32_row_opaque(dst, expanded, msg->width, fg, bg);
+            dst += data->bytesperrow;
+            mask_row += msg->modulo;
+        }
+
+        FreeVec(expanded);
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
+}
+
+/*********  BitMap::BlitColorExpansion()  ****************************/
+VOID MNAME_BM(BlitColorExpansion)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_BlitColorExpansion *msg)
+{
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow &&
+        GC_DRMD(msg->gc) == vHidd_GC_DrawMode_Copy &&
+        GC_COLEXP(msg->gc) == vHidd_GC_ColExp_Opaque)
+    {
+        HIDDT_Pixel fg = GC_FG(msg->gc);
+        HIDDT_Pixel bg = GC_BG(msg->gc);
+        UBYTE *dst = data->VideoData + msg->destY * data->bytesperrow + msg->destX * 4;
+        ULONG row_bytes = msg->width * sizeof(ULONG);
+        ULONG *srcline = AllocVec(row_bytes, MEMF_PUBLIC);
+        WORD y;
+
+        if (!srcline)
+        {
+            OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+            return;
+        }
+
+        for (y = 0; y < msg->height; y++)
+        {
+            HIDD_BM_GetImage(msg->srcBitMap, (UBYTE *)srcline, row_bytes,
+                msg->srcX, msg->srcY + y, msg->width, 1, vHidd_StdPixFmt_Native32);
+            neon_blit_mask32_row_opaque(dst, srcline, msg->width, fg, bg);
+            dst += data->bytesperrow;
+        }
+
+        FreeVec(srcline);
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
+}
+
+/*********  BitMap::GetImage()  *************************************/
+VOID MNAME_BM(GetImage)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_GetImage *msg)
+{
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+    if (data->VideoData && data->bytesperpix == 4 && data->bytesperrow &&
+        (msg->pixFmt == vHidd_StdPixFmt_Native || msg->pixFmt == vHidd_StdPixFmt_Native32))
+    {
+        UBYTE *src = data->VideoData + msg->y * data->bytesperrow + msg->x * 4;
+        UBYTE *dst = msg->pixels;
+        ULONG copy_width = msg->width * 4;
+        WORD y;
+
+        if ((copy_width * msg->height) >= VC4_DMA_GET_THRESHOLD &&
+            vc4_dma_get(XSD(cl), (ULONG)(IPTR)src, data->bytesperrow,
+                        dst, msg->modulo, copy_width, msg->height))
+            return;
+
+        for (y = 0; y < msg->height; y++)
+        {
+            neon_copyline(dst, src, copy_width);
+            src += data->bytesperrow;
+            dst += msg->modulo;
+        }
+    }
+    else
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
+}
 
 BOOL MNAME_BM(SetColors)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_SetColors *msg)
 {
@@ -118,6 +309,16 @@ VOID MNAME_ROOT(Get)(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
         {
         case aoHidd_VideoCoreGfxBitMap_Drawable:
             *msg->storage = (IPTR)data->VideoData;
+            break;
+        case aoHidd_VideoCoreGfxBitMap_BackDrawable:
+#ifdef OnBitmap
+            *msg->storage = (IPTR)vc4_fb_backpage(XSD(cl));
+#else
+            *msg->storage = 0;
+#endif
+            break;
+        case aoHidd_VideoCoreGfxBitMap_Flip:
+            *msg->storage = 0;
             break;
         default:
             OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
@@ -1,0 +1,358 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: BCM VideoCore4 Gfx Hidd - DMA-accelerated 2D operations.
+
+    Uses a full BCM2835 DMA engine (allocated from dma.resource) in 2D
+    stride mode for framebuffer copies and image transfers. The
+    framebuffer is mapped uncached, so CPU reads from it are extremely
+    slow — the DMA engine reads at memory speed, which is where the win
+    comes from.
+
+    All operations are synchronous: the caller (graphics.library)
+    expects the pixels to be in place on return.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/dma.h>
+
+#include <exec/memory.h>
+
+#include "vc4gfx_hidd.h"
+#include "vc4gfx_hardware.h"
+#include "vc4gfx_neon.h"
+
+extern APTR KernelBase;
+APTR DMABase = NULL;
+
+static inline void vc4_dsb(void) { asm volatile("dsb" ::: "memory"); }
+
+/* BCM system timer ticks at 1 MHz. */
+static inline ULONG vc4_now_us(void)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)SYSTIMER_CLO);
+}
+
+/* 2D mode field limits: XLENGTH is 16 bits, YLENGTH 14 bits, the two
+ * stride halves are signed 16-bit. */
+#define VC4_DMA_MAX_XLEN    0xFFFF
+#define VC4_DMA_MAX_YLEN    0x3FFF
+#define VC4_DMA_MAX_STRIDE  0x7FFF
+
+int FNAME_SUPPORT(InitDMA)(struct VideoCoreGfx_staticdata *xsd)
+{
+    APTR raw;
+
+    xsd->vcsd_DMAChannel = -1;
+    InitSemaphore(&xsd->vcsd_DMALock);
+
+    if ((DMABase = OpenResource("dma.resource")) == NULL)
+        return FALSE;
+
+    /* CB (32 bytes, 32-byte aligned) + the fill source pixel directly
+     * behind it, so one cache flush covers both. */
+    if ((raw = AllocVec(sizeof(struct BCM2708DMACB) + 32 + sizeof(ULONG),
+                        MEMF_PUBLIC | MEMF_CLEAR)) == NULL)
+        return FALSE;
+
+    xsd->vcsd_DMACBRaw = raw;
+    xsd->vcsd_DMACB = (struct BCM2708DMACB *)(((IPTR)raw + 31) & ~31);
+    xsd->vcsd_DMAFillPx = (ULONG *)(xsd->vcsd_DMACB + 1);
+
+    if ((xsd->vcsd_DMAChannel = DMAAllocChannel(DMACHF_TDMODE | DMACHF_IRQ)) < 0)
+    {
+        FreeVec(raw);
+        xsd->vcsd_DMACBRaw = NULL;
+        return FALSE;
+    }
+
+    /* Bounce buffer for DMA reads (GetImage). DMA must not write into
+     * cached caller memory — an edge cache line could be written back over
+     * the DMA'd data. The bounce is 32-byte aligned and ours alone, so a
+     * pre-DMA clean+invalidate makes it safe. Optional: without it
+     * vc4_dma_get returns FALSE and the NEON path runs. */
+    if ((xsd->vcsd_DMABounceRaw = AllocVec(VC4_DMA_BOUNCE_SIZE + 31,
+                                           MEMF_PUBLIC)) != NULL)
+    {
+        xsd->vcsd_DMABounce =
+            (UBYTE *)(((IPTR)xsd->vcsd_DMABounceRaw + 31) & ~31);
+        xsd->vcsd_DMABouncePhys =
+            (ULONG)(IPTR)KrnVirtualToPhysical(xsd->vcsd_DMABounce);
+    }
+
+    D(bug("[VideoCoreGfx] %s: DMA channel %d\n", __PRETTY_FUNCTION__,
+        (int)xsd->vcsd_DMAChannel));
+    return TRUE;
+}
+
+/* Kick the prepared CB and wait for completion. Must be called with
+ * vcsd_DMALock held. Returns FALSE (after a channel reset) on timeout. */
+static BOOL vc4_dma_run(struct VideoCoreGfx_staticdata *xsd, const char *op)
+{
+    volatile ULONG *dma_cs = (volatile ULONG *)DMA_CS(xsd->vcsd_DMAChannel);
+    volatile ULONG *dma_cb = (volatile ULONG *)DMA_CONBLK_AD(xsd->vcsd_DMAChannel);
+    ULONG cb_phys = (ULONG)(IPTR)KrnVirtualToPhysical(xsd->vcsd_DMACB);
+    ULONG start;
+
+    /* Diagnostic: one line per DMA use, CB fields in host byte order. */
+    D(bug("[VideoCoreGfx] DMA %s ch=%d ti=0x%08x len=0x%08x stride=0x%08x "
+        "src=0x%08x dst=0x%08x\n", op, (int)xsd->vcsd_DMAChannel,
+        AROS_LE2LONG(xsd->vcsd_DMACB->ti),
+        AROS_LE2LONG(xsd->vcsd_DMACB->txfr_len),
+        AROS_LE2LONG(xsd->vcsd_DMACB->stride),
+        AROS_LE2LONG(xsd->vcsd_DMACB->source_ad),
+        AROS_LE2LONG(xsd->vcsd_DMACB->dest_ad)));
+
+    CacheClearE(xsd->vcsd_DMACB, sizeof(struct BCM2708DMACB) + sizeof(ULONG),
+                CACRF_ClearD);
+    vc4_dsb();
+
+    *dma_cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+    *dma_cb = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(cb_phys));
+    vc4_dsb();
+    *dma_cs = AROS_LONG2LE(
+        DMA_CS_WAIT_FOR_WRITES |
+        DMA_CS_PANIC_PRI(15) |
+        DMA_CS_PRI(8) |
+        DMA_CS_ACTIVE);
+
+    /* IRQ-driven wait via dma.resource (INTEN set in the CBs): sleeps the
+     * task, handles the wedge-safe timeout, resets the channel on failure. */
+    if (DMAWaitChannel(xsd->vcsd_DMAChannel, 100000) == 0)
+        return TRUE;
+
+    bug("[VideoCoreGfx] DMA %s timeout\n", op);
+    return FALSE;
+}
+
+/*
+ * 2D rectangle copy between two uncached physical buffers (FB regions).
+ * bottom_up walks rows last-to-first via negative strides — required when
+ * src/dest overlap with the destination below the source.
+ */
+BOOL vc4_dma_copy(struct VideoCoreGfx_staticdata *xsd,
+                  ULONG src_phys, ULONG src_pitch,
+                  ULONG dst_phys, ULONG dst_pitch,
+                  ULONG width_bytes, ULONG height, BOOL bottom_up)
+{
+    struct BCM2708DMACB *cb;
+    LONG s_stride, d_stride;
+    BOOL ok;
+
+    if (xsd->vcsd_DMAChannel < 0 || width_bytes == 0 || height == 0)
+        return FALSE;
+    if (width_bytes > VC4_DMA_MAX_XLEN || (height - 1) > VC4_DMA_MAX_YLEN)
+        return FALSE;
+
+    if (bottom_up)
+    {
+        src_phys += (height - 1) * src_pitch;
+        dst_phys += (height - 1) * dst_pitch;
+        s_stride = -(LONG)(src_pitch + width_bytes);
+        d_stride = -(LONG)(dst_pitch + width_bytes);
+    }
+    else
+    {
+        s_stride = (LONG)(src_pitch - width_bytes);
+        d_stride = (LONG)(dst_pitch - width_bytes);
+    }
+    if (s_stride < -VC4_DMA_MAX_STRIDE || s_stride > VC4_DMA_MAX_STRIDE ||
+        d_stride < -VC4_DMA_MAX_STRIDE || d_stride > VC4_DMA_MAX_STRIDE)
+        return FALSE;
+
+    ObtainSemaphore(&xsd->vcsd_DMALock);
+
+    cb = xsd->vcsd_DMACB;
+    cb->ti = AROS_LONG2LE(DMA_TI_INTEN | DMA_TI_SRC_INC | DMA_TI_DEST_INC |
+                          DMA_TI_BURST_LENGTH(8) | DMA_TI_TDMODE);
+    cb->source_ad = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(src_phys));
+    cb->dest_ad   = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(dst_phys));
+    cb->txfr_len  = AROS_LONG2LE(DMA_TXFR_LEN_2D(width_bytes, height - 1));
+    cb->stride    = AROS_LONG2LE(DMA_STRIDE_2D((UWORD)s_stride, (UWORD)d_stride));
+    cb->nextconbk = 0;
+    cb->reserved[0] = 0;
+    cb->reserved[1] = 0;
+
+    ok = vc4_dma_run(xsd, bottom_up ? "copy^" : "copy");
+
+    ReleaseSemaphore(&xsd->vcsd_DMALock);
+    return ok;
+}
+
+/*
+ * Rectangle copy from cached RAM (PutImage source) into an uncached
+ * physical buffer. Source rows are cleaned to RAM first so the engine,
+ * reading through the uncached alias, sees the CPU's latest data. RAM is
+ * identity-mapped here, so rows are physically contiguous.
+ */
+BOOL vc4_dma_put(struct VideoCoreGfx_staticdata *xsd,
+                 const UBYTE *src, ULONG src_modulo,
+                 ULONG dst_phys, ULONG dst_pitch,
+                 ULONG width_bytes, ULONG height)
+{
+    struct BCM2708DMACB *cb;
+    LONG s_stride = (LONG)(src_modulo - width_bytes);
+    LONG d_stride = (LONG)(dst_pitch - width_bytes);
+    ULONG src_phys;
+    BOOL ok;
+
+    if (xsd->vcsd_DMAChannel < 0 || width_bytes == 0 || height == 0)
+        return FALSE;
+    if (width_bytes > VC4_DMA_MAX_XLEN || (height - 1) > VC4_DMA_MAX_YLEN ||
+        s_stride < 0 || s_stride > VC4_DMA_MAX_STRIDE ||
+        d_stride < 0 || d_stride > VC4_DMA_MAX_STRIDE)
+        return FALSE;
+
+    src_phys = (ULONG)(IPTR)KrnVirtualToPhysical((APTR)src);
+
+    if (src_modulo == width_bytes)
+        CacheClearE((APTR)src, height * width_bytes, CACRF_ClearD);
+    else
+    {
+        ULONG y;
+        for (y = 0; y < height; y++)
+            CacheClearE((APTR)(src + y * src_modulo), width_bytes, CACRF_ClearD);
+    }
+    vc4_dsb();
+
+    ObtainSemaphore(&xsd->vcsd_DMALock);
+
+    cb = xsd->vcsd_DMACB;
+    cb->ti = AROS_LONG2LE(DMA_TI_INTEN | DMA_TI_SRC_INC | DMA_TI_DEST_INC |
+                          DMA_TI_BURST_LENGTH(8) | DMA_TI_TDMODE);
+    cb->source_ad = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(src_phys));
+    cb->dest_ad   = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(dst_phys));
+    cb->txfr_len  = AROS_LONG2LE(DMA_TXFR_LEN_2D(width_bytes, height - 1));
+    cb->stride    = AROS_LONG2LE(DMA_STRIDE_2D((UWORD)s_stride, (UWORD)d_stride));
+    cb->nextconbk = 0;
+    cb->reserved[0] = 0;
+    cb->reserved[1] = 0;
+
+    ok = vc4_dma_run(xsd, "put");
+
+    ReleaseSemaphore(&xsd->vcsd_DMALock);
+    return ok;
+}
+
+/*
+ * Rectangle copy from an uncached physical buffer into cached RAM (GetImage
+ * destination). DMA lands in the private bounce buffer and NEON copies rows
+ * out, avoiding DMA writes into cache lines the caller may touch.
+ */
+BOOL vc4_dma_get(struct VideoCoreGfx_staticdata *xsd,
+                 ULONG src_phys, ULONG src_pitch,
+                 UBYTE *dst, ULONG dst_modulo,
+                 ULONG width_bytes, ULONG height)
+{
+    LONG s_stride = (LONG)(src_pitch - width_bytes);
+    ULONG rows_per_chunk, done = 0;
+    BOOL ok = TRUE;
+
+    if (xsd->vcsd_DMAChannel < 0 || !xsd->vcsd_DMABounce ||
+        width_bytes == 0 || height == 0)
+        return FALSE;
+    if (width_bytes > VC4_DMA_BOUNCE_SIZE ||
+        s_stride < 0 || s_stride > VC4_DMA_MAX_STRIDE)
+        return FALSE;
+
+    rows_per_chunk = VC4_DMA_BOUNCE_SIZE / width_bytes;
+    if (rows_per_chunk > VC4_DMA_MAX_YLEN)
+        rows_per_chunk = VC4_DMA_MAX_YLEN;
+
+    ObtainSemaphore(&xsd->vcsd_DMALock);
+
+    while (done < height && ok)
+    {
+        ULONG n = height - done;
+        struct BCM2708DMACB *cb = xsd->vcsd_DMACB;
+        ULONG y;
+
+        if (n > rows_per_chunk)
+            n = rows_per_chunk;
+
+        /* Evict the bounce region (including clean lines cached by the
+         * previous chunk's copy-out) before the engine writes it. */
+        CacheClearE(xsd->vcsd_DMABounce, n * width_bytes, CACRF_ClearD);
+        vc4_dsb();
+
+        cb->ti = AROS_LONG2LE(DMA_TI_INTEN | DMA_TI_SRC_INC | DMA_TI_DEST_INC |
+                              DMA_TI_BURST_LENGTH(8) | DMA_TI_TDMODE);
+        cb->source_ad = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(
+            src_phys + done * src_pitch));
+        cb->dest_ad   = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(
+            xsd->vcsd_DMABouncePhys));
+        cb->txfr_len  = AROS_LONG2LE(DMA_TXFR_LEN_2D(width_bytes, n - 1));
+        cb->stride    = AROS_LONG2LE(DMA_STRIDE_2D((UWORD)s_stride, 0));
+        cb->nextconbk = 0;
+        cb->reserved[0] = 0;
+        cb->reserved[1] = 0;
+
+        ok = vc4_dma_run(xsd, "get");
+
+        if (ok)
+        {
+            /* Invalidate again post-DMA: the CPU may have speculatively
+             * prefetched bounce lines while the engine wrote them, leaving
+             * them stale (seen on Pi 3 as 8-pixel stripes of old data).
+             * Lines are clean here (CPU only reads the bounce), so
+             * invalidate-only is safe. */
+            CacheClearE(xsd->vcsd_DMABounce, n * width_bytes,
+                        CACRF_InvalidateD);
+            vc4_dsb();
+
+            for (y = 0; y < n; y++)
+                neon_copyline(dst + (done + y) * dst_modulo,
+                              xsd->vcsd_DMABounce + y * width_bytes,
+                              width_bytes);
+            done += n;
+        }
+    }
+
+    ReleaseSemaphore(&xsd->vcsd_DMALock);
+    return ok;
+}
+
+/*
+ * 2D rectangle fill of a physically-addressed uncached buffer. The
+ * engine reads the pixel value from a single non-incrementing source
+ * word and streams it across the rectangle.
+ */
+BOOL vc4_dma_fill(struct VideoCoreGfx_staticdata *xsd,
+                  ULONG dst_phys, ULONG dst_pitch,
+                  ULONG width_bytes, ULONG height, ULONG pixel)
+{
+    struct BCM2708DMACB *cb;
+    LONG d_stride = (LONG)(dst_pitch - width_bytes);
+    BOOL ok;
+
+    if (xsd->vcsd_DMAChannel < 0 || width_bytes == 0 || height == 0)
+        return FALSE;
+    if (width_bytes > VC4_DMA_MAX_XLEN || (height - 1) > VC4_DMA_MAX_YLEN ||
+        d_stride > VC4_DMA_MAX_STRIDE)
+        return FALSE;
+
+    ObtainSemaphore(&xsd->vcsd_DMALock);
+
+    *xsd->vcsd_DMAFillPx = pixel;
+
+    cb = xsd->vcsd_DMACB;
+    cb->ti = AROS_LONG2LE(DMA_TI_DEST_INC |
+                          DMA_TI_WAIT_RESP | DMA_TI_TDMODE);
+    cb->source_ad = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(
+        (ULONG)(IPTR)KrnVirtualToPhysical((APTR)xsd->vcsd_DMAFillPx)));
+    cb->dest_ad   = AROS_LONG2LE(BCM2708_DMA_BUS_ADDR(dst_phys));
+    cb->txfr_len  = AROS_LONG2LE(DMA_TXFR_LEN_2D(width_bytes, height - 1));
+    cb->stride    = AROS_LONG2LE(DMA_STRIDE_2D(0, (UWORD)d_stride));
+    cb->nextconbk = 0;
+    cb->reserved[0] = 0;
+    cb->reserved[1] = 0;
+
+    ok = vc4_dma_run(xsd, "fill");
+
+    ReleaseSemaphore(&xsd->vcsd_DMALock);
+    return ok;
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hidd.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hidd.h
@@ -12,11 +12,12 @@
 #include <exec/types.h>
 #include <proto/exec.h>
 
+#include <hardware/bcm2708_dma.h>
+
 #include "vc4gfx_hardware.h"
 
-/* vcsd_MBoxMessage is a single shared buffer used by every mailbox
- * round-trip (palette, framebuffer alloc, cursor, mode set, memory).
- * Take vcsd_GPUMemLock around every pack-write-read sequence. */
+/* vcsd_MBoxMessage is one shared buffer for every mailbox round-trip;
+ * take vcsd_GPUMemLock around each pack-write-read sequence. */
 #define VC4_MBOX_LOCK(xsd)   ObtainSemaphore(&(xsd)->vcsd_GPUMemLock)
 #define VC4_MBOX_UNLOCK(xsd) ReleaseSemaphore(&(xsd)->vcsd_GPUMemLock)
 
@@ -45,6 +46,8 @@ struct VideoCoreGfx_staticdata {
         struct MemHeaderExt     vcsd_GPUMemManage;
 
         OOP_Class 	    	*vcsd_basebm;            /* baseclass for CreateObject */
+        OOP_Class               *vcsd_basegallium;       /* baseclass for CreateObject */
+        struct Library          *vcsd_VC4GalliumLib;     /* keeps vc4gallium.hidd loaded */
 
         OOP_Class               *vcsd_VideoCoreGfxClass;
 	OOP_Object              *vcsd_VideoCoreGfxInstance;
@@ -67,14 +70,56 @@ struct VideoCoreGfx_staticdata {
         LONG                    vcsd_CurY;
         BOOL                    vcsd_CurVisible;
 
-        /* Firmware-reported native HDMI resolution, populated by
-         * HDMI_SyncGen at init time. Used as the default returned by
-         * NominalDimensions so a fresh boot lands on the panel's native
-         * mode instead of the AROS hardcoded 800x600.
+        /* Firmware-reported native HDMI resolution (set by HDMI_SyncGen),
+         * used as the NominalDimensions default so a fresh boot lands on
+         * the panel's native mode rather than 800x600.
          */
         ULONG                   vcsd_NativeWidth;
         ULONG                   vcsd_NativeHeight;
+
+        /* DMA-accelerated 2D state. Channel from dma.resource
+         * (DMACHF_TDMODE); -1 means no DMA (fall back to NEON). The shared
+         * CB and bounce buffer are serialized by vcsd_DMALock.
+         */
+        LONG                    vcsd_DMAChannel;
+        APTR                    vcsd_DMACBRaw;
+        struct BCM2708DMACB     *vcsd_DMACB;
+        ULONG                   *vcsd_DMAFillPx;    /* Fill source word */
+        APTR                    vcsd_DMABounceRaw;
+        UBYTE                   *vcsd_DMABounce;    /* 32-byte aligned */
+        ULONG                   vcsd_DMABouncePhys;
+        struct SignalSemaphore  vcsd_DMALock;
+
+        /* SETVOFFSET page flipping. The framebuffer is allocated at twice
+         * the virtual height and the two pages flipped with SETVOFFSET;
+         * full-frame producers (GL, video) render to the back and flip,
+         * incremental UI targets the front. vcsd_FBPages == 1 = no flipping
+         * (alloc/validation failed).
+         */
+        OOP_Object              *vcsd_FBObj;        /* The framebuffer bitmap */
+        ULONG                   vcsd_FBPage[2];     /* Page base phys addresses */
+        ULONG                   vcsd_FBPageHeight;  /* Rows per page */
+        UBYTE                   vcsd_FBPages;       /* 1 or 2 */
+        UBYTE                   vcsd_FBFront;       /* Currently scanned-out page */
 };
+
+/* DMA has a per-call setup + poll cost; below these sizes NEON wins.
+ * Uncached reads are ~10x slower than writes, hence the lower thresholds
+ * for read-heavy operations.
+ */
+#define VC4_DMA_COPY_THRESHOLD  2048    /* bytes (e.g. 32x16 px) */
+#define VC4_DMA_FILL_THRESHOLD  16384   /* bytes (e.g. 64x64 px) */
+#define VC4_DMA_PUT_THRESHOLD   16384   /* cached source, writes only */
+#define VC4_DMA_GET_THRESHOLD   4096    /* uncached source reads */
+
+/* Bounce buffer for DMA reads into cached memory. */
+#define VC4_DMA_BOUNCE_SIZE     65536
+
+/* Offscreen 32bpp bitmaps at least this large go in GPU memory so blits
+ * can use the DMA engine without cache maintenance; smaller ones stay in
+ * (cached) system RAM.
+ */
+#define VC4_GPUBM_THRESHOLD     65536
 
 /* Maximum HW cursor size supported by VideoCore firmware. */
 #define VC4_CURSOR_MAX_W 64
@@ -128,8 +173,28 @@ struct DisplayMode
 
 int     FNAME_SUPPORT(InitMem)(void *, int, struct VideoCoreGfxBase *);
 int     FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *);
+int     FNAME_SUPPORT(InitDMA)(struct VideoCoreGfx_staticdata *);
 int     FNAME_SUPPORT(SDTV_SyncGen)(struct List *, OOP_Class *);
 int     FNAME_SUPPORT(HDMI_SyncGen)(struct List *, OOP_Class *);
 APTR    FNAME_SUPPORT(GenPixFmts)(OOP_Class *);
+
+BOOL    vc4_dma_copy(struct VideoCoreGfx_staticdata *xsd,
+                     ULONG src_phys, ULONG src_pitch,
+                     ULONG dst_phys, ULONG dst_pitch,
+                     ULONG width_bytes, ULONG height, BOOL bottom_up);
+BOOL    vc4_dma_fill(struct VideoCoreGfx_staticdata *xsd,
+                     ULONG dst_phys, ULONG dst_pitch,
+                     ULONG width_bytes, ULONG height, ULONG pixel);
+BOOL    vc4_dma_put(struct VideoCoreGfx_staticdata *xsd,
+                    const UBYTE *src, ULONG src_modulo,
+                    ULONG dst_phys, ULONG dst_pitch,
+                    ULONG width_bytes, ULONG height);
+BOOL    vc4_dma_get(struct VideoCoreGfx_staticdata *xsd,
+                    ULONG src_phys, ULONG src_pitch,
+                    UBYTE *dst, ULONG dst_modulo,
+                    ULONG width_bytes, ULONG height);
+
+ULONG   vc4_fb_backpage(struct VideoCoreGfx_staticdata *xsd);
+BOOL    vc4_fb_flip(struct VideoCoreGfx_staticdata *xsd);
 
 #endif /* _VIDEOCOREGFX_CLASS_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
@@ -22,6 +22,7 @@
 #include <hardware/custom.h>
 #include <hidd/hidd.h>
 #include <hidd/gfx.h>
+#include <hidd/gallium.h>
 #include <oop/oop.h>
 #include <clib/alib_protos.h>
 #include <string.h>
@@ -30,6 +31,7 @@
 
 #include "vc4gfx_hidd.h"
 #include "vc4gfx_hardware.h"
+#include "vc4gfx_neon.h"
 
 #ifdef MBoxBase
 #undef MBoxBase
@@ -218,16 +220,11 @@ VOID MNAME_ROOT(Get)(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
 
 int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
 {
-    /* Allocate a 64x64 ARGB scratch buffer in GPU memory for cursor pixels.
-     * The firmware reads cursor pixels from this buffer each time we issue
-     * SETCURSORINFO, so it must remain locked for the lifetime of the driver.
-     * Use VCMEM_DIRECT (uncached, 0xC alias) so the CPU can write pixels
-     * via the MMU's uncached mapping - VCMEM_NORMAL is rejected by the
-     * firmware when the request comes from ARM (videocore.h:108).
-     *
-     * ALLOCMEM tag layout: [tag, value_buf_size, code, size, alignment,
-     * flags] - the request value buffer is 3 u32 (size/align/flags),
-     * the response writes a 1 u32 handle into the first slot.
+    /* 64x64 ARGB cursor buffer in GPU memory, locked for the driver's
+     * lifetime (firmware re-reads it on each SETCURSORINFO). VCMEM_DIRECT
+     * (uncached 0xC alias) lets the CPU write pixels; VCMEM_NORMAL is
+     * rejected for ARM-side requests.
+     * ALLOCMEM value buffer: size/align/flags in, handle out.
      */
     VC4_MBOX_LOCK(xsd);
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(10 * 4);
@@ -254,9 +251,7 @@ int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
         return FALSE;
     }
 
-    /* LOCKMEM tag layout: [tag, value_buf_size, code, handle] - request
-     * value is the handle, response overwrites it with the bus address.
-     */
+    /* LOCKMEM: handle in, bus address out (same value slot). */
     xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
     xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
     xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_LOCKMEM);
@@ -277,12 +272,9 @@ int FNAME_SUPPORT(InitCursor)(struct VideoCoreGfx_staticdata *xsd)
     VC4_MBOX_UNLOCK(xsd);
     xsd->vcsd_CurVisible = FALSE;
 
-    /* The firmware should hand back a GPU bus address with the alias
-     * bits set (VCMEM_DIRECT == 0xC, VCMEM_NORMAL == 0x4). QEMU's
-     * mailbox emulation may return a bare low-RAM address instead,
-     * which overlaps with CPU-side allocations and would corrupt
-     * unrelated state. Treat anything outside the GPU alias range as
-     * "no HW cursor available".
+    /* A valid bus address has the GPU alias bits set (0xC/0x4). QEMU may
+     * return a bare low-RAM address that overlaps CPU allocations; treat
+     * anything outside the alias range as "no HW cursor".
      */
     if ((xsd->vcsd_CurBufBus & 0xC0000000) == 0)
     {
@@ -303,9 +295,8 @@ VOID MNAME_GFX(NominalDimensions)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx
 {
     struct VideoCoreGfx_staticdata *xsd = XSD(cl);
 
-    /* Hand back the panel's native HDMI resolution if we know it. Falls
-     * through to the superclass (which returns AROS_NOMINAL_*) when GETRES
-     * couldn't tell us - e.g. headless boot or unsupported firmware.
+    /* Return the panel's native HDMI resolution if known, else fall
+     * through to the superclass (AROS_NOMINAL_*).
      */
     if (xsd->vcsd_NativeWidth && xsd->vcsd_NativeHeight)
     {
@@ -355,12 +346,8 @@ BOOL MNAME_GFX(SetCursorShape)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_Se
         width > VC4_CURSOR_MAX_W || height > VC4_CURSOR_MAX_H)
         return FALSE;
 
-    /* The VideoCore firmware wants cursor pixels as bytes R,G,B,A in
-     * memory (mailbox SET_CURSOR_INFO format=0), which corresponds to
-     * AROS' vHidd_StdPixFmt_RGBA32. HIDD's GetImage handles conversion.
-     */
     HIDD_BM_GetImage(msg->shape, (UBYTE *)xsd->vcsd_CurBuf,
-                     width * 4, 0, 0, width, height, vHidd_StdPixFmt_RGBA32);
+                     width * 4, 0, 0, width, height, vHidd_StdPixFmt_BGRA32);
 
     xsd->vcsd_CurWidth  = width;
     xsd->vcsd_CurHeight = height;
@@ -402,8 +389,11 @@ BOOL MNAME_GFX(SetCursorPos)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_SetC
     if (!xsd->vcsd_CurBuf)
         return FALSE;
 
-    xsd->vcsd_CurX = msg->x;
-    xsd->vcsd_CurY = msg->y;
+    /* Firmware places the image top-left at (x,y) and ignores the
+     * SETCURSORINFO hotspot, so apply the AROS hotspot offset here
+     * (vcsd_CurHotX/Y = pointer xoffset/yoffset, typically <= 0). */
+    xsd->vcsd_CurX = (LONG)msg->x + (LONG)xsd->vcsd_CurHotX;
+    xsd->vcsd_CurY = (LONG)msg->y + (LONG)xsd->vcsd_CurHotY;
 
     if (!xsd->vcsd_CurVisible)
         return TRUE;
@@ -415,8 +405,8 @@ BOOL MNAME_GFX(SetCursorPos)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_SetC
     xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(16);
     xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(16);
     xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(1);     /* enable */
-    xsd->vcsd_MBoxMessage[6] = AROS_LE2LONG((ULONG)msg->x);
-    xsd->vcsd_MBoxMessage[7] = AROS_LE2LONG((ULONG)msg->y);
+    xsd->vcsd_MBoxMessage[6] = AROS_LE2LONG((ULONG)xsd->vcsd_CurX);
+    xsd->vcsd_MBoxMessage[7] = AROS_LE2LONG((ULONG)xsd->vcsd_CurY);
     xsd->vcsd_MBoxMessage[8] = AROS_LE2LONG(1);     /* 1 = framebuffer coords (firmware scales) */
     xsd->vcsd_MBoxMessage[9] = 0;
 
@@ -450,6 +440,124 @@ VOID MNAME_GFX(SetCursorVisible)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_
     VC4_MBOX_UNLOCK(xsd);
 }
 
+/* Returns the DMA-addressable buffer base for our on/offscreen bitmaps
+ * (uncached framebuffer / GPU mem), or 0 for foreign / RAM-backed ones.
+ */
+static ULONG vc4_bm_dma_base(OOP_Class *cl, OOP_Object *bm)
+{
+    OOP_Class *bmcl = OOP_OCLASS(bm);
+
+    if (bmcl == XSD(cl)->vcsd_VideoCoreGfxOnBMClass ||
+        bmcl == XSD(cl)->vcsd_VideoCoreGfxOffBMClass)
+    {
+        struct BitmapData *data = OOP_INST_DATA(bmcl, bm);
+        return (ULONG)(IPTR)data->VideoData;
+    }
+    return 0;
+}
+
+/* NEON rect copy between two chunky 32bpp bitmaps; falls through to
+ * super otherwise. Handles same-buffer overlap via row direction;
+ * same-row right-shift uses a reverse copyline.
+ */
+VOID MNAME_GFX(CopyBox)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_CopyBox *msg)
+{
+    IPTR src_buf = 0, dst_buf = 0;
+    IPTR src_pitch = 0, dst_pitch = 0;
+    IPTR src_bpp = 0, dst_bpp = 0;
+    UBYTE *srow_base, *drow_base;
+    ULONG row_bytes;
+    LONG y, y_start, y_end, y_step;
+    BOOL same_row_overlap;
+
+    if (GC_DRMD(msg->gc) != vHidd_GC_DrawMode_Copy)
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        return;
+    }
+
+    OOP_GetAttr(msg->src,  aHidd_ChunkyBM_Buffer,    &src_buf);
+    OOP_GetAttr(msg->dest, aHidd_ChunkyBM_Buffer,    &dst_buf);
+    OOP_GetAttr(msg->src,  aHidd_BitMap_BytesPerRow, &src_pitch);
+    OOP_GetAttr(msg->dest, aHidd_BitMap_BytesPerRow, &dst_pitch);
+    {
+        OOP_Object *src_pf = NULL, *dst_pf = NULL;
+        OOP_GetAttr(msg->src,  aHidd_BitMap_PixFmt, (IPTR *)&src_pf);
+        OOP_GetAttr(msg->dest, aHidd_BitMap_PixFmt, (IPTR *)&dst_pf);
+        if (src_pf)
+            OOP_GetAttr(src_pf, aHidd_PixFmt_BytesPerPixel, &src_bpp);
+        if (dst_pf)
+            OOP_GetAttr(dst_pf, aHidd_PixFmt_BytesPerPixel, &dst_bpp);
+    }
+
+    if (!src_buf || !dst_buf || src_bpp != 4 || dst_bpp != 4)
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        return;
+    }
+
+    row_bytes = msg->width * 4;
+    srow_base = (UBYTE *)src_buf + msg->srcY  * src_pitch + msg->srcX  * 4;
+    drow_base = (UBYTE *)dst_buf + msg->destY * dst_pitch + msg->destX * 4;
+
+    /* Pick row iteration direction so overlapping in-buffer copies
+     * read each source row before it's overwritten by a dest row.
+     */
+    if (src_buf == dst_buf && msg->destY > msg->srcY)
+    {
+        y_start = msg->height - 1;
+        y_end   = -1;
+        y_step  = -1;
+    }
+    else
+    {
+        y_start = 0;
+        y_end   = msg->height;
+        y_step  = 1;
+    }
+
+    /* Same buffer, same row(s), dest right of source within its extent:
+     * rows alias byte-wise, need a reverse copy.
+     */
+    same_row_overlap = (src_buf == dst_buf
+                        && msg->destY == msg->srcY
+                        && msg->destX > msg->srcX
+                        && (ULONG)(msg->destX - msg->srcX) < msg->width);
+
+    /* No page flip here: desktop rendering is incremental read-modify-write
+     * and higher layers cache the framebuffer base, so flipping would expose
+     * a stale page. Page flipping stays in the gallium full-screen path,
+     * where Mesa renders a complete frame in its own BO.
+     */
+
+    /* Large copies between two uncached DMA-addressable buffers go through
+     * the DMA engine (uncached CPU reads dominate the NEON cost). Same-row
+     * horizontal overlap can't be done in 2D stride mode (rows always go
+     * forward), so it stays on the NEON reverse copy.
+     */
+    if (!same_row_overlap
+        && (row_bytes * msg->height) >= VC4_DMA_COPY_THRESHOLD
+        && vc4_bm_dma_base(cl, msg->src) == (ULONG)src_buf
+        && vc4_bm_dma_base(cl, msg->dest) == (ULONG)dst_buf
+        && src_buf && dst_buf)
+    {
+        if (vc4_dma_copy(XSD(cl), (ULONG)(IPTR)srow_base, src_pitch,
+                         (ULONG)(IPTR)drow_base, dst_pitch,
+                         row_bytes, msg->height, (y_step < 0)))
+            return;
+    }
+
+    for (y = y_start; y != y_end; y += y_step)
+    {
+        UBYTE *srow = srow_base + y * src_pitch;
+        UBYTE *drow = drow_base + y * dst_pitch;
+        if (same_row_overlap)
+            neon_copyline_rev(drow, srow, row_bytes);
+        else
+            neon_copyline(drow, srow, row_bytes);
+    }
+}
+
 OOP_Object *MNAME_GFX(CreateObject)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_CreateObject *msg)
 {
     OOP_Object      *object = NULL;
@@ -474,13 +582,17 @@ OOP_Object *MNAME_GFX(CreateObject)(OOP_Class *cl, OOP_Object *o, struct pHidd_G
         }
         else
         {
-            /* Non-displayable friends of our bitmaps are plain chunky bitmaps */
+            /* Displayable bitmaps and friends of ours go to the offscreen
+             * class: large 32bpp ones land in GPU memory, the rest in a
+             * plain ChunkyBM system-RAM buffer. */
             OOP_Object *friend = (OOP_Object *)GetTagData(aHidd_BitMap_Friend, 0, msg->attrList);
+            OOP_Class *frcl = friend ? OOP_OCLASS(friend) : NULL;
 
-            if (displayable || (friend && (OOP_OCLASS(friend) == XSD(cl)->vcsd_VideoCoreGfxOnBMClass)))
+            if (displayable || frcl == XSD(cl)->vcsd_VideoCoreGfxOnBMClass
+                            || frcl == XSD(cl)->vcsd_VideoCoreGfxOffBMClass)
             {
-                newbm_tags[0].ti_Tag  = aHidd_BitMap_ClassID;
-                newbm_tags[0].ti_Data = (IPTR)CLID_Hidd_ChunkyBM;
+                newbm_tags[0].ti_Tag  = aHidd_BitMap_ClassPtr;
+                newbm_tags[0].ti_Data = (IPTR)XSD(cl)->vcsd_VideoCoreGfxOffBMClass;
             }
         }
 
@@ -491,7 +603,30 @@ OOP_Object *MNAME_GFX(CreateObject)(OOP_Class *cl, OOP_Object *o, struct pHidd_G
         object = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&newbm_msg);
     }
     else
-        object = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    {
+        /* Lazy lookup: at InitLib time the disk FS and gallium framework
+         * aren't up. By the time CreatePipe calls HIDD_Gfx_CreateObject the
+         * disk is mounted and CLID_Hidd_Gallium is registered. */
+        if (!XSD(cl)->vcsd_basegallium)
+            XSD(cl)->vcsd_basegallium = OOP_FindClass(CLID_Hidd_Gallium);
+
+        if (XSD(cl)->vcsd_basegallium && msg->cl == XSD(cl)->vcsd_basegallium)
+        {
+            /* hidd.gallium.vc4 lives on the FS; load it on first request
+             * so its OOP class registers before OOP_NewObject. */
+            if (!XSD(cl)->vcsd_VC4GalliumLib)
+                XSD(cl)->vcsd_VC4GalliumLib = OpenLibrary("vc4gallium.hidd", 0);
+
+            if (XSD(cl)->vcsd_VC4GalliumLib)
+            {
+                /* Must match CLID_Hidd_Gallium_VC4 in vc4gallium_intern.h */
+                object = OOP_NewObject(NULL, (STRPTR)"hidd.gallium.vc4", msg->attrList);
+            }
+            /* else: object stays NULL; CreatePipe will use its softpipe fallback. */
+        }
+        else
+            object = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    }
 
     return object;
 }

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
@@ -21,6 +21,7 @@
 #include <graphics/driver.h>
 #include <graphics/gfxbase.h>
 #include <hidd/gfx.h>
+#include <hidd/gallium.h>
 #include <oop/oop.h>
 #include <utility/utility.h>
 #include <aros/symbolsets.h>
@@ -102,9 +103,8 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
     xsd->vcsd_MBoxMessage =
         (unsigned int *)((xsd->vcsd_MBoxBuff + 0xF) & ~0x0000000F);
 
-    /* Initialise the mailbox lock here, before the first MBoxWrite/Read,
-     * so every subsequent transaction (including ones triggered before
-     * InitMem runs) can take it. */
+    /* Init the mailbox lock before the first MBoxWrite/Read so every
+     * transaction (even those before InitMem) can take it. */
     InitSemaphore(&xsd->vcsd_GPUMemLock);
 
     D(bug("[VideoCoreGfx] %s: VideoCore Mailbox resource @ 0x%p\n", __PRETTY_FUNCTION__, MBoxBase));
@@ -135,10 +135,16 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
 
             FNAME_HW(InitGfxHW)((APTR)xsd);
             FNAME_SUPPORT(InitCursor)(xsd);
+            FNAME_SUPPORT(InitDMA)(xsd);
 
             if ((GfxBase = (struct GfxBase *)OpenLibrary("graphics.library", 41)) != NULL)
             {
                 LIBBASE->vsd.vcsd_basebm = OOP_FindClass(CLID_Hidd_BitMap);
+
+                /* vc4gallium.hidd lives on the FS, so it can't be opened from
+                 * InitLib (no disk yet); it loads lazily from
+                 * HIDD_Gfx_CreateObject, falling back to softpipe. */
+
                 if (AddDisplayDriver(LIBBASE->vsd.vcsd_VideoCoreGfxClass, NULL, TAG_DONE) == DD_OK)
                 {
                     D(bug("[VideoCoreGfx] Display Driver Registered\n"));

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
@@ -1,0 +1,148 @@
+#ifndef _VIDEOCOREGFX_NEON_H
+#define _VIDEOCOREGFX_NEON_H
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    NEON-accelerated framebuffer memory operations.
+
+    Uses NEON load/store multiple (vldm/vstm) for bulk transfers, faster than
+    memcpy for writes to uncached FB memory since NEON stores coalesce in the
+    ARM write buffer.
+
+    NEON registers are caller-saved in AROS (VFP saved/restored on task
+    switch), so using them in HIDD methods is safe.
+*/
+
+#include <exec/types.h>
+
+#define NEON_PREFIX ".fpu neon\n\t"
+
+static inline void neon_copyline(UBYTE *dst, const UBYTE *src, ULONG bytes)
+{
+    /* 64-byte bulk copy using NEON: vldm/vstm with 4 q-regs (d0-d7) */
+    while (bytes >= 64)
+    {
+        asm volatile(
+            NEON_PREFIX
+            "vldm %[s]!, {d0-d7}\n\t"
+            "vstm %[d]!, {d0-d7}\n\t"
+            : [s] "+r"(src), [d] "+r"(dst)
+            :
+            : "d0","d1","d2","d3","d4","d5","d6","d7","memory"
+        );
+        bytes -= 64;
+    }
+    /* Tail: word-at-a-time */
+    while (bytes >= 4)
+    {
+        *(ULONG *)dst = *(const ULONG *)src;
+        dst += 4;
+        src += 4;
+        bytes -= 4;
+    }
+    while (bytes--)
+        *dst++ = *src++;
+}
+
+/* Copy backward (end toward start). Needed when src/dst alias on the same
+ * row with dst > src, where a forward copy would clobber unread source bytes.
+ */
+static inline void neon_copyline_rev(UBYTE *dst, const UBYTE *src, ULONG bytes)
+{
+    dst += bytes;
+    src += bytes;
+    while (bytes >= 64)
+    {
+        src -= 64;
+        dst -= 64;
+        bytes -= 64;
+        asm volatile(
+            NEON_PREFIX
+            "vldm %[s], {d0-d7}\n\t"
+            "vstm %[d], {d0-d7}\n\t"
+            : : [s] "r"(src), [d] "r"(dst)
+            : "d0","d1","d2","d3","d4","d5","d6","d7","memory"
+        );
+    }
+    while (bytes >= 4)
+    {
+        src -= 4;
+        dst -= 4;
+        bytes -= 4;
+        *(ULONG *)dst = *(const ULONG *)src;
+    }
+    while (bytes--)
+    {
+        src--;
+        dst--;
+        *dst = *src;
+    }
+}
+
+/* Opaque colour expansion of a Native32 mask row: where mask[i] != 0
+ * write fg, else write bg. width is in pixels. dst must be 4-byte aligned.
+ */
+static inline void neon_blit_mask32_row_opaque(UBYTE *dst,
+    const ULONG *mask, ULONG width, ULONG fg, ULONG bg)
+{
+    ULONG quads = width >> 2;
+    if (quads)
+    {
+        asm volatile(
+            NEON_PREFIX
+            "vdup.32 q2, %[fg]\n\t"
+            "vdup.32 q3, %[bg]\n\t"
+            "1:\n\t"
+            "vld1.32 {q0}, [%[m]]!\n\t"
+            "vceq.i32 q1, q0, #0\n\t"
+            "vbsl q1, q3, q2\n\t"
+            "vst1.32 {q1}, [%[d]]!\n\t"
+            "subs %[n], %[n], #1\n\t"
+            "bne 1b\n\t"
+            : [m] "+r"(mask), [d] "+r"(dst), [n] "+r"(quads)
+            : [fg] "r"(fg), [bg] "r"(bg)
+            : "q0","q1","q2","q3","cc","memory"
+        );
+    }
+    width &= 3;
+    while (width--)
+    {
+        *(ULONG *)dst = (*mask++ != 0) ? fg : bg;
+        dst += 4;
+    }
+}
+
+static inline void neon_fillline(UBYTE *dst, ULONG fill_val, ULONG bytes)
+{
+    asm volatile(
+        NEON_PREFIX
+        "vdup.32 d0, %[val]\n\t"
+        "vmov d1, d0\n\t"
+        "vmov d2, d0\n\t"
+        "vmov d3, d0\n\t"
+        "vmov d4, d0\n\t"
+        "vmov d5, d0\n\t"
+        "vmov d6, d0\n\t"
+        "vmov d7, d0\n\t"
+        : : [val] "r"(fill_val) : "d0","d1","d2","d3","d4","d5","d6","d7"
+    );
+    while (bytes >= 64)
+    {
+        asm volatile(
+            NEON_PREFIX
+            "vstm %[d]!, {d0-d7}\n\t"
+            : [d] "+r"(dst)
+            :
+            : "memory"
+        );
+        bytes -= 64;
+    }
+    while (bytes >= 4)
+    {
+        *(ULONG *)dst = fill_val;
+        dst += 4;
+        bytes -= 4;
+    }
+}
+
+#endif /* _VIDEOCOREGFX_NEON_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_offbitmap.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_offbitmap.c
@@ -1,0 +1,285 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: BCM VideoCore4 Gfx Hidd Offscreen Bitmap Class.
+
+    Large 32bpp offscreen bitmaps are placed in firmware (GPU) memory:
+    uncached and physically contiguous, so CopyBox/PutImage/GetImage
+    against the framebuffer run entirely on the DMA engine with no
+    cache maintenance. Small bitmaps, non-32bpp formats and allocation
+    failures fall back to the ChunkyBM superclass' system-RAM buffer,
+    with VideoData left NULL so every accelerated path skips them.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#define __OOP_NOATTRBASES__
+
+#include <proto/oop.h>
+#include <proto/mbox.h>
+#include <proto/utility.h>
+#include <exec/memory.h>
+#include <graphics/gfx.h>
+#include <hidd/gfx.h>
+#include <oop/oop.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "vc4gfx_bitmap.h"
+#include "vc4gfx_hidd.h"
+
+#include LC_LIBDEFS_FILE
+
+#ifdef MBoxBase
+#undef MBoxBase
+#endif
+
+#define MBoxBase      (&((struct VideoCoreGfxBase *)cl->UserData)->vsd)->vcsd_MBoxBase
+
+#define MNAME_ROOT(x) VideoCoreGfxOffBM__Root__ ## x
+#define MNAME_BM(x) VideoCoreGfxOffBM__Hidd_BitMap__ ## x
+
+#include "vc4gfx_bitmapclass.c"
+
+/* Included bitmapclass.c sets its own DEBUG; reset to this file's value. */
+#undef DEBUG
+#define DEBUG 0
+
+/* Helpers below carry 'xsd'; switch MBoxBase to it (as in vc4gfx_onbitmap.c). */
+#undef MBoxBase
+#define MBoxBase      xsd->vcsd_MBoxBase
+
+/* GPU-memory placement of offscreen bitmaps is DISABLED.
+ *
+ * ALLOCMEM's address masked to physical (& 0x3fffffff) is mapped *cached*
+ * by the ARM MMU, but DMA reaches it through the *uncached* 0xC0000000
+ * alias. The CPU rendering paths do no cache maintenance, so a CPU-drawn
+ * bitmap blitted by DMA shows stale lines — seen on real Pi 3 as 8-pixel
+ * vertical stripes in Zune gadgets. (QEMU rejects ALLOCMEM, so it always
+ * took the RAM fallback and never hit this.)
+ *
+ * Re-enabling needs the allocation mapped uncached for the CPU (an MMU
+ * attribute change, as the kernel does for the framebuffer). Until then
+ * offscreen bitmaps live in cached RAM and FB<->RAM transfers go through
+ * vc4_dma_put/get, which handle cache maintenance.
+ */
+#define VC4_GPUBM_ENABLE 0
+
+#if VC4_GPUBM_ENABLE
+
+/* ALLOCMEM + LOCKMEM, using the tag layout proven by InitCursor.
+ * Returns the CPU-physical address (uncached mapping) or NULL; the
+ * firmware handle needed for freeing is stored in *handle_out.
+ */
+static APTR vc4_gpumem_alloc(struct VideoCoreGfx_staticdata *xsd,
+                             ULONG size, ULONG *handle_out)
+{
+    ULONG handle, bus;
+
+    VC4_MBOX_LOCK(xsd);
+    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(10 * 4);
+    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_ALLOCMEM);
+    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(12);
+    xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(12);
+    xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(size);
+    xsd->vcsd_MBoxMessage[6] = AROS_LE2LONG(32);
+    xsd->vcsd_MBoxMessage[7] = AROS_LE2LONG(VCMEM_DIRECT);
+    xsd->vcsd_MBoxMessage[8] = 0;
+    xsd->vcsd_MBoxMessage[9] = 0;
+
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        == (volatile unsigned int *)-1)
+    {
+        VC4_MBOX_UNLOCK(xsd);
+        return NULL;
+    }
+    handle = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+    if (!handle)
+    {
+        VC4_MBOX_UNLOCK(xsd);
+        return NULL;
+    }
+
+    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
+    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_LOCKMEM);
+    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(handle);
+    xsd->vcsd_MBoxMessage[6] = 0;
+    xsd->vcsd_MBoxMessage[7] = 0;
+
+    if (MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+        == (volatile unsigned int *)-1)
+    {
+        VC4_MBOX_UNLOCK(xsd);
+        return NULL;
+    }
+    bus = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+    VC4_MBOX_UNLOCK(xsd);
+
+    /* Firmware returns a bus address with alias bits set. QEMU may return a
+     * bare low-RAM address overlapping CPU allocations — reject it (as the
+     * cursor buffer does). */
+    if ((bus & 0xC0000000) == 0)
+    {
+        VC4_MBOX_LOCK(xsd);
+        xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
+        xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+        xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_FREEMEM);
+        xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(handle);
+        xsd->vcsd_MBoxMessage[6] = 0;
+        MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+        VC4_MBOX_UNLOCK(xsd);
+        return NULL;
+    }
+
+    *handle_out = handle;
+    return (APTR)(bus & 0x3fffffff);
+}
+
+static void vc4_gpumem_free(struct VideoCoreGfx_staticdata *xsd, ULONG handle)
+{
+    VC4_MBOX_LOCK(xsd);
+    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
+    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_UNLOCKMEM);
+    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(handle);
+    xsd->vcsd_MBoxMessage[6] = 0;
+    xsd->vcsd_MBoxMessage[7] = 0;
+    MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+
+    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
+    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_FREEMEM);
+    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(4);
+    xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(handle);
+    xsd->vcsd_MBoxMessage[6] = 0;
+    MBoxCall((void*)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+    VC4_MBOX_UNLOCK(xsd);
+}
+
+#endif /* VC4_GPUBM_ENABLE */
+
+/*********** BitMap::New() *************************************/
+
+OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    D(bug("[VideoCoreGfx] VideoCoreGfx.OffBitMap::New()\n"));
+
+#if VC4_GPUBM_ENABLE
+    {
+    struct VideoCoreGfx_staticdata *xsd = XSD(cl);
+    OOP_Object *friend_bm, *pf = NULL;
+    IPTR width, height, bytesperpix = 0;
+    HIDDT_ModeID modeid;
+    ULONG pitch = 0, size = 0, handle = 0;
+    APTR gpu_ptr = NULL;
+
+    width     = GetTagData(aHidd_BitMap_Width,  0, msg->attrList);
+    height    = GetTagData(aHidd_BitMap_Height, 0, msg->attrList);
+    friend_bm = (OOP_Object *)GetTagData(aHidd_BitMap_Friend, 0, msg->attrList);
+    modeid    = (HIDDT_ModeID)GetTagData(aHidd_BitMap_ModeID, vHidd_ModeID_Invalid, msg->attrList);
+
+    /* Pixel cell size: from the mode for displayable bitmaps, from the
+     * friend's pixfmt otherwise. If it can't be determined, the bitmap
+     * stays in system RAM. */
+    if (modeid != vHidd_ModeID_Invalid)
+    {
+        OOP_Object *sync = NULL, *modepf = NULL;
+
+        if (HIDD_Gfx_GetMode(xsd->vcsd_VideoCoreGfxInstance, modeid, &sync, &modepf)
+            && modepf)
+        {
+            pf = modepf;
+            if (!width && sync)
+                OOP_GetAttr(sync, aHidd_Sync_HDisp, &width);
+            if (!height && sync)
+                OOP_GetAttr(sync, aHidd_Sync_VDisp, &height);
+        }
+    }
+    else if (friend_bm)
+        OOP_GetAttr(friend_bm, aHidd_BitMap_PixFmt, (IPTR *)&pf);
+
+    if (pf)
+        OOP_GetAttr(pf, aHidd_PixFmt_BytesPerPixel, &bytesperpix);
+
+    if (width && height && bytesperpix == 4)
+    {
+        pitch = ((width * 4) + 31) & ~31;
+        size = pitch * height;
+        if (size >= VC4_GPUBM_THRESHOLD)
+            gpu_ptr = vc4_gpumem_alloc(xsd, size, &handle);
+    }
+
+    if (gpu_ptr)
+    {
+        struct TagItem extra_tags[] =
+        {
+            { aHidd_ChunkyBM_Buffer,    (IPTR)gpu_ptr          },
+            { aHidd_BitMap_BytesPerRow, pitch                  },
+            { TAG_MORE,                 (IPTR)msg->attrList    }
+        };
+        struct pRoot_New new_msg;
+
+        new_msg.mID = msg->mID;
+        new_msg.attrList = extra_tags;
+
+        o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&new_msg);
+        if (o)
+        {
+            struct BitmapData *data = OOP_INST_DATA(cl, o);
+
+            memset(data, 0, sizeof(struct BitmapData));
+            data->VideoData   = (UBYTE *)gpu_ptr;
+            data->width       = width;
+            data->height      = height;
+            data->bytesperrow = pitch;
+            data->bytesperpix = 4;
+            data->bpp         = 32;
+            data->gpuhandle   = handle;
+
+            D(bug("[VideoCoreGfx] OffBitMap::New: %dx%d GPU mem @ 0x%p, pitch %d\n",
+                (int)width, (int)height, gpu_ptr, (int)pitch));
+        }
+        else
+            vc4_gpumem_free(xsd, handle);
+
+        return o;
+    }
+    }
+#endif /* VC4_GPUBM_ENABLE */
+
+    /* Plain ChunkyBM system-RAM bitmap. VideoData stays NULL, so the
+     * accelerated bitmap methods fall through to the super class. */
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    if (o)
+        memset(OOP_INST_DATA(cl, o), 0, sizeof(struct BitmapData));
+
+    return o;
+}
+
+/**********  Bitmap::Dispose()  ***********************************/
+
+VOID MNAME_ROOT(Dispose)(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
+{
+#if VC4_GPUBM_ENABLE
+    struct VideoCoreGfx_staticdata *xsd = XSD(cl);
+    struct BitmapData *data = OOP_INST_DATA(cl, o);
+    ULONG handle = data->gpuhandle;
+
+    OOP_DoSuperMethod(cl, o, msg);
+
+    if (handle)
+        vc4_gpumem_free(xsd, handle);
+#else
+    OOP_DoSuperMethod(cl, o, msg);
+#endif
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_onbitmap.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_onbitmap.c
@@ -20,6 +20,7 @@
 #include <graphics/gfx.h>
 #include <hidd/gfx.h>
 #include <oop/oop.h>
+#include <stddef.h>
 
 #include "vc4gfx_bitmap.h"
 #include "vc4gfx_hidd.h"
@@ -38,25 +39,96 @@
 #define OnBitmap 1
 #include "vc4gfx_bitmapclass.c"
 
-/* vc4gfx_bitmapclass.c sets its own DEBUG; reset here so the value
- * chosen at the top of this file applies to the code below.
- */
+/* Included bitmapclass.c sets its own DEBUG; reset to this file's value. */
 #undef DEBUG
 #define DEBUG 0
 
-/* The file-level MBoxBase above resolves through 'cl' because the
- * included bitmapclass.c expects that. Below we have stand-alone
- * helpers and OOP methods that all carry an 'xsd' pointer; switch the
- * macro to pull MBoxBase off it directly so the helpers can call
- * MBoxWrite/MBoxRead without needing a class pointer.
+/* bitmapclass.c's MBoxBase resolves through 'cl'; the helpers below carry
+ * 'xsd' instead, so switch the macro to pull MBoxBase off it directly.
  */
 #undef MBoxBase
 #define MBoxBase      xsd->vcsd_MBoxBase
 
-/* Drive the firmware framebuffer to the requested geometry and report
- * back the resulting CPU pointer and scanout pitch. Used by both
- * BitMap::New (initial allocation) and BitMap::Set (mode switch on
- * the framebuffer when gfx.hidd's Show() picks a non-native mode).
+/* Program the scanout window offset within the virtual framebuffer.
+ * Returns TRUE only if the firmware echoes the requested offset back.
+ */
+static BOOL vc4_set_voffset(struct VideoCoreGfx_staticdata *xsd, ULONG yoffset)
+{
+    BOOL ok;
+
+    VC4_MBOX_LOCK(xsd);
+    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(8 * 4);
+    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_SETVOFFSET);
+    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(8);
+    xsd->vcsd_MBoxMessage[4] = AROS_LE2LONG(8);
+    xsd->vcsd_MBoxMessage[5] = AROS_LE2LONG(0);
+    xsd->vcsd_MBoxMessage[6] = AROS_LE2LONG(yoffset);
+    xsd->vcsd_MBoxMessage[7] = 0;
+
+    ok = (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+            != (volatile unsigned int *)-1)
+        && (xsd->vcsd_MBoxMessage[4] == AROS_LE2LONG(VCTAG_RESP + 8))
+        && (AROS_LE2LONG(xsd->vcsd_MBoxMessage[6]) == yoffset);
+    VC4_MBOX_UNLOCK(xsd);
+
+    return ok;
+}
+
+/* Phys address of the back page, or 0 when flipping is unavailable. */
+ULONG vc4_fb_backpage(struct VideoCoreGfx_staticdata *xsd)
+{
+    if (xsd->vcsd_FBPages < 2)
+        return 0;
+    return xsd->vcsd_FBPage[1 - xsd->vcsd_FBFront];
+}
+
+/* Make the back page visible and retarget rendering (data->VideoData and
+ * the ChunkyBM buffer) at it. Caller must have drawn the full frame first.
+ */
+BOOL vc4_fb_flip(struct VideoCoreGfx_staticdata *xsd)
+{
+    UBYTE nf;
+
+    if (xsd->vcsd_FBPages < 2 || !xsd->vcsd_FBObj)
+        return FALSE;
+
+    /* The mailbox lock also serializes concurrent flippers; the nested
+     * Obtain inside vc4_set_voffset is fine for the owning task. */
+    VC4_MBOX_LOCK(xsd);
+
+    nf = 1 - xsd->vcsd_FBFront;
+    if (!vc4_set_voffset(xsd, nf * xsd->vcsd_FBPageHeight))
+    {
+        /* Firmware refused — disable flipping for good. */
+        xsd->vcsd_FBPages = 1;
+        VC4_MBOX_UNLOCK(xsd);
+        return FALSE;
+    }
+    xsd->vcsd_FBFront = nf;
+
+    {
+        OOP_Class *bmcl = xsd->vcsd_VideoCoreGfxOnBMClass;
+        struct BitmapData *data = OOP_INST_DATA(bmcl, xsd->vcsd_FBObj);
+        struct TagItem btags[] =
+        {
+            { xsd->vcsd_attrBases[2] + aoHidd_ChunkyBM_Buffer, xsd->vcsd_FBPage[nf] },
+            { TAG_DONE, 0 }
+        };
+
+        data->VideoData = (UBYTE *)xsd->vcsd_FBPage[nf];
+        OOP_SetAttrs(xsd->vcsd_FBObj, btags);
+    }
+
+    VC4_MBOX_UNLOCK(xsd);
+    return TRUE;
+}
+
+/* Drive the firmware framebuffer to the requested geometry; report back the
+ * CPU pointer and scanout pitch. Used by BitMap::New and BitMap::Set.
+ *
+ * A double-height virtual framebuffer is requested first; the second page
+ * enables SETVOFFSET flipping. Falls back to a single page if unavailable.
  */
 static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
     ULONG aligned_width, ULONG height, UBYTE bytesperpix,
@@ -64,95 +136,128 @@ static BOOL vc4_program_fb(struct VideoCoreGfx_staticdata *xsd,
 {
     ULONG bitsperpixel = bytesperpix * 8;
     APTR fb_ptr = NULL;
-    ULONG fb_pitch = 0;
+    ULONG fb_pitch = 0, fb_size = 0;
+    int pages;
 
-    /* Hold the mailbox lock across the whole multi-transaction sequence
-     * (FBFREE -> batched mode/depth/pixfmt/FBALLOC -> GETPITCH). */
-    VC4_MBOX_LOCK(xsd);
-
-    /* Free any previous framebuffer the firmware was holding. */
-    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(6 * 4);
-    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
-    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_FBFREE);
-    xsd->vcsd_MBoxMessage[3] = 0;
-    xsd->vcsd_MBoxMessage[4] = 0;
-    xsd->vcsd_MBoxMessage[5] = 0;
-    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
-
-    /* SETRES + SETVRES + SETDEPTH + SETPIXFMT + FBALLOC, all in one
-     * batch. SETPIXFMT pins the channel order to RGB so the layout
-     * matches our pftags_32bpp declaration (R in low bits) on every
-     * firmware - on real Pi3 the default would otherwise be BGR,
-     * giving a brown/blue-tinted image. QEMU happens to pick RGB by
-     * default, hiding the issue there.
-     */
-    xsd->vcsd_MBoxMessage[1]  = AROS_LE2LONG(VCTAG_REQ);
-    xsd->vcsd_MBoxMessage[2]  = AROS_LE2LONG(VCTAG_SETRES);
-    xsd->vcsd_MBoxMessage[3]  = AROS_LE2LONG(8);
-    xsd->vcsd_MBoxMessage[4]  = AROS_LE2LONG(8);
-    xsd->vcsd_MBoxMessage[5]  = AROS_LE2LONG(aligned_width);
-    xsd->vcsd_MBoxMessage[6]  = AROS_LE2LONG(height);
-
-    xsd->vcsd_MBoxMessage[7]  = AROS_LE2LONG(VCTAG_SETVRES);
-    xsd->vcsd_MBoxMessage[8]  = AROS_LE2LONG(8);
-    xsd->vcsd_MBoxMessage[9]  = AROS_LE2LONG(8);
-    xsd->vcsd_MBoxMessage[10] = AROS_LE2LONG(aligned_width);
-    xsd->vcsd_MBoxMessage[11] = AROS_LE2LONG(height);
-
-    xsd->vcsd_MBoxMessage[12] = AROS_LE2LONG(VCTAG_SETDEPTH);
-    xsd->vcsd_MBoxMessage[13] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[14] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[15] = AROS_LE2LONG(bitsperpixel);
-
-    xsd->vcsd_MBoxMessage[16] = AROS_LE2LONG(VCTAG_SETPIXFMT);
-    xsd->vcsd_MBoxMessage[17] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[18] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[19] = AROS_LE2LONG(VCPXFMT_RGB);
-
-    xsd->vcsd_MBoxMessage[20] = AROS_LE2LONG(VCTAG_FBALLOC);
-    xsd->vcsd_MBoxMessage[21] = AROS_LE2LONG(8);
-    xsd->vcsd_MBoxMessage[22] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[23] = AROS_LE2LONG(16);
-    xsd->vcsd_MBoxMessage[24] = 0;
-
-    xsd->vcsd_MBoxMessage[25] = 0;
-    xsd->vcsd_MBoxMessage[0]  = AROS_LE2LONG(26 << 2);
-
-    if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
-            == (volatile unsigned int *)-1)
-        || (xsd->vcsd_MBoxMessage[1] != AROS_LE2LONG(VCTAG_RESP))
-        || (xsd->vcsd_MBoxMessage[22] != AROS_LE2LONG(VCTAG_RESP + 8)))
+    for (pages = 2; pages >= 1; pages--)
     {
+        /* Hold the mailbox lock across the whole multi-transaction sequence
+         * (FBFREE -> batched mode/depth/pixfmt/FBALLOC -> GETPITCH). */
+        VC4_MBOX_LOCK(xsd);
+
+        /* Free any previous framebuffer the firmware was holding. */
+        xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(6 * 4);
+        xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+        xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_FBFREE);
+        xsd->vcsd_MBoxMessage[3] = 0;
+        xsd->vcsd_MBoxMessage[4] = 0;
+        xsd->vcsd_MBoxMessage[5] = 0;
+        MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage);
+
+        /* SETRES + SETVRES + SETDEPTH + SETPIXFMT + FBALLOC in one batch.
+         * SETPIXFMT pins channel order to RGB to match pftags_32bpp (R in
+         * low bits); real Pi3 defaults to BGR (brown/blue tint), QEMU to RGB.
+         */
+        xsd->vcsd_MBoxMessage[1]  = AROS_LE2LONG(VCTAG_REQ);
+        xsd->vcsd_MBoxMessage[2]  = AROS_LE2LONG(VCTAG_SETRES);
+        xsd->vcsd_MBoxMessage[3]  = AROS_LE2LONG(8);
+        xsd->vcsd_MBoxMessage[4]  = AROS_LE2LONG(8);
+        xsd->vcsd_MBoxMessage[5]  = AROS_LE2LONG(aligned_width);
+        xsd->vcsd_MBoxMessage[6]  = AROS_LE2LONG(height);
+
+        xsd->vcsd_MBoxMessage[7]  = AROS_LE2LONG(VCTAG_SETVRES);
+        xsd->vcsd_MBoxMessage[8]  = AROS_LE2LONG(8);
+        xsd->vcsd_MBoxMessage[9]  = AROS_LE2LONG(8);
+        xsd->vcsd_MBoxMessage[10] = AROS_LE2LONG(aligned_width);
+        xsd->vcsd_MBoxMessage[11] = AROS_LE2LONG(height * pages);
+
+        xsd->vcsd_MBoxMessage[12] = AROS_LE2LONG(VCTAG_SETDEPTH);
+        xsd->vcsd_MBoxMessage[13] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[14] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[15] = AROS_LE2LONG(bitsperpixel);
+
+        xsd->vcsd_MBoxMessage[16] = AROS_LE2LONG(VCTAG_SETPIXFMT);
+        xsd->vcsd_MBoxMessage[17] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[18] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[19] = AROS_LE2LONG(VCPXFMT_BGR);
+
+        xsd->vcsd_MBoxMessage[20] = AROS_LE2LONG(VCTAG_FBALLOC);
+        xsd->vcsd_MBoxMessage[21] = AROS_LE2LONG(8);
+        xsd->vcsd_MBoxMessage[22] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[23] = AROS_LE2LONG(16);
+        xsd->vcsd_MBoxMessage[24] = 0;
+
+        xsd->vcsd_MBoxMessage[25] = 0;
+        xsd->vcsd_MBoxMessage[0]  = AROS_LE2LONG(26 << 2);
+
+        if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+                == (volatile unsigned int *)-1)
+            || (xsd->vcsd_MBoxMessage[1] != AROS_LE2LONG(VCTAG_RESP))
+            || (xsd->vcsd_MBoxMessage[22] != AROS_LE2LONG(VCTAG_RESP + 8)))
+        {
+            VC4_MBOX_UNLOCK(xsd);
+            if (pages > 1)
+                continue;
+            return FALSE;
+        }
+        fb_ptr = (APTR)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[23]) & 0x3fffffff);
+        fb_size = AROS_LE2LONG(xsd->vcsd_MBoxMessage[24]);
+
+        /* Use the firmware-reported pitch verbatim: it may align rows, or
+         * (QEMU) keep a default virtual width that ignores our request.
+         */
+        xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
+        xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
+        xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_GETPITCH);
+        xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
+        xsd->vcsd_MBoxMessage[4] = 0;
+        xsd->vcsd_MBoxMessage[5] = 0;
+        xsd->vcsd_MBoxMessage[6] = 0;
+
+        if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
+                != (volatile unsigned int *)-1)
+            && (xsd->vcsd_MBoxMessage[4] == AROS_LE2LONG(VCTAG_RESP + 4)))
+        {
+            fb_pitch = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
+        }
+        else
+        {
+            /* Fallback: assume packed rows. */
+            fb_pitch = aligned_width * bytesperpix;
+        }
+
         VC4_MBOX_UNLOCK(xsd);
-        return FALSE;
+
+        /* Did the allocation really cover both pages? */
+        if (pages > 1 && fb_size < fb_pitch * height * 2)
+            continue;
+        break;
     }
-    fb_ptr = (APTR)(AROS_LE2LONG(xsd->vcsd_MBoxMessage[23]) & 0x3fffffff);
 
-    /* Query the firmware-decided pitch. The firmware may align rows or
-     * (in QEMU) leave the virtual width at a default that doesn't match
-     * what we requested, so we must use the reported pitch verbatim.
-     */
-    xsd->vcsd_MBoxMessage[0] = AROS_LE2LONG(7 * 4);
-    xsd->vcsd_MBoxMessage[1] = AROS_LE2LONG(VCTAG_REQ);
-    xsd->vcsd_MBoxMessage[2] = AROS_LE2LONG(VCTAG_GETPITCH);
-    xsd->vcsd_MBoxMessage[3] = AROS_LE2LONG(4);
-    xsd->vcsd_MBoxMessage[4] = 0;
-    xsd->vcsd_MBoxMessage[5] = 0;
-    xsd->vcsd_MBoxMessage[6] = 0;
+    xsd->vcsd_FBPage[0]    = (ULONG)(IPTR)fb_ptr;
+    xsd->vcsd_FBPage[1]    = (ULONG)(IPTR)fb_ptr + fb_pitch * height;
+    xsd->vcsd_FBPageHeight = height;
+    xsd->vcsd_FBFront      = 0;
+    xsd->vcsd_FBPages      = 1;
 
-    if ((MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, xsd->vcsd_MBoxMessage)
-            != (volatile unsigned int *)-1)
-        && (xsd->vcsd_MBoxMessage[4] == AROS_LE2LONG(VCTAG_RESP + 4)))
+    if (pages == 2)
     {
-        fb_pitch = AROS_LE2LONG(xsd->vcsd_MBoxMessage[5]);
-    }
-    else
-    {
-        /* Fallback: assume packed rows. */
-        fb_pitch = aligned_width * bytesperpix;
+        /* Only trust flipping if the firmware honours SETVOFFSET
+         * round-trips (QEMU's emulation may not). */
+        if (vc4_set_voffset(xsd, height) && vc4_set_voffset(xsd, 0))
+        {
+            /* Clear the back page so the first flip can't expose stale
+             * memory. CPU memset to the uncached FB — DMA fill hangs on HW. */
+            memset((APTR)(IPTR)xsd->vcsd_FBPage[1], 0, fb_pitch * height);
+            xsd->vcsd_FBPages = 2;
+        }
+        else
+            vc4_set_voffset(xsd, 0);
     }
 
-    VC4_MBOX_UNLOCK(xsd);
+    D(bug("[VideoCoreGfx] %s: %d page(s) @ 0x%p, pitch %d\n",
+        __PRETTY_FUNCTION__, (int)xsd->vcsd_FBPages, fb_ptr, (int)fb_pitch));
+
     *fb_ptr_out   = fb_ptr;
     *fb_pitch_out = fb_pitch;
     return TRUE;
@@ -210,15 +315,13 @@ OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
     D(bug("[VideoCoreGfx] VideoCoreGfx.OnBitMap::New()\n"));
 
-    /* Extract attrs we need to drive FBALLOC directly from the incoming
-     * attrList. We do this before super-call because ChunkyBM/BitMap cache
-     * BytesPerRow at New time - if we wait until after super-call to do
-     * FBALLOC + GETPITCH and then SetAttrs, ChunkyBM keeps a stale
-     * bytesperrow and rendering uses the wrong stride.
+    /* Extract the attrs we need for FBALLOC before super-call: ChunkyBM/
+     * BitMap cache BytesPerRow at New time, so doing FBALLOC + GETPITCH
+     * later and SetAttrs'ing would leave a stale stride.
      *
-     * The framebuffer bitmap is created with just FrameBuffer=TRUE +
-     * ModeID; Width/Height/PixFmt are normally derived inside BitMap::New
-     * from the mode database. We replicate that lookup here.
+     * The FB bitmap arrives with just FrameBuffer=TRUE + ModeID;
+     * Width/Height/PixFmt are normally derived from the mode database
+     * inside BitMap::New, so we replicate that lookup here.
      */
     modeid = (HIDDT_ModeID)GetTagData(aHidd_BitMap_ModeID, vHidd_ModeID_Invalid, msg->attrList);
     width  = GetTagData(aHidd_BitMap_Width,  0, msg->attrList);
@@ -260,23 +363,19 @@ OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
         return NULL;
     }
 
-    /* The Pi firmware's SETDEPTH wants the cell size in bits. AROS
-     * pixfmts that pad colour into wider cells (e.g. BGR032: 24-bit
-     * colour in a 4-byte cell) have BitsPerPixel == colour depth, not
-     * the cell size, so use bytesperpix * 8 which is always the cell
-     * width.
+    /* SETDEPTH wants the cell size in bits. AROS pixfmts that pad colour
+     * into wider cells (e.g. BGR032: 24-bit in a 4-byte cell) report
+     * BitsPerPixel as colour depth, so use bytesperpix * 8 (the cell width).
      */
     aligned_width = (width + 15) & ~15;
     bytesperpix = (UBYTE)bytesperpix_attr;
-    bitsperpixel = bytesperpix * 8;
+    bitsperpixel = (IPTR)bytesperpix * 8;
 
 #if !defined(DEBUGDISPLAY)
-    /* Detach the kernel's bootloader-installed framebuffer console.
-     * Writing 0x03 to RawPutChar drops ARMI_PutChar (see
-     * arch/arm-native/kernel/kernel_debug.c) so subsequent bug()/kprintf
-     * output goes to the serial port only - critical, otherwise the
-     * console keeps drawing characters into the FB we are about to
-     * hand over to Workbench, overwriting the title bar.
+    /* Detach the bootloader's FB console: 0x03 to RawPutChar drops
+     * ARMI_PutChar (arch/arm-native/kernel/kernel_debug.c) so debug output
+     * goes to serial only. Otherwise it keeps drawing into the FB we hand
+     * to Workbench, overwriting the title bar.
      */
     RawPutChar(0x03);
 
@@ -293,8 +392,8 @@ OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
 #endif
 
-    /* Hand the discovered FB and pitch to super::New via an extended
-     * attrList. ChunkyBM and BitMap then cache the right values up-front.
+    /* Hand the FB and pitch to super::New so ChunkyBM/BitMap cache the
+     * right values up-front.
      */
     {
         struct TagItem extra_tags[] =
@@ -319,10 +418,14 @@ OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
         data->VideoData   = (UBYTE *)fb_ptr;
         data->width       = aligned_width;
         data->height      = height;
+        data->bytesperrow = fb_pitch;
         data->bpp         = bitsperpixel;
         data->bytesperpix = bytesperpix;
         data->disp        = -1;
         data->data        = &XSD(cl)->data;
+        data->dispwidth   = width;
+
+        xsd->vcsd_FBObj   = o;
 
         D(bug("[VideoCoreGfx] OnBitMap::New: object @ 0x%p, FB @ 0x%p, pitch %d\n",
             o, data->VideoData, (int)fb_pitch));
@@ -333,17 +436,14 @@ OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
 /**********  Bitmap::Set()  ***************************************/
 
-/* gfx.hidd's Show() switches the framebuffer to a different ModeID
- * by calling SetAttrs(aHidd_BitMap_ModeID, ...) on us; if we leave
- * that to the BitMap superclass alone, it updates the bitmap's
- * Width/Height/BytesPerRow but the firmware keeps scanning out at
- * the original resolution and pitch - which manifests as sheared
- * "intertwined" rendering at every non-native mode. Reprogram the
- * firmware so its scanout matches the new geometry, then forward
- * the new buffer + pitch to super so the cached attributes line up.
+/* gfx.hidd's Show() switches the FB ModeID via SetAttrs on us. Left to the
+ * BitMap superclass alone it updates Width/Height/BytesPerRow but the
+ * firmware keeps scanning out at the old geometry — sheared "intertwined"
+ * rendering at every non-native mode. So reprogram the firmware first, then
+ * forward the new buffer + pitch to super so cached attributes line up.
  *
- * Returns IPTR to match BM__Root__Set; gfx.hidd's Show() bails out
- * (and never copies the new bitmap into us) when SetAttrs returns 0.
+ * Returns IPTR to match BM__Root__Set; Show() bails (never copying the new
+ * bitmap into us) when SetAttrs returns 0.
  */
 IPTR MNAME_ROOT(Set)(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg)
 {
@@ -364,6 +464,15 @@ IPTR MNAME_ROOT(Set)(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg)
         {
             newmodeid = (HIDDT_ModeID)tag->ti_Data;
             has_modeid = TRUE;
+        }
+        else if (IS_VideoCoreGfxBM_ATTR(tag->ti_Tag, idx)
+                 && idx == aoHidd_VideoCoreGfxBitMap_Flip)
+        {
+            /* Page-flip request (e.g. from vc4gallium after a full-frame
+             * blit to the back page). */
+            if (tag->ti_Data)
+                vc4_fb_flip(xsd);
+            return TRUE;
         }
     }
 
@@ -410,8 +519,10 @@ IPTR MNAME_ROOT(Set)(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg)
                     data->VideoData   = (UBYTE *)fb_ptr;
                     data->width       = aligned_width;
                     data->height      = height;
+                    data->bytesperrow = fb_pitch;
                     data->bytesperpix = bytesperpix;
                     data->bpp         = bytesperpix * 8;
+                    data->dispwidth   = width;
 
                     D(bug("[VideoCoreGfx] OnBitMap::Set: switched to %dx%d %dbpp FB @ 0x%p, pitch %d (super=%d)\n",
                         (int)aligned_width, (int)height, (int)data->bpp,

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_pixfmts.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_pixfmts.c
@@ -20,50 +20,49 @@
 #define ARRAYSIZE_LUT           15
 
 #if defined(VC_FMT_32)
-/* With VCTAG_SETPIXFMT=VCPXFMT_RGB the VideoCore firmware lays out
- * 32-bpp framebuffers as R,G,B,X in memory order. The canonical AROS
- * pixfmt for that layout is vHidd_StdPixFmt_RGB032, with shifts and
- * masks taken from rom/hidds/gfx/stdpixfmts_{le,be}.h.
+/* With VCTAG_SETPIXFMT=VCPXFMT_RGB the firmware lays out 32-bpp as
+ * R,G,B,X in memory order; shifts/masks per
+ * rom/hidds/gfx/stdpixfmts_{le,be}.h.
  */
 #if AROS_BIG_ENDIAN
 IPTR pftags_32bpp[ARRAYSIZE_TRUECOLOR] =
 {
     ARRAYSIZE_TRUECOLOR,
-    0,
-    8,
     16,
+    8,
     0,
-    0xFF000000,
-    0x00FF0000,
+    0,
     0x0000FF00,
+    0x00FF0000,
+    0xFF000000,
     0x00000000,
     32,
     4,
     32,
-    vHidd_StdPixFmt_RGB032
+    vHidd_StdPixFmt_BGR032
 };
 #else
 IPTR pftags_32bpp[ARRAYSIZE_TRUECOLOR] =
 {
     ARRAYSIZE_TRUECOLOR,
-    24,
-    16,
     8,
+    16,
+    24,
     0,
-    0x000000FF,
-    0x0000FF00,
     0x00FF0000,
+    0x0000FF00,
+    0x000000FF,
     0x00000000,
     32,
     4,
     32,
-    vHidd_StdPixFmt_RGB032
+    vHidd_StdPixFmt_BGR032
 };
 #endif
 #endif
 
 #if defined(VC_FMT_24)
-/* 24-bpp packed: firmware lays out B,G,R bytes in memory. Match
+/* 24-bpp packed: firmware lays out B,G,R bytes; matches
  * vHidd_StdPixFmt_BGR24 from rom/hidds/gfx/stdpixfmts_{le,be}.h.
  */
 #if AROS_BIG_ENDIAN


### PR DESCRIPTION
Add BCM2708 DMA and NEON blit paths, offscreen bitmaps backed by GPU memory, and SETVOFFSET double-buffered page flipping. Also corrects the hardware-cursor hotspot offset.