### PR TITLE
raspi: add file-backed battclock.resource

### DIFF
--- a/arch/arm-raspi/battclock/battclock_intern.h
+++ b/arch/arm-raspi/battclock/battclock_intern.h
@@ -1,0 +1,20 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Internal definitions for battclock.resource, Raspberry Pi version.
+*/
+
+#ifndef BATTCLOCK_INTERN_H
+#define BATTCLOCK_INTERN_H
+
+#include <exec/libraries.h>
+
+/* File on the boot volume that persists the clock across reboots. */
+#define BATTCLOCK_FILE "DEVS:battclock"
+
+struct BattClockBase
+{
+    struct Library bb_LibNode;
+};
+
+#endif /* BATTCLOCK_INTERN_H */

--- a/arch/arm-raspi/battclock/mmakefile.src
+++ b/arch/arm-raspi/battclock/mmakefile.src
@@ -1,0 +1,11 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+USER_INCLUDES := -I$(SRCDIR)/$(CURDIR) -I$(SRCDIR)/rom/battclock
+
+%build_archspecific \
+  mainmmake=kernel-battclock maindir=rom/battclock \
+  arch=raspi-arm modname=battclock \
+  files="readbattclock writebattclock"
+
+%common

--- a/arch/arm-raspi/battclock/readbattclock.c
+++ b/arch/arm-raspi/battclock/readbattclock.c
@@ -1,0 +1,56 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: ReadBattClock() function, Raspberry Pi file-backed version.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <dos/dos.h>
+#include <dos/dosextens.h>
+
+#include "battclock_intern.h"
+
+AROS_LH0(ULONG, ReadBattClock,
+         struct BattClockBase *, BattClockBase, 2, Battclock)
+{
+    AROS_LIBFUNC_INIT
+
+    struct DosLibrary *DOSBase;
+    ULONG secs = 0;
+
+    /*
+     * The Raspberry Pi has no battery-backed RTC, so the clock is kept in a
+     * plain file on the boot volume (written by WriteBattClock()). The clock
+     * does not tick while the file is at rest; it simply preserves the value
+     * SetClock SAVE last stored.
+     */
+    DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
+    if (DOSBase)
+    {
+        BPTR fh;
+
+        fh = Open(BATTCLOCK_FILE, MODE_OLDFILE);
+        if (fh)
+        {
+            ULONG val;
+            LONG n;
+
+            n = Read(fh, &val, sizeof(val));
+            if (n == sizeof(val))
+                secs = val;
+
+            Close(fh);
+        }
+
+        CloseLibrary((struct Library *)DOSBase);
+    }
+
+    D(bug("[battclock] ReadBattClock: returning %lu\n", secs));
+    return secs;
+
+    AROS_LIBFUNC_EXIT
+} /* ReadBattClock */

--- a/arch/arm-raspi/battclock/writebattclock.c
+++ b/arch/arm-raspi/battclock/writebattclock.c
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: WriteBattClock() function, Raspberry Pi file-backed version.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <dos/dos.h>
+#include <dos/dosextens.h>
+
+#include "battclock_intern.h"
+
+AROS_LH1(void, WriteBattClock,
+         AROS_LHA(ULONG, time, D0),
+         struct BattClockBase *, BattClockBase, 3, Battclock)
+{
+    AROS_LIBFUNC_INIT
+
+    struct DosLibrary *DOSBase;
+
+    /* Persist the time to the boot volume; see ReadBattClock() for rationale. */
+    DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
+    if (DOSBase)
+    {
+        BPTR fh;
+
+        fh = Open(BATTCLOCK_FILE, MODE_NEWFILE);
+        if (fh)
+        {
+            LONG n;
+
+            n = Write(fh, &time, sizeof(time));
+            D(bug("[battclock] WriteBattClock: Write returned %ld\n", (long)n));
+            Close(fh);
+        }
+
+        CloseLibrary((struct Library *)DOSBase);
+    }
+
+    AROS_LIBFUNC_EXIT
+} /* WriteBattClock */

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -89,6 +89,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-package-raspi-arm: \
 #MM linklibs-stdc-static \
 #MM kernel-dos \
+#MM kernel-battclock \
 #MM kernel-bootloader \
 #MM kernel-dosboot \
 #MM kernel-oop \
@@ -138,9 +139,6 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-usb-romstrap-raspi \
 #MM kernel-econsole
 
-#MM kernel-package-raspi-arm-missing: \
-#MM kernel-battclock
-
 RASPIFW_BRANCH    := master
 RASPIFW_URI       := https://github.com/raspberrypi/firmware/blob/$(RASPIFW_BRANCH)/boot
 RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-rpi-2-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb
@@ -148,7 +146,7 @@ RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-r
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
 PKG_LIBS_ARCH := expansion
 PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma
-PKG_RSRC_ARCH := processor
+PKG_RSRC_ARCH := processor battclock
 PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer
 PKG_HANDLERS  := con ram cdrom sfs fat afs


### PR DESCRIPTION
Fake battclock.resource implementation for Raspberry PI. 
