### PR TITLE
posixc: make readlink() fail with EINVAL on non-symlinks

### DIFF
--- a/compiler/crt/posixc/readlink.c
+++ b/compiler/crt/posixc/readlink.c
@@ -33,7 +33,7 @@
         path    - the path to the symbolic link
         buf     - pointer to the buffer where to store the symbolic link content
         bufsize - the size of the buffer in bytes
-      
+
     RESULT
         The call returns the count of characters placed in the buffer if it
         succeeds, or a -1 if an error occurs, placing the error code in the
@@ -59,8 +59,21 @@
         return res;
 
     dvp = GetDeviceProc(path, NULL);
+    if (dvp == NULL)
+    {
+        errno = __stdc_ioerr2errno(IoErr());
+        return res;
+    }
 
     res = ReadLink(dvp->dvp_Port, dvp->dvp_Lock, path, buf, bufsize);
+    if (res == 0) {
+        /* Filesystems that don't implement ACTION_READ_LINK (e.g. FAT)
+           answer it with DOSFALSE (0). POSIX readlink() must fail with
+           EINVAL on a non-symlink, so treat a 0 result as that error. */
+        FreeDeviceProc(dvp);
+        errno = EINVAL;
+        return -1;
+    }
     if (res == -1) {
         error = IoErr();
     } else {
@@ -68,7 +81,7 @@
             res = bufsize;
         error = me->pr_Result2 = 0;
     }
-    
+
     FreeDeviceProc(dvp);
 
     if (error)


### PR DESCRIPTION
Filesystems that don't implement ACTION_READ_LINK (e.g. FAT and AFS) answer it with DOSFALSE (0). POSIX readlink() must fail with EINVAL on a non-symlink, so treat a 0 result as that error. 