### PR TITLE
raspi: WiFi support for Raspberry Pi 3 / 3B+ / 4 (Broadcom FullMAC)

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm.conf
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm.conf
@@ -1,0 +1,31 @@
+##begin config
+version 0.1
+residentpri 86
+libbase BWFMBase
+libbasetype struct BWFMBase
+##end config
+##begin cdef
+#include <inttypes.h>
+#include <exec/tasks.h>
+##end cdef
+##begin cdefprivate
+#include "bwfm_private.h"
+##end cdefprivate
+##begin functionlist
+int BWFMAttach() ()
+uint32_t BWFMChipID() ()
+int BWFMStartFirmware(void * fw, uint32_t fwlen, void * nvram, uint32_t nvlen) (A0, D0, A1, D1)
+int BWFMGetMAC(uint8_t * mac) (A0)
+int BWFMIoctl(uint32_t cmd, int set, void * buf, uint32_t len) (D0, D1, A0, D2)
+int BWFMIovar(uint8_t * name, int set, void * buf, uint32_t len) (A0, D0, A1, D1)
+int BWFMScan(void * out, int max) (A0, D0)
+int BWFMLoadCLM(void * clm, uint32_t clmlen) (A0, D0)
+int BWFMTxData(void * eth, uint32_t ethlen) (A0, D0)
+int BWFMRxFrame(void * buf, uint32_t bufsize, uint32_t * info) (A0, D0, A1)
+int BWFMJoin(uint8_t * ssid, uint32_t ssidlen, uint8_t * pass, uint32_t passlen) (A0, D0, A1, D1)
+int BWFMSetRxSignal(struct Task * task, uint32_t sigmask) (A0, D0)
+void BWFMAckRx() ()
+void BWFMClearInt() ()
+void BWFMEventPost(void * ev, uint32_t len) (A0, D0)
+int BWFMScanIE(int idx, void * buf, uint32_t bufsize) (D0, A0, D1)
+##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_init.c
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_init.c
@@ -1,0 +1,2525 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Portions ported from OpenBSD's sys/dev/ic/bwfm.c and
+    sys/dev/sdmmc/if_bwfm_sdio.c, which carry the ISC licence:
+
+      Copyright (c) 2010-2016 Broadcom Corporation
+      Copyright (c) 2016,2017 Patrick Wildt <patrick@blueri.se>
+
+      Permission to use, copy, modify, and/or distribute this software for any
+      purpose with or without fee is hereby granted, provided that the above
+      copyright notice and this permission notice appear in all copies.
+
+      THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+      WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+      MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+      ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+      WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+      ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+      OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    bwfm.resource - Broadcom FullMAC WiFi chip bring-up over SDIO.
+
+    Phase 2: chip bring-up - identify the chip (ChipCommon CHIPID over the
+    silicon backplane), enumerate the backplane cores from the EROM, halt
+    them (set_passive) and size the chip RAM. Ported from OpenBSD's bwfm.c /
+    if_bwfm_sdio.c (see the ISC notice above), reworked to drive the chip
+    through sdio.resource (CMD52/CMD53) instead of the OpenBSD sdmmc layer;
+    AI interconnect only.
+
+    Firmware download (needs DOS/filesystem) and the SANA-II network device
+    (bwfm.device) sit on top of this chip layer in later phases.
+*/
+
+#define DEBUG 0
+
+#include <aros/macros.h>
+#include <aros/debug.h>
+#include <aros/symbolsets.h>
+#include <aros/libcall.h>
+#include <devices/timer.h>
+#include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/sdio.h>
+
+#include "bwfmreg.h"
+#include "bwfm_sdio.h"
+#include "bwfm_scan.h"
+#include "bwfm_private.h"
+
+APTR SDIOBase __attribute__((used)) = NULL;     /* sdio.resource (proto/sdio.h base) */
+APTR KernelBase __attribute__((used)) = NULL;
+
+/* Busy-wait microseconds off the BCM2835 1 MHz system timer (CLO). */
+static void bwfm_udelay(struct BWFMBase *BWFMBase, ULONG us)
+{
+    volatile ULONG *clo = (volatile ULONG *)(BWFMBase->bwfm_periiobase + 0x3004);
+    ULONG start = AROS_LE2LONG(*clo);
+
+    while ((AROS_LE2LONG(*clo) - start) < us)
+        ;
+}
+
+/*
+ * Zero a buffer of run-time length. The volatile store stops gcc from
+ * synthesising a memset() call out of the loop - this resource is resident
+ * in the kickstart where stdc.library cannot be opened, so any implicit
+ * memset/memcpy reference makes the module's autoinit fail at boot.
+ */
+static void bwfm_zero(UBYTE *p, ULONG n)
+{
+    volatile UBYTE *d = p;
+
+    while (n--)
+        *d++ = 0;
+}
+
+/* ----------------------------------------------------------------------- */
+/* SDIO register access (ported from if_bwfm_sdio.c)                       */
+
+/*
+ * Address-range based function selection:
+ *   0x00000-0x007FF : function 0 (CCCR / FBR)
+ *   0x10000-0x1FFFF : function 1 miscellaneous registers
+ *   otherwise       : function 1 silicon-backplane window
+ */
+static inline uint32_t bwfm_func(uint32_t addr)
+{
+    return ((addr & ~0x7ff) == 0) ? 0 : 1;
+}
+
+static uint8_t bwfm_read_1(uint32_t addr)
+{
+    return SDIOReadByte(bwfm_func(addr), addr);
+}
+
+static void bwfm_write_1(uint32_t addr, uint8_t val)
+{
+    SDIOWriteByte(bwfm_func(addr), addr, val);
+}
+
+static void bwfm_backplane(struct BWFMBase *BWFMBase, uint32_t bar0)
+{
+    if (BWFMBase->bwfm_bar0 == bar0)
+        return;
+
+    bwfm_write_1(BWFM_SDIO_FUNC1_SBADDRLOW,  (bar0 >> 8) & 0x80);
+    bwfm_write_1(BWFM_SDIO_FUNC1_SBADDRMID,  (bar0 >> 16) & 0xff);
+    bwfm_write_1(BWFM_SDIO_FUNC1_SBADDRHIGH, (bar0 >> 24) & 0xff);
+    BWFMBase->bwfm_bar0 = bar0;
+}
+
+static uint32_t bwfm_read_4(struct BWFMBase *BWFMBase, uint32_t addr)
+{
+    uint32_t bar0 = addr & ~BWFM_SDIO_SB_OFT_ADDR_MASK;
+    uint32_t val = 0xffffffff;
+
+    bwfm_backplane(BWFMBase, bar0);
+
+    addr &= BWFM_SDIO_SB_OFT_ADDR_MASK;
+    addr |= BWFM_SDIO_SB_ACCESS_2_4B_FLAG;
+
+    if (SDIOReadExt(bwfm_func(addr), addr, &val, 4, 1))
+        return 0xffffffff;
+    return val;
+}
+
+static void bwfm_write_4(struct BWFMBase *BWFMBase, uint32_t addr, uint32_t val)
+{
+    uint32_t bar0 = addr & ~BWFM_SDIO_SB_OFT_ADDR_MASK;
+
+    bwfm_backplane(BWFMBase, bar0);
+
+    addr &= BWFM_SDIO_SB_OFT_ADDR_MASK;
+    addr |= BWFM_SDIO_SB_ACCESS_2_4B_FLAG;
+
+    SDIOWriteExt(bwfm_func(addr), addr, &val, 4, 1);
+}
+
+/*
+ * Bring up the ALP clock so the backplane is accessible (ported from
+ * bwfm_sdio_buscore_prepare).
+ */
+static int bwfm_buscore_prepare(struct BWFMBase *BWFMBase)
+{
+    uint8_t clkset, clkmask, clkval;
+    int i;
+
+    clkset = BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL_REQ |
+             BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HW_CLKREQ_OFF;
+    bwfm_write_1(BWFM_SDIO_FUNC1_CHIPCLKCSR, clkset);
+
+    clkmask = BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL |
+              BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL;
+    clkval = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+
+    if ((clkval & ~clkmask) != clkset)
+    {
+        D(bug("[bwfm] CHIPCLKCSR wrote 0x%02x read 0x%02x\n", clkset, clkval));
+        return 1;
+    }
+
+    for (i = 1000; i > 0; i--)
+    {
+        clkval = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+        if (clkval & clkmask)
+            break;
+        bwfm_udelay(BWFMBase, 1);       /* bound the wait in time, not read count */
+    }
+    if (i == 0)
+    {
+        D(bug("[bwfm] timeout waiting for ALP, clkval 0x%02x\n", clkval));
+        return 1;
+    }
+
+    clkset = BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HW_CLKREQ_OFF |
+             BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_ALP;
+    bwfm_write_1(BWFM_SDIO_FUNC1_CHIPCLKCSR, clkset);
+    bwfm_udelay(BWFMBase, 65);          /* let ALP settle (matches reference) */
+
+    bwfm_write_1(BWFM_SDIO_FUNC1_SDIOPULLUP, 0);
+
+    return 0;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Core enumeration and reset (ported from bwfm.c, AI interconnect only)   */
+
+static struct bwfm_core *bwfm_get_core_idx(struct BWFMBase *BWFMBase, int id, int idx)
+{
+    int i;
+
+    for (i = 0; i < BWFMBase->bwfm_ncores; i++)
+        if (BWFMBase->bwfm_cores[i].co_id == id && idx-- == 0)
+            return &BWFMBase->bwfm_cores[i];
+    return NULL;
+}
+
+static struct bwfm_core *bwfm_get_core(struct BWFMBase *BWFMBase, int id)
+{
+    return bwfm_get_core_idx(BWFMBase, id, 0);
+}
+
+static struct bwfm_core *bwfm_get_pmu(struct BWFMBase *BWFMBase)
+{
+    struct bwfm_core *cc, *pmu;
+
+    cc = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_CHIPCOMMON);
+    if (cc->co_rev >= 35 &&
+        (BWFMBase->bwfm_cc_caps_ext & BWFM_CHIP_REG_CAPABILITIES_EXT_AOB_PRESENT))
+    {
+        pmu = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_PMU);
+        if (pmu)
+            return pmu;
+    }
+    return cc;
+}
+
+static int bwfm_ai_isup(struct BWFMBase *BWFMBase, struct bwfm_core *core)
+{
+    uint32_t ioctl, reset;
+
+    ioctl = bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL);
+    reset = bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL);
+
+    if (((ioctl & (BWFM_AGENT_IOCTL_FGC | BWFM_AGENT_IOCTL_CLK)) == BWFM_AGENT_IOCTL_CLK) &&
+        ((reset & BWFM_AGENT_RESET_CTL_RESET) == 0))
+        return 1;
+    return 0;
+}
+
+static void bwfm_ai_disable(struct BWFMBase *BWFMBase, struct bwfm_core *core,
+                            uint32_t prereset, uint32_t reset)
+{
+    uint32_t val;
+    int i;
+
+    val = bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL);
+    if ((val & BWFM_AGENT_RESET_CTL_RESET) == 0)
+    {
+        bwfm_write_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL,
+                     prereset | BWFM_AGENT_IOCTL_FGC | BWFM_AGENT_IOCTL_CLK);
+        bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL);
+
+        bwfm_write_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL,
+                     BWFM_AGENT_RESET_CTL_RESET);
+        bwfm_udelay(BWFMBase, 20);
+
+        for (i = 300; i > 0; i--)
+            if (bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL) ==
+                BWFM_AGENT_RESET_CTL_RESET)
+                break;
+        if (i == 0)
+            D(bug("[bwfm] timeout on core disable\n"));
+    }
+
+    bwfm_write_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL,
+                 reset | BWFM_AGENT_IOCTL_FGC | BWFM_AGENT_IOCTL_CLK);
+    bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL);
+}
+
+static void bwfm_ai_reset(struct BWFMBase *BWFMBase, struct bwfm_core *core,
+                          uint32_t prereset, uint32_t reset, uint32_t postreset)
+{
+    int i;
+
+    bwfm_ai_disable(BWFMBase, core, prereset, reset);
+
+    for (i = 50; i > 0; i--)
+    {
+        if ((bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL) &
+             BWFM_AGENT_RESET_CTL_RESET) == 0)
+            break;
+        bwfm_write_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_RESET_CTL, 0);
+        bwfm_udelay(BWFMBase, 60);
+    }
+    if (i == 0)
+        D(bug("[bwfm] timeout on core reset\n"));
+
+    bwfm_write_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL,
+                 postreset | BWFM_AGENT_IOCTL_CLK);
+    bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL);
+}
+
+static int bwfm_dmp_get_regaddr(struct BWFMBase *BWFMBase, uint32_t *erom,
+                                uint32_t *base, uint32_t *wrap)
+{
+    uint8_t type = 0, stype, wraptype;
+    uint32_t val;
+
+    *base = 0;
+    *wrap = 0;
+
+    val = bwfm_read_4(BWFMBase, *erom);
+    type = val & BWFM_DMP_DESC_MASK;
+    if (type == BWFM_DMP_DESC_MASTER_PORT)
+    {
+        wraptype = BWFM_DMP_SLAVE_TYPE_MWRAP;
+        *erom += 4;
+    }
+    else if ((type & ~BWFM_DMP_DESC_ADDRSIZE_GT32) == BWFM_DMP_DESC_ADDRESS)
+        wraptype = BWFM_DMP_SLAVE_TYPE_SWRAP;
+    else
+        return 1;
+
+    do
+    {
+        uint8_t sztype;
+
+        do
+        {
+            val = bwfm_read_4(BWFMBase, *erom);
+            type = val & BWFM_DMP_DESC_MASK;
+            if (type == BWFM_DMP_DESC_COMPONENT)
+                return 0;
+            if (type == BWFM_DMP_DESC_EOT)
+                return 1;
+            *erom += 4;
+        }
+        while ((type & ~BWFM_DMP_DESC_ADDRSIZE_GT32) != BWFM_DMP_DESC_ADDRESS);
+
+        if (type & BWFM_DMP_DESC_ADDRSIZE_GT32)
+            *erom += 4;
+
+        sztype = (val & BWFM_DMP_SLAVE_SIZE_TYPE) >> BWFM_DMP_SLAVE_SIZE_TYPE_S;
+        if (sztype == BWFM_DMP_SLAVE_SIZE_DESC)
+        {
+            uint32_t v2 = bwfm_read_4(BWFMBase, *erom);
+            if ((v2 & BWFM_DMP_DESC_MASK) & BWFM_DMP_DESC_ADDRSIZE_GT32)
+                *erom += 8;
+            else
+                *erom += 4;
+        }
+        if (sztype != BWFM_DMP_SLAVE_SIZE_4K && sztype != BWFM_DMP_SLAVE_SIZE_8K)
+            continue;
+
+        stype = (val & BWFM_DMP_SLAVE_TYPE) >> BWFM_DMP_SLAVE_TYPE_S;
+        if (*base == 0 && stype == BWFM_DMP_SLAVE_TYPE_SLAVE)
+            *base = val & BWFM_DMP_SLAVE_ADDR_BASE;
+        if (*wrap == 0 && stype == wraptype)
+            *wrap = val & BWFM_DMP_SLAVE_ADDR_BASE;
+    }
+    while (*base == 0 || *wrap == 0);
+
+    return 0;
+}
+
+static void bwfm_erom_scan(struct BWFMBase *BWFMBase)
+{
+    uint32_t erom, val, base, wrap;
+    uint8_t type = 0, nmw, nsw, rev;
+    uint16_t id;
+
+    BWFMBase->bwfm_ncores = 0;
+
+    erom = bwfm_read_4(BWFMBase, BWFM_CHIP_BASE + BWFM_CHIP_REG_EROMPTR);
+    while (type != BWFM_DMP_DESC_EOT)
+    {
+        val = bwfm_read_4(BWFMBase, erom);
+        type = val & BWFM_DMP_DESC_MASK;
+        erom += 4;
+
+        if (type != BWFM_DMP_DESC_COMPONENT)
+            continue;
+
+        id = (val & BWFM_DMP_COMP_PARTNUM) >> BWFM_DMP_COMP_PARTNUM_S;
+
+        val = bwfm_read_4(BWFMBase, erom);
+        type = val & BWFM_DMP_DESC_MASK;
+        erom += 4;
+        if (type != BWFM_DMP_DESC_COMPONENT)
+        {
+            D(bug("[bwfm] EROM: not a component descriptor\n"));
+            return;
+        }
+
+        nmw = (val & BWFM_DMP_COMP_NUM_MWRAP) >> BWFM_DMP_COMP_NUM_MWRAP_S;
+        nsw = (val & BWFM_DMP_COMP_NUM_SWRAP) >> BWFM_DMP_COMP_NUM_SWRAP_S;
+        rev = (val & BWFM_DMP_COMP_REVISION) >> BWFM_DMP_COMP_REVISION_S;
+
+        if (nmw + nsw == 0 && id != BWFM_AGENT_CORE_PMU && id != BWFM_AGENT_CORE_GCI)
+            continue;
+
+        if (bwfm_dmp_get_regaddr(BWFMBase, &erom, &base, &wrap))
+            continue;
+
+        if (BWFMBase->bwfm_ncores >= BWFM_MAX_CORES)
+        {
+            D(bug("[bwfm] EROM: core table full\n"));
+            return;
+        }
+        BWFMBase->bwfm_cores[BWFMBase->bwfm_ncores].co_id = id;
+        BWFMBase->bwfm_cores[BWFMBase->bwfm_ncores].co_rev = rev;
+        BWFMBase->bwfm_cores[BWFMBase->bwfm_ncores].co_base = base;
+        BWFMBase->bwfm_cores[BWFMBase->bwfm_ncores].co_wrapbase = wrap;
+        BWFMBase->bwfm_ncores++;
+    }
+}
+
+/* Put the CPU/802.11/memory cores into a known halted (passive) state. */
+static void bwfm_set_passive(struct BWFMBase *BWFMBase)
+{
+    struct bwfm_core *core;
+
+    if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_ARM_CR4)) != NULL)
+    {
+        uint32_t val = bwfm_read_4(BWFMBase, core->co_wrapbase + BWFM_AGENT_IOCTL);
+        int i = 0;
+
+        bwfm_ai_reset(BWFMBase, core, val & BWFM_AGENT_IOCTL_ARMCR4_CPUHALT,
+                      BWFM_AGENT_IOCTL_ARMCR4_CPUHALT, BWFM_AGENT_IOCTL_ARMCR4_CPUHALT);
+        while ((core = bwfm_get_core_idx(BWFMBase, BWFM_AGENT_CORE_80211, i++)))
+            bwfm_ai_disable(BWFMBase, core,
+                            BWFM_AGENT_D11_IOCTL_PHYRESET | BWFM_AGENT_D11_IOCTL_PHYCLOCKEN,
+                            BWFM_AGENT_D11_IOCTL_PHYCLOCKEN);
+        return;
+    }
+
+    if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_ARM_CM3)) != NULL)
+    {
+        bwfm_ai_disable(BWFMBase, core, 0, 0);
+        core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_80211);
+        bwfm_ai_reset(BWFMBase, core,
+                      BWFM_AGENT_D11_IOCTL_PHYRESET | BWFM_AGENT_D11_IOCTL_PHYCLOCKEN,
+                      BWFM_AGENT_D11_IOCTL_PHYCLOCKEN, BWFM_AGENT_D11_IOCTL_PHYCLOCKEN);
+        core = bwfm_get_core(BWFMBase, BWFM_AGENT_INTERNAL_MEM);
+        bwfm_ai_reset(BWFMBase, core, 0, 0, 0);
+
+        if (BWFMBase->bwfm_chip == BRCM_CC_43430_CHIP_ID)
+        {
+            bwfm_write_4(BWFMBase, core->co_base + BWFM_SOCRAM_BANKIDX, 3);
+            bwfm_write_4(BWFMBase, core->co_base + BWFM_SOCRAM_BANKPDA, 0);
+        }
+        return;
+    }
+}
+
+static void bwfm_socram_ramsize(struct BWFMBase *BWFMBase, struct bwfm_core *core)
+{
+    uint32_t coreinfo, nb, lss, banksize, bankinfo;
+    uint32_t ramsize = 0, srsize = 0;
+    int i;
+
+    if (!bwfm_ai_isup(BWFMBase, core))
+        bwfm_ai_reset(BWFMBase, core, 0, 0, 0);
+
+    coreinfo = bwfm_read_4(BWFMBase, core->co_base + BWFM_SOCRAM_COREINFO);
+    nb = (coreinfo & BWFM_SOCRAM_COREINFO_SRNB_MASK) >> BWFM_SOCRAM_COREINFO_SRNB_SHIFT;
+
+    if (core->co_rev <= 7 || core->co_rev == 12)
+    {
+        banksize = coreinfo & BWFM_SOCRAM_COREINFO_SRBSZ_MASK;
+        lss = (coreinfo & BWFM_SOCRAM_COREINFO_LSS_MASK) >> BWFM_SOCRAM_COREINFO_LSS_SHIFT;
+        if (lss != 0)
+            nb--;
+        ramsize = nb * (1 << (banksize + BWFM_SOCRAM_COREINFO_SRBSZ_BASE));
+        if (lss != 0)
+            ramsize += (1 << ((lss - 1) + BWFM_SOCRAM_COREINFO_SRBSZ_BASE));
+    }
+    else
+    {
+        for (i = 0; i < nb; i++)
+        {
+            bwfm_write_4(BWFMBase, core->co_base + BWFM_SOCRAM_BANKIDX,
+                         (BWFM_SOCRAM_BANKIDX_MEMTYPE_RAM << BWFM_SOCRAM_BANKIDX_MEMTYPE_SHIFT) | i);
+            bankinfo = bwfm_read_4(BWFMBase, core->co_base + BWFM_SOCRAM_BANKINFO);
+            banksize = ((bankinfo & BWFM_SOCRAM_BANKINFO_SZMASK) + 1) * BWFM_SOCRAM_BANKINFO_SZBASE;
+            ramsize += banksize;
+            if (bankinfo & BWFM_SOCRAM_BANKINFO_RETNTRAM_MASK)
+                srsize += banksize;
+        }
+    }
+
+    if (BWFMBase->bwfm_chip == BRCM_CC_43430_CHIP_ID)
+        srsize = 64 * 1024;
+
+    BWFMBase->bwfm_ramsize = ramsize;
+    BWFMBase->bwfm_srsize = srsize;
+}
+
+static void bwfm_tcm_ramsize(struct BWFMBase *BWFMBase, struct bwfm_core *core)
+{
+    uint32_t cap, nab, nbb, totb, bxinfo, blksize, ramsize = 0;
+    int i;
+
+    cap = bwfm_read_4(BWFMBase, core->co_base + BWFM_ARMCR4_CAP);
+    nab = (cap & BWFM_ARMCR4_CAP_TCBANB_MASK) >> BWFM_ARMCR4_CAP_TCBANB_SHIFT;
+    nbb = (cap & BWFM_ARMCR4_CAP_TCBBNB_MASK) >> BWFM_ARMCR4_CAP_TCBBNB_SHIFT;
+    totb = nab + nbb;
+
+    for (i = 0; i < totb; i++)
+    {
+        bwfm_write_4(BWFMBase, core->co_base + BWFM_ARMCR4_BANKIDX, i);
+        bxinfo = bwfm_read_4(BWFMBase, core->co_base + BWFM_ARMCR4_BANKINFO);
+        blksize = (bxinfo & BWFM_ARMCR4_BANKINFO_BLK_1K_MASK) ? 1024 : 8192;
+        ramsize += ((bxinfo & BWFM_ARMCR4_BANKINFO_BSZ_MASK) + 1) * blksize;
+    }
+
+    BWFMBase->bwfm_ramsize = ramsize;
+}
+
+static void bwfm_tcm_rambase(struct BWFMBase *BWFMBase)
+{
+    switch (BWFMBase->bwfm_chip)
+    {
+    case BRCM_CC_4345_CHIP_ID:          /* Pi 3B+ / Pi 4 (BCM43455) */
+        BWFMBase->bwfm_rambase = 0x198000;
+        break;
+    case BRCM_CC_4339_CHIP_ID:
+        BWFMBase->bwfm_rambase = 0x180000;
+        break;
+    default:
+        D(bug("[bwfm] unknown TCM rambase for chip %x\n", BWFMBase->bwfm_chip));
+        break;
+    }
+}
+
+/* ----------------------------------------------------------------------- */
+/* Chip identification                                                     */
+
+static int bwfm_do_attach(struct BWFMBase *BWFMBase)
+{
+    uint32_t val;
+    int type;
+
+    BWFMBase->bwfm_attached = FALSE;
+    BWFMBase->bwfm_bar0 = ~0u;          /* force first backplane write */
+
+    if (!SDIOBase)
+        return FALSE;
+
+    /* Drive the lazy SDIO bring-up: the first SDIOProbe() powers the WiFi chip
+     * and runs CMD5/CMD3/CMD7; later calls return the cached result (it is
+     * idempotent on sdio_Present), so this is safe to call on every attach. */
+    if (!SDIOProbe())
+    {
+        D(bug("[bwfm] no SDIO device present\n"));
+        return FALSE;
+    }
+
+    /* Block sizes: F1 (backplane) 64, F2 (data) 512; enable F1 */
+    SDIOSetBlockSize(1, 64);
+    SDIOSetBlockSize(2, 512);
+    if (SDIOEnableFunction(1))
+    {
+        D(bug("[bwfm] cannot enable function 1\n"));
+        return FALSE;
+    }
+
+    if (bwfm_buscore_prepare(BWFMBase))
+        return FALSE;
+
+    val = bwfm_read_4(BWFMBase, BWFM_CHIP_BASE + BWFM_CHIP_REG_CHIPID);
+    BWFMBase->bwfm_chip = BWFM_CHIP_CHIPID_ID(val);
+    BWFMBase->bwfm_chiprev = BWFM_CHIP_CHIPID_REV(val);
+    type = BWFM_CHIP_CHIPID_TYPE(val);
+
+    /* Print like OpenBSD: decimal for "43xxx" parts, hex for "0x4xxx" parts */
+    if (BWFMBase->bwfm_chip > 0xa000 || BWFMBase->bwfm_chip < 0x4000)
+        D(bug("[bwfm] CHIPID 0x%08x -> BCM%u rev %d (type %d)\n",
+              val, BWFMBase->bwfm_chip, BWFMBase->bwfm_chiprev, type));
+    else
+        D(bug("[bwfm] CHIPID 0x%08x -> BCM%x rev %d (type %d)\n",
+              val, BWFMBase->bwfm_chip, BWFMBase->bwfm_chiprev, type));
+
+    if (type != BWFM_CHIP_CHIPID_TYPE_SOCI_AI)
+    {
+        D(bug("[bwfm] unsupported SoC interconnect type %d\n", type));
+        return FALSE;
+    }
+
+    /* Enumerate the silicon-backplane cores from the EROM */
+    bwfm_erom_scan(BWFMBase);
+    {
+        int i, cpu_found = 0, need_socram = 0, has_socram = 0;
+        int cc_found = 0, d11_found = 0, sdiodev_found = 0;
+
+        for (i = 0; i < BWFMBase->bwfm_ncores; i++)
+        {
+            struct bwfm_core *core = &BWFMBase->bwfm_cores[i];
+
+            D(bug("[bwfm]   core 0x%03x rev %d base 0x%08x wrap 0x%08x\n",
+                  core->co_id, core->co_rev, core->co_base, core->co_wrapbase));
+
+            switch (core->co_id)
+            {
+            case BWFM_AGENT_CORE_ARM_CM3:
+                need_socram = 1;
+                /* fallthrough */
+            case BWFM_AGENT_CORE_ARM_CR4:
+            case BWFM_AGENT_CORE_ARM_CA7:
+                cpu_found = 1;
+                break;
+            case BWFM_AGENT_INTERNAL_MEM:
+                has_socram = 1;
+                break;
+            case BWFM_AGENT_CORE_CHIPCOMMON:
+                cc_found = 1;
+                break;
+            case BWFM_AGENT_CORE_80211:
+                d11_found = 1;
+                break;
+            case BWFM_AGENT_CORE_SDIO_DEV:
+                sdiodev_found = 1;
+                break;
+            }
+        }
+
+        if (!cpu_found)
+        {
+            D(bug("[bwfm] no CPU core detected\n"));
+            return FALSE;
+        }
+        if (need_socram && !has_socram)
+        {
+            D(bug("[bwfm] RAM core not provided\n"));
+            return FALSE;
+        }
+        /* ChipCommon, the 802.11 MAC and the SDIO device core are dereferenced
+         * unconditionally below (bwfm_set_passive / bwfm_get_pmu / bwfm_dev_* /
+         * bwfm_frame_rw); a malformed EROM that omits any of them would fault,
+         * so bail here instead. The datapath only runs once bwfm_attached, so
+         * this one check makes every later bwfm_get_core() of these safe. */
+        if (!cc_found || !d11_found || !sdiodev_found)
+        {
+            D(bug("[bwfm] required core missing (cc %d d11 %d sdiodev %d)\n",
+                  cc_found, d11_found, sdiodev_found));
+            return FALSE;
+        }
+    }
+
+    /* Halt the cores, then size the chip RAM */
+    bwfm_set_passive(BWFMBase);
+
+    {
+        struct bwfm_core *core, *cc, *pmu;
+
+        if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_ARM_CR4)) != NULL)
+        {
+            bwfm_tcm_ramsize(BWFMBase, core);
+            bwfm_tcm_rambase(BWFMBase);
+        }
+        else if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_INTERNAL_MEM)) != NULL)
+        {
+            bwfm_socram_ramsize(BWFMBase, core);
+        }
+
+        cc = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_CHIPCOMMON);
+        BWFMBase->bwfm_cc_caps = bwfm_read_4(BWFMBase,
+            cc->co_base + BWFM_CHIP_REG_CAPABILITIES);
+        BWFMBase->bwfm_cc_caps_ext = bwfm_read_4(BWFMBase,
+            cc->co_base + BWFM_CHIP_REG_CAPABILITIES_EXT);
+
+        pmu = bwfm_get_pmu(BWFMBase);
+        if (BWFMBase->bwfm_cc_caps & BWFM_CHIP_REG_CAPABILITIES_PMU)
+            BWFMBase->bwfm_pmurev = bwfm_read_4(BWFMBase,
+                pmu->co_base + BWFM_CHIP_REG_PMUCAPABILITIES) &
+                BWFM_CHIP_REG_PMUCAPABILITIES_REV_MASK;
+    }
+
+    D(bug("[bwfm] %d cores, RAM base 0x%06x size %d KB (sr %d KB), PMU rev %d\n",
+          BWFMBase->bwfm_ncores, BWFMBase->bwfm_rambase,
+          BWFMBase->bwfm_ramsize / 1024, BWFMBase->bwfm_srsize / 1024,
+          BWFMBase->bwfm_pmurev));
+
+    /*
+     * Post-enumeration chip setup (from bwfm_sdio_attach):
+     *  - KSO ("keep SDIO on") for SDIO_DEV core rev >= 12 (BCM43455/3B+/4):
+     *    without it the chip may drop the SDIO clock and go silent;
+     *  - assert the WLAN reset bit in the Broadcom CARDCTRL CCCR register;
+     *  - trigger a PMU resource reload.
+     */
+    {
+        struct bwfm_core *sdiodev = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_SDIO_DEV);
+        struct bwfm_core *pmu = bwfm_get_pmu(BWFMBase);
+
+        if (sdiodev && sdiodev->co_rev >= 12)
+        {
+            uint8_t cs = bwfm_read_1(BWFM_SDIO_FUNC1_SLEEPCSR);
+            if (!(cs & BWFM_SDIO_FUNC1_SLEEPCSR_KSO))
+                bwfm_write_1(BWFM_SDIO_FUNC1_SLEEPCSR,
+                             cs | BWFM_SDIO_FUNC1_SLEEPCSR_KSO);
+        }
+
+        bwfm_write_1(BWFM_SDIO_CCCR_CARDCTRL,
+                     bwfm_read_1(BWFM_SDIO_CCCR_CARDCTRL) |
+                     BWFM_SDIO_CCCR_CARDCTRL_WLANRESET);
+
+        if (pmu)
+            bwfm_write_4(BWFMBase, pmu->co_base + BWFM_CHIP_REG_PMUCONTROL,
+                         bwfm_read_4(BWFMBase, pmu->co_base + BWFM_CHIP_REG_PMUCONTROL) |
+                         (BWFM_CHIP_REG_PMUCONTROL_RES_RELOAD <<
+                          BWFM_CHIP_REG_PMUCONTROL_RES_SHIFT));
+    }
+
+    BWFMBase->bwfm_attached = TRUE;
+    return TRUE;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Firmware download (ported from if_bwfm_sdio.c bwfm_sdio_load_microcode)  */
+
+/* Write a buffer into chip RAM through the backplane, paging at 32 KB
+ * windows and chunking each window into <=512-byte CMD53 byte-mode writes
+ * (sdio.resource's extended transfer limit). Lengths are rounded up to 4. */
+static int bwfm_ram_write(struct BWFMBase *BWFMBase, uint32_t ramaddr,
+                          const UBYTE *data, ULONG len)
+{
+    UBYTE bounce[512];
+    ULONG off = 0;
+
+    while (len > 0)
+    {
+        uint32_t sbaddr = ramaddr + off;
+        uint32_t sdoff = sbaddr & BWFM_SDIO_SB_OFT_ADDR_MASK;
+        ULONG winleft = BWFM_SDIO_SB_OFT_ADDR_PAGE - sdoff;
+        ULONG n = (len < winleft) ? len : winleft;
+        ULONG done = 0;
+
+        bwfm_backplane(BWFMBase, sbaddr & ~BWFM_SDIO_SB_OFT_ADDR_MASK);
+
+        while (done < n)
+        {
+            ULONG chunk = (n - done < 512) ? (n - done) : 512;
+            /* Round up to the func1 block size (64) so sdio.resource uses
+             * block-mode CMD53 (a large byte-mode access returns OUT_OF_RANGE).
+             * The few pad bytes land in chip RAM beyond the image - harmless. */
+            ULONG wlen = (chunk + 63) & ~63UL;
+            const UBYTE *src = data + off + done;
+
+            if (wlen != chunk)
+            {
+                CopyMem((APTR)src, bounce, chunk);
+                bwfm_zero(bounce + chunk, wlen - chunk);
+                src = bounce;
+            }
+
+            if (SDIOWriteExt(1, (sdoff + done) | BWFM_SDIO_SB_ACCESS_2_4B_FLAG,
+                             (APTR)src, wlen, 1))
+                return -1;
+            done += chunk;
+        }
+
+        off += n;
+        len -= n;
+    }
+    return 0;
+}
+
+/*
+ * Request and wait for the ALP clock. Firmware is uploaded on ALP - the
+ * HT/PLL clock is not available until the firmware configures the PMU, so
+ * waiting for HT here would just time out. HT is forced only after the
+ * firmware signals ready (see BWFMStartFirmware). Matches OpenBSD/brcmfmac.
+ */
+static int bwfm_alpclk_on(struct BWFMBase *BWFMBase)
+{
+    uint8_t clk = 0;
+    int i;
+
+    bwfm_write_1(BWFM_SDIO_FUNC1_CHIPCLKCSR, BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL_REQ);
+    for (i = 0; i < 5000; i++)
+    {
+        clk = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+        if (clk & (BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL |
+                   BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL))
+            return 0;
+        bwfm_udelay(BWFMBase, 1000);
+    }
+    D(bug("[bwfm] ALP clock timeout (csr 0x%02x)\n", clk));
+    return -1;
+}
+
+/* SDPCM (SDIO_DEV core) register access */
+static uint32_t bwfm_dev_read(struct BWFMBase *BWFMBase, uint32_t reg)
+{
+    struct bwfm_core *core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_SDIO_DEV);
+    return bwfm_read_4(BWFMBase, core->co_base + reg);
+}
+
+static void bwfm_dev_write(struct BWFMBase *BWFMBase, uint32_t reg, uint32_t val)
+{
+    struct bwfm_core *core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_SDIO_DEV);
+    bwfm_write_4(BWFMBase, core->co_base + reg, val);
+}
+
+static void bwfm_buscore_activate(struct BWFMBase *BWFMBase, uint32_t rstvec)
+{
+    bwfm_dev_write(BWFMBase, SDPCMD_INTSTATUS, 0xFFFFFFFF);
+    if (rstvec)
+        bwfm_write_4(BWFMBase, 0, rstvec);      /* exactly 4 bytes, like OpenBSD;
+                                                 * bwfm_ram_write would block-mode
+                                                 * pad this to 64 and clobber RAM
+                                                 * at backplane addr 4..63 */
+}
+
+/* Kick the CPU core out of reset to run the just-loaded firmware. */
+static int bwfm_set_active(struct BWFMBase *BWFMBase, uint32_t rstvec)
+{
+    struct bwfm_core *core, *mem;
+
+    if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_ARM_CR4)) != NULL)
+    {
+        bwfm_buscore_activate(BWFMBase, rstvec);
+        bwfm_ai_reset(BWFMBase, core, BWFM_AGENT_IOCTL_ARMCR4_CPUHALT, 0, 0);
+        return 0;
+    }
+
+    if ((core = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_ARM_CM3)) != NULL)
+    {
+        mem = bwfm_get_core(BWFMBase, BWFM_AGENT_INTERNAL_MEM);
+        if (!bwfm_ai_isup(BWFMBase, mem))
+            return -1;
+        bwfm_buscore_activate(BWFMBase, 0);
+        bwfm_ai_reset(BWFMBase, core, 0, 0, 0);
+        return 0;
+    }
+
+    return -1;
+}
+
+/* ----------------------------------------------------------------------- */
+/* SDPCM control channel + BCDC commands                                    */
+
+/* Read/write one SDPCM frame through function 2 at the ChipCommon window.
+ * Control frames are small, so a single (<=512 byte) CMD53 suffices. */
+static int bwfm_frame_rw(struct BWFMBase *BWFMBase, APTR buf, ULONG len, int write)
+{
+    struct bwfm_core *cc = bwfm_get_core(BWFMBase, BWFM_AGENT_CORE_CHIPCOMMON);
+    uint32_t addr = cc->co_base;
+
+    bwfm_backplane(BWFMBase, addr & ~BWFM_SDIO_SB_OFT_ADDR_MASK);
+    addr = (addr & BWFM_SDIO_SB_OFT_ADDR_MASK) | BWFM_SDIO_SB_ACCESS_2_4B_FLAG;
+
+    /* Function 2 is the frame FIFO: writes increment the address, but reads
+     * use a FIXED address (incr=0) so successive header/body reads pull from
+     * the FIFO - matching OpenBSD's read_multi_1 vs write_region_1 split. */
+    if (write)
+        return SDIOWriteExt(2, addr, buf, len, 1);
+    return SDIOReadExt(2, addr, buf, len, 0);
+}
+
+/* Forward decls: bwfm_dcmd salvages frames that arrive while it polls (below). */
+static int bwfm_frame_eth(UBYTE *frame, ULONG flen, ULONG *ehoff, ULONG *ethlen);
+static void bwfm_glom_salvage(struct BWFMBase *BWFMBase, UBYTE *desc, ULONG flen);
+
+/*
+ * Push one already-extracted 802.3 event frame into the hand-off ring for an
+ * in-progress join/scan. Caller holds bwfm_Sem. Factored out of BWFMEventPost
+ * so bwfm_dcmd can reuse it from its event-salvage path.
+ */
+static void bwfm_event_push(struct BWFMBase *BWFMBase, const UBYTE *ev, ULONG len)
+{
+    struct bwfm_evslot *s;
+
+    if (!BWFMBase->bwfm_evlisten || ev == NULL || len == 0)
+        return;
+    if (len > BWFM_EVSLOT_SIZE)
+        len = BWFM_EVSLOT_SIZE;
+    if ((UWORD)(BWFMBase->bwfm_evhead - BWFMBase->bwfm_evtail) >= BWFM_EVRING_SLOTS)
+        BWFMBase->bwfm_evtail++;             /* ring full: drop the oldest */
+    s = &BWFMBase->bwfm_evring[BWFMBase->bwfm_evhead % BWFM_EVRING_SLOTS];
+    s->ev_len = (UWORD)len;
+    CopyMem((APTR)ev, s->ev_data, len);
+    BWFMBase->bwfm_evhead++;
+}
+
+/*
+ * Issue one BCDC command over the SDPCM control channel and wait for the
+ * matching response (synchronous, polled - no glomming/flow-control, which
+ * is fine for control transactions). For GET, the response payload is
+ * copied back into data. Returns 0 on success, firmware status on error,
+ * -1 on transport failure/timeout.
+ */
+static int bwfm_dcmd(struct BWFMBase *BWFMBase, int cmd, int set, void *data, ULONG dlen)
+{
+    UBYTE frame[512];
+    struct bwfm_sdio_hwhdr *hw = (struct bwfm_sdio_hwhdr *)frame;
+    struct bwfm_sdio_swhdr *sw = (struct bwfm_sdio_swhdr *)(frame + 4);
+    struct bwfm_bcdc_dcmd_hdr *dc = (struct bwfm_bcdc_dcmd_hdr *)(frame + 12);
+    ULONG total, padded;
+    int reqid = (++BWFMBase->bwfm_reqid) & 0xffff;
+    int tries;
+
+    if (dlen > sizeof(frame) - (12 + 16))
+        return -1;
+
+    dc->cmd = AROS_LONG2LE(cmd);
+    dc->len = AROS_LONG2LE(dlen);
+    dc->flags = AROS_LONG2LE((set ? BWFM_BCDC_DCMD_SET : 0) | BWFM_BCDC_DCMD_ID_SET(reqid));
+    dc->status = 0;
+    if (dlen)
+        CopyMem(data, frame + 12 + 16, dlen);
+
+    total = 12 + 16 + dlen;
+    hw->frmlen = AROS_WORD2LE(total);
+    hw->cksum = AROS_WORD2LE((UWORD)~total);
+    sw->seqnr = BWFMBase->bwfm_txseq++;
+    sw->chanflag = BWFM_SDIO_SWHDR_CHANNEL_CONTROL;
+    sw->nextlen = 0;
+    sw->dataoff = 12;
+    sw->flowctl = 0;
+    sw->maxseqnr = 0;
+    sw->res0 = 0;
+
+    padded = (total + 3) & ~3UL;
+    bwfm_zero(frame + total, padded - total);
+
+    if (bwfm_frame_rw(BWFMBase, frame, padded, 1))
+        return -1;
+
+    for (tries = 0; tries < 1000; tries++)
+    {
+        UWORD frmlen, cksum;
+        ULONG flen, rlen;
+
+        if (bwfm_frame_rw(BWFMBase, frame, 12, 0))
+        {
+            bwfm_udelay(BWFMBase, 1000);
+            continue;
+        }
+        frmlen = AROS_LE2WORD(hw->frmlen);
+        cksum = AROS_LE2WORD(hw->cksum);
+        if (frmlen == 0 && cksum == 0)
+        {
+            bwfm_udelay(BWFMBase, 1000);
+            continue;
+        }
+        if ((UWORD)(frmlen ^ cksum) != 0xffff || frmlen < 12)
+            return -1;
+
+        flen = frmlen - 12;
+        rlen = (flen + 3) & ~3UL;
+        if (12 + rlen > sizeof(frame))
+            return -1;          /* oversized frame - cannot buffer (rare) */
+        if (flen && bwfm_frame_rw(BWFMBase, frame + 12, rlen, 0))
+            return -1;
+
+        BWFMBase->bwfm_txmax = sw->maxseqnr;    /* update the tx-credit window */
+
+        if ((sw->chanflag & BWFM_SDIO_SWHDR_CHANNEL_MASK) == BWFM_SDIO_SWHDR_CHANNEL_CONTROL)
+        {
+            struct bwfm_bcdc_dcmd_hdr *rdc;
+            ULONG rflags;
+
+            /* Validate dataoff before dereferencing - a malformed frame
+             * must not push the BCDC header past the bounce buffer. */
+            if (sw->dataoff < 12 || (ULONG)sw->dataoff + sizeof(*rdc) > 12 + flen)
+                return -1;
+
+            rdc = (struct bwfm_bcdc_dcmd_hdr *)(frame + sw->dataoff);
+            rflags = AROS_LE2LONG(rdc->flags);
+
+            if (BWFM_BCDC_DCMD_ID_GET(rflags) != (ULONG)reqid)
+                continue;       /* not our response */
+            if (rflags & BWFM_BCDC_DCMD_ERROR)
+                return (int)AROS_LE2LONG(rdc->status);
+            if (data && dlen)
+            {
+                ULONG rdlen = AROS_LE2LONG(rdc->len);
+                ULONG avail = (12 + flen) - ((ULONG)sw->dataoff + 16);
+                ULONG n = (rdlen < dlen) ? rdlen : dlen;
+                if (n > avail)          /* never read past the received payload */
+                    n = avail;
+                CopyMem((UBYTE *)rdc + 16, data, n);
+            }
+            return 0;
+        }
+        /* Non-control frame arriving while we poll for our control reply. */
+        {
+            int ch = sw->chanflag & BWFM_SDIO_SWHDR_CHANNEL_MASK;
+            ULONG ehoff, ethlen;
+
+            if (ch == BWFM_SDIO_SWHDR_CHANNEL_GLOM)
+            {
+                /* A GLOM superframe leaves its sub-frames sitting in F2 after
+                 * the descriptor we just read - they MUST be deaggregated even
+                 * if no one is listening, or every later read desyncs. Salvage
+                 * any events to the ring (no-op when not listening), drop data. */
+                bwfm_glom_salvage(BWFMBase, frame, flen);
+            }
+            else if (BWFMBase->bwfm_evlisten &&
+                     (ch == BWFM_SDIO_SWHDR_CHANNEL_EVENT ||
+                      ch == BWFM_SDIO_SWHDR_CHANNEL_DATA) &&
+                     bwfm_frame_eth(frame, flen, &ehoff, &ethlen))
+            {
+                /* Don't lose a firmware event (LINK_CTL) that lands while we
+                 * poll: hand it to the ring so the join/scan still sees it. A
+                 * swallowed E_LINK/E_SET_SSID here made join flaky. The full
+                 * EVENT/DATA frame was already read, so F2 is not left desynced. */
+                struct bwfm_event *e = (struct bwfm_event *)(frame + ehoff);
+
+                if (ethlen >= sizeof(*e) &&
+                    AROS_BE2WORD(e->ehdr.ether_type) == BWFM_ETHERTYPE_LINK_CTL)
+                    bwfm_event_push(BWFMBase, frame + ehoff, ethlen);
+            }
+            if (BWFMBase->bwfm_evlisten)
+                D(bug("[bwfm] dcmd salvaged chan %d frame (len %u) while polling reply\n",
+                      ch, (unsigned)flen));
+        }
+    }
+    return -1;
+}
+
+/* Set a named firmware variable (iovar). Caller holds bwfm_Sem. */
+static int bwfm_iovar_set(struct BWFMBase *BWFMBase, const char *name,
+                          const void *data, ULONG len)
+{
+    UBYTE tmp[300];
+    ULONG nlen = 0;
+
+    while (name[nlen])
+        nlen++;
+    if (nlen + 1 + len > sizeof(tmp))
+        return -1;
+
+    CopyMem((APTR)name, tmp, nlen + 1);
+    if (len)
+        CopyMem((APTR)data, tmp + nlen + 1, len);
+
+    return bwfm_dcmd(BWFMBase, BWFM_C_SET_VAR, 1, tmp, nlen + 1 + len);
+}
+
+/* Get a named firmware variable (iovar). Caller holds bwfm_Sem. */
+static int bwfm_iovar_get(struct BWFMBase *BWFMBase, const char *name,
+                          void *data, ULONG len)
+{
+    UBYTE tmp[300];
+    ULONG nlen = 0;
+    int err;
+
+    while (name[nlen])
+        nlen++;
+    if (nlen + 1 + len > sizeof(tmp))
+        return -1;
+
+    CopyMem((APTR)name, tmp, nlen + 1);
+    if (len)
+        bwfm_zero(tmp + nlen + 1, len);
+
+    err = bwfm_dcmd(BWFMBase, BWFM_C_GET_VAR, 0, tmp, nlen + 1 + len);
+    if (!err && len)
+        CopyMem(tmp, data, len);
+    return err;
+}
+
+/* Issue an integer firmware ioctl (the payload is a single little-endian u32). */
+static int bwfm_set_int(struct BWFMBase *BWFMBase, int cmd, uint32_t val)
+{
+    uint32_t le = AROS_LONG2LE(val);
+
+    return bwfm_dcmd(BWFMBase, cmd, 1, &le, sizeof(le));
+}
+
+/* Set a named firmware variable to a little-endian u32. */
+static int bwfm_iovar_set_int(struct BWFMBase *BWFMBase, const char *name, uint32_t val)
+{
+    uint32_t le = AROS_LONG2LE(val);
+
+    return bwfm_iovar_set(BWFMBase, name, &le, sizeof(le));
+}
+
+/*
+ * Read one raw SDPCM frame off the func2 FIFO into `frame` (max framesz bytes).
+ * On success returns 1, sets *flenp to the payload length after the 12-byte
+ * SDPCM hw/sw header and *chanp to the SDPCM channel. Returns 0 if nothing is
+ * pending or the frame is malformed. Caller holds bwfm_Sem.
+ */
+static int bwfm_rx_read(struct BWFMBase *BWFMBase, UBYTE *frame, ULONG framesz,
+                        ULONG *flenp, int *chanp)
+{
+    struct bwfm_sdio_hwhdr *hw = (struct bwfm_sdio_hwhdr *)frame;
+    struct bwfm_sdio_swhdr *sw = (struct bwfm_sdio_swhdr *)(frame + 4);
+    UWORD frmlen, cksum;
+    ULONG flen, rlen;
+
+    if (bwfm_frame_rw(BWFMBase, frame, 12, 0))
+        return 0;
+    frmlen = AROS_LE2WORD(hw->frmlen);
+    cksum = AROS_LE2WORD(hw->cksum);
+    if (frmlen == 0 && cksum == 0)
+        return 0;
+    if ((UWORD)(frmlen ^ cksum) != 0xffff || frmlen < 12)
+        return 0;
+
+    flen = frmlen - 12;
+    rlen = (flen + 3) & ~3UL;
+    if (flen == 0 || 12 + rlen > framesz)
+        return 0;
+    if (bwfm_frame_rw(BWFMBase, frame + 12, rlen, 0))
+        return 0;
+
+    BWFMBase->bwfm_txmax = sw->maxseqnr;     /* tx-credit window from every frame */
+    *flenp = flen;
+    *chanp = sw->chanflag & BWFM_SDIO_SWHDR_CHANNEL_MASK;
+    return 1;
+}
+
+/*
+ * Locate the 802.3 ethernet frame inside an already-read SDPCM EVENT/DATA frame
+ * (`frame` = 12-byte hw/sw header + flen payload). Sets *ehoff (offset within
+ * frame, past the SDPCM headers and the BCDC/BDC data header) and *ethlen.
+ * Returns 1 on a well-formed EVENT/DATA frame, 0 otherwise.
+ */
+static int bwfm_frame_eth(UBYTE *frame, ULONG flen, ULONG *ehoff, ULONG *ethlen)
+{
+    struct bwfm_sdio_swhdr *sw = (struct bwfm_sdio_swhdr *)(frame + 4);
+    struct bwfm_bcdc_data_hdr *bcdc;
+    ULONG off, eo;
+
+    if (sw->dataoff < 12)
+        return 0;
+    off = sw->dataoff;
+    if (off + sizeof(*bcdc) > 12 + flen)
+        return 0;
+    bcdc = (struct bwfm_bcdc_data_hdr *)(frame + off);
+    eo = off + sizeof(*bcdc) + (ULONG)bcdc->data_offset * 4;
+    if (eo > 12 + flen)
+        return 0;
+    *ehoff = eo;
+    *ethlen = (12 + flen) - eo;
+    return 1;
+}
+
+/*
+ * Encode the *info word BWFMRxFrame hands the pump: SDPCM channel in the low
+ * byte, BWFM_RX_EVENT if the 802.3 frame is a firmware event (LINK_CTL
+ * ethertype), and the event type in the high half.
+ */
+static ULONG bwfm_rx_info(UBYTE *eth, ULONG ethlen, int chan)
+{
+    struct bwfm_event *e = (struct bwfm_event *)eth;
+    int is_event = (ethlen >= sizeof(*e) &&
+                    AROS_BE2WORD(e->ehdr.ether_type) == BWFM_ETHERTYPE_LINK_CTL);
+    ULONG etype = is_event ? (AROS_BE2LONG(e->msg.event_type) & 0xffff) : 0;
+
+    return ((ULONG)chan & 0xff) | (is_event ? BWFM_RX_EVENT : 0) | (etype << 16);
+}
+
+/* ----------------------------------------------------------------------- */
+/* GLOM (aggregated RX) deaggregation                                       */
+
+#define BWFM_GLOM_MAXSUB        16
+#define BWFM_GLOM_BUFSZ         (BWFM_GLOM_MAXSUB * 2048)   /* 32 KB: hold a full
+                                * data glom (was 8 KB - too small once rxglom is
+                                * on, dropped sub-frames past ~5 full data frames) */
+
+/* Sub-frames split out of the last GLOM superframe, awaiting delivery. Only the
+ * pump's BWFMRxFrame touches these, serialized by bwfm_Sem. */
+static UBYTE bwfm_glom_buf[BWFM_GLOM_BUFSZ];
+static struct
+{
+    UWORD   ehoff;          /* 802.3 frame offset within bwfm_glom_buf */
+    UWORD   ethlen;
+    UBYTE   chan;
+} bwfm_glom_q[BWFM_GLOM_MAXSUB];
+static int bwfm_glom_n, bwfm_glom_i;
+
+/*
+ * Deaggregate a GLOM superframe. `desc` is the just-read GLOM-channel descriptor
+ * frame; right after its 12-byte SDPCM header it carries an array of uint16
+ * sub-frame lengths (flen bytes => nsub = flen/2). The nsub sub-frames follow
+ * back-to-back on F2; the first carries an extra 12-byte superframe header, the
+ * rest are plain SDPCM frames. Each EVENT/DATA sub-frame is parsed to its 802.3
+ * frame and queued in bwfm_glom_q for BWFMRxFrame to return one at a time.
+ *
+ * CRITICAL: every announced sub-frame MUST be read off F2, in order, with its
+ * announced length - even one we cannot buffer or do not want - or the F2 FIFO
+ * desyncs and every later read returns garbage (RX dies; e.g. a bulk transfer
+ * stalls partway). So surplus/oversize sub-frames are drained into a throwaway
+ * and dropped (a dropped frame is recoverable via TCP; a desync is not).
+ * Ported from OpenBSD bwfm_sdio_rx_glom(). Caller holds bwfm_Sem.
+ */
+static void bwfm_rx_glom(struct BWFMBase *BWFMBase, UBYTE *desc, ULONG flen)
+{
+    static UBYTE discard[2048];
+    ULONG nsub = flen / 2, i, off = 0, dropped = 0;
+    int bail = 0;
+
+    bwfm_glom_n = bwfm_glom_i = 0;
+    if (nsub == 0)
+        return;
+
+    if (BWFMBase->bwfm_evlisten)
+        D(bug("[bwfm] glom: %u sub-frame(s)\n", (unsigned)nsub));
+
+    for (i = 0; i < nsub; i++)
+    {
+        UBYTE *sp = desc + 12 + i * 2;          /* byte-wise: avoid an unaligned */
+        ULONG sl = (ULONG)(sp[0] | (sp[1] << 8));    /* 16-bit load (gcc->memcpy) */
+        ULONG rl = (sl + 3) & ~3UL;
+        ULONG subtot, subflen, ehoff, ethlen;
+        struct bwfm_sdio_hwhdr *hw;
+        struct bwfm_sdio_swhdr *sw;
+        UBYTE *sub;
+        UWORD frmlen, cksum;
+        int ch, keep;
+
+        if (rl == 0 || rl > sizeof(discard))    /* nonsense length: cannot resync */
+        {
+            bail = 1;
+            break;
+        }
+
+        /* Keep it in the glom buffer only if it fits alongside what is already
+         * queued AND the queue has room; otherwise drain it off F2 and drop. */
+        keep = (off + rl <= sizeof(bwfm_glom_buf)) && (bwfm_glom_n < BWFM_GLOM_MAXSUB);
+        if (bwfm_frame_rw(BWFMBase, keep ? (bwfm_glom_buf + off) : discard, rl, 0))
+        {
+            bail = 1;
+            break;
+        }
+        if (!keep)
+        {
+            dropped++;
+            continue;
+        }
+
+        sub = bwfm_glom_buf + off;
+        subtot = sl;
+
+        /* The first sub-frame is prefixed with a 12-byte superframe header. */
+        if (i == 0)
+        {
+            sub += 12;
+            subtot -= 12;
+        }
+        if (subtot < 12)
+            continue;
+
+        hw = (struct bwfm_sdio_hwhdr *)sub;
+        sw = (struct bwfm_sdio_swhdr *)(sub + 4);
+        frmlen = AROS_LE2WORD(hw->frmlen);
+        cksum = AROS_LE2WORD(hw->cksum);
+        if ((UWORD)(frmlen ^ cksum) != 0xffff || frmlen < 12)
+        {
+            if (BWFMBase->bwfm_evlisten)
+                D(bug("[bwfm] glom sub %u bad hdr (frmlen %u)\n", (unsigned)i, frmlen));
+            continue;
+        }
+        BWFMBase->bwfm_txmax = sw->maxseqnr;     /* refresh the tx-credit window
+                                                  * from EVERY glommed sub-frame,
+                                                  * not just the descriptor - under a
+                                                  * bulk RX glom the descriptor's
+                                                  * maxseqnr lags and TX stalls at
+                                                  * seq==max (matches OpenBSD) */
+        ch = sw->chanflag & BWFM_SDIO_SWHDR_CHANNEL_MASK;
+        subflen = frmlen - 12;
+        if (BWFMBase->bwfm_evlisten)
+            D(bug("[bwfm] glom sub %u chan %d flen %u\n", (unsigned)i, ch, (unsigned)subflen));
+        if (ch != BWFM_SDIO_SWHDR_CHANNEL_EVENT && ch != BWFM_SDIO_SWHDR_CHANNEL_DATA)
+            continue;
+        if (12 + subflen > subtot)
+            continue;
+        if (!bwfm_frame_eth(sub, subflen, &ehoff, &ethlen))
+            continue;
+
+        bwfm_glom_q[bwfm_glom_n].ehoff = (UWORD)((sub - bwfm_glom_buf) + ehoff);
+        bwfm_glom_q[bwfm_glom_n].ethlen = (UWORD)ethlen;
+        bwfm_glom_q[bwfm_glom_n].chan = (UBYTE)ch;
+        bwfm_glom_n++;
+        off += rl;          /* keep this sub-frame; next reads land after it */
+    }
+
+    /* Rare-path diagnostic (un-gated): a glom we could not fully buffer, or an
+     * F2 read failure mid-superframe, is the prime suspect for a bulk-transfer
+     * stall - surface it. bail => F2 is likely now desynced (read nothing more). */
+    if (bail || dropped)
+        D(bug("[bwfm] glom: %u subs, %d queued, %u dropped%s\n", (unsigned)nsub,
+              bwfm_glom_n, (unsigned)dropped, bail ? ", BAILED (F2 desync risk)" : ""));
+}
+
+/* Pop the next deaggregated glom sub-frame into buf; returns its length (0 if
+ * the queue is empty). Caller holds bwfm_Sem. */
+static int bwfm_glom_pop(UBYTE *buf, ULONG bufsize, uint32_t *info)
+{
+    ULONG ehoff, ethlen;
+    int chan;
+
+    if (bwfm_glom_i >= bwfm_glom_n)
+        return 0;
+    ehoff = bwfm_glom_q[bwfm_glom_i].ehoff;
+    ethlen = bwfm_glom_q[bwfm_glom_i].ethlen;
+    chan = bwfm_glom_q[bwfm_glom_i].chan;
+    bwfm_glom_i++;
+    if (ethlen > bufsize)
+        ethlen = bufsize;
+    CopyMem(bwfm_glom_buf + ehoff, buf, ethlen);
+    if (info)
+        *info = bwfm_rx_info(bwfm_glom_buf + ehoff, ethlen, chan);
+    return (int)ethlen;
+}
+
+/*
+ * Deaggregate a GLOM superframe that landed inside a synchronous bwfm_dcmd
+ * (i.e. while polling for a control reply) and salvage its firmware events to
+ * the hand-off ring. bwfm_rx_glom reads the sub-frames off F2 - the essential
+ * part, so the control read does not desync - then we push any event (LINK_CTL)
+ * sub-frame to the ring (bwfm_event_push is a no-op when nobody is listening).
+ * Data sub-frames are dropped: the datapath is the pump's job, and the unit is
+ * not online during the control ops (join) where this fires. Caller holds
+ * bwfm_Sem. Shares the global glom queue with the pump, which is safe because
+ * the pump blocks on bwfm_Sem while we hold it.
+ */
+static void bwfm_glom_salvage(struct BWFMBase *BWFMBase, UBYTE *desc, ULONG flen)
+{
+    int i;
+
+    bwfm_rx_glom(BWFMBase, desc, flen);         /* fills bwfm_glom_q from F2 */
+
+    for (i = 0; i < bwfm_glom_n; i++)
+    {
+        UBYTE *eth = bwfm_glom_buf + bwfm_glom_q[i].ehoff;
+        struct bwfm_event *e = (struct bwfm_event *)eth;
+        ULONG ethlen = bwfm_glom_q[i].ethlen;
+
+        if (ethlen >= sizeof(*e) &&
+            AROS_BE2WORD(e->ehdr.ether_type) == BWFM_ETHERTYPE_LINK_CTL)
+            bwfm_event_push(BWFMBase, eth, ethlen);
+    }
+    bwfm_glom_n = bwfm_glom_i = 0;              /* consumed here, not by the pump */
+}
+
+/* ----------------------------------------------------------------------- */
+/* Firmware-event hand-off ring (single FIFO reader = the device RX pump)    */
+
+/*
+ * Enable or disable event capture for a control op (join/scan). Enabling
+ * discards any events left over from a previous op. Safe to call while
+ * already holding bwfm_Sem - the semaphore nests.
+ */
+static void bwfm_event_listen(struct BWFMBase *BWFMBase, int on)
+{
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+    BWFMBase->bwfm_evlisten = on;
+    if (on)
+        BWFMBase->bwfm_evtail = BWFMBase->bwfm_evhead;
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+}
+
+/* Pop the oldest queued event frame into buf; returns its length (0 if none). */
+static ULONG bwfm_event_pop(struct BWFMBase *BWFMBase, UBYTE *buf, ULONG bufsize)
+{
+    ULONG n = 0;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+    if (BWFMBase->bwfm_evhead != BWFMBase->bwfm_evtail)
+    {
+        struct bwfm_evslot *s =
+            &BWFMBase->bwfm_evring[BWFMBase->bwfm_evtail % BWFM_EVRING_SLOTS];
+
+        n = s->ev_len;
+        if (n > bufsize)
+            n = bufsize;
+        CopyMem(s->ev_data, buf, n);
+        BWFMBase->bwfm_evtail++;
+    }
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return n;
+}
+
+/*
+ * A timer.device handle a control op uses to sleep (and bound its wait) while
+ * the RX pump runs. Opened on demand at runtime - never at kickstart init.
+ */
+struct bwfm_timer
+{
+    struct MsgPort     *bt_port;
+    struct timerequest *bt_req;
+    int                 bt_ok;
+};
+
+static void bwfm_timer_open(struct bwfm_timer *t)
+{
+    t->bt_ok = 0;
+    t->bt_req = NULL;
+    t->bt_port = CreateMsgPort();
+    if (t->bt_port == NULL)
+        return;
+    t->bt_req = (struct timerequest *)CreateIORequest(t->bt_port,
+                                                      sizeof(struct timerequest));
+    if (t->bt_req != NULL &&
+        OpenDevice((CONST_STRPTR)"timer.device", UNIT_MICROHZ,
+                   (struct IORequest *)t->bt_req, 0) == 0)
+        t->bt_ok = 1;
+}
+
+static void bwfm_timer_close(struct bwfm_timer *t)
+{
+    if (t->bt_ok)
+        CloseDevice((struct IORequest *)t->bt_req);
+    if (t->bt_req)
+        DeleteIORequest((struct IORequest *)t->bt_req);
+    if (t->bt_port)
+        DeleteMsgPort(t->bt_port);
+}
+
+/*
+ * Sleep ~micros, yielding the CPU so the RX pump can read the FIFO and post
+ * events. Falls back to a busy-wait only if the timer could not be opened
+ * (which would re-starve the pump, but should never happen post-DOS).
+ */
+static void bwfm_timer_wait(struct BWFMBase *BWFMBase, struct bwfm_timer *t, ULONG micros)
+{
+    if (!t->bt_ok)
+    {
+        bwfm_udelay(BWFMBase, micros);
+        return;
+    }
+    t->bt_req->tr_node.io_Command = TR_ADDREQUEST;
+    t->bt_req->tr_time.tv_secs = micros / 1000000;
+    t->bt_req->tr_time.tv_micro = micros % 1000000;
+    DoIO((struct IORequest *)t->bt_req);
+}
+
+/* ----------------------------------------------------------------------- */
+/* Resource init                                                           */
+
+static int bwfm_init(struct BWFMBase *BWFMBase)
+{
+    D(bug("[bwfm] %s()\n", __PRETTY_FUNCTION__));
+
+    InitSemaphore(&BWFMBase->bwfm_Sem);
+    BWFMBase->bwfm_bar0 = ~0u;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        BWFMBase->bwfm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
+
+    SDIOBase = OpenResource("sdio.resource");
+    if (!SDIOBase)
+        D(bug("[bwfm] sdio.resource not available\n"));
+
+    /* Chip bring-up (power + enumeration) is deferred to the first BWFMAttach(),
+     * which bwfm.device calls when it is opened - so the WiFi chip stays
+     * unpowered until something actually uses it. */
+    return TRUE;
+}
+
+ADD2INITLIB(bwfm_init, 0)
+
+/* ----------------------------------------------------------------------- */
+/* Public API                                                              */
+
+AROS_LH0(int, BWFMAttach,
+                struct BWFMBase *, BWFMBase, 1, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    int ok;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+    ok = BWFMBase->bwfm_attached ? TRUE : bwfm_do_attach(BWFMBase);
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+
+    return ok;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH0(uint32_t, BWFMChipID,
+                struct BWFMBase *, BWFMBase, 2, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    return BWFMBase->bwfm_attached ? BWFMBase->bwfm_chip : 0;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Load firmware + nvram into chip RAM and start the CPU. The caller
+ * (bwfm.device) supplies the blobs read from disk; nvram must already be
+ * in the converted binary form (with its trailing size token). Returns 0
+ * once the firmware signals ready. The upload is NOT read back for verification:
+ * large block-mode reads of the backplane RAM are unreliable on this chip (the
+ * nvram region's non-64-aligned address returned a data CRC), while the writes
+ * themselves are reliable.
+ */
+AROS_LH4(int, BWFMStartFirmware,
+                AROS_LHA(APTR, fw, A0),
+                AROS_LHA(uint32_t, fwlen, D0),
+                AROS_LHA(APTR, nvram, A1),
+                AROS_LHA(uint32_t, nvlen, D1),
+                struct BWFMBase *, BWFMBase, 3, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    int err = -1, i;
+    uint32_t rstvec;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    if (!BWFMBase->bwfm_attached || fw == NULL || fwlen < 4)
+        goto done;
+
+    /* Guard the RAM layout: a zero ramsize (unsized chip) or an over-large
+     * firmware would make the nvram address underflow (rambase+ramsize-nvlen)
+     * and scribble a wild backplane window. rambase==0 is valid (SOCRAM). */
+    if (BWFMBase->bwfm_ramsize == 0 || fwlen > BWFMBase->bwfm_ramsize)
+    {
+        D(bug("[bwfm] bad RAM layout (size %u, fw %u) - refusing upload\n",
+              BWFMBase->bwfm_ramsize, fwlen));
+        goto done;
+    }
+
+    if (bwfm_alpclk_on(BWFMBase))   /* upload on ALP; HT forced after FWREADY */
+        goto done;
+
+    rstvec = *(uint32_t *)fw;       /* reset vector = first firmware word */
+
+    D(bug("[bwfm] uploading firmware (%u bytes) to RAM 0x%06x\n",
+          fwlen, BWFMBase->bwfm_rambase));
+    if (bwfm_ram_write(BWFMBase, BWFMBase->bwfm_rambase, fw, fwlen))
+        goto done;
+
+    if (nvram && nvlen)
+    {
+        uint32_t nvaddr;
+
+        if (nvlen >= BWFMBase->bwfm_ramsize)
+        {
+            D(bug("[bwfm] nvram (%u bytes) too large for RAM (%u)\n",
+                  nvlen, BWFMBase->bwfm_ramsize));
+            goto done;
+        }
+        nvaddr = BWFMBase->bwfm_rambase + BWFMBase->bwfm_ramsize - nvlen;
+        D(bug("[bwfm] uploading nvram (%u bytes) to RAM 0x%06x\n", nvlen, nvaddr));
+        if (bwfm_ram_write(BWFMBase, nvaddr, nvram, nvlen))
+            goto done;
+    }
+
+    if (bwfm_set_active(BWFMBase, rstvec))
+    {
+        D(bug("[bwfm] failed to start CPU core\n"));
+        goto done;
+    }
+
+    for (i = 0; i < 2000; i++)
+    {
+        uint32_t mb = bwfm_dev_read(BWFMBase, SDPCMD_TOHOSTMAILBOXDATA);
+        if (mb & (SDPCMD_TOHOSTMAILBOXDATA_FWREADY | SDPCMD_TOHOSTMAILBOXDATA_DEVREADY))
+        {
+            bwfm_dev_write(BWFMBase, SDPCMD_TOSBMAILBOX, SDPCMD_TOSBMAILBOX_INT_ACK);
+            err = 0;
+            break;
+        }
+        bwfm_udelay(BWFMBase, 1000);
+    }
+
+    D(bug("[bwfm] firmware %s\n", err ? "ready timeout" : "ready"));
+
+    if (!err)
+    {
+        /* Post-firmware bus bring-up: force HT, advertise the SDPCM
+         * protocol version, enable the data function and set up the
+         * host interrupt mask + FIFO watermark. */
+        uint8_t clk = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+        bwfm_write_1(BWFM_SDIO_FUNC1_CHIPCLKCSR,
+                     clk | BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HT);
+        bwfm_dev_write(BWFMBase, SDPCMD_TOSBMAILBOXDATA,
+                       SDPCM_PROT_VERSION << SDPCM_PROT_VERSION_SHIFT);
+        SDIOEnableFunction(2);
+        bwfm_dev_write(BWFMBase, SDPCMD_HOSTINTMASK,
+                       SDPCMD_INTSTATUS_HMB_SW_MASK | SDPCMD_INTSTATUS_CHIPACTIVE);
+        bwfm_write_1(BWFM_SDIO_WATERMARK, 8);
+        BWFMBase->bwfm_txseq = 0xff;     /* matches OpenBSD; firmware grants */
+        BWFMBase->bwfm_txmax = 1;        /* credit from RX maxseqnr; seed 1 */
+        BWFMBase->bwfm_reqid = 0;
+
+        /* Keep RX frame glomming OFF. Turning it on (rxglom=1) broke the
+         * synchronous control channel on this firmware: every dcmd right after
+         * firmware-ready (GetMAC, clmload, C_UP, join) timed out -1. With glom on
+         * the firmware also aggregates the BCDC control *responses* onto the GLOM
+         * channel (chan 3), and our deaggregation drops control sub-frames
+         * (bwfm_rx_glom keeps only EVENT/DATA), so the polled dcmd never sees its
+         * reply. rxglom=0 keeps control replies on their own channel. The firmware
+         * still glomms EVENT/DATA under load regardless - that is handled by the
+         * pump (bwfm_rx_glom) and by bwfm_dcmd's glom drain, so those paths stay
+         * robust; we just must not ask for glom on the control path. */
+        bwfm_iovar_set_int(BWFMBase, "bus:rxglom", 0);
+    }
+
+done:
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Read the chip's current MAC address via the BCDC "cur_etheraddr" iovar.
+ * Valid only after BWFMStartFirmware has succeeded. mac must hold 6 bytes.
+ */
+AROS_LH1(int, BWFMGetMAC,
+                AROS_LHA(UBYTE *, mac, A0),
+                struct BWFMBase *, BWFMBase, 4, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    static const char var[] = "cur_etheraddr";
+    UBYTE buf[16];
+    int err, i;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    for (i = 0; var[i]; i++)
+        buf[i] = var[i];
+    buf[i++] = '\0';            /* name + NUL = 14 bytes (>= 6 result bytes) */
+
+    err = bwfm_dcmd(BWFMBase, BWFM_C_GET_VAR, 0, buf, i);
+    if (!err)
+        CopyMem(buf, mac, 6);
+
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Raw firmware ioctl. For GET, the response is copied back into buf; for
+ * SET, buf holds the argument (may be NULL/0). Returns 0 / firmware status.
+ */
+AROS_LH4(int, BWFMIoctl,
+                AROS_LHA(uint32_t, cmd, D0),
+                AROS_LHA(int, set, D1),
+                AROS_LHA(void *, buf, A0),
+                AROS_LHA(uint32_t, len, D2),
+                struct BWFMBase *, BWFMBase, 5, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    int err;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+    err = bwfm_dcmd(BWFMBase, cmd, set, buf, len);
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Named firmware variable (iovar) access. Encodes "name\0" + payload and
+ * issues GET_VAR/SET_VAR. For GET, the value is copied back into buf.
+ */
+AROS_LH4(int, BWFMIovar,
+                AROS_LHA(uint8_t *, name, A0),
+                AROS_LHA(int, set, D0),
+                AROS_LHA(void *, buf, A1),
+                AROS_LHA(uint32_t, len, D1),
+                struct BWFMBase *, BWFMBase, 6, Bwfm)
+{
+    UBYTE tmp[256];
+    ULONG nlen = 0;
+    int err;
+
+    AROS_LIBFUNC_INIT
+
+    while (name[nlen])
+        nlen++;
+    if (nlen + 1 + len > sizeof(tmp))
+        return -1;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    CopyMem(name, tmp, nlen + 1);               /* name + NUL */
+    if (len)
+        CopyMem(buf, tmp + nlen + 1, len);
+
+    err = bwfm_dcmd(BWFMBase, set ? BWFM_C_SET_VAR : BWFM_C_GET_VAR, set,
+                    tmp, nlen + 1 + len);
+    if (!err && !set && len)
+        CopyMem(tmp, buf, len);
+
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Per-result beacon IEs captured by the last BWFMScan, fetched afterwards via
+ * BWFMScanIE() (parallel to the scanresult array). Kept out of struct
+ * bwfm_scanresult so the device/test don't have to mirror a variable-size blob.
+ */
+#define BWFM_SCAN_IE_MAX        32      /* results we keep IEs for */
+#define BWFM_SCAN_IE_SIZE       256     /* IE bytes captured per result */
+static UBYTE bwfm_scan_ie[BWFM_SCAN_IE_MAX][BWFM_SCAN_IE_SIZE];
+static UWORD bwfm_scan_ie_len[BWFM_SCAN_IE_MAX];
+
+/*
+ * Run a broadcast escan and collect results. `outp` is an array of
+ * struct bwfm_scanresult (max entries); returns the number filled. Triggers
+ * an escan, then polls the SDPCM event channel for ESCAN_RESULT events,
+ * parsing each bss_info, until the firmware reports scan complete or ~5s pass.
+ */
+AROS_LH2(int, BWFMScan,
+                AROS_LHA(void *, outp, A0),
+                AROS_LHA(int, max, D0),
+                struct BWFMBase *, BWFMBase, 7, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    static UBYTE frame[2048];
+    struct bwfm_scanresult *out = (struct bwfm_scanresult *)outp;
+    struct bwfm_escan_params_v0 p;
+    struct bwfm_timer tmr;
+    UBYTE evmask[BWFM_EVENT_MASK_LEN];
+    int count = 0, done = 0, tries, i;
+
+    if (!BWFMBase->bwfm_attached || out == NULL || max <= 0)
+        return 0;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    /*
+     * The escan request layout depends on the firmware's scan version.
+     * OpenBSD queries "scan_ver" (default 0 = v0 if the iovar is absent).
+     * We only build v0 params; warn if the firmware expects a newer version
+     * so a wrong-layout escan is diagnosable rather than silently failing.
+     */
+    {
+        uint32_t scan_ver = 0;
+        if (bwfm_iovar_get(BWFMBase, "scan_ver", &scan_ver, sizeof(scan_ver)) == 0)
+        {
+            scan_ver = AROS_LE2LONG(scan_ver);
+            D(bug("[bwfm] scan_ver = %u\n", scan_ver));
+            if (scan_ver != 0)
+                D(bug("[bwfm] WARNING: firmware escan v%u, we send v0\n", scan_ver));
+        }
+        else
+            D(bug("[bwfm] scan_ver iovar absent (escan v0)\n"));
+    }
+
+    /* Enable the events we care about (STA mode set) */
+    bwfm_zero(evmask, sizeof(evmask));
+#define EV(e) (evmask[(e) / 8] |= (1 << ((e) % 8)))
+    EV(BWFM_E_IF); EV(BWFM_E_LINK); EV(BWFM_E_AUTH); EV(BWFM_E_ASSOC);
+    EV(BWFM_E_EAPOL_MSG); EV(BWFM_E_DEAUTH); EV(BWFM_E_DISASSOC);
+    EV(BWFM_E_ESCAN_RESULT);
+#undef EV
+    bwfm_iovar_set(BWFMBase, "event_msgs", evmask, sizeof(evmask));
+
+    /*
+     * Bring the STA interface up the way the reference does before scanning.
+     * A bare C_UP returns success but escan still fails with NOTUP (-4): the
+     * firmware needs the operating mode configured (infra STA, not AP) and the
+     * scan timing / power-management set first. Mirror OpenBSD bwfm_init()'s
+     * order: scan times, PM, C_UP, then INFRA/AP. mpc=0 keeps the radio awake.
+     */
+    {
+        int e;
+        bwfm_set_int(BWFMBase, BWFM_C_SET_SCAN_CHANNEL_TIME, 40);
+        bwfm_set_int(BWFMBase, BWFM_C_SET_SCAN_UNASSOC_TIME, 40);
+        bwfm_set_int(BWFMBase, BWFM_C_SET_SCAN_PASSIVE_TIME, 120);
+        bwfm_set_int(BWFMBase, BWFM_C_SET_PM, BWFM_PM_FAST_PS);
+        {
+            uint32_t mpc = 0;
+            bwfm_iovar_set(BWFMBase, "mpc", &mpc, sizeof(mpc));
+        }
+        e = bwfm_dcmd(BWFMBase, BWFM_C_UP, 1, NULL, 0);
+        bwfm_set_int(BWFMBase, BWFM_C_SET_INFRA, 1);
+        bwfm_set_int(BWFMBase, BWFM_C_SET_AP, 0);
+        bwfm_udelay(BWFMBase, 50000);
+        D(bug("[bwfm] pre-scan: interface up (C_UP err %d)\n", e));
+    }
+
+    /* Broadcast passive escan, all channels */
+    bwfm_zero((UBYTE *)&p, sizeof(p));
+    for (i = 0; i < ETHER_ADDR_LEN; i++)
+        p.scan_params.bssid[i] = 0xff;
+    p.scan_params.bss_type = DOT11_BSSTYPE_ANY;
+    p.scan_params.scan_type = BWFM_SCANTYPE_PASSIVE;
+    p.scan_params.nprobes = AROS_LONG2LE(0xffffffff);
+    p.scan_params.active_time = AROS_LONG2LE(0xffffffff);
+    p.scan_params.passive_time = AROS_LONG2LE(0xffffffff);
+    p.scan_params.home_time = AROS_LONG2LE(0xffffffff);
+    p.scan_params.channel_num = 0;
+    p.version = AROS_LONG2LE(BWFM_ESCAN_REQ_VERSION);
+    p.action = AROS_WORD2LE(WL_ESCAN_ACTION_START);
+    p.sync_id = AROS_WORD2LE(0x1234);
+
+    /* Match OpenBSD's size exactly: the trailing channel_list[] is empty
+     * for an all-channel scan (channel_num == 0), so exclude it. */
+    {
+        ULONG psize = sizeof(p) - sizeof(p.scan_params.channel_list);
+        int err;
+
+        /* Collect events from here on, then release the bus: the RX pump (the
+         * single FIFO reader) reads the escan results and posts them to us. */
+        bwfm_event_listen(BWFMBase, 1);
+        err = bwfm_iovar_set(BWFMBase, "escan", &p, psize);
+        ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+        if (err)
+        {
+            D(bug("[bwfm] escan trigger failed (err %d, size %u)\n", err, psize));
+            bwfm_event_listen(BWFMBase, 0);
+            return 0;
+        }
+    }
+
+    bwfm_timer_open(&tmr);
+
+    /* ~5s window: 100 ticks of 50ms, yielding so the pump keeps reading. */
+    for (tries = 0; tries < 100 && !done; tries++)
+    {
+        ULONG n;
+
+        while ((n = bwfm_event_pop(BWFMBase, frame, sizeof(frame))) > 0)
+        {
+            struct bwfm_event *e = (struct bwfm_event *)frame;
+            struct bwfm_escan_results *res;
+            ULONG evlen, status, remain;
+            UBYTE *bp;
+            UWORD bcount;
+
+            if (n < sizeof(*e))
+                continue;
+            evlen = n - sizeof(*e);
+            if (AROS_BE2LONG(e->msg.event_type) != BWFM_E_ESCAN_RESULT)
+                continue;
+
+            status = AROS_BE2LONG(e->msg.status);
+            if (status == BWFM_E_STATUS_SUCCESS)
+            {
+                done = 1;
+                continue;
+            }
+            if (status != BWFM_E_STATUS_PARTIAL || evlen < 12)
+                continue;
+
+            /* escan_results header is 12 bytes; bss_info[] follows */
+            res = (struct bwfm_escan_results *)(e + 1);
+            bcount = AROS_LE2WORD(res->bss_count);
+            bp = (UBYTE *)&res->bss_info[0];
+            remain = evlen - 12;
+
+            for (i = 0; i < bcount; i++)
+            {
+                struct bwfm_bss_info *bi = (struct bwfm_bss_info *)bp;
+                ULONG bilen, sl;
+                int16_t rssi;
+                int j, dup = -1;
+
+                if (remain < sizeof(struct bwfm_bss_info))
+                    break;
+                bilen = AROS_LE2LONG(bi->length);
+                if (bilen < sizeof(struct bwfm_bss_info) || bilen > remain)
+                    break;
+
+                rssi = (int16_t)AROS_LE2WORD(bi->rssi);
+                sl = bi->ssid_len;
+                if (sl > BWFM_MAX_SSID_LEN)
+                    sl = BWFM_MAX_SSID_LEN;
+
+                /*
+                 * Dedupe by BSSID: escan emits a PARTIAL event per beacon
+                 * heard, so the same BSS recurs across the scan window. Keep
+                 * one entry per BSSID with the strongest RSSI; fill in the
+                 * SSID if an earlier (hidden) sighting had none.
+                 */
+                for (j = 0; j < count; j++)
+                {
+                    UBYTE *a = out[j].bssid;
+                    UBYTE *b = bi->bssid;
+
+                    if (a[0] == b[0] && a[1] == b[1] && a[2] == b[2] &&
+                        a[3] == b[3] && a[4] == b[4] && a[5] == b[5])
+                    {
+                        dup = j;
+                        break;
+                    }
+                }
+
+                if (dup >= 0)
+                {
+                    if (rssi > out[dup].rssi)
+                        out[dup].rssi = rssi;
+                    if (out[dup].ssid_len == 0 && sl > 0)
+                    {
+                        out[dup].ssid_len = sl;
+                        CopyMem(bi->ssid, out[dup].ssid, sl);
+                    }
+                    out[dup].chanspec = AROS_LE2WORD(bi->chanspec);
+                }
+                else if (count < max)
+                {
+                    CopyMem(bi->bssid, out[count].bssid, ETHER_ADDR_LEN);
+                    out[count].ssid_len = sl;
+                    CopyMem(bi->ssid, out[count].ssid, sl);
+                    out[count].rssi = rssi;
+                    out[count].chanspec = AROS_LE2WORD(bi->chanspec);
+
+                    /* Capture this BSS's beacon IEs (SSID, rates, RSN/WPA, ...)
+                     * so the SANA-II scan can hand them to wpa_supplicant, which
+                     * needs the RSN/WPA element to match a WPA2 network. */
+                    if (count < BWFM_SCAN_IE_MAX)
+                    {
+                        ULONG ieoff = AROS_LE2WORD(bi->ie_offset);
+                        ULONG ielen = AROS_LE2LONG(bi->ie_length);
+                        UBYTE *ies = (UBYTE *)bi + ieoff;
+
+                        bwfm_scan_ie_len[count] = 0;
+                        /* Validate the bss_info layout before trusting ie_offset:
+                         * the first beacon IE is always the SSID element (id 0,
+                         * length == ssid_len). If that doesn't hold, ie_offset is
+                         * wrong for this firmware - skip rather than feed
+                         * wpa_supplicant garbage (which crashed it). */
+                        if (ielen && ieoff + 2 <= bilen && ieoff + ielen <= bilen &&
+                            ies[0] == 0 && ies[1] == bi->ssid_len)
+                        {
+                            if (ielen > BWFM_SCAN_IE_SIZE)
+                                ielen = BWFM_SCAN_IE_SIZE;
+                            CopyMem(ies, bwfm_scan_ie[count], ielen);
+                            bwfm_scan_ie_len[count] = (UWORD)ielen;
+                        }
+                        else
+                            D(bug("[bwfm] scan IE skip: off=%u len=%u first=%02x/%02x"
+                                  " ssidlen=%u bilen=%u\n", (unsigned)ieoff,
+                                  (unsigned)ielen, ies[0], ies[1],
+                                  (unsigned)bi->ssid_len, (unsigned)bilen));
+                    }
+                    count++;
+                }
+
+                bp += bilen;
+                remain -= bilen;
+            }
+        }
+
+        if (!done)
+            bwfm_timer_wait(BWFMBase, &tmr, 50000);
+    }
+
+    bwfm_timer_close(&tmr);
+    bwfm_event_listen(BWFMBase, 0);
+
+    D(bug("[bwfm] scan done: %d result(s)\n", count));
+    return count;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Upload the regulatory CLM (Country Locale Matrix) blob to the running
+ * firmware via the "clmload" iovar. The firmware for this chip ships without
+ * built-in regulatory data, so without the blob the radio has no valid
+ * channels and "wl up" leaves the interface NOTUP (escan fails). The blob is
+ * sent in chunks small enough to fit the synchronous BCDC control frame, the
+ * first marked BEGIN and the last END. Ported from OpenBSD bwfm_process_blob().
+ * A NULL/empty blob is a no-op (firmware falls back to its built-in regulatory).
+ */
+#define BWFM_CLM_CHUNK  256
+
+AROS_LH2(int, BWFMLoadCLM,
+                AROS_LHA(void *, clm, A0),
+                AROS_LHA(uint32_t, clmlen, D0),
+                struct BWFMBase *, BWFMBase, 8, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    UBYTE buf[sizeof(struct bwfm_dload_data) + BWFM_CLM_CHUNK];
+    struct bwfm_dload_data *d = (struct bwfm_dload_data *)buf;
+    UBYTE *src = (UBYTE *)clm;
+    ULONG off = 0, remain = clmlen;
+    int err = 0;
+
+    if (!BWFMBase->bwfm_attached || clm == NULL || clmlen == 0)
+        return 0;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    while (remain)
+    {
+        ULONG len = (remain < BWFM_CLM_CHUNK) ? remain : BWFM_CLM_CHUNK;
+        UWORD flag = BWFM_DLOAD_FLAG_HANDLER_VER_1;
+
+        if (off == 0)
+            flag |= BWFM_DLOAD_FLAG_BEGIN;
+        if (remain <= BWFM_CLM_CHUNK)
+            flag |= BWFM_DLOAD_FLAG_END;
+
+        d->flag = AROS_WORD2LE(flag);
+        d->type = AROS_WORD2LE(BWFM_DLOAD_TYPE_CLM);
+        d->len = AROS_LONG2LE(len);
+        d->crc = 0;
+        CopyMem(src + off, buf + sizeof(*d), len);
+
+        err = bwfm_iovar_set(BWFMBase, "clmload", buf, sizeof(*d) + len);
+        if (err)
+        {
+            D(bug("[bwfm] clmload failed at %u/%u (err %d)\n", off, clmlen, err));
+            break;
+        }
+
+        off += len;
+        remain -= len;
+    }
+
+    if (!err)
+        D(bug("[bwfm] CLM loaded (%u bytes)\n", clmlen));
+
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Send one 802.3 data frame to the firmware: wrap it in an SDPCM hw/sw header
+ * (DATA channel) plus a BCDC/BDC data header, zero-pad to 4 bytes (or the
+ * block size for >512B frames) and write it to the func2 FIFO. Mirrors
+ * OpenBSD bwfm_sdio_tx_dataframe(). Called from the device's CMD_WRITE path.
+ */
+AROS_LH2(int, BWFMTxData,
+                AROS_LHA(void *, eth, A0),
+                AROS_LHA(uint32_t, ethlen, D0),
+                struct BWFMBase *, BWFMBase, 9, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    static UBYTE frame[2048];
+    struct bwfm_sdio_hwhdr *hw = (struct bwfm_sdio_hwhdr *)frame;
+    struct bwfm_sdio_swhdr *sw = (struct bwfm_sdio_swhdr *)(frame + 4);
+    struct bwfm_bcdc_data_hdr *bcdc = (struct bwfm_bcdc_data_hdr *)(frame + 12);
+    ULONG total, padded;
+    int err;
+
+    if (!BWFMBase->bwfm_attached || eth == NULL || ethlen == 0)
+        return -1;
+
+    total = 12 + sizeof(*bcdc) + ethlen;        /* hw+sw = 12, bcdc = 4 */
+    padded = (total > 512 && (total % 512)) ? ((total + 511) & ~511UL)
+                                            : ((total + 3) & ~3UL);
+    if (padded > sizeof(frame))
+        return -1;
+
+    /*
+     * Data frames are gated by the firmware's tx-credit window: we may only
+     * send while (txmax - txseq) is non-zero with its top bit clear (OpenBSD
+     * bwfm_sdio_tx_ok). Control frames are exempt. The window is refreshed from
+     * every received frame's maxseqnr, so wait (releasing the bus so the RX
+     * pump can run and update it) until a credit appears or we give up.
+     */
+    {
+        int waited = 0;
+        struct bwfm_timer tmr;
+        int have_timer = 0;
+
+        ObtainSemaphore(&BWFMBase->bwfm_Sem);
+        while (1)
+        {
+            uint8_t space = (uint8_t)(BWFMBase->bwfm_txmax - BWFMBase->bwfm_txseq);
+
+            if (space != 0 && (space & 0x80) == 0)
+                break;
+            ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+            if (++waited > 200)         /* ~200ms - the window should be open */
+            {
+                D(bug("[bwfm] TxData: no tx credit (seq %u max %u)\n",
+                      BWFMBase->bwfm_txseq, BWFMBase->bwfm_txmax));
+                if (have_timer)
+                    bwfm_timer_close(&tmr);
+                return -1;
+            }
+            /* Yield via timer.device rather than busy-spinning so the RX pump
+             * can run and refresh the credit window. The timer is opened lazily
+             * - the common path has credit at once and never reaches here. */
+            if (!have_timer)
+            {
+                bwfm_timer_open(&tmr);
+                have_timer = 1;
+            }
+            bwfm_timer_wait(BWFMBase, &tmr, 1000);
+            ObtainSemaphore(&BWFMBase->bwfm_Sem);
+        }
+        if (have_timer)
+            bwfm_timer_close(&tmr);
+    }
+
+    hw->frmlen = AROS_WORD2LE((UWORD)total);
+    hw->cksum = AROS_WORD2LE((UWORD)~total);
+    sw->seqnr = BWFMBase->bwfm_txseq++;
+    sw->chanflag = BWFM_SDIO_SWHDR_CHANNEL_DATA;
+    sw->nextlen = 0;
+    sw->dataoff = 12;
+    sw->flowctl = 0;
+    sw->maxseqnr = 0;
+    sw->res0 = 0;
+
+    bcdc->flags = BWFM_BCDC_FLAG_VER(BWFM_BCDC_FLAG_PROTO_VER);
+    bcdc->priority = 0;
+    bcdc->flags2 = 0;
+    bcdc->data_offset = 0;
+
+    CopyMem(eth, frame + 12 + sizeof(*bcdc), ethlen);
+    bwfm_zero(frame + total, padded - total);
+
+    err = bwfm_frame_rw(BWFMBase, frame, padded, 1);
+
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Read one pending SDPCM frame for the device's RX pump. Copies the 802.3
+ * ethernet frame into `buf` and returns its length (0 if nothing pending).
+ * *info gets the SDPCM channel in the low byte plus BWFM_RX_EVENT if the
+ * frame is a firmware event (LINK_CTL ethertype) rather than network data.
+ */
+AROS_LH3(int, BWFMRxFrame,
+                AROS_LHA(void *, buf, A0),
+                AROS_LHA(uint32_t, bufsize, D0),
+                AROS_LHA(uint32_t *, info, A1),
+                struct BWFMBase *, BWFMBase, 10, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    static UBYTE frame[2048];
+    ULONG flen = 0, ehoff = 0, ethlen = 0;
+    int chan = 0, ret = 0;
+
+    if (!BWFMBase->bwfm_attached)
+        return 0;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    /* Deliver any queued GLOM sub-frames before pulling more off F2. */
+    ret = bwfm_glom_pop(buf, bufsize, info);
+    if (ret == 0 && bwfm_rx_read(BWFMBase, frame, sizeof(frame), &flen, &chan))
+    {
+        if (BWFMBase->bwfm_evlisten)
+            D(bug("[bwfm] rx frame chan %d len %u\n", chan, (unsigned)flen));
+
+        if (chan == BWFM_SDIO_SWHDR_CHANNEL_GLOM)
+        {
+            bwfm_rx_glom(BWFMBase, frame, flen);
+            ret = bwfm_glom_pop(buf, bufsize, info);
+        }
+        else if (chan == BWFM_SDIO_SWHDR_CHANNEL_EVENT ||
+                 chan == BWFM_SDIO_SWHDR_CHANNEL_DATA)
+        {
+            if (bwfm_frame_eth(frame, flen, &ehoff, &ethlen))
+            {
+                if (ethlen > bufsize)
+                    ethlen = bufsize;
+                CopyMem(frame + ehoff, buf, ethlen);
+                if (info)
+                    *info = bwfm_rx_info(frame + ehoff, ethlen, chan);
+                ret = (int)ethlen;
+            }
+        }
+        /* CONTROL or malformed: nothing to deliver */
+    }
+
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+    return ret;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Associate to an access point by SSID. With no passphrase this is an OPEN
+ * join; with one, WPA2-PSK is configured and the passphrase is handed to the
+ * firmware's internal supplicant (sup_wpa=1), which runs the 4-way handshake
+ * for us - we have no host supplicant (OpenBSD relies on net80211 for this and
+ * keeps sup_wpa=0; we do the opposite). Sets the security iovars + the "join"
+ * iovar (ext_join_params, any BSSID/any channel), then polls the event channel
+ * for the result. Returns 0 when linked, <0 on failure/timeout. Caller (the
+ * device) must NOT hold an open CMD_READ on the bus; the RX pump waits on
+ * bwfm_Sem while we run.
+ */
+AROS_LH4(int, BWFMJoin,
+                AROS_LHA(uint8_t *, ssid, A0),
+                AROS_LHA(uint32_t, ssidlen, D0),
+                AROS_LHA(uint8_t *, pass, A1),
+                AROS_LHA(uint32_t, passlen, D1),
+                struct BWFMBase *, BWFMBase, 11, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    static UBYTE frame[2048];
+    struct bwfm_ext_join_params jp;
+    struct bwfm_timer tmr;
+    UBYTE evmask[BWFM_EVENT_MASK_LEN];
+    ULONG psize;
+    int i, tries, attempt, result = -1;
+
+    if (!BWFMBase->bwfm_attached || ssid == NULL || ssidlen == 0 ||
+        ssidlen > BWFM_MAX_SSID_LEN)
+        return -1;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    /*
+     * Enable the association events we wait on. The firmware's default event
+     * mask delivers E_IF but NOT the assoc events (E_LINK/E_SET_SSID/E_AUTH/...),
+     * so without this the join would never see a link-up event and always time
+     * out. (BWFMScan sets the same mask; join must not depend on a prior scan
+     * having run.) Mirrors OpenBSD's pre-join event_msgs setup.
+     */
+    bwfm_zero(evmask, sizeof(evmask));
+#define EV(e) (evmask[(e) / 8] |= (1 << ((e) % 8)))
+    EV(BWFM_E_IF); EV(BWFM_E_LINK); EV(BWFM_E_AUTH); EV(BWFM_E_ASSOC);
+    EV(BWFM_E_EAPOL_MSG); EV(BWFM_E_DEAUTH); EV(BWFM_E_DISASSOC);
+    EV(BWFM_E_SET_SSID);
+#undef EV
+    bwfm_iovar_set(BWFMBase, "event_msgs", evmask, sizeof(evmask));
+
+    /*
+     * Put the interface in infrastructure-STA mode and keep the radio powered.
+     * BWFMScan sets these as part of its pre-scan bwfm_init() sequence; doing
+     * them here makes a join self-contained so the datapath works without a
+     * prior scan. mpc=0 is the key one: with the default (mpc on) the firmware
+     * powers the MAC down when briefly idle and drops unsolicited RX like the
+     * DHCP offer, so association succeeds but no IP ever arrives.
+     */
+    bwfm_set_int(BWFMBase, BWFM_C_SET_INFRA, 1);
+    bwfm_set_int(BWFMBase, BWFM_C_SET_AP, 0);
+    bwfm_iovar_set_int(BWFMBase, "mpc", 0);
+    bwfm_set_int(BWFMBase, BWFM_C_SET_PM, BWFM_PM_FAST_PS);
+
+    if (passlen > 0)
+    {
+        struct bwfm_wsec_pmk pmk;
+
+        bwfm_zero((UBYTE *)&pmk, sizeof(pmk));
+        if (passlen > sizeof(pmk.key))
+            passlen = sizeof(pmk.key);
+        pmk.key_len = AROS_WORD2LE((UWORD)passlen);
+        pmk.flags = AROS_WORD2LE(BWFM_WSEC_PASSPHRASE);
+        CopyMem(pass, pmk.key, passlen);
+
+        bwfm_iovar_set_int(BWFMBase, "sup_wpa", 1);
+        bwfm_iovar_set_int(BWFMBase, "wsec", BWFM_WSEC_AES);
+        bwfm_iovar_set_int(BWFMBase, "wpa_auth", BWFM_WPA_AUTH_WPA2_PSK);
+        bwfm_dcmd(BWFMBase, BWFM_C_SET_WSEC_PMK, 1, &pmk, sizeof(pmk));
+    }
+    else
+    {
+        bwfm_iovar_set_int(BWFMBase, "sup_wpa", 0);
+        bwfm_iovar_set_int(BWFMBase, "wpa_auth", BWFM_WPA_AUTH_DISABLED);
+        bwfm_iovar_set_int(BWFMBase, "wsec", BWFM_WSEC_NONE);
+    }
+    bwfm_iovar_set_int(BWFMBase, "auth", BWFM_AUTH_OPEN);
+    bwfm_iovar_set_int(BWFMBase, "mfp", BWFM_MFP_NONE);
+
+    /* Build the join request: SSID, any BSSID, any channel. */
+    bwfm_zero((UBYTE *)&jp, sizeof(jp));
+    jp.ssid.len = AROS_LONG2LE(ssidlen);
+    CopyMem(ssid, jp.ssid.ssid, ssidlen);
+    for (i = 0; i < ETHER_ADDR_LEN; i++)
+        jp.assoc.bssid[i] = 0xff;
+    jp.assoc.chanspec_num = 0;
+    jp.scan.scan_type = 0xff;                   /* default scan */
+    jp.scan.nprobes = AROS_LONG2LE(0xffffffff);
+    jp.scan.active_time = AROS_LONG2LE(0xffffffff);
+    jp.scan.passive_time = AROS_LONG2LE(0xffffffff);
+    jp.scan.home_time = AROS_LONG2LE(0xffffffff);
+
+    psize = sizeof(jp) - sizeof(jp.assoc.chanspec_list);
+
+    /* Collect events from here on, then release the bus so the RX pump (the
+     * single FIFO reader) can deliver the association events to us. */
+    bwfm_event_listen(BWFMBase, 1);
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+
+    bwfm_timer_open(&tmr);
+
+    /*
+     * Issue the join and wait for the link. The first association attempt
+     * often returns E_AUTH timeout (status 2) on this firmware, so retry a
+     * couple of times before giving up.
+     */
+    for (attempt = 0; attempt < 3 && result != 0; attempt++)
+    {
+        result = -1;
+
+        ObtainSemaphore(&BWFMBase->bwfm_Sem);
+        {
+            int jerr = bwfm_iovar_set(BWFMBase, "join", &jp, psize);
+
+            if (jerr)
+            {
+                /* Older firmware: fall back to BWFM_C_SET_SSID with join_params. */
+                struct bwfm_join_params jpp;
+                int serr;
+
+                bwfm_zero((UBYTE *)&jpp, sizeof(jpp));
+                jpp.ssid.len = AROS_LONG2LE(ssidlen);
+                CopyMem(ssid, jpp.ssid.ssid, ssidlen);
+                for (i = 0; i < ETHER_ADDR_LEN; i++)
+                    jpp.assoc.bssid[i] = 0xff;
+                serr = bwfm_dcmd(BWFMBase, BWFM_C_SET_SSID, 1, &jpp,
+                                 sizeof(jpp) - sizeof(jpp.assoc.chanspec_list));
+                D(bug("[bwfm] join iovar err %d, SET_SSID fallback err %d\n", jerr, serr));
+            }
+            else
+                D(bug("[bwfm] join iovar accepted\n"));
+        }
+        ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+
+        D(bug("[bwfm] join \"%s\" (%s) attempt %d - waiting for link\n", ssid,
+              passlen ? "WPA2-PSK" : "open", attempt + 1));
+
+        /* Consume association events from the pump (~10s, 50ms ticks). */
+        for (tries = 0; tries < 200 && result < 0; tries++)
+        {
+            ULONG etype, status, flags, n;
+
+            while ((n = bwfm_event_pop(BWFMBase, frame, sizeof(frame))) > 0)
+            {
+                struct bwfm_event *e = (struct bwfm_event *)frame;
+
+                if (n < sizeof(*e))
+                    continue;
+
+                etype = AROS_BE2LONG(e->msg.event_type);
+                status = AROS_BE2LONG(e->msg.status);
+                flags = AROS_BE2WORD(e->msg.flags);
+                D(bug("[bwfm] join event type %u status %u flags 0x%x\n",
+                      etype, status, flags));
+
+                if (etype == BWFM_E_LINK)
+                    result = (flags & BWFM_EVENT_FLAG_LINK_UP) ? 0 : -2;
+                else if (etype == BWFM_E_SET_SSID)
+                {
+                    if (status != BWFM_E_STATUS_SUCCESS)
+                        result = -3;            /* association rejected */
+                    /* success: keep polling for the E_LINK up that follows */
+                }
+                else if (etype == BWFM_E_DEAUTH || etype == BWFM_E_DISASSOC)
+                    result = -4;                /* kicked off (e.g. wrong passphrase) */
+            }
+
+            /*
+             * The E_LINK up event is sometimes glommed (SDPCM channel 3) and
+             * dropped by our one-frame-at-a-time RX path, so confirm the link
+             * directly every few ticks: GET_BSSID returns the AP's BSSID once
+             * associated. This also makes re-joining an already-connected
+             * network succeed immediately (idempotent).
+             */
+            if (result < 0 && (tries % 4) == 3)
+            {
+                uint8_t bssid[ETHER_ADDR_LEN];
+
+                bwfm_zero(bssid, sizeof(bssid));
+                ObtainSemaphore(&BWFMBase->bwfm_Sem);
+                if (bwfm_dcmd(BWFMBase, BWFM_C_GET_BSSID, 0, bssid, sizeof(bssid)) == 0 &&
+                    (bssid[0] | bssid[1] | bssid[2] |
+                     bssid[3] | bssid[4] | bssid[5]) != 0)
+                    result = 0;
+                ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+            }
+
+            if (result < 0)
+                bwfm_timer_wait(BWFMBase, &tmr, 50000);
+        }
+
+        D(bug("[bwfm] join attempt %d %s (result %d)\n", attempt + 1,
+              result == 0 ? "OK" : "FAILED", result));
+    }
+
+    bwfm_timer_close(&tmr);
+    bwfm_event_listen(BWFMBase, 0);
+    return result;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Route the SDIO card interrupt to the device's RX pump: `task` is signalled
+ * with `sigmask` when the chip has a frame. Thin wrapper over sdio.resource so
+ * the device never touches the SDIO layer directly.
+ */
+AROS_LH2(int, BWFMSetRxSignal,
+                AROS_LHA(struct Task *, task, A0),
+                AROS_LHA(uint32_t, sigmask, D0),
+                struct BWFMBase *, BWFMBase, 12, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    return SDIOSetInterrupt(task, sigmask);
+
+    AROS_LIBFUNC_EXIT
+}
+
+/* Re-arm the card interrupt after the pump has drained pending frames. */
+AROS_LH0(void, BWFMAckRx,
+                struct BWFMBase *, BWFMBase, 13, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    SDIOAckInterrupt();
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Clear the chip's SDPCM interrupt status (the func1/card-interrupt source) so
+ * DAT1 deasserts. The RX pump calls this before draining + re-arming, so a
+ * re-armed card interrupt does not immediately re-fire on a still-asserted
+ * line. Mirrors OpenBSD bwfm_sdio_task()'s INTSTATUS read + W1C.
+ */
+AROS_LH0(void, BWFMClearInt,
+                struct BWFMBase *, BWFMBase, 14, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    uint32_t ist, raw;
+    uint8_t clk, devctl;
+    int i;
+
+    if (!BWFMBase->bwfm_attached)
+        return;
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+
+    /*
+     * Make the chip clock available before touching frames. When the card
+     * interrupt is enabled the chip may doze and only wake the host via the
+     * interrupt with DEVICE_CTL_CA_INT_ONLY set - in that state it signals
+     * HMB_FRAME_IND but does NOT DMA the frame into the F2 FIFO until the host
+     * requests HT and clears CA_INT_ONLY. This explains the symptom: FRAME_IND
+     * set but F2 empty. Mirrors OpenBSD bwfm_sdio_clkctl(CLK_AVAIL).
+     */
+    clk = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+    if (!(clk & BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL))
+    {
+        bwfm_write_1(BWFM_SDIO_FUNC1_CHIPCLKCSR,
+                     clk | BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HT);
+        for (i = 0; i < 100; i++)
+        {
+            clk = bwfm_read_1(BWFM_SDIO_FUNC1_CHIPCLKCSR);
+            if (clk & BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL)
+                break;
+            bwfm_udelay(BWFMBase, 100);
+        }
+    }
+    devctl = bwfm_read_1(BWFM_SDIO_DEVICE_CTL);
+    if (devctl & BWFM_SDIO_DEVICE_CTL_CA_INT_ONLY)
+        bwfm_write_1(BWFM_SDIO_DEVICE_CTL,
+                     devctl & ~BWFM_SDIO_DEVICE_CTL_CA_INT_ONLY);
+
+    raw = bwfm_dev_read(BWFMBase, SDPCMD_INTSTATUS);
+    ist = raw & (SDPCMD_INTSTATUS_HMB_SW_MASK | SDPCMD_INTSTATUS_CHIPACTIVE);
+
+    /* Diagnostic: dump interrupt + clock state during a join/scan. */
+    if (BWFMBase->bwfm_evlisten)
+        D(bug("[bwfm] clrint INTSTATUS 0x%08x clk 0x%02x devctl 0x%02x\n",
+              raw, clk, devctl));
+
+    /* The host-mailbox interrupt needs the SDPCM handshake before its status
+     * bit may be cleared - read the mailbox data and ACK it, or the chip's
+     * mailbox protocol wedges and it stops delivering events/frames (this
+     * broke join when the pump cleared it bare). Mirrors OpenBSD. */
+    if (ist & SDPCMD_INTSTATUS_HMB_HOST_INT)
+    {
+        bwfm_dev_read(BWFMBase, SDPCMD_TOHOSTMAILBOXDATA);
+        bwfm_dev_write(BWFMBase, SDPCMD_TOSBMAILBOX, SDPCMD_TOSBMAILBOX_INT_ACK);
+    }
+
+    /* W1C the latched status bits (incl. HMB_FRAME_IND). The pump calls us
+     * AFTER draining F2, so clearing the frame-ready bit with the FIFO empty
+     * deasserts DAT1 and lets the next frame re-trigger the edge-sensitive
+     * card interrupt. (The earlier "clearing halts the firmware" was really the
+     * missing event_msgs mask, since fixed - clearing here is correct.) */
+    if (ist)
+        bwfm_dev_write(BWFMBase, SDPCMD_INTSTATUS, ist);
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Queue a firmware event frame for an in-progress control op (join/scan). The
+ * device's RX pump - the single SDPCM FIFO reader - calls this for every event
+ * frame it reads. If no control op is listening the frame is dropped (events
+ * outside join/scan are not acted on yet). On overflow the oldest entry is
+ * dropped so the pump never blocks.
+ */
+AROS_LH2(void, BWFMEventPost,
+                AROS_LHA(void *, ev, A0),
+                AROS_LHA(uint32_t, len, D0),
+                struct BWFMBase *, BWFMBase, 15, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&BWFMBase->bwfm_Sem);
+    bwfm_event_push(BWFMBase, ev, len);
+    ReleaseSemaphore(&BWFMBase->bwfm_Sem);
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Copy the beacon IEs captured for scan result `idx` (by the last BWFMScan)
+ * into buf; returns the length (0 if none / out of range). The SANA-II device's
+ * S2_GETNETWORKS hands these to wpa_supplicant as S2INFO_InfoElements.
+ */
+AROS_LH3(int, BWFMScanIE,
+                AROS_LHA(int, idx, D0),
+                AROS_LHA(void *, buf, A0),
+                AROS_LHA(uint32_t, bufsize, D1),
+                struct BWFMBase *, BWFMBase, 16, Bwfm)
+{
+    AROS_LIBFUNC_INIT
+
+    ULONG n;
+
+    if (idx < 0 || idx >= BWFM_SCAN_IE_MAX || buf == NULL)
+        return 0;
+    n = bwfm_scan_ie_len[idx];
+    if (n > bufsize)
+        n = bufsize;
+    if (n)
+        CopyMem(bwfm_scan_ie[idx], buf, n);
+    return (int)n;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_private.h
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_private.h
@@ -1,0 +1,80 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Private state for bwfm.resource - Broadcom FullMAC WiFi chip bring-up
+    over SDIO (consumes sdio.resource). Phase 2: chip identification, core
+    enumeration and RAM sizing. The SANA-II network front-end (bwfm.device)
+    will be built on top of this chip layer later.
+*/
+
+#ifndef BWFM_PRIVATE_H_
+#define BWFM_PRIVATE_H_
+
+#include <exec/nodes.h>
+#include <exec/semaphores.h>
+#include <inttypes.h>
+
+/* One silicon-backplane core, as enumerated from the EROM. */
+struct bwfm_core
+{
+    uint16_t                co_id;
+    uint16_t                co_rev;
+    uint32_t                co_base;
+    uint32_t                co_wrapbase;
+};
+
+#define BWFM_MAX_CORES          24
+
+/*
+ * Firmware-event hand-off ring. The device's RX pump is the single SDPCM FIFO
+ * reader; it posts received event frames here, and an in-progress control op
+ * (join / scan) pops them. One bus reader avoids a pump-vs-control race on the
+ * FIFO and keeps the chip mailbox serviced while a join/scan waits.
+ */
+#define BWFM_EVRING_SLOTS       8
+#define BWFM_EVSLOT_SIZE        2048
+
+struct bwfm_evslot
+{
+    uint16_t                ev_len;
+    uint8_t                 ev_data[BWFM_EVSLOT_SIZE];
+};
+
+struct BWFMBase
+{
+    struct Node             bwfm_Node;
+    struct SignalSemaphore  bwfm_Sem;
+
+    unsigned int            bwfm_periiobase;    /* for the busy-wait timer */
+    uint32_t                bwfm_bar0;          /* Current backplane window base */
+
+    /* Identified chip */
+    uint16_t                bwfm_chip;          /* ChipCommon chip ID */
+    uint8_t                 bwfm_chiprev;
+    int                     bwfm_attached;
+
+    /* Enumerated cores */
+    struct bwfm_core        bwfm_cores[BWFM_MAX_CORES];
+    int                     bwfm_ncores;
+
+    /* Capabilities / RAM layout */
+    uint32_t                bwfm_cc_caps;
+    uint32_t                bwfm_cc_caps_ext;
+    uint8_t                 bwfm_pmurev;
+    uint32_t                bwfm_rambase;
+    uint32_t                bwfm_ramsize;
+    uint32_t                bwfm_srsize;
+
+    /* SDPCM / BCDC control channel */
+    uint8_t                 bwfm_txseq;     /* next host->device frame seqnr */
+    uint8_t                 bwfm_txmax;     /* firmware tx-credit window (maxseqnr) */
+    uint16_t                bwfm_reqid;
+
+    /* Event hand-off from the RX pump to an in-progress join/scan */
+    int                     bwfm_evlisten;  /* a control op is collecting events */
+    uint16_t                bwfm_evhead;    /* ring producer index */
+    uint16_t                bwfm_evtail;    /* ring consumer index */
+    struct bwfm_evslot      bwfm_evring[BWFM_EVRING_SLOTS];
+};
+
+#endif /* BWFM_PRIVATE_H_ */

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_scan.h
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_scan.h
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2010-2016 Broadcom Corporation
+ * Copyright (c) 2016,2017 Patrick Wildt <patrick@blueri.se>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Scan/event structures, subset of OpenBSD sys/dev/ic/bwfmreg.h ported for
+ * AROS. Multi-byte protocol fields are little-endian except the BRCM event
+ * header (event_type/status are big-endian - use the be helpers).
+ */
+
+#ifndef BWFM_SCAN_H
+#define BWFM_SCAN_H
+
+#include <inttypes.h>
+
+#define BWFM_MAX_SSID_LEN       32
+#define ETHER_ADDR_LEN          6
+
+/* --- escan request --------------------------------------------------- */
+
+struct bwfm_ssid
+{
+    uint32_t    len;
+    uint8_t     ssid[BWFM_MAX_SSID_LEN];
+} __attribute__((packed));
+
+struct bwfm_scan_params_v0
+{
+    struct bwfm_ssid ssid;
+    uint8_t     bssid[ETHER_ADDR_LEN];
+    uint8_t     bss_type;
+    uint8_t     scan_type;
+    uint32_t    nprobes;
+    uint32_t    active_time;
+    uint32_t    passive_time;
+    uint32_t    home_time;
+    uint32_t    channel_num;
+    uint16_t    channel_list[1];
+} __attribute__((packed));
+
+#define BWFM_SCANTYPE_PASSIVE   1
+#define DOT11_BSSTYPE_ANY       2
+
+struct bwfm_escan_params_v0
+{
+    uint32_t    version;
+#define BWFM_ESCAN_REQ_VERSION  1
+    uint16_t    action;
+#define WL_ESCAN_ACTION_START   1
+    uint16_t    sync_id;
+    struct bwfm_scan_params_v0 scan_params;
+} __attribute__((packed));
+
+/* --- join / association ---------------------------------------------- */
+
+struct bwfm_assoc_params
+{
+    uint8_t     bssid[ETHER_ADDR_LEN];
+    uint16_t    pad;
+    uint32_t    chanspec_num;
+    uint16_t    chanspec_list[1];       /* empty for an any-channel join */
+} __attribute__((packed));
+
+struct bwfm_join_scan_params
+{
+    uint8_t     scan_type;
+    uint8_t     pad[3];
+    uint32_t    nprobes;
+    uint32_t    active_time;
+    uint32_t    passive_time;
+    uint32_t    home_time;
+} __attribute__((packed));
+
+struct bwfm_ext_join_params
+{
+    struct bwfm_ssid ssid;
+    struct bwfm_join_scan_params scan;
+    struct bwfm_assoc_params assoc;
+} __attribute__((packed));
+
+struct bwfm_join_params       /* legacy BWFM_C_SET_SSID fallback */
+{
+    struct bwfm_ssid ssid;
+    struct bwfm_assoc_params assoc;
+} __attribute__((packed));
+
+/* Passphrase/PMK for the firmware-internal WPA supplicant (BWFM_C_SET_WSEC_PMK) */
+struct bwfm_wsec_pmk
+{
+    uint16_t    key_len;
+    uint16_t    flags;
+    uint8_t     key[2 * 32 + 1];
+} __attribute__((packed));
+
+/* --- escan results --------------------------------------------------- */
+
+#define BWFM_MCSSET_LEN         16
+
+/* Full bss_info layout (ported from OpenBSD bwfmreg.h) so ie_offset/ie_length
+ * land at the correct offsets - the IEs (incl. the RSN/WPA element wpa_supplicant
+ * needs) follow at (uint8_t *)bss + ie_offset for ie_length bytes. */
+struct bwfm_bss_info
+{
+    uint32_t    version;
+    uint32_t    length;
+    uint8_t     bssid[ETHER_ADDR_LEN];
+    uint16_t    beacon_period;
+    uint16_t    capability;
+    uint8_t     ssid_len;
+    uint8_t     ssid[BWFM_MAX_SSID_LEN];
+    uint8_t     pad0;
+    uint32_t    nrates;
+    uint8_t     rates[16];
+    uint16_t    chanspec;
+    uint16_t    atim_window;
+    uint8_t     dtim_period;
+    uint8_t     pad1;
+    uint16_t    rssi;
+    uint8_t     phy_noise;
+    uint8_t     n_cap;
+    uint16_t    pad2;
+    uint32_t    nbss_cap;
+    uint8_t     ctl_ch;
+    uint8_t     pad3[3];
+    uint32_t    reserved32[1];
+    uint8_t     flags;
+    uint8_t     reserved[3];
+    uint8_t     basic_mcs[BWFM_MCSSET_LEN];
+    uint16_t    ie_offset;
+    uint16_t    pad4;
+    uint32_t    ie_length;
+    uint16_t    snr;
+} __attribute__((packed));
+
+struct bwfm_escan_results
+{
+    uint32_t    buflen;
+    uint32_t    version;
+    uint16_t    sync_id;
+    uint16_t    bss_count;
+    struct bwfm_bss_info bss_info[1];
+} __attribute__((packed));
+
+/* --- async event header (precedes event payload) --------------------- */
+
+struct bwfm_ether_header
+{
+    uint8_t     dst[ETHER_ADDR_LEN];
+    uint8_t     src[ETHER_ADDR_LEN];
+    uint16_t    ether_type;
+} __attribute__((packed));
+
+struct bwfm_ethhdr
+{
+    uint16_t    subtype;
+    uint16_t    length;
+    uint8_t     version;
+    uint8_t     oui[3];
+    uint16_t    usr_subtype;
+} __attribute__((packed));
+
+struct bwfm_event_msg
+{
+    uint16_t    version;
+    uint16_t    flags;
+    uint32_t    event_type;     /* big-endian */
+    uint32_t    status;         /* big-endian */
+    uint32_t    reason;
+    uint32_t    auth_type;
+    uint32_t    datalen;
+    uint8_t     addr[ETHER_ADDR_LEN];
+    char        ifname[16];
+    uint8_t     ifidx;
+    uint8_t     bsscfgidx;
+} __attribute__((packed));
+
+struct bwfm_event
+{
+    struct bwfm_ether_header ehdr;
+#define BWFM_ETHERTYPE_LINK_CTL 0x886c
+    struct bwfm_ethhdr hdr;
+    struct bwfm_event_msg msg;
+} __attribute__((packed));
+
+/* BCDC data header that precedes event/data payloads on the SDPCM bus */
+struct bwfm_bcdc_data_hdr
+{
+    uint8_t     flags;
+    uint8_t     priority;
+    uint8_t     flags2;
+    uint8_t     data_offset;    /* in 4-byte words */
+} __attribute__((packed));
+
+/* Event types / status (subset) */
+#define BWFM_E_SET_SSID         0
+#define BWFM_E_AUTH             3
+#define BWFM_E_DEAUTH           5
+#define BWFM_E_ASSOC            7
+#define BWFM_E_DISASSOC         11
+#define BWFM_E_LINK             16
+#define BWFM_E_EAPOL_MSG        25
+#define BWFM_E_IF               54
+#define BWFM_E_ESCAN_RESULT     69
+#define BWFM_E_LAST             139
+#define BWFM_EVENT_MASK_LEN     ((BWFM_E_LAST + 7) / 8)
+
+#define BWFM_E_STATUS_SUCCESS   0
+#define BWFM_E_STATUS_PARTIAL   8
+
+/* Result handed back to a scan caller */
+struct bwfm_scanresult
+{
+    uint8_t     bssid[ETHER_ADDR_LEN];
+    uint8_t     ssid_len;
+    uint8_t     ssid[BWFM_MAX_SSID_LEN];
+    int16_t     rssi;
+    uint16_t    chanspec;
+};
+
+#endif /* BWFM_SCAN_H */

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_sdio.h
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_sdio.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2010-2016 Broadcom Corporation
+ * Copyright (c) 2018 Patrick Wildt <patrick@blueri.se>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Subset of OpenBSD sys/dev/sdmmc/if_bwfm_sdio.h ported for AROS.
+ */
+
+#ifndef BWFM_SDIO_H
+#define BWFM_SDIO_H
+
+/* Broadcom-specific CCCR (function 0) registers */
+#define BWFM_SDIO_CCCR_CARDCAP                  0xf0
+#define  BWFM_SDIO_CCCR_CARDCAP_CMD14_SUPPORT       (1 << 1)
+#define  BWFM_SDIO_CCCR_CARDCAP_CMD14_EXT           (1 << 2)
+#define  BWFM_SDIO_CCCR_CARDCAP_CMD_NODEC           (1 << 3)
+#define BWFM_SDIO_CCCR_CARDCTRL                 0xf1
+#define  BWFM_SDIO_CCCR_CARDCTRL_WLANRESET          (1 << 1)
+#define BWFM_SDIO_CCCR_SEPINT                   0xf2
+
+/* Function 1 miscellaneous registers (0x10000-0x1FFFF) */
+#define BWFM_SDIO_WATERMARK                     0x10008
+#define BWFM_SDIO_DEVICE_CTL                    0x10009
+#define BWFM_SDIO_FUNC1_SBADDRLOW               0x1000A
+#define BWFM_SDIO_FUNC1_SBADDRMID               0x1000B
+#define BWFM_SDIO_FUNC1_SBADDRHIGH              0x1000C
+#define BWFM_SDIO_FUNC1_CHIPCLKCSR              0x1000E
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_ALP           0x01
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HT            0x02
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_ILP           0x04
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL_REQ       0x08
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL_REQ        0x10
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_FORCE_HW_CLKREQ_OFF 0x20
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_ALP_AVAIL           0x40
+#define  BWFM_SDIO_FUNC1_CHIPCLKCSR_HT_AVAIL            0x80
+#define BWFM_SDIO_FUNC1_SDIOPULLUP              0x1000F
+#define BWFM_SDIO_FUNC1_WAKEUPCTRL              0x1001E
+#define BWFM_SDIO_FUNC1_SLEEPCSR                0x1001F
+#define  BWFM_SDIO_FUNC1_SLEEPCSR_KSO               (1 << 0)
+#define  BWFM_SDIO_FUNC1_SLEEPCSR_DEVON             (1 << 1)
+
+#define  BWFM_SDIO_DEVICE_CTL_CA_INT_ONLY           0x04
+
+/* Silicon-backplane access windowing */
+#define BWFM_SDIO_SB_OFT_ADDR_PAGE              0x08000
+#define BWFM_SDIO_SB_OFT_ADDR_MASK              0x07FFF
+#define BWFM_SDIO_SB_ACCESS_2_4B_FLAG           0x08000
+
+/* SDIO_DEV (SDPCM) core registers (offsets from the SDIO_DEV core base) */
+#define SDPCMD_INTSTATUS                        0x020
+#define  SDPCMD_INTSTATUS_HMB_SW_MASK               0x000000f0
+#define  SDPCMD_INTSTATUS_HMB_FRAME_IND             (1 << 6)    /* HMB_SW2 */
+#define  SDPCMD_INTSTATUS_HMB_HOST_INT              (1 << 7)    /* HMB_SW3: needs mbox ack */
+#define  SDPCMD_INTSTATUS_CHIPACTIVE                (1 << 29)
+#define SDPCMD_HOSTINTMASK                      0x024
+#define SDPCMD_TOSBMAILBOX                      0x040
+#define  SDPCMD_TOSBMAILBOX_INT_ACK                 (1 << 1)
+#define SDPCMD_TOSBMAILBOXDATA                  0x048
+#define SDPCMD_TOHOSTMAILBOXDATA                0x04C
+#define  SDPCMD_TOHOSTMAILBOXDATA_DEVREADY          (1 << 1)
+#define  SDPCMD_TOHOSTMAILBOXDATA_FWREADY           (1 << 3)
+
+/* SDPCM protocol version handshake (written to TOSBMAILBOXDATA) */
+#define SDPCM_PROT_VERSION                      4
+#define SDPCM_PROT_VERSION_SHIFT                16
+
+/* SDPCM frame headers and channels */
+struct bwfm_sdio_hwhdr
+{
+    uint16_t    frmlen;
+    uint16_t    cksum;          /* ~frmlen */
+};
+
+struct bwfm_sdio_swhdr
+{
+    uint8_t     seqnr;
+    uint8_t     chanflag;
+    uint8_t     nextlen;
+    uint8_t     dataoff;
+    uint8_t     flowctl;
+    uint8_t     maxseqnr;
+    uint16_t    res0;
+};
+
+#define BWFM_SDIO_SWHDR_CHANNEL_CONTROL         0x00
+#define BWFM_SDIO_SWHDR_CHANNEL_EVENT           0x01
+#define BWFM_SDIO_SWHDR_CHANNEL_DATA            0x02
+#define BWFM_SDIO_SWHDR_CHANNEL_GLOM            0x03
+#define BWFM_SDIO_SWHDR_CHANNEL_MASK            0x0f
+
+/* BCDC control message header (precedes the command payload) */
+struct bwfm_bcdc_dcmd_hdr
+{
+    uint32_t    cmd;
+    uint32_t    len;
+    uint32_t    flags;
+    uint32_t    status;
+};
+
+#define BWFM_BCDC_DCMD_ERROR                    (1 << 0)
+#define BWFM_BCDC_DCMD_SET                      (1 << 1)
+#define BWFM_BCDC_DCMD_ID_SET(x)                (((x) & 0xffff) << 16)
+#define BWFM_BCDC_DCMD_ID_GET(x)                (((x) >> 16) & 0xffff)
+
+/* BCDC/BDC data header (precedes data/event payloads, struct bwfm_bcdc_data_hdr) */
+#define BWFM_BCDC_FLAG_PROTO_VER                2
+#define BWFM_BCDC_FLAG_VER(x)                   (((x) & 0xf) << 4)
+
+/* BWFMRxFrame() *info flags (low byte = SDPCM channel) */
+#define BWFM_RX_EVENT                           0x100
+
+/*
+ * Blob download header for the "clmload" iovar (regulatory CLM data). The blob
+ * is sent as a sequence of chunks, each prefixed with this header; the first
+ * chunk sets BEGIN and the last sets END. Ported from OpenBSD bwfm_dload_data.
+ */
+struct bwfm_dload_data
+{
+    uint16_t    flag;
+    uint16_t    type;
+    uint32_t    len;
+    uint32_t    crc;
+    /* chunk data follows */
+};
+
+#define BWFM_DLOAD_FLAG_BEGIN                   (1 << 1)
+#define BWFM_DLOAD_FLAG_END                     (1 << 2)
+#define BWFM_DLOAD_FLAG_HANDLER_VER_1           (1 << 12)
+#define BWFM_DLOAD_TYPE_CLM                     2
+
+/* Firmware command numbers */
+#define BWFM_C_UP                               2
+#define BWFM_C_DOWN                             3
+#define BWFM_C_SET_INFRA                        20
+#define BWFM_C_GET_BSSID                        23
+#define BWFM_C_SET_SSID                         26
+#define BWFM_C_DISASSOC                         52
+#define BWFM_C_SET_PM                           86
+#define BWFM_C_SET_AP                           118
+#define BWFM_C_SET_SCAN_CHANNEL_TIME            185
+#define BWFM_C_SET_SCAN_UNASSOC_TIME            187
+#define BWFM_C_SET_SCAN_PASSIVE_TIME            258
+#define BWFM_C_GET_VAR                          262
+#define BWFM_C_SET_VAR                          263
+#define BWFM_C_SET_WSEC_PMK                     268
+
+/* Security setup for join (wsec / wpa_auth / auth / mfp iovars) */
+#define BWFM_AUTH_OPEN                          0
+#define BWFM_MFP_NONE                           0
+#define BWFM_WPA_AUTH_DISABLED                  0
+#define BWFM_WPA_AUTH_WPA2_PSK                  (1 << 7)
+#define BWFM_WSEC_NONE                          0
+#define BWFM_WSEC_AES                           (1 << 2)
+#define BWFM_WSEC_PASSPHRASE                    (1 << 0)
+
+/* E_LINK event_msg flags: bit0 = link up */
+#define BWFM_EVENT_FLAG_LINK_UP                 (1 << 0)
+
+/* Power-management modes (BWFM_C_SET_PM) */
+#define BWFM_PM_CAM                             0
+#define BWFM_PM_FAST_PS                         2
+
+#endif /* BWFM_SDIO_H */

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfmreg.h
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfmreg.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2016 Broadcom Corporation
+ * Copyright (c) 2016,2017 Patrick Wildt <patrick@blueri.se>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Subset of OpenBSD sys/dev/ic/bwfmreg.h ported for AROS.
+ */
+
+#ifndef BWFMREG_H
+#define BWFMREG_H
+
+/* ChipCommon core registers (backplane base) */
+#define BWFM_CHIP_BASE                          0x18000000
+#define BWFM_CHIP_REG_CHIPID                    0x00000000
+#define  BWFM_CHIP_CHIPID_ID(x)                     (((x) >> 0) & 0xffff)
+#define  BWFM_CHIP_CHIPID_REV(x)                    (((x) >> 16) & 0xf)
+#define  BWFM_CHIP_CHIPID_PKG(x)                    (((x) >> 20) & 0xf)
+#define  BWFM_CHIP_CHIPID_CC(x)                     (((x) >> 24) & 0xf)
+#define  BWFM_CHIP_CHIPID_TYPE(x)                   (((x) >> 28) & 0xf)
+#define  BWFM_CHIP_CHIPID_TYPE_SOCI_SB              0
+#define  BWFM_CHIP_CHIPID_TYPE_SOCI_AI              1
+#define BWFM_CHIP_REG_CAPABILITIES              0x00000004
+#define  BWFM_CHIP_REG_CAPABILITIES_PMU             0x10000000
+#define BWFM_CHIP_REG_CAPABILITIES_EXT          0x000000AC
+#define  BWFM_CHIP_REG_CAPABILITIES_EXT_AOB_PRESENT 0x00000040
+#define BWFM_CHIP_REG_EROMPTR                   0x000000FC
+#define BWFM_CHIP_REG_PMUCONTROL                0x00000600
+#define  BWFM_CHIP_REG_PMUCONTROL_RES_MASK          0x00006000
+#define  BWFM_CHIP_REG_PMUCONTROL_RES_SHIFT         13
+#define  BWFM_CHIP_REG_PMUCONTROL_RES_RELOAD        0x2
+#define BWFM_CHIP_REG_PMUCAPABILITIES           0x00000604
+#define  BWFM_CHIP_REG_PMUCAPABILITIES_REV_MASK     0x000000ff
+
+/* AI (silicon-backplane agent) wrapper registers */
+#define BWFM_AGENT_IOCTL                        0x0408
+#define  BWFM_AGENT_IOCTL_CLK                       0x0001
+#define  BWFM_AGENT_IOCTL_FGC                       0x0002
+#define  BWFM_AGENT_IOCTL_CORE_BITS                 0x3FFC
+#define  BWFM_AGENT_IOCTL_ARMCR4_CPUHALT            0x0020
+#define BWFM_AGENT_RESET_CTL                    0x0800
+#define  BWFM_AGENT_RESET_CTL_RESET                 0x0001
+
+/* CPU-core IOCTL bits */
+#define BWFM_AGENT_IOCTL_ARMCR4_CPUHALT         0x0020
+#define BWFM_AGENT_D11_IOCTL_PHYCLOCKEN         0x0004
+#define BWFM_AGENT_D11_IOCTL_PHYRESET           0x0008
+
+/* ARM CR4 core (TCM RAM) registers */
+#define BWFM_ARMCR4_CAP                         0x0004
+#define  BWFM_ARMCR4_CAP_TCBANB_MASK                0xf
+#define  BWFM_ARMCR4_CAP_TCBANB_SHIFT               0
+#define  BWFM_ARMCR4_CAP_TCBBNB_MASK                0xf0
+#define  BWFM_ARMCR4_CAP_TCBBNB_SHIFT               4
+#define BWFM_ARMCR4_BANKIDX                     0x0040
+#define BWFM_ARMCR4_BANKINFO                    0x0044
+#define  BWFM_ARMCR4_BANKINFO_BSZ_MASK              0x7f
+#define  BWFM_ARMCR4_BANKINFO_BLK_1K_MASK           0x200
+
+/* SOCRAM / SYSMEM core registers */
+#define BWFM_SOCRAM_COREINFO                    0x0000
+#define  BWFM_SOCRAM_COREINFO_SRBSZ_BASE            14
+#define  BWFM_SOCRAM_COREINFO_SRBSZ_MASK            0xf
+#define  BWFM_SOCRAM_COREINFO_SRNB_MASK             0xf0
+#define  BWFM_SOCRAM_COREINFO_SRNB_SHIFT            4
+#define  BWFM_SOCRAM_COREINFO_LSS_MASK              0xf00000
+#define  BWFM_SOCRAM_COREINFO_LSS_SHIFT             20
+#define BWFM_SOCRAM_BANKIDX                     0x0010
+#define  BWFM_SOCRAM_BANKIDX_MEMTYPE_RAM            0
+#define  BWFM_SOCRAM_BANKIDX_MEMTYPE_SHIFT          8
+#define BWFM_SOCRAM_BANKINFO                    0x0040
+#define  BWFM_SOCRAM_BANKINFO_SZBASE                8192
+#define  BWFM_SOCRAM_BANKINFO_SZMASK                0x7f
+#define  BWFM_SOCRAM_BANKINFO_RETNTRAM_MASK         0x10000
+#define BWFM_SOCRAM_BANKPDA                     0x0044
+
+/* DMP (EROM) descriptor format */
+#define BWFM_DMP_DESC_MASK                      0x0000000F
+#define BWFM_DMP_DESC_COMPONENT                 0x00000001
+#define BWFM_DMP_DESC_MASTER_PORT               0x00000003
+#define BWFM_DMP_DESC_ADDRESS                   0x00000005
+#define BWFM_DMP_DESC_ADDRSIZE_GT32             0x00000008
+#define BWFM_DMP_DESC_EOT                       0x0000000F
+#define BWFM_DMP_COMP_PARTNUM                   0x000FFF00
+#define BWFM_DMP_COMP_PARTNUM_S                 8
+#define BWFM_DMP_COMP_REVISION                  0xFF000000
+#define BWFM_DMP_COMP_REVISION_S                24
+#define BWFM_DMP_COMP_NUM_SWRAP                 0x00F80000
+#define BWFM_DMP_COMP_NUM_SWRAP_S               19
+#define BWFM_DMP_COMP_NUM_MWRAP                 0x0007C000
+#define BWFM_DMP_COMP_NUM_MWRAP_S               14
+#define BWFM_DMP_MASTER_PORT_NUM                0x000000F0
+#define BWFM_DMP_MASTER_PORT_NUM_S              4
+#define BWFM_DMP_SLAVE_ADDR_BASE                0xFFFFF000
+#define BWFM_DMP_SLAVE_TYPE                     0x000000C0
+#define BWFM_DMP_SLAVE_TYPE_S                   6
+#define  BWFM_DMP_SLAVE_TYPE_SLAVE                  0
+#define  BWFM_DMP_SLAVE_TYPE_SWRAP                  2
+#define  BWFM_DMP_SLAVE_TYPE_MWRAP                  3
+#define BWFM_DMP_SLAVE_SIZE_TYPE                0x00000030
+#define BWFM_DMP_SLAVE_SIZE_TYPE_S              4
+#define  BWFM_DMP_SLAVE_SIZE_4K                     0
+#define  BWFM_DMP_SLAVE_SIZE_8K                     1
+#define  BWFM_DMP_SLAVE_SIZE_DESC                   3
+
+/* Core IDs (DMP/EROM) */
+#define BWFM_AGENT_CORE_CHIPCOMMON              0x800
+#define BWFM_AGENT_INTERNAL_MEM                 0x80E
+#define BWFM_AGENT_CORE_80211                   0x812
+#define BWFM_AGENT_CORE_PMU                     0x827
+#define BWFM_AGENT_CORE_SDIO_DEV                0x829
+#define BWFM_AGENT_CORE_ARM_CM3                 0x82A
+#define BWFM_AGENT_CORE_ARM_CR4                 0x83E
+#define BWFM_AGENT_CORE_GCI                     0x840
+#define BWFM_AGENT_CORE_ARM_CA7                 0x847
+#define BWFM_AGENT_SYS_MEM                      0x849
+
+/* Chipcommon chip IDs (selected; Pi 3 = 43430, Pi 3B+/4 = 0x4345) */
+#define BRCM_CC_43430_CHIP_ID                   43430
+#define BRCM_CC_4345_CHIP_ID                    0x4345
+#define BRCM_CC_4339_CHIP_ID                    0x4339
+#define BRCM_CC_43340_CHIP_ID                   43340
+#define BRCM_CC_43362_CHIP_ID                   43362
+
+#endif /* BWFMREG_H */

--- a/arch/arm-native/soc/broadcom/2708/bwfm/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/mmakefile.src
@@ -1,0 +1,6 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+%build_module mmake=kernel-bwfm-bcm2708 	\
+  modname=bwfm modtype=resource		\
+  files="bwfm_init"

--- a/arch/arm-native/soc/broadcom/2708/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/mmakefile.src
@@ -13,6 +13,7 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 #MM kernel-gpio-bcm2708 \
 #MM kernel-mbox-bcm2708 \
 #MM kernel-dma-bcm2708 \
+#MM kernel-sdio-bcm2708 \
 #MM kernel-sdcard \
 #MM hidd-i2c-bcm2708 \
 #MM hidd-vc4gfx \
@@ -23,7 +24,7 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 
 PKG_LIBS      :=
 PKG_LIBS_ARCH :=
-PKG_RSRC      := gpio mbox dma
+PKG_RSRC      := gpio mbox dma sdio
 PKG_RSRC_ARCH :=
 PKG_DEVS      := sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer

--- a/arch/arm-native/soc/broadcom/2708/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/mmakefile.src
@@ -14,6 +14,7 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 #MM kernel-mbox-bcm2708 \
 #MM kernel-dma-bcm2708 \
 #MM kernel-sdio-bcm2708 \
+#MM kernel-bwfm-bcm2708 \
 #MM kernel-sdcard \
 #MM hidd-i2c-bcm2708 \
 #MM hidd-vc4gfx \
@@ -24,7 +25,7 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 
 PKG_LIBS      :=
 PKG_LIBS_ARCH :=
-PKG_RSRC      := gpio mbox dma sdio
+PKG_RSRC      := gpio mbox dma sdio bwfm
 PKG_RSRC_ARCH :=
 PKG_DEVS      := sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer

--- a/arch/arm-native/soc/broadcom/2708/sdio/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/sdio/mmakefile.src
@@ -1,0 +1,6 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+%build_module mmake=kernel-sdio-bcm2708 	\
+  modname=sdio modtype=resource		\
+  files="sdio_init"

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio.conf
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio.conf
@@ -1,0 +1,25 @@
+##begin config
+version 0.1
+residentpri 87
+libbase SDIOBase
+libbasetype struct SDIOBase
+##end config
+##begin cdef
+#include <inttypes.h>
+#include <exec/tasks.h>
+##end cdef
+##begin cdefprivate
+#include "sdio_private.h"
+##end cdefprivate
+##begin functionlist
+int SDIOProbe() ()
+uint8_t SDIOReadByte(uint32_t func, uint32_t addr) (D0, D1)
+void SDIOWriteByte(uint32_t func, uint32_t addr, uint8_t val) (D0, D1, D2)
+int SDIOReadExt(uint32_t func, uint32_t addr, void * buf, uint32_t len, uint32_t incr) (D0, D1, D2, D3, D4)
+int SDIOWriteExt(uint32_t func, uint32_t addr, void * buf, uint32_t len, uint32_t incr) (D0, D1, D2, D3, D4)
+int SDIOEnableFunction(uint32_t func) (D0)
+int SDIOSetBlockSize(uint32_t func, uint32_t size) (D0, D1)
+int SDIOIsPresent() ()
+int SDIOSetInterrupt(struct Task * task, uint32_t sigmask) (A0, D0)
+void SDIOAckInterrupt() ()
+##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
@@ -1,0 +1,1289 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    sdio.resource - SDIO host bound to the BCM2835 Arasan SDHCI controller.
+
+    On Raspberry Pi 3/3B/4 the Arasan controller (peripheral offset 0x300000)
+    is wired to the on-board Broadcom WiFi chip over a 4-bit SDIO bus, while
+    the SD card uses the separate SDHOST controller. This resource brings up
+    the Arasan controller, performs SDIO card initialisation (CMD5/CMD3/CMD7)
+    and exposes a generic CMD52/CMD53 function-I/O API for client drivers.
+
+    The low-level command issue mirrors the proven sequence in
+    rom/devs/sdcard/sdcard_bus.c (the BCM2835 Arasan needs an atomic 32-bit
+    TRANSFER_MODE+COMMAND write and a short delay between register writes),
+    but runs fully polled - no IRQ is routed to the ARM (SIGNAL_ENABLE = 0).
+*/
+
+#define DEBUG 0
+
+#include <aros/macros.h>
+#include <aros/debug.h>
+#include <aros/symbolsets.h>
+#include <aros/libcall.h>
+#include <proto/kernel.h>
+#include <proto/exec.h>
+#include <proto/mbox.h>
+#include <proto/sdio.h>
+
+#include <hardware/sdhc.h>
+#include <hardware/mmc.h>
+#include <hardware/videocore.h>
+
+#include "sdio_private.h"
+
+APTR KernelBase __attribute__((used)) = NULL;
+APTR MBoxBase __attribute__((used)) = NULL;
+
+/* VideoCore property-channel constants (not in the public videocore.h;
+ * mirrored from the sdcard driver's intern header). */
+#define VCMB_PROPCHAN           8
+#define VCPOWER_SDHCI           0
+#define VCPOWER_STATE_ON        (1 << 0)
+#define VCPOWER_STATE_WAIT      (1 << 1)
+#define VCCLOCK_SDHCI           1
+
+/*
+ * VideoCore firmware GPIO-expander property tags. On Pi 3/3B+/4 the WiFi
+ * enable line (WL_REG_ON / "WL_ON") is not a SoC GPIO but expander pin 1,
+ * reachable only through the firmware. Expander pins are addressed at an
+ * offset of RPI_EXP_GPIO_BASE in the firmware GPIO numbering; driving
+ * WL_ON high powers up the WiFi chip. These tag values and the config
+ * payload order are part of the VideoCore firmware mailbox ABI.
+ */
+#define RPI_FW_SET_GPIO_CONFIG  0x00038043
+#define RPI_FW_SET_GPIO_STATE   0x00038041
+#define RPI_FW_GET_GPIO_STATE   0x00030041
+#define RPI_FW_TAG_RESP         0x80000000      /* set in tag size word when handled */
+#define RPI_EXP_GPIO_BASE       128
+#define RPI_EXP_GPIO_WL_ON      1
+#define RPI_EXP_GPIO_DIR_OUT    1
+
+/*
+ * The BCM434xx combo chip needs a 32.768 kHz low-power oscillator (LPO)
+ * clock to run its internal logic, including the SDIO core. On the Pi
+ * 3/3B+ the SoC supplies it on GPCLK2 (GPIO43), but the firmware does not
+ * start it for us: GPIO43 comes up as a plain input. Without the LPO the
+ * chip stays asleep and never answers CMD5.
+ * Derive ~32.768 kHz from the 19.2 MHz crystal with the MASH-1 fractional
+ * divider: 19.2e6 / 585.9375 = 32768 Hz (DIVI 585, DIVF 0.9375*4096=3840).
+ */
+#define CM_GP2CTL               (CLOCK_BASE + 0x80)
+#define CM_GP2DIV               (CLOCK_BASE + 0x84)
+#define SDIO_LPO_DIVI           585
+#define SDIO_LPO_DIVF           3840
+
+/* MMC command opcodes reused from the memory-card set */
+#define SDIO_CMD_SEND_RELATIVE_ADDR     MMC_CMD_SET_RELATIVE_ADDR       /* CMD3, R6 */
+#define SDIO_CMD_SELECT_CARD            MMC_CMD_SELECT_CARD             /* CMD7, R1b */
+
+#define SDIO_IDENT_CLOCK                400000          /* 400 kHz identification clock */
+#define SDIO_FULL_CLOCK                 25000000        /* post-init bus clock target */
+
+/* ----------------------------------------------------------------------- */
+/* Timing                                                                  */
+
+static inline ULONG sdio_now(struct SDIOBase *SDIOBase)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)SYSTIMER_CLO);
+}
+
+static void sdio_udelay(struct SDIOBase *SDIOBase, ULONG us)
+{
+    ULONG start = sdio_now(SDIOBase);
+
+    while ((sdio_now(SDIOBase) - start) < us)
+        ;
+}
+
+/* ----------------------------------------------------------------------- */
+/* MMIO accessors (SDHCI registers are 8/16/32-bit; the bus requires       */
+/* 32-bit aligned access, and back-to-back writes need a short gap).       */
+
+static UBYTE sdio_rb(struct SDIOBase *SDIOBase, ULONG reg)
+{
+    ULONG val = AROS_LE2LONG(*(volatile ULONG *)((SDIOBase->sdio_iobase + reg) & ~3));
+    return (val >> ((reg & 3) << 3)) & 0xFF;
+}
+
+static UWORD sdio_rw(struct SDIOBase *SDIOBase, ULONG reg)
+{
+    ULONG val = AROS_LE2LONG(*(volatile ULONG *)((SDIOBase->sdio_iobase + reg) & ~3));
+    return (val >> (((reg >> 1) & 1) << 4)) & 0xFFFF;
+}
+
+static ULONG sdio_rl(struct SDIOBase *SDIOBase, ULONG reg)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)(SDIOBase->sdio_iobase + reg));
+}
+
+static void sdio_wl(struct SDIOBase *SDIOBase, ULONG reg, ULONG val)
+{
+    /* BCM2835 Arasan erratum: two SD-clock cycles must elapse between
+     * successive controller writes. At the 400 kHz identification clock
+     * that is 5 us; use 6 us to match the proven sdcard_bcm2708bus.c. */
+    while ((sdio_now(SDIOBase) - SDIOBase->sdio_LastWrite) < 6)
+        ;
+
+    *(volatile ULONG *)(SDIOBase->sdio_iobase + reg) = AROS_LONG2LE(val);
+    SDIOBase->sdio_LastWrite = sdio_now(SDIOBase);
+}
+
+static void sdio_wb(struct SDIOBase *SDIOBase, ULONG reg, UBYTE val)
+{
+    ULONG cur = AROS_LE2LONG(*(volatile ULONG *)((SDIOBase->sdio_iobase + reg) & ~3));
+    ULONG shift = (reg & 3) << 3;
+    ULONG mask = 0xFF << shift;
+
+    sdio_wl(SDIOBase, reg & ~3, (cur & ~mask) | (val << shift));
+}
+
+static void sdio_ww(struct SDIOBase *SDIOBase, ULONG reg, UWORD val)
+{
+    ULONG cur = AROS_LE2LONG(*(volatile ULONG *)((SDIOBase->sdio_iobase + reg) & ~3));
+    ULONG shift = ((reg >> 1) & 1) << 4;
+    ULONG mask = 0xFFFF << shift;
+
+    sdio_wl(SDIOBase, reg & ~3, (cur & ~mask) | (val << shift));
+}
+
+/*
+ * Raw 32-bit access to the PIO data port (SDHCI_BUFFER). The inter-write
+ * erratum delay in sdio_wl applies to *control* registers only; the data
+ * FIFO must be filled/drained at full speed (the reference driver polls
+ * with no per-word delay), so these bypass it.
+ */
+static inline ULONG sdio_fifo_r(struct SDIOBase *SDIOBase)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)(SDIOBase->sdio_iobase + SDHCI_BUFFER));
+}
+
+static inline void sdio_fifo_w(struct SDIOBase *SDIOBase, ULONG val)
+{
+    *(volatile ULONG *)(SDIOBase->sdio_iobase + SDHCI_BUFFER) = AROS_LONG2LE(val);
+}
+
+/* ----------------------------------------------------------------------- */
+/* Controller bring-up                                                     */
+
+static void sdio_softreset(struct SDIOBase *SDIOBase, UBYTE mask)
+{
+    ULONG timeout = 100;
+
+    sdio_wb(SDIOBase, SDHCI_RESET, mask);
+    while (sdio_rb(SDIOBase, SDHCI_RESET) & mask)
+    {
+        if (timeout-- == 0)
+        {
+            D(bug("[SDIO] reset timeout (mask 0x%02x)\n", mask));
+            break;
+        }
+        sdio_udelay(SDIOBase, 1000);
+    }
+}
+
+static void sdio_setclock(struct SDIOBase *SDIOBase, ULONG speed)
+{
+    ULONG n, timeout;
+    UWORD ctrl;
+
+    /*
+     * SDHCI clock = base / (2 * N). The BCM2835 Arasan core requires the
+     * divisor N to be a power of two (a linear value leaves multiple bits
+     * set in the frequency-select field and produces a bad/no SD clock).
+     * Pick the smallest power-of-two N giving <= speed.
+     */
+    n = 1;
+    while ((SDIOBase->sdio_ClockMax / (2 * n)) > speed && n < 0x400)
+        n <<= 1;          /* 10-bit divider (8 low + 2 high), so up to 0x3ff */
+
+    ctrl = ((n & SDHCI_DIV_MASK) << SDHCI_DIVIDER_SHIFT) |
+           (((n >> SDHCI_DIV_MASK_LEN) & 0x3) << SDHCI_DIVIDER_HI_SHIFT);
+
+    D(bug("[SDIO] clock divisor N=%u -> ~%u Hz (ctrl 0x%04x)\n",
+          n, SDIOBase->sdio_ClockMax / (2 * n), ctrl));
+
+    sdio_ww(SDIOBase, SDHCI_CLOCK_CONTROL, 0);
+    sdio_ww(SDIOBase, SDHCI_CLOCK_CONTROL, ctrl | SDHCI_CLOCK_INT_EN);
+
+    timeout = 20;
+    while (!(sdio_rw(SDIOBase, SDHCI_CLOCK_CONTROL) & SDHCI_CLOCK_INT_STABLE))
+    {
+        if (timeout-- == 0)
+        {
+            D(bug("[SDIO] clock failed to stabilise\n"));
+            break;
+        }
+        sdio_udelay(SDIOBase, 1000);
+    }
+
+    ctrl = sdio_rw(SDIOBase, SDHCI_CLOCK_CONTROL) | SDHCI_CLOCK_CARD_EN;
+    sdio_ww(SDIOBase, SDHCI_CLOCK_CONTROL, ctrl);
+}
+
+static void sdio_setpower(struct SDIOBase *SDIOBase)
+{
+    sdio_wb(SDIOBase, SDHCI_POWER_CONTROL, SDHCI_POWER_330);
+    sdio_wb(SDIOBase, SDHCI_POWER_CONTROL, SDHCI_POWER_330 | SDHCI_POWER_ON);
+    sdio_udelay(SDIOBase, 10000);       /* let the rail ramp before the first CMD */
+}
+
+/*
+ * Route GPIO 34-39 to ALT3 (= SD1 / Arasan SDHCI), the WiFi SDIO bus on
+ * Pi 3/3B/4. The SD card uses GPIO 48-53 on the SDHOST controller and is
+ * untouched here.
+ */
+static void sdio_gpio_mux(struct SDIOBase *SDIOBase)
+{
+    volatile ULONG *fsel3 = (volatile ULONG *)GPFSEL3;
+    ULONG val = AROS_LE2LONG(*fsel3);
+    int pin;
+
+    /* GPIO 34..39 occupy fields 4..9 of GPFSEL3 (3 bits each). The function
+     * select encoding for ALT3 is 0b111 (7). */
+    for (pin = 34; pin <= 39; pin++)
+    {
+        int shift = (pin % 10) * 3;
+        val &= ~(0x7 << shift);
+        val |= (0x7 << shift);          /* ALT3 = SD1 / Arasan SDHCI */
+    }
+    *fsel3 = AROS_LONG2LE(val);
+
+    D(bug("[SDIO] GPIO34-39 -> ALT3 (GPFSEL3=0x%08x)\n", val));
+}
+
+/*
+ * Pull configuration for the SDIO bus, matching the Pi device tree:
+ * CLK (GPIO34) no pull, CMD/DAT (GPIO35-39) pull-up. Uses the legacy
+ * BCM2835 GPPUD/GPPUDCLK clocked sequence (bank 1 = GPIO32-53).
+ */
+static void sdio_gpio_pulls(struct SDIOBase *SDIOBase)
+{
+    volatile ULONG *gppud = (volatile ULONG *)GPPUD;
+    volatile ULONG *clk1 = (volatile ULONG *)GPPUDCLK1;
+
+    /* GPIO35-39: pull-up (GPPUD = 2) */
+    *gppud = AROS_LONG2LE(2);
+    sdio_udelay(SDIOBase, 1);
+    *clk1 = AROS_LONG2LE((1 << 3) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7));
+    sdio_udelay(SDIOBase, 1);
+    *gppud = AROS_LONG2LE(0);
+    *clk1 = AROS_LONG2LE(0);
+
+    /* GPIO34: no pull (GPPUD = 0) */
+    *gppud = AROS_LONG2LE(0);
+    sdio_udelay(SDIOBase, 1);
+    *clk1 = AROS_LONG2LE(1 << 2);
+    sdio_udelay(SDIOBase, 1);
+    *gppud = AROS_LONG2LE(0);
+    *clk1 = AROS_LONG2LE(0);
+}
+
+/*
+ * Start the 32.768 kHz LPO clock the WiFi chip runs from, on GPCLK2/GPIO43.
+ * Must run before WL_REG_ON so the clock is stable when the chip powers up.
+ */
+static void sdio_wifi_clock(struct SDIOBase *SDIOBase)
+{
+    volatile ULONG *ctl = (volatile ULONG *)CM_GP2CTL;
+    volatile ULONG *divr = (volatile ULONG *)CM_GP2DIV;
+    volatile ULONG *fsel4 = (volatile ULONG *)GPFSEL4;
+    int shift = (43 % 10) * 3;          /* GPIO43 = field 3 of GPFSEL4 */
+    ULONG val, timeout;
+
+    D(bug("[SDIO] GPCLK2 before: CTL=0x%08x DIV=0x%08x GPFSEL4=0x%08x\n",
+          AROS_LE2LONG(*ctl), AROS_LE2LONG(*divr), AROS_LE2LONG(*fsel4)));
+
+    /* Stop the clock generator and wait for it to go idle */
+    *ctl = AROS_LONG2LE(CM_PASSWORD | CM_SRC_OSC);
+    timeout = 1000;
+    while ((AROS_LE2LONG(*ctl) & CM_BUSY) && timeout--)
+        sdio_udelay(SDIOBase, 10);
+
+    /* Fractional (MASH-1) divider from the 19.2 MHz crystal */
+    *divr = AROS_LONG2LE(CM_PASSWORD | (SDIO_LPO_DIVI << 12) | SDIO_LPO_DIVF);
+
+    /* Select source + MASH, then enable in a second write (per datasheet) */
+    *ctl = AROS_LONG2LE(CM_PASSWORD | CM_MASH(1) | CM_SRC_OSC);
+    *ctl = AROS_LONG2LE(CM_PASSWORD | CM_MASH(1) | CM_SRC_OSC | CM_ENAB);
+    timeout = 1000;
+    while (!(AROS_LE2LONG(*ctl) & CM_BUSY) && timeout--)
+        sdio_udelay(SDIOBase, 10);
+
+    /* Route GPIO43 to ALT0 = GPCLK2 */
+    val = AROS_LE2LONG(*fsel4);
+    val &= ~(0x7 << shift);
+    val |= (0x4 << shift);              /* ALT0 */
+    *fsel4 = AROS_LONG2LE(val);
+
+    D(bug("[SDIO] GPCLK2 32kHz LPO on GPIO43: CTL=0x%08x DIV=0x%08x GPFSEL4=0x%08x\n",
+          AROS_LE2LONG(*ctl), AROS_LE2LONG(*divr), AROS_LE2LONG(*fsel4)));
+}
+
+/*
+ * Power up the WiFi chip by driving WL_REG_ON (firmware expander pin 1)
+ * high via the VideoCore property mailbox. Without this the chip stays
+ * unpowered and never answers CMD5.
+ */
+static void sdio_wifi_power(struct SDIOBase *SDIOBase)
+{
+    unsigned int *raw = AllocMem(16 * 4 + 16, MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *msg;
+    unsigned int gpio = RPI_EXP_GPIO_BASE + RPI_EXP_GPIO_WL_ON;
+    int state;
+
+    if (!raw)
+        return;
+    msg = (unsigned int *)((((IPTR)raw) + 15) & ~15);
+
+    /* Configure the expander pin as an output (initial level low) */
+    msg[0] = AROS_LONG2LE(12 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(RPI_FW_SET_GPIO_CONFIG);
+    msg[3] = AROS_LONG2LE(24);
+    msg[4] = 0;                                     /* req/resp code: 0 on request */
+    msg[5] = AROS_LONG2LE(gpio);
+    msg[6] = AROS_LONG2LE(RPI_EXP_GPIO_DIR_OUT);    /* direction */
+    msg[7] = AROS_LONG2LE(0);                       /* polarity */
+    msg[8] = AROS_LONG2LE(0);                       /* term_en */
+    msg[9] = AROS_LONG2LE(0);                       /* term_pull_up */
+    msg[10] = AROS_LONG2LE(0);                      /* state */
+    msg[11] = 0;
+    MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+    D(bug("[SDIO] SET_GPIO_CONFIG resp 0x%08x tag 0x%08x\n",
+          AROS_LE2LONG(msg[1]), AROS_LE2LONG(msg[4])));
+
+    /* Power cycle WL_REG_ON: drive low, settle, then high */
+    for (state = 0; state <= 1; state++)
+    {
+        msg[0] = AROS_LONG2LE(8 * 4);
+        msg[1] = AROS_LONG2LE(VCTAG_REQ);
+        msg[2] = AROS_LONG2LE(RPI_FW_SET_GPIO_STATE);
+        msg[3] = AROS_LONG2LE(8);
+        msg[4] = 0;                                 /* req/resp code: 0 on request */
+        msg[5] = AROS_LONG2LE(gpio);
+        msg[6] = AROS_LONG2LE(state);
+        msg[7] = 0;
+        MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+        D(bug("[SDIO] SET_GPIO_STATE %d resp 0x%08x tag 0x%08x\n",
+              state, AROS_LE2LONG(msg[1]), AROS_LE2LONG(msg[4])));
+        sdio_udelay(SDIOBase, 10000);
+    }
+
+    /* Read the pin back to confirm the firmware actually drives it */
+    msg[0] = AROS_LONG2LE(8 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(RPI_FW_GET_GPIO_STATE);
+    msg[3] = AROS_LONG2LE(8);
+    msg[4] = 0;                                     /* req/resp code: 0 on request */
+    msg[5] = AROS_LONG2LE(gpio);
+    msg[6] = 0;
+    msg[7] = 0;
+    MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+    D(bug("[SDIO] GET_GPIO_STATE gpio %u -> state %u (tag 0x%08x)\n",
+          gpio, AROS_LE2LONG(msg[6]), AROS_LE2LONG(msg[4])));
+
+    FreeMem(raw, 16 * 4 + 16);
+
+    D(bug("[SDIO] WL_REG_ON sequence done\n"));
+}
+
+/* ----------------------------------------------------------------------- */
+/* VideoCore mailbox: power the Arasan controller and read its base clock  */
+
+static int sdio_mbox_setup(struct SDIOBase *SDIOBase)
+{
+    unsigned int *raw = AllocMem(8 * 4 + 16, MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *msg = (unsigned int *)((((IPTR)raw) + 15) & ~15);
+    int ok = FALSE;
+
+    if (!raw)
+        return FALSE;
+
+    /* Power on the SDHCI controller */
+    msg[0] = AROS_LONG2LE(8 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(VCTAG_SETPOWER);
+    msg[3] = AROS_LONG2LE(8);
+    msg[4] = AROS_LONG2LE(8);
+    msg[5] = AROS_LONG2LE(VCPOWER_SDHCI);
+    msg[6] = AROS_LONG2LE(VCPOWER_STATE_ON | VCPOWER_STATE_WAIT);
+    msg[7] = 0;
+    MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+
+    /*
+     * Enable the EMMC/SDHCI clock (id 1). AROS drives the SD card via the
+     * SDHOST controller, so the firmware may have gated the Arasan clock
+     * off - without it the controller has no clock to drive the bus and
+     * every command times out. (WiFiPi does set_clock_state(1,1) here.)
+     */
+    msg[0] = AROS_LONG2LE(8 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(VCTAG_SETCLKSTATE);
+    msg[3] = AROS_LONG2LE(8);
+    msg[4] = AROS_LONG2LE(8);
+    msg[5] = AROS_LONG2LE(VCCLOCK_SDHCI);
+    msg[6] = AROS_LONG2LE(1);                   /* bit0 = enable */
+    msg[7] = 0;
+    MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+    D(bug("[SDIO] SETCLKSTATE resp 0x%08x state 0x%08x\n",
+          AROS_LE2LONG(msg[1]), AROS_LE2LONG(msg[6])));
+
+    /* Query the controller base clock */
+    msg[0] = AROS_LONG2LE(8 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);
+    msg[3] = AROS_LONG2LE(8);
+    msg[4] = AROS_LONG2LE(4);
+    msg[5] = AROS_LONG2LE(VCCLOCK_SDHCI);
+    msg[6] = 0;
+    msg[7] = 0;
+    if (MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg) == msg)
+    {
+        SDIOBase->sdio_ClockMax = AROS_LE2LONG(msg[6]);
+        ok = (SDIOBase->sdio_ClockMax != 0);
+    }
+
+    FreeMem(raw, 8 * 4 + 16);
+    return ok;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Polled command engine                                                   */
+
+#define SDIO_CMD_ERR    (SDHCI_INT_ERROR | SDHCI_INT_TIMEOUT | SDHCI_INT_CRC | \
+                         SDHCI_INT_END_BIT | SDHCI_INT_INDEX)
+
+/* SDHCI "Transfer Complete" is bit 1. hardware/sdhc.h mislabels bit 2 as
+ * SDHCI_INT_DATA_END (bit 2 is actually Block Gap Event, which never fires
+ * for a normal transfer), so use the correct bit for the data-phase done
+ * wait. (Not fixing the shared header - the sdcard driver tolerates it by
+ * also exiting on byte-count.) */
+#define SDIO_INT_XFER_DONE      (1 << 1)
+
+/* Verbose per-command tracing - enabled only around the bring-up probe so
+ * normal CMD52/CMD53 traffic stays quiet once the chip answers. */
+static int sdio_trace = 0;
+
+/* Trace the first few DATA-phase (CMD53 with payload) transfers so the first
+ * large transfer (firmware upload) can be diagnosed without flooding. */
+static int sdio_data_trace = 6;
+
+/* One-shot full controller register snapshot for bring-up diagnosis. */
+static void sdio_dumpregs(struct SDIOBase *SDIOBase, const char *when)
+{
+    D(bug("[SDIO] regs (%s):\n", when));
+    D(bug("[SDIO]   BLKSZ=0x%04x BLKCNT=0x%04x ARG=0x%08x TM/CMD=0x%08x\n",
+          sdio_rw(SDIOBase, SDHCI_BLOCK_SIZE), sdio_rw(SDIOBase, SDHCI_BLOCK_COUNT),
+          sdio_rl(SDIOBase, SDHCI_ARGUMENT), sdio_rl(SDIOBase, SDHCI_TRANSFER_MODE)));
+    D(bug("[SDIO]   PRESENT=0x%08x HOSTCTL=0x%02x PWR=0x%02x CLKCTL=0x%04x TMOUT=0x%02x\n",
+          sdio_rl(SDIOBase, SDHCI_PRESENT_STATE), sdio_rb(SDIOBase, SDHCI_HOST_CONTROL),
+          sdio_rb(SDIOBase, SDHCI_POWER_CONTROL), sdio_rw(SDIOBase, SDHCI_CLOCK_CONTROL),
+          sdio_rb(SDIOBase, SDHCI_TIMEOUT_CONTROL)));
+    D(bug("[SDIO]   INTSTAT=0x%08x INTEN=0x%08x SIGEN=0x%08x CTRL2=0x%08x CAPS=0x%08x\n",
+          sdio_rl(SDIOBase, SDHCI_INT_STATUS), sdio_rl(SDIOBase, SDHCI_INT_ENABLE),
+          sdio_rl(SDIOBase, SDHCI_SIGNAL_ENABLE), sdio_rl(SDIOBase, SDHCI_ACMD12_ERR),
+          sdio_rl(SDIOBase, SDHCI_CAPABILITIES)));
+    /* GPIO function-select banks: GPFSEL3 must still read 0x3ffff000 (GPIO
+     * 34-39 = ALT3/SD1). If it changed, the VideoCore firmware re-muxed the
+     * SDIO pins away from the Arasan and our commands never reach the chip. */
+    D(bug("[SDIO]   GPFSEL3=0x%08x GPFSEL4=0x%08x GPFSEL5=0x%08x\n",
+          AROS_LE2LONG(*(volatile ULONG *)GPFSEL3),
+          AROS_LE2LONG(*(volatile ULONG *)GPFSEL4),
+          AROS_LE2LONG(*(volatile ULONG *)GPFSEL5)));
+}
+
+/*
+ * blksz > 0 selects multi-block mode (BLOCK_SIZE=blksz, BLOCK_COUNT=datalen/
+ * blksz, TRANSMOD_MULTI) - required for CMD53 transfers larger than a single
+ * byte-mode access on a given function. blksz == 0 is single byte-mode.
+ */
+static int sdio_command(struct SDIOBase *SDIOBase, UWORD cmd, ULONG arg,
+                        ULONG rsptype, ULONG *resp,
+                        APTR data, ULONG datalen, int dataread, ULONG blksz)
+{
+    ULONG inhibit = SDHCI_PS_CMD_INHIBIT | SDHCI_PS_DATA_INHIBIT;
+    ULONG timeout, status;
+    UWORD flags, transmode = 0;
+
+    /* Wait for the controller to be ready (a slow in-flight data block at the
+     * 400 kHz ident clock can hold DATA_INHIBIT for ~10 ms, so allow margin). */
+    timeout = 200;
+    while (sdio_rl(SDIOBase, SDHCI_PRESENT_STATE) & inhibit)
+    {
+        if (timeout-- == 0)
+        {
+            D(bug("[SDIO] CMD%u: inhibit stuck (PRESENT=0x%08x)\n", cmd,
+                  sdio_rl(SDIOBase, SDHCI_PRESENT_STATE)));
+            sdio_softreset(SDIOBase, SDHCI_RESET_CMD);
+            sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+            return -1;
+        }
+        sdio_udelay(SDIOBase, 1000);
+    }
+
+    sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDHCI_INT_ALL_MASK);
+
+    if (!(rsptype & MMC_RSP_PRESENT))
+        flags = SDHCI_CMD_RESP_NONE;
+    else if (rsptype & MMC_RSP_136)
+        flags = SDHCI_CMD_RESP_LONG;
+    else if (rsptype & MMC_RSP_BUSY)
+        flags = SDHCI_CMD_RESP_SHORT_BUSY;
+    else
+        flags = SDHCI_CMD_RESP_SHORT;
+
+    if (rsptype & MMC_RSP_CRC)
+        flags |= SDHCI_CMD_CRC;
+    if (rsptype & MMC_RSP_OPCODE)
+        flags |= SDHCI_CMD_INDEX;
+
+    if (datalen > 0)
+    {
+        flags |= SDHCI_CMD_DATA;
+        transmode = SDHCI_TRANSMOD_BLK_CNT_EN;
+        if (dataread)
+            transmode |= SDHCI_TRANSMOD_READ;
+
+        sdio_wb(SDIOBase, SDHCI_TIMEOUT_CONTROL, SDHCI_TIMEOUT_MAX);
+        if (blksz > 0)
+        {
+            /* Block mode: datalen/blksz blocks of blksz bytes */
+            transmode |= SDHCI_TRANSMOD_MULTI;
+            sdio_ww(SDIOBase, SDHCI_BLOCK_SIZE, SDHCI_MAKE_BLCKSIZE(1, blksz));
+            sdio_ww(SDIOBase, SDHCI_BLOCK_COUNT, datalen / blksz);
+        }
+        else
+        {
+            /* Byte mode: one "block" of datalen bytes */
+            sdio_ww(SDIOBase, SDHCI_BLOCK_SIZE, SDHCI_MAKE_BLCKSIZE(1, datalen));
+            sdio_ww(SDIOBase, SDHCI_BLOCK_COUNT, 1);
+        }
+    }
+
+    sdio_wl(SDIOBase, SDHCI_ARGUMENT, arg);
+
+    /* BCM2835 Arasan: TRANSFER_MODE and COMMAND must be written together
+     * as a single 32-bit access when a data phase is present. */
+    if (datalen > 0)
+        sdio_wl(SDIOBase, SDHCI_TRANSFER_MODE,
+                (SDHCI_MAKE_CMD(cmd, flags) << 16) | transmode);
+    else
+        sdio_ww(SDIOBase, SDHCI_COMMAND, SDHCI_MAKE_CMD(cmd, flags));
+
+    if (sdio_trace)
+    {
+        /* Capture the controller state the instant the command is issued,
+         * BEFORE any (slow) serial output: if CMD_INHIBIT (PRESENT bit0) is
+         * set here the controller accepted the command and is clocking it
+         * out; if it never sets, the COMMAND write didn't start a transfer. */
+        ULONG ps0 = sdio_rl(SDIOBase, SDHCI_PRESENT_STATE);
+        ULONG is0 = sdio_rl(SDIOBase, SDHCI_INT_STATUS);
+        D(bug("[SDIO] CMD%u arg=0x%08x flags=0x%02x issued: PRESENT=0x%08x INT=0x%08x ARGrb=0x%08x CMDrb=0x%04x\n",
+              cmd, arg, flags, ps0, is0,
+              sdio_rl(SDIOBase, SDHCI_ARGUMENT), sdio_rw(SDIOBase, SDHCI_COMMAND)));
+    }
+
+    {
+    ULONG started = sdio_now(SDIOBase);
+    timeout = 100000;
+    while (!((status = sdio_rl(SDIOBase, SDHCI_INT_STATUS)) & (SDHCI_INT_RESPONSE | SDIO_CMD_ERR)))
+    {
+        if (timeout-- == 0)
+        {
+            D(bug("[SDIO] CMD%u: response timeout (status 0x%08x PRESENT=0x%08x)\n",
+                  cmd, status, sdio_rl(SDIOBase, SDHCI_PRESENT_STATE)));
+            sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDHCI_INT_ALL_MASK);
+            sdio_softreset(SDIOBase, SDHCI_RESET_CMD);
+            if (datalen > 0)            /* don't leave a pending CMD53 data phase
+                                         * half-armed - the next CMD53 would see
+                                         * stale DATA_AVAIL/SPACE_AVAIL */
+                sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+            return -1;
+        }
+        sdio_udelay(SDIOBase, 10);
+    }
+
+    if (status & SDIO_CMD_ERR)
+    {
+        D(bug("[SDIO] CMD%u: error status 0x%08x after %uus PRESENT=0x%08x\n",
+              cmd, status, sdio_now(SDIOBase) - started,
+              sdio_rl(SDIOBase, SDHCI_PRESENT_STATE)));
+        sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDHCI_INT_ALL_MASK);
+        sdio_softreset(SDIOBase, SDHCI_RESET_CMD);
+        if (datalen > 0)                /* clear a half-armed data phase so the
+                                         * next CMD53 doesn't desync on the FIFO */
+            sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+        return -1;
+    }
+    if (sdio_trace)
+        D(bug("[SDIO] CMD%u: response after %uus (status 0x%08x)\n",
+              cmd, sdio_now(SDIOBase) - started, status));
+    }
+
+    if (resp && (rsptype & MMC_RSP_PRESENT) && !(rsptype & MMC_RSP_136))
+        *resp = sdio_rl(SDIOBase, SDHCI_RESPONSE);
+
+    /* W1C the response bit */
+    sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDHCI_INT_RESPONSE);
+
+    /* PIO data phase */
+    if (datalen > 0)
+    {
+        ULONG intmask = dataread ? SDHCI_INT_DATA_AVAIL : SDHCI_INT_SPACE_AVAIL;
+        ULONG bsize = (blksz > 0) ? blksz : datalen;    /* bytes per buffer-ready */
+        ULONG nblk = (blksz > 0) ? (datalen / blksz) : 1;
+        ULONG blk, off2 = 0;
+        int dtr = (sdio_data_trace > 0 && datalen > 64);    /* skip tiny attach reads */
+
+        if (dtr)
+            D(bug("[SDIO] CMD%u data %s len=%u blksz=%u PRESENT=0x%08x INT=0x%08x\n",
+                  cmd, dataread ? "rd" : "wr", datalen, blksz,
+                  sdio_rl(SDIOBase, SDHCI_PRESENT_STATE),
+                  sdio_rl(SDIOBase, SDHCI_INT_STATUS)));
+
+        /* One buffer-ready handshake + PIO transfer per block. */
+        for (blk = 0; blk < nblk; blk++)
+        {
+            ULONG words = (bsize + 3) >> 2, w;
+
+            timeout = 100000;
+            while (!(sdio_rl(SDIOBase, SDHCI_INT_STATUS) & (intmask | SDIO_CMD_ERR)))
+            {
+                if (timeout-- == 0)
+                {
+                    D(bug("[SDIO] CMD%u: data ready timeout blk %u (INT=0x%08x PRESENT=0x%08x)\n",
+                          cmd, blk, sdio_rl(SDIOBase, SDHCI_INT_STATUS),
+                          sdio_rl(SDIOBase, SDHCI_PRESENT_STATE)));
+                    sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+                    return -1;
+                }
+                sdio_udelay(SDIOBase, 10);
+            }
+            if (sdio_rl(SDIOBase, SDHCI_INT_STATUS) & SDIO_CMD_ERR)
+            {
+                D(bug("[SDIO] CMD%u: data error blk %u INT=0x%08x\n", cmd, blk,
+                      sdio_rl(SDIOBase, SDHCI_INT_STATUS)));
+                sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDHCI_INT_ALL_MASK);
+                sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+                return -1;
+            }
+            sdio_wl(SDIOBase, SDHCI_INT_STATUS, intmask);
+
+            for (w = 0; w < words; w++)
+            {
+                ULONG n = bsize - (w << 2);
+                if (n > 4)
+                    n = 4;
+                if (dataread)
+                {
+                    ULONG v = sdio_fifo_r(SDIOBase);
+                    CopyMem(&v, (UBYTE *)data + off2 + (w << 2), n);
+                }
+                else
+                {
+                    ULONG v = 0;
+                    CopyMem((UBYTE *)data + off2 + (w << 2), &v, n);
+                    sdio_fifo_w(SDIOBase, v);
+                }
+            }
+            off2 += bsize;
+        }
+
+        timeout = 100000;
+        while (!(sdio_rl(SDIOBase, SDHCI_INT_STATUS) & (SDIO_INT_XFER_DONE | SDIO_CMD_ERR)))
+        {
+            if (timeout-- == 0)
+            {
+                D(bug("[SDIO] CMD%u: data end timeout (INT=0x%08x PRESENT=0x%08x)\n",
+                      cmd, sdio_rl(SDIOBase, SDHCI_INT_STATUS),
+                      sdio_rl(SDIOBase, SDHCI_PRESENT_STATE)));
+                sdio_softreset(SDIOBase, SDHCI_RESET_DATA);
+                return -1;
+            }
+            sdio_udelay(SDIOBase, 10);
+        }
+        sdio_wl(SDIOBase, SDHCI_INT_STATUS, SDIO_INT_XFER_DONE);
+
+        if (dtr)
+        {
+            D(bug("[SDIO] CMD%u data done PRESENT=0x%08x INT=0x%08x\n", cmd,
+                  sdio_rl(SDIOBase, SDHCI_PRESENT_STATE),
+                  sdio_rl(SDIOBase, SDHCI_INT_STATUS)));
+            sdio_data_trace--;
+        }
+    }
+
+    return 0;
+}
+
+/* CMD52 - single register read/write */
+static int sdio_rw_direct(struct SDIOBase *SDIOBase, int write, uint32_t func,
+                          uint32_t addr, uint8_t in, uint8_t *out)
+{
+    ULONG arg, resp = 0;
+    int err;
+
+    arg = (func << SDIO_ARG_FUNC_SHIFT) | ((addr & SDIO_ARG_ADDR_MASK) << SDIO_ARG_ADDR_SHIFT);
+    if (write)
+        arg |= SDIO_ARG_RW_WRITE | (out ? SDIO_ARG_RAW : 0) | in;
+
+    err = sdio_command(SDIOBase, SDIO_CMD_IO_RW_DIRECT, arg, MMC_RSP_R5, &resp, NULL, 0, 0, 0);
+    if (err)
+        return err;
+
+    if ((resp >> 8) & SDIO_R5_ERRORS)
+    {
+        D(bug("[SDIO] CMD52 R5 flags 0x%02x (func %u addr 0x%05x)\n",
+              (resp >> 8) & 0xff, func, addr));
+        return -1;
+    }
+
+    if (out)
+        *out = resp & 0xff;
+    return 0;
+}
+
+/*
+ * CMD53 - extended read/write. A single CMD53 moves at most 512 bytes (byte
+ * mode) or 511 blocks (block mode), so larger transfers are split: whole
+ * blocks go in block mode (required by e.g. the func1 backplane and func2
+ * frame FIFO - a big byte-mode CMD53 returns R5 OUT_OF_RANGE), the sub-block
+ * remainder in byte mode. For incr==0 (func2 frame FIFO, func1 4-byte window)
+ * the address is fixed across chunks; for incr==1 (backplane RAM regions) it
+ * advances by the bytes moved. Without the split, an event/data frame larger
+ * than 512 bytes failed AND left the FIFO unread (desyncing every later read).
+ */
+static int sdio_rw_extended(struct SDIOBase *SDIOBase, int write, uint32_t func,
+                            uint32_t addr, APTR buf, uint32_t len, uint32_t incr)
+{
+    ULONG blksz = (func < 8) ? SDIOBase->sdio_BlkSize[func] : 0;
+    UBYTE *p = (UBYTE *)buf;
+
+    if (len == 0)
+        return -1;
+
+    while (len > 0)
+    {
+        ULONG arg, resp = 0, chunk;
+        int useblock, err;
+
+        if (blksz > 0 && len >= blksz)
+        {
+            ULONG nblk = len / blksz;
+
+            if (nblk > SDIO_ARG_COUNT_MASK)
+                nblk = SDIO_ARG_COUNT_MASK;
+            chunk = nblk * blksz;
+            useblock = 1;
+        }
+        else
+        {
+            chunk = (len > 512) ? 512 : len;
+            useblock = 0;
+        }
+
+        arg = (write ? SDIO_ARG_RW_WRITE : 0) | (func << SDIO_ARG_FUNC_SHIFT);
+        if (incr)
+            arg |= SDIO_ARG_OPCODE_INCR;
+        arg |= (addr & SDIO_ARG_ADDR_MASK) << SDIO_ARG_ADDR_SHIFT;
+        if (useblock)
+            arg |= SDIO_ARG_BLOCKMODE | ((chunk / blksz) & SDIO_ARG_COUNT_MASK);
+        else
+            arg |= (chunk == 512 ? 0 : chunk) & SDIO_ARG_COUNT_MASK;  /* 0 => 512 */
+
+        err = sdio_command(SDIOBase, SDIO_CMD_IO_RW_EXTENDED, arg, MMC_RSP_R5,
+                           &resp, p, chunk, write ? 0 : 1, useblock ? blksz : 0);
+        if (err)
+            return err;
+
+        if ((resp >> 8) & SDIO_R5_ERRORS)
+        {
+            D(bug("[SDIO] CMD53 R5 flags 0x%02x (func %u addr 0x%05x len %u %s)\n",
+                  (resp >> 8) & 0xff, func, addr, chunk, write ? "wr" : "rd"));
+            return -1;
+        }
+
+        p += chunk;
+        len -= chunk;
+        if (incr)
+            addr += chunk;
+    }
+
+    return 0;
+}
+
+/*
+ * Once the card is selected (CMD7), switch from the 1-bit / 400 kHz
+ * identification setup to a 4-bit bus at 25 MHz (SDIO default speed). Both
+ * card (CCCR) and host (Arasan HOST_CONTROL) must agree; CMD52 runs on the
+ * single CMD line so the width change is safe to issue before flipping the
+ * host. Hugely speeds up firmware upload + the datapath.
+ *
+ * NOTE: SDIO high-speed mode is deliberately NOT used. The BCM2835 Arasan
+ * SDHCI HISPD bit is a known-broken quirk - setting it wedged the bus (the
+ * next CMD52 timed out 0x18000). 25 MHz is the default-speed maximum, which
+ * needs no HISPD bit, so we cap there.
+ */
+static void sdio_set_bus_speed(struct SDIOBase *SDIOBase)
+{
+    uint8_t v = 0, ctrl;
+
+    /* 4-bit bus (CCCR Bus Interface Control 0x07, low 2 bits = 10b). */
+    if (sdio_rw_direct(SDIOBase, 0, 0, SDIO_CCCR_BUS_CONTROL, 0, &v) == 0)
+    {
+        v = (v & ~SDIO_CCCR_BUS_WIDTH_MASK) | SDIO_CCCR_BUS_WIDTH_4BIT;
+        if (sdio_rw_direct(SDIOBase, 1, 0, SDIO_CCCR_BUS_CONTROL, v, NULL) == 0)
+        {
+            ctrl = sdio_rb(SDIOBase, SDHCI_HOST_CONTROL) | SDHCI_HCTRL_4BITBUS;
+            sdio_wb(SDIOBase, SDHCI_HOST_CONTROL, ctrl);
+            D(bug("[SDIO] 4-bit bus enabled\n"));
+        }
+    }
+
+    sdio_setclock(SDIOBase, SDIO_FULL_CLOCK);
+}
+
+/*
+ * SDIO card identification: CMD5 OCR negotiation, CMD3 (relative address)
+ * and CMD7 (select). Caller holds sdio_Sem (or is single-threaded init).
+ */
+/* Defined below in the card-interrupt section; installed by sdio_do_probe. */
+static void sdio_irq_handler(void *data1, void *data2);
+
+static int sdio_do_probe(struct SDIOBase *SDIOBase)
+{
+    ULONG ocr = 0, resp = 0;
+    int retries;
+
+    /* The chip is initialised once (CMD5/CMD3/CMD7, card selected). A second
+     * full probe would send CMD0 + CMD5 to an already-selected card, which no
+     * longer answers the init-phase CMD5 - so report the cached result. bwfm
+     * calls SDIOProbe() before using the card; it must not re-initialise it. */
+    if (SDIOBase->sdio_Present)
+        return TRUE;
+
+    SDIOBase->sdio_Present = FALSE;
+
+    /* Lazy WiFi-chip bring-up: start the 32 kHz LPO and drive WL_REG_ON high,
+     * then let the chip's power-on reset settle before probing. Done here (not
+     * in sdio_init) so the chip stays unpowered until a client opens the bus.
+     * Re-running on a probe retry just re-asserts the same lines (harmless). */
+    sdio_wifi_clock(SDIOBase);
+    sdio_wifi_power(SDIOBase);
+    sdio_udelay(SDIOBase, 50000);
+
+    sdio_dumpregs(SDIOBase, "pre-probe");
+
+    /* Re-assert the SDIO pin mux: the firmware writes GPIO banks concurrently
+     * (GPFSEL4 was seen changing between reads), so 34-39 may have been
+     * re-routed since sdio_init muxed them. Harmless no-op if still ALT3. */
+    sdio_gpio_mux(SDIOBase);
+
+    sdio_trace = 1;             /* verbose per-command tracing for the probe */
+
+    /*
+     * SD/SDIO init preamble. The BCM43xx needs the standard SD reset +
+     * interface-condition handshake before it will answer CMD5; sending
+     * CMD5 cold (as a pure SDIO card would allow) just times out on this
+     * chip. CMD0/CMD8 results are advisory here - proceed regardless.
+     */
+    sdio_command(SDIOBase, MMC_CMD_GO_IDLE_STATE, 0, MMC_RSP_NONE, NULL, NULL, 0, 0, 0);
+    sdio_udelay(SDIOBase, 2000);
+    sdio_command(SDIOBase, SD_CMD_SEND_IF_COND, 0x1AA, MMC_RSP_R7, &resp, NULL, 0, 0, 0);
+
+    /* CMD5 with arg 0: read the I/O OCR */
+    if (sdio_command(SDIOBase, SDIO_CMD_IO_SEND_OP_COND, 0, MMC_RSP_R4, &ocr, NULL, 0, 0, 0))
+        return FALSE;
+
+    SDIOBase->sdio_NumFunc = (ocr & SDIO_OCR_NUM_FUNC_MASK) >> SDIO_OCR_NUM_FUNC_SHIFT;
+
+    /* CMD5 with the supported voltage window: wait for I/O ready */
+    for (retries = 100; retries > 0; retries--)
+    {
+        if (sdio_command(SDIOBase, SDIO_CMD_IO_SEND_OP_COND,
+                         ocr & SDIO_OCR_VOLTAGE_MASK, MMC_RSP_R4, &resp, NULL, 0, 0, 0))
+            return FALSE;
+        if (resp & SDIO_OCR_IOREADY)
+            break;
+        sdio_udelay(SDIOBase, 1000);
+    }
+    if (!(resp & SDIO_OCR_IOREADY))
+        return FALSE;
+
+    SDIOBase->sdio_OCR = resp;
+
+    /* CMD3: ask the card to publish its relative address */
+    if (sdio_command(SDIOBase, SDIO_CMD_SEND_RELATIVE_ADDR, 0, MMC_RSP_R6, &resp, NULL, 0, 0, 0))
+        return FALSE;
+    SDIOBase->sdio_RCA = (resp >> 16) & 0xffff;
+
+    /* CMD7: select the card (move to command state) */
+    if (sdio_command(SDIOBase, SDIO_CMD_SELECT_CARD,
+                     SDIOBase->sdio_RCA << 16, MMC_RSP_R1b, &resp, NULL, 0, 0, 0))
+        return FALSE;
+
+    /* Card selected: leave identification mode for 4-bit + full clock. */
+    sdio_set_bus_speed(SDIOBase);
+
+    SDIOBase->sdio_Present = TRUE;
+    sdio_trace = 0;
+
+    D(bug("[SDIO] SDIO device present: OCR 0x%08x, %u function(s), RCA 0x%04x\n",
+          SDIOBase->sdio_OCR, SDIOBase->sdio_NumFunc, SDIOBase->sdio_RCA));
+
+    /* Install the card-interrupt handler now that a device answered (stays
+     * masked out of INT_ENABLE until a consumer arms it via SDIOSetInterrupt).
+     * The sdio_Present guard above ensures this runs only once. */
+    if (SDIOBase->sdio_IRQHandle == NULL)
+    {
+        SDIOBase->sdio_IRQHandle = KrnAddIRQHandler(IRQ_VC_ARASANSDIO,
+                                                    sdio_irq_handler, SDIOBase, NULL);
+        D(bug("[SDIO] card IRQ handler %p on irq %u\n",
+              SDIOBase->sdio_IRQHandle, IRQ_VC_ARASANSDIO));
+    }
+    return TRUE;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Card interrupt (SDIO DAT1) -> consumer task                             */
+
+/*
+ * INT_ENABLE value with the card interrupt suppressed. On the BCM2835 Arasan
+ * the card interrupt reaches the ARM whenever it is SET in INT_STATUS, which
+ * is gated by INT_ENABLE (0x34) - NOT by SIGNAL_ENABLE (0x38). So masking via
+ * SIGNAL_ENABLE does nothing (a storm); we mask/arm the card int by toggling
+ * it in INT_ENABLE with constant writes (no read-modify-write race with the
+ * handler). The other (command/data) bits stay enabled for the polled path.
+ */
+#define SDIO_INTEN_BASE  (SDHCI_INT_ALL_MASK & ~SDHCI_INT_CARD_INT)
+
+/*
+ * Arasan IRQ handler. The only source we arm is the SDIO card interrupt (the
+ * chip pulls DAT1 low when SDPCMD_INTSTATUS has an enabled bit). Mask it here
+ * (drop CARD_INT from INT_ENABLE) so it cannot re-fire, and signal the bwfm RX
+ * pump. The pump clears the chip's SDPCMD_INTSTATUS - which releases DAT1 -
+ * drains its frames, then re-arms via SDIOAckInterrupt().
+ */
+static void sdio_irq_handler(void *data1, void *data2)
+{
+    struct SDIOBase *SDIOBase = (struct SDIOBase *)data1;
+
+    if (sdio_rl(SDIOBase, SDHCI_INT_STATUS) & SDHCI_INT_CARD_INT)
+    {
+        sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE);
+        if (SDIOBase->sdio_IRQTask)
+            Signal(SDIOBase->sdio_IRQTask, SDIOBase->sdio_IRQSig);
+    }
+}
+
+/* ----------------------------------------------------------------------- */
+/* Resource init                                                           */
+
+static int sdio_init(struct SDIOBase *SDIOBase)
+{
+    D(bug("[SDIO] %s()\n", __PRETTY_FUNCTION__));
+
+    KernelBase = OpenResource("kernel.resource");
+    MBoxBase = OpenResource("mbox.resource");
+    if (!KernelBase || !MBoxBase)
+        return FALSE;
+
+    if ((SDIOBase->sdio_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase)) == 0)
+        return FALSE;
+
+    InitSemaphore(&SDIOBase->sdio_Sem);
+    SDIOBase->sdio_iobase = SDIOBase->sdio_periiobase + 0x300000;       /* ARASAN_BASE */
+    SDIOBase->sdio_LastWrite = sdio_now(SDIOBase);
+
+    if (!sdio_mbox_setup(SDIOBase))
+    {
+        D(bug("[SDIO] mailbox power/clock query failed\n"));
+        return FALSE;
+    }
+    D(bug("[SDIO] Arasan base clock %u Hz\n", SDIOBase->sdio_ClockMax));
+
+    sdio_gpio_mux(SDIOBase);
+    sdio_gpio_pulls(SDIOBase);
+
+    /*
+     * The firmware boots the SD card on the Arasan (SD1) with GPIO48-53 left
+     * at ALT3 - the SAME SD1 controller we just routed GPIO34-39 to for WiFi.
+     * With two pad groups on one controller the boot card's idle-high CMD/DAT
+     * lines mask the WiFi chip's responses, so every command times out. Park
+     * GPIO48-53 as inputs so SD1 reaches only the WiFi pins. sdcard.device's
+     * SDHOST driver (lower init priority, runs later) re-routes 48-53 to
+     * ALT0/SD0 for the SD card. NOTE: assumes the SDHOST build (the Arasan is
+     * not used for the SD card); see arch/.../sdcard mmakefile BCM2708BUILDFILES.
+     */
+    {
+        volatile ULONG *fsel4 = (volatile ULONG *)GPFSEL4;
+        volatile ULONG *fsel5 = (volatile ULONG *)GPFSEL5;
+
+        *fsel4 = AROS_LONG2LE(AROS_LE2LONG(*fsel4) & ~((0x7u << 24) | (0x7u << 27)));
+        *fsel5 = AROS_LONG2LE(AROS_LE2LONG(*fsel5) &
+                 ~((0x7u << 0) | (0x7u << 3) | (0x7u << 6) | (0x7u << 9)));
+        D(bug("[SDIO] GPIO48-53 -> input (free SD1 for WiFi) GPFSEL4=0x%08x GPFSEL5=0x%08x\n",
+              AROS_LE2LONG(*fsel4), AROS_LE2LONG(*fsel5)));
+    }
+
+    /* WiFi-chip power (LPO clock + WL_REG_ON) is deferred to the first probe
+     * (sdio_do_probe), so the chip stays unpowered until a client opens the
+     * bus. The controller bring-up + GPIO arbitration above stays eager - it
+     * must win the boot race against the SDHOST/sdcard driver for GPIO48-53. */
+
+    sdio_softreset(SDIOBase, SDHCI_RESET_ALL);
+    D(bug("[SDIO] host version 0x%04x caps 0x%08x\n",
+          sdio_rw(SDIOBase, SDHCI_HOST_VERSION),
+          sdio_rl(SDIOBase, SDHCI_CAPABILITIES)));
+
+    /*
+     * Clear CONTROL2 (host_control2 at 0x3C): the firmware uses this Arasan
+     * controller for the boot SD card and may leave it in a UHS / 1.8V
+     * signalling mode. The WiFi SDIO bus is 3.3V (1.8V is broken on the Pi),
+     * so force plain 3.3V SDR12 by zeroing it. (WiFiPi does the same.)
+     */
+    D(bug("[SDIO] CONTROL2 (0x3C) was 0x%08x, clearing\n",
+          sdio_rl(SDIOBase, SDHCI_ACMD12_ERR)));
+    sdio_wl(SDIOBase, SDHCI_ACMD12_ERR, 0);     /* 0x3C = EMMC_CONTROL2 */
+
+    /* Data timeout counter (TMCLK * 2^(7+13)) */
+    sdio_wb(SDIOBase, SDHCI_TIMEOUT_CONTROL, 0x07);
+
+    sdio_setpower(SDIOBase);
+    sdio_setclock(SDIOBase, SDIO_IDENT_CLOCK);
+
+    /* 1-bit bus, no high speed for identification */
+    sdio_wb(SDIOBase, SDHCI_HOST_CONTROL,
+            sdio_rb(SDIOBase, SDHCI_HOST_CONTROL) &
+            ~(SDHCI_HCTRL_8BITBUS | SDHCI_HCTRL_4BITBUS | SDHCI_HCTRL_HISPD));
+
+    /* Latch status bits for polling; no IRQ routed yet (card int masked out
+     * of INT_ENABLE until a consumer arms it via SDIOSetInterrupt). */
+    sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE);
+    sdio_wl(SDIOBase, SDHCI_SIGNAL_ENABLE, 0);
+
+    D(bug("[SDIO] controller initialised (chip power + probe deferred to first open)\n"));
+
+    return TRUE;
+}
+
+ADD2INITLIB(sdio_init, 0)
+
+/* ----------------------------------------------------------------------- */
+/* Public API                                                              */
+
+AROS_LH0(int, SDIOProbe,
+                struct SDIOBase *, SDIOBase, 1, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    int present;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    present = sdio_do_probe(SDIOBase);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    return present;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH2(uint8_t, SDIOReadByte,
+                AROS_LHA(uint32_t, func, D0),
+                AROS_LHA(uint32_t, addr, D1),
+                struct SDIOBase *, SDIOBase, 2, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    uint8_t val = 0;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    sdio_rw_direct(SDIOBase, 0, func, addr, 0, &val);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    return val;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH3(void, SDIOWriteByte,
+                AROS_LHA(uint32_t, func, D0),
+                AROS_LHA(uint32_t, addr, D1),
+                AROS_LHA(uint8_t, val, D2),
+                struct SDIOBase *, SDIOBase, 3, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    sdio_rw_direct(SDIOBase, 1, func, addr, val, NULL);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH5(int, SDIOReadExt,
+                AROS_LHA(uint32_t, func, D0),
+                AROS_LHA(uint32_t, addr, D1),
+                AROS_LHA(void *, buf, D2),
+                AROS_LHA(uint32_t, len, D3),
+                AROS_LHA(uint32_t, incr, D4),
+                struct SDIOBase *, SDIOBase, 4, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    int err;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    err = sdio_rw_extended(SDIOBase, 0, func, addr, buf, len, incr);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH5(int, SDIOWriteExt,
+                AROS_LHA(uint32_t, func, D0),
+                AROS_LHA(uint32_t, addr, D1),
+                AROS_LHA(void *, buf, D2),
+                AROS_LHA(uint32_t, len, D3),
+                AROS_LHA(uint32_t, incr, D4),
+                struct SDIOBase *, SDIOBase, 5, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    int err;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    err = sdio_rw_extended(SDIOBase, 1, func, addr, buf, len, incr);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH1(int, SDIOEnableFunction,
+                AROS_LHA(uint32_t, func, D0),
+                struct SDIOBase *, SDIOBase, 6, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    uint8_t reg = 0;
+    int retries, err;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+
+    err = sdio_rw_direct(SDIOBase, 0, 0, SDIO_CCCR_IO_ENABLE, 0, &reg);
+    if (!err)
+    {
+        reg |= (1 << func);
+        err = sdio_rw_direct(SDIOBase, 1, 0, SDIO_CCCR_IO_ENABLE, reg, NULL);
+    }
+
+    for (retries = 50; !err && retries > 0; retries--)
+    {
+        uint8_t rdy = 0;
+        if (sdio_rw_direct(SDIOBase, 0, 0, SDIO_CCCR_IO_READY, 0, &rdy))
+        {
+            err = -1;
+            break;
+        }
+        if (rdy & (1 << func))
+            break;
+        sdio_udelay(SDIOBase, 1000);
+    }
+
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH2(int, SDIOSetBlockSize,
+                AROS_LHA(uint32_t, func, D0),
+                AROS_LHA(uint32_t, size, D1),
+                struct SDIOBase *, SDIOBase, 7, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    int err;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    err = sdio_rw_direct(SDIOBase, 1, 0, SDIO_FBR_BASE(func) + SDIO_FBR_BLOCK_SIZE0,
+                         size & 0xff, NULL);
+    if (!err)
+        err = sdio_rw_direct(SDIOBase, 1, 0, SDIO_FBR_BASE(func) + SDIO_FBR_BLOCK_SIZE1,
+                             (size >> 8) & 0xff, NULL);
+    if (!err && func < 8)
+        SDIOBase->sdio_BlkSize[func] = size;        /* cache for CMD53 block mode */
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Cheap presence query: returns whether the card was enumerated+selected by
+ * the resource's own init probe. Unlike SDIOProbe() this issues no bus
+ * traffic, so a client (bwfm) can gate on it without re-running CMD0/CMD5 on
+ * the already-selected card.
+ */
+AROS_LH0(int, SDIOIsPresent,
+                struct SDIOBase *, SDIOBase, 8, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    return SDIOBase->sdio_Present;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Register `task` to be signalled (with `sigmask`) whenever the SDIO card
+ * interrupt fires. Enables the chip's interrupt master + function-1 source
+ * (CCCR 0x04) and routes the SDHCI card interrupt to the ARM. The handler
+ * masks the interrupt each time; the consumer re-arms it with
+ * SDIOAckInterrupt() after draining its frames.
+ */
+AROS_LH2(int, SDIOSetInterrupt,
+                AROS_LHA(struct Task *, task, A0),
+                AROS_LHA(uint32_t, sigmask, D0),
+                struct SDIOBase *, SDIOBase, 9, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    int err;
+
+    SDIOBase->sdio_IRQTask = task;
+    SDIOBase->sdio_IRQSig = sigmask;
+
+    ObtainSemaphore(&SDIOBase->sdio_Sem);
+    err = sdio_rw_direct(SDIOBase, 1, 0, SDIO_CCCR_INT_ENABLE,
+                         SDIO_CCCR_IEN_MASTER | SDIO_CCCR_IEN_FUNC1, NULL);
+    ReleaseSemaphore(&SDIOBase->sdio_Sem);
+
+    /* Arm the card interrupt (gated by INT_ENABLE on this controller). */
+    sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE | SDHCI_INT_CARD_INT);
+
+    D(bug("[SDIO] card interrupt armed (CCCR err %d)\n", err));
+    return err;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Re-arm the card interrupt after the consumer has drained pending frames.
+ * (The handler masks it on each fire to avoid a level-triggered storm.)
+ */
+AROS_LH0(void, SDIOAckInterrupt,
+                struct SDIOBase *, SDIOBase, 10, Sdio)
+{
+    AROS_LIBFUNC_INIT
+
+    sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE | SDHCI_INT_CARD_INT);
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_private.h
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_private.h
@@ -1,0 +1,104 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Private state for sdio.resource: an SDIO host bound to the BCM2835
+    Arasan SDHCI controller (peripheral offset 0x300000). On the Raspberry
+    Pi 3/3B/4 this controller is wired to the on-board Broadcom WiFi chip
+    over a 4-bit SDIO bus; the SD card itself uses the separate SDHOST
+    controller (see rom/devs/sdcard). The resource exposes a generic
+    SDIO function-I/O API (CMD52/CMD53) for client drivers (e.g. bwfm).
+*/
+
+#ifndef SDIO_PRIVATE_H_
+#define SDIO_PRIVATE_H_
+
+#include <exec/nodes.h>
+#include <exec/semaphores.h>
+#include <inttypes.h>
+
+struct SDIOBase
+{
+    struct Node             sdio_Node;
+    struct SignalSemaphore  sdio_Sem;       /* Serialises command issue */
+    unsigned int            sdio_periiobase;
+    unsigned int            sdio_iobase;    /* Arasan SDHCI MMIO base */
+    unsigned int            sdio_ClockMax;  /* Controller base clock (Hz) */
+    uint16_t                sdio_RCA;       /* Relative card address (CMD3) */
+    uint32_t                sdio_OCR;       /* I/O OCR from CMD5 */
+    uint8_t                 sdio_NumFunc;   /* I/O function count from CMD5 */
+    int                     sdio_Present;   /* An SDIO device answered CMD5 */
+    unsigned int            sdio_LastWrite; /* SYSTIMER stamp of last MMIO write */
+    uint16_t                sdio_BlkSize[8];/* per-function block size (CMD53 block mode) */
+
+    /* SDIO card-interrupt (DAT1) routing to a consumer task (the RX pump) */
+    APTR                    sdio_IRQHandle; /* KrnAddIRQHandler handle */
+    struct Task            *sdio_IRQTask;   /* task to Signal on the card int */
+    uint32_t                sdio_IRQSig;    /* signal mask to send it */
+};
+
+#define ARM_PERIIOBASE SDIOBase->sdio_periiobase
+#include <hardware/bcm2708.h>
+
+/*
+ * SDIO-specific command opcodes (not in hardware/mmc.h, which only covers
+ * the memory-card command set).
+ */
+#define SDIO_CMD_IO_SEND_OP_COND        5       /* R4 */
+#define SDIO_CMD_IO_RW_DIRECT           52      /* R5 - CMD52 */
+#define SDIO_CMD_IO_RW_EXTENDED         53      /* R5 - CMD53 */
+
+/* OCR (CMD5 response) fields */
+#define SDIO_OCR_NUM_FUNC_SHIFT         28
+#define SDIO_OCR_NUM_FUNC_MASK          (0x7 << SDIO_OCR_NUM_FUNC_SHIFT)
+#define SDIO_OCR_MEM_PRESENT            (1 << 27)
+#define SDIO_OCR_IOREADY                (1 << 31)
+#define SDIO_OCR_VOLTAGE_MASK           0x00ffff00      /* 2.0-3.6V window */
+
+/* CMD52/CMD53 argument layout (IO_RW_DIRECT / IO_RW_EXTENDED) */
+#define SDIO_ARG_RW_WRITE               (1u << 31)
+#define SDIO_ARG_FUNC_SHIFT             28
+#define SDIO_ARG_RAW                    (1u << 27)      /* read-after-write */
+#define SDIO_ARG_BLOCKMODE              (1u << 27)      /* CMD53: block mode */
+#define SDIO_ARG_OPCODE_INCR            (1u << 26)      /* CMD53: address increments */
+#define SDIO_ARG_ADDR_SHIFT             9
+#define SDIO_ARG_ADDR_MASK              0x1ffff
+#define SDIO_ARG_COUNT_MASK             0x1ff           /* CMD53 byte/block count */
+
+/* R5 response (CMD52/53) flags byte (bits 15:8 of the 32-bit response).
+ * Bits 5:4 are IO_CURRENT_STATE (card state: 0=DIS, 1=CMD, 2=TRN) - NOT an
+ * error, so they must be excluded from the error check (a selected card
+ * reports state 1 = bit4 set on every CMD52/CMD53). */
+#define SDIO_R5_OUT_OF_RANGE            (1 << 0)
+#define SDIO_R5_FUNCTION_NUMBER         (1 << 1)
+#define SDIO_R5_ERROR                   (1 << 3)
+#define SDIO_R5_ILLEGAL_COMMAND         (1 << 6)
+#define SDIO_R5_COM_CRC_ERROR           (1 << 7)
+#define SDIO_R5_ERRORS                  (SDIO_R5_COM_CRC_ERROR | SDIO_R5_ILLEGAL_COMMAND | \
+                                         SDIO_R5_ERROR | SDIO_R5_FUNCTION_NUMBER | \
+                                         SDIO_R5_OUT_OF_RANGE)
+
+/* CCCR (function 0) register offsets */
+#define SDIO_CCCR_CCCR_REV              0x00
+#define SDIO_CCCR_SD_REV                0x01
+#define SDIO_CCCR_IO_ENABLE             0x02
+#define SDIO_CCCR_IO_READY              0x03
+#define SDIO_CCCR_INT_ENABLE            0x04
+#define  SDIO_CCCR_IEN_MASTER           0x01    /* IENM: master int enable */
+#define  SDIO_CCCR_IEN_FUNC1            0x02    /* IEN1: function 1 int enable */
+#define SDIO_CCCR_INT_PENDING           0x05
+#define SDIO_CCCR_BUS_CONTROL           0x07
+#define SDIO_CCCR_BUS_WIDTH_4BIT        0x02
+#define SDIO_CCCR_BUS_WIDTH_MASK        0x03
+#define SDIO_CCCR_CAPABILITY            0x08
+#define SDIO_CCCR_HIGH_SPEED            0x13
+#define  SDIO_CCCR_SHS                  0x01    /* supports high speed */
+#define  SDIO_CCCR_EHS                  0x02    /* enable high speed */
+#define SDIO_CCCR_FN0_BLOCK_SIZE0       0x10    /* FBR-style: F0 block size */
+#define SDIO_CCCR_FN0_BLOCK_SIZE1       0x11
+
+/* Per-function FBR base (function n at 0x100 * n), block-size at +0x10/0x11 */
+#define SDIO_FBR_BASE(f)                (0x100 * (f))
+#define SDIO_FBR_BLOCK_SIZE0            0x10
+#define SDIO_FBR_BLOCK_SIZE1            0x11
+
+#endif /* SDIO_PRIVATE_H_ */

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -75,6 +75,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-mbox-bcm2708-quick \
 #MM kernel-dma-bcm2708-quick \
 #MM kernel-sdio-bcm2708-quick \
+#MM kernel-bwfm-bcm2708-quick \
 #MM hidd-i2c-quick \
 #MM kernel-hidd-gfx-quick \
 #MM hidd-vc4gfx-quick \
@@ -128,6 +129,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-mbox-bcm2708 \
 #MM kernel-dma-bcm2708 \
 #MM kernel-sdio-bcm2708 \
+#MM kernel-bwfm-bcm2708 \
 #MM kernel-sdcard \
 #MM hidd-i2c \
 #MM hidd-i2c-bcm2708 \
@@ -147,7 +149,7 @@ RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-r
 
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
 PKG_LIBS_ARCH := expansion
-PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio
+PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio bwfm
 PKG_RSRC_ARCH := processor battclock
 PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -74,6 +74,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-processor-quick \
 #MM kernel-mbox-bcm2708-quick \
 #MM kernel-dma-bcm2708-quick \
+#MM kernel-sdio-bcm2708-quick \
 #MM hidd-i2c-quick \
 #MM kernel-hidd-gfx-quick \
 #MM hidd-vc4gfx-quick \
@@ -126,6 +127,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-processor \
 #MM kernel-mbox-bcm2708 \
 #MM kernel-dma-bcm2708 \
+#MM kernel-sdio-bcm2708 \
 #MM kernel-sdcard \
 #MM hidd-i2c \
 #MM hidd-i2c-bcm2708 \
@@ -145,7 +147,7 @@ RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-r
 
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
 PKG_LIBS_ARCH := expansion
-PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma
+PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio
 PKG_RSRC_ARCH := processor battclock
 PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -28,12 +28,16 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM distfiles-raspi : \
 #MM kernel-raspi-arm \
 #MM kernel-package-raspi-arm \
-#MM distfiles-raspi-fw
+#MM workbench-devs-networks-bwfm \
+#MM distfiles-raspi-fw \
+#MM distfiles-raspi-wifi-fw
 
 #MM distfiles-raspi-be : \
 #MM kernel-raspi-arm \
 #MM kernel-package-raspi-arm \
-#MM distfiles-raspi-fw
+#MM workbench-devs-networks-bwfm \
+#MM distfiles-raspi-fw \
+#MM distfiles-raspi-wifi-fw
 
 #MM kernel-package-raspi-arm-quick: \
 #MM linklibs-stdc-static-quick \
@@ -147,6 +151,18 @@ RASPIFW_BRANCH    := master
 RASPIFW_URI       := https://github.com/raspberrypi/firmware/blob/$(RASPIFW_BRANCH)/boot
 RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-rpi-2-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb
 
+# Broadcom WiFi firmware for bwfm.device (loaded at runtime from DEVS:Firmware).
+# The "buster" branch keeps real files under brcm/ (newer branches symlink to
+# cypress/, which github ?raw= would return as link text). The generic nvram
+# .txt names match what bwfm.device requests for the detected chip; brcmfmac
+# firmware is redistributable under LICENCE.broadcom_bcm43xx (shipped too).
+RASPIWIFIFW_BRANCH := buster
+RASPIWIFIFW_URI    := https://github.com/RPi-Distro/firmware-nonfree/blob/$(RASPIWIFIFW_BRANCH)
+RASPIWIFIFW_FILES  := brcm/brcmfmac43455-sdio.bin brcm/brcmfmac43455-sdio.txt \
+                     brcm/brcmfmac43455-sdio.clm_blob \
+                     brcm/brcmfmac43430-sdio.bin brcm/brcmfmac43430-sdio.txt \
+                     LICENCE.broadcom_bcm43xx
+
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
 PKG_LIBS_ARCH := expansion
 PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio bwfm
@@ -165,6 +181,14 @@ PKG_CLASSES   := USB/hub USB/massstorage
 #MM
 distfiles-raspi-fw:
 	$(foreach file, $(RASPIFW_FILES), $(shell wget -t 5 -T 15 -c "$(addprefix $(RASPIFW_URI)/, $(addsuffix ?raw=true, $(file)))" -O "$(addprefix $(AROSDIR)/, $(file))"))
+
+#MM
+distfiles-raspi-wifi-fw:
+	@$(MKDIR) $(AROSDIR)/Devs/Firmware
+	@for f in $(RASPIWIFIFW_FILES) ; do \
+	    wget -t 5 -T 15 -c "$(RASPIWIFIFW_URI)/$$f?raw=true" -O "$(AROSDIR)/Devs/Firmware/$${f##*/}" \
+	        || $(ECHO) "WARNING: could not fetch WiFi firmware $$f" ; \
+	done
 
 #MM
 distfiles-raspi-be-bootimg: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img

--- a/compiler/include/devices/sana2wireless.h
+++ b/compiler/include/devices/sana2wireless.h
@@ -33,6 +33,7 @@
 #define S2INFO_WPAInfo        (TAG_USER + 12)
 #define S2INFO_Band           (TAG_USER + 13)
 #define S2INFO_DefaultKeyNo   (TAG_USER + 14)
+#define S2INFO_Passphrase     (TAG_USER + 15)  /* PSK passphrase (driver-side 4-way) */
 
 /* Wireless Commands */
 

--- a/workbench/devs/networks/bwfm/bwfm.conf
+++ b/workbench/devs/networks/bwfm/bwfm.conf
@@ -1,0 +1,11 @@
+##begin config
+basename        bwfm_device
+version         0.1
+libbasetype     struct bwfm_base
+beginio_func    begin_io
+abortio_func    abort_io
+##end config
+
+##begin cdefprivate
+#include "bwfm.h"
+##end cdefprivate

--- a/workbench/devs/networks/bwfm/bwfm.h
+++ b/workbench/devs/networks/bwfm/bwfm.h
@@ -1,0 +1,92 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    bwfm.device - SANA-II network device for the Broadcom FullMAC WiFi chip
+    on Raspberry Pi 3/3B+/4. The chip bring-up and SDIO access live in
+    bwfm.resource; this device adds the DOS-side firmware loading and the
+    SANA-II datapath / 802.11 management on top.
+
+    Structure modelled on the AROS tap.device (APL).
+*/
+
+#ifndef BWFM_DEV_H
+#define BWFM_DEV_H
+
+#include <exec/devices.h>
+#include <exec/semaphores.h>
+#include <exec/lists.h>
+#include <devices/sana2.h>
+#include <utility/hooks.h>
+#include <aros/libcall.h>
+#include <aros/symbolsets.h>
+
+#define BWFM_MAX_UNITS          1
+#define ETHER_ADDR_LEN          6
+
+/* BWFMRxFrame() *info flag (low byte = SDPCM channel); mirrors bwfm_sdio.h. */
+#define BWFM_RX_EVENT           0x100
+
+/* Per-opener state (one per OpenDevice) */
+struct bwfm_opener
+{
+    struct MinNode      node;
+    struct MsgPort      read_pending;       /* queued CMD_READ requests */
+    BOOL                (*rx)(APTR, APTR, ULONG);   /* S2_CopyToBuff[16] */
+    BOOL                (*tx)(APTR, APTR, ULONG);   /* S2_CopyFromBuff[16/32] */
+    struct Hook        *filter;             /* S2_PacketFilter hook */
+};
+
+/* Per packet-type statistics tracker (SANA-II S2_TRACKTYPE) */
+struct bwfm_tracker
+{
+    struct MinNode      node;
+    ULONG               refcount;
+    ULONG               packet_type;
+    struct Sana2PacketTypeStats stats;
+};
+
+/* Per-unit state */
+struct bwfm_unit
+{
+    LONG                num;
+    ULONG               refcount;
+    ULONG               state;              /* SANA2 unit flags (online etc.) */
+    int                 online;             /* S2_ONLINE: deliver received frames */
+    int                 joined;             /* associated to the configured AP */
+    UBYTE               hwaddr[ETHER_ADDR_LEN];
+    struct Sana2DeviceQuery info;
+    struct Sana2DeviceStats stats;
+    struct SignalSemaphore lock;        /* guards openers/read_pending/
+                                         * event_pending/trackers/assoc_* and
+                                         * pending_events across tasks (SMP) */
+    struct MinList      openers;
+    struct MinList      trackers;
+    struct MinList      event_pending;      /* queued S2_ONEVENT requests */
+    ULONG               pending_events;     /* edge events (CONNECT/DISCONNECT)
+                                             * latched until a listener arms */
+    /* Async associate job: S2_SETOPTIONS copies the params here and signals the
+     * bwfm.ctrl worker, then replies at once, so BWFMJoin runs off the caller's
+     * (wpa_supplicant's) event loop. */
+    int                 assoc_pending;
+    ULONG               assoc_ssidlen;
+    ULONG               assoc_passlen;
+    UBYTE               assoc_ssid[33];
+    UBYTE               assoc_pass[64];
+};
+
+struct bwfm_base
+{
+    struct Device       device;
+    struct bwfm_unit    unit[BWFM_MAX_UNITS];
+    int                 fw_loaded;          /* chip firmware brought up once */
+    struct Process     *pump;               /* async SDPCM RX pump process */
+    struct Process     *ctrl;               /* async control worker (associate) */
+    struct Task        *ctrl_task;          /* ctrl worker task, for Signal() */
+    ULONG               ctrl_sig;           /* ctrl worker wake signal mask */
+};
+
+/* Pulls in genmodule's GM_UNIQUENAME / LIBBASE / LIBBASETYPEPTR macros.
+ * Must follow the struct bwfm_base definition (libbasetype). */
+#include LC_LIBDEFS_FILE
+
+#endif /* BWFM_DEV_H */

--- a/workbench/devs/networks/bwfm/bwfm_dev.c
+++ b/workbench/devs/networks/bwfm/bwfm_dev.c
@@ -1,0 +1,1523 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    bwfm.device - SANA-II network device for the Broadcom FullMAC WiFi chip.
+
+    Phase 3 skeleton: opens bwfm.resource (chip bring-up), manages units and
+    openers, and answers the SANA-II query commands. The actual datapath
+    (CMD_READ/WRITE) and 802.11 management arrive once firmware download +
+    SDPCM are wired up; for now those commands report the unit offline.
+
+    Genmodule device structure modelled on the AROS tap.device (APL).
+*/
+
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <aros/macros.h>
+#include <aros/libcall.h>
+#include <aros/symbolsets.h>
+#include <exec/errors.h>
+#include <dos/dos.h>
+#include <dos/dostags.h>
+#include <devices/sana2.h>
+#include <devices/sana2wireless.h>
+#include <devices/newstyle.h>
+#include <devices/timer.h>
+#include <utility/hooks.h>
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/utility.h>
+#include <proto/bwfm.h>
+
+#include "bwfm.h"
+
+APTR BWFMBase __attribute__((used)) = NULL;     /* bwfm.resource (proto/bwfm.h base) */
+struct DosLibrary *DOSBase __attribute__((used)) = NULL;
+static LIBBASETYPEPTR PumpBase = NULL;          /* device base for the RX pump */
+
+#define BWFM_FW_DIR     "DEVS:Firmware/"
+#define BWFM_C_UP       2               /* firmware "interface up" ioctl */
+#define BWFM_C_GET_BSSID 23             /* firmware "get associated BSSID" */
+
+#define ETH_ALEN        6
+#define ETH_HLEN        14
+#define ETH_FRAME_LEN   1518
+
+/*
+ * Arm the SDIO card interrupt (1) or poll only (0). The BCM2835 Arasan card
+ * interrupt fires once but does not reliably re-edge per frame (the chip-side
+ * re-arm is a known quirk - michalsc's WiFiPi.device polls for the same reason),
+ * so the RX pump uses adaptive-backoff polling instead and leaves this off.
+ */
+#define BWFM_USE_IRQ    0
+
+/* RX poll backoff window: poll fast while frames flow, ease off when idle. */
+#define BWFM_POLL_MIN   1000            /* 1 ms  - busy */
+#define BWFM_POLL_MAX   100000          /* 100 ms - idle */
+
+/* 802.3 frame header (matches the on-wire layout the firmware hands us). */
+struct bwfm_ethhdr
+{
+    UBYTE   h_dest[ETH_ALEN];
+    UBYTE   h_source[ETH_ALEN];
+    UWORD   h_proto;
+};
+
+/* One scan result, layout shared with bwfm.resource's BWFMScan() output
+ * (struct bwfm_scanresult in bwfm_scan.h - the resource header is not on our
+ * include path, so the layout is mirrored here; clean-build, no ABI concerns). */
+#define BWFM_MAX_SSID_LEN       32
+#define BWFM_MAX_SCAN           40      /* networks BWFMScan() may return */
+
+struct bwfm_scanresult
+{
+    UBYTE   bssid[ETH_ALEN];
+    UBYTE   ssid_len;
+    UBYTE   ssid[BWFM_MAX_SSID_LEN];
+    WORD    rssi;
+    UWORD   chanspec;
+};
+
+static const ULONG rx_tags[] = { S2_CopyToBuff, S2_CopyToBuff16 };
+static const ULONG tx_tags[] = { S2_CopyFromBuff, S2_CopyFromBuff16, S2_CopyFromBuff32 };
+
+static const UWORD supported_commands[] =
+{
+    CMD_READ, CMD_WRITE, CMD_FLUSH,
+    S2_DEVICEQUERY, S2_GETSTATIONADDRESS, S2_CONFIGINTERFACE,
+    S2_ONLINE, S2_OFFLINE,
+    S2_BROADCAST, S2_MULTICAST,
+    S2_TRACKTYPE, S2_UNTRACKTYPE, S2_GETTYPESTATS, S2_GETGLOBALSTATS,
+    S2_ADDMULTICASTADDRESS, S2_DELMULTICASTADDRESS,
+    /* SANA-II wireless extensions (drives wpa_supplicant / WirelessManager).
+     * Listing S2_GETNETWORKS makes wpa_supplicant treat us as a hard-MAC
+     * (FullMAC) device, which matches the chip. */
+    S2_GETNETWORKS, S2_GETCRYPTTYPES, S2_ONEVENT, S2_SETOPTIONS, S2_SETKEY,
+    S2_GETNETWORKINFO,
+    NSCMD_DEVICEQUERY,
+    0
+};
+
+/* ----------------------------------------------------------------------- */
+
+static int GM_UNIQUENAME(init)(LIBBASETYPEPTR LIBBASE)
+{
+    int i;
+
+    BWFMBase = OpenResource("bwfm.resource");
+    if (BWFMBase)
+        D(bug("[bwfm.device] bwfm.resource present (chip brought up on first open)\n"));
+    else
+        D(bug("[bwfm.device] bwfm.resource not available\n"));
+
+    DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
+
+    for (i = 0; i < BWFM_MAX_UNITS; i++)
+    {
+        LIBBASE->unit[i].num = i;
+        InitSemaphore(&LIBBASE->unit[i].lock);
+    }
+
+    return TRUE;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Firmware loading from disk (DEVS:Firmware), then hand to bwfm.resource   */
+
+static void str_append(char **p, const char *s)
+{
+    while (*s)
+        *(*p)++ = *s++;
+}
+
+/* Build "DEVS:Firmware/brcmfmac<id>-sdio<ext>" for the detected chip. */
+static int fw_filename(char *out, ULONG chip, const char *ext)
+{
+    const char *id;
+    char *p = out;
+
+    switch (chip)
+    {
+    case 43430:     id = "43430"; break;        /* Pi 3 / 3B (BCM43430) */
+    case 0x4345:    id = "43455"; break;        /* Pi 3B+ / 4 (BCM43455) */
+    default:        return -1;
+    }
+
+    str_append(&p, BWFM_FW_DIR "brcmfmac");
+    str_append(&p, id);
+    str_append(&p, "-sdio");
+    str_append(&p, ext);
+    *p = '\0';
+    return 0;
+}
+
+/* Read a whole file into a freshly AllocVec'd buffer. */
+static APTR read_file(const char *name, ULONG *lenp)
+{
+    BPTR fh;
+    LONG size;
+    APTR buf;
+
+    fh = Open((CONST_STRPTR)name, MODE_OLDFILE);
+    if (!fh)
+        return NULL;
+
+    Seek(fh, 0, OFFSET_END);
+    size = Seek(fh, 0, OFFSET_BEGINNING);       /* returns the end position */
+    if (size <= 0)
+    {
+        Close(fh);
+        return NULL;
+    }
+
+    buf = AllocVec(size, MEMF_PUBLIC);
+    if (buf && Read(fh, buf, size) != size)
+    {
+        FreeVec(buf);
+        buf = NULL;
+    }
+    Close(fh);
+
+    if (buf)
+        *lenp = size;
+    return buf;
+}
+
+/*
+ * Convert a brcmfmac nvram text file into the binary form the firmware
+ * expects: comment/blank lines dropped, '\n' -> '\0', padded to a 4-byte
+ * boundary and terminated with a (count/4) size token. Ported from
+ * OpenBSD bwfm_nvram_convert (no device-tree MAC append).
+ */
+static APTR nvram_convert(const UBYTE *src, ULONG size, ULONG *newlenp)
+{
+    const UBYTE *end = src + size;
+    UBYTE *dst, *newbuf;
+    ULONG count, pad;
+    int skip = 0;
+    uint32_t token;
+
+    newbuf = AllocVec(size + 64, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!newbuf)
+        return NULL;
+    dst = newbuf;
+    count = 0;
+
+    for (; src != end; ++src)
+    {
+        if (*src == '\n')
+        {
+            if (count > 0)
+                *dst++ = '\0';
+            count = 0;
+            skip = 0;
+            continue;
+        }
+        if (skip)
+            continue;
+        if (*src == '#' && count == 0)
+        {
+            skip = 1;
+            continue;
+        }
+        if (*src == '\r')
+            continue;
+        *dst++ = *src;
+        ++count;
+    }
+
+    count = dst - newbuf;
+    pad = (((count + 1) + 3) & ~3UL) - count;   /* roundup(count+1,4) - count */
+    dst += pad;
+    count += pad;                               /* pad bytes already zeroed */
+
+    token = (count / 4) & 0xffff;
+    token |= (~token) << 16;
+    *(uint32_t *)dst = AROS_LONG2LE(token);
+    count += sizeof(token);
+
+    *newlenp = count;
+    return newbuf;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Async SDPCM RX pump + SANA-II datapath                                  */
+
+/*
+ * Deliver one received 802.3 frame to whichever opener has a matching pending
+ * CMD_READ request. Modelled on tap.device's tap_receive().
+ */
+static void rx_deliver(LIBBASETYPEPTR LIBBASE, struct bwfm_unit *unit,
+                       UBYTE *buf, ULONG len)
+{
+    struct bwfm_ethhdr *eth = (struct bwfm_ethhdr *)buf;
+    struct bwfm_opener *opener, *onext;
+    struct IOSana2Req *req, *rnext;
+    WORD packet_type;
+    UBYTE *dst;
+    BOOL bcast = FALSE, mcast = FALSE;
+
+    if (len < ETH_HLEN)
+        return;
+
+    packet_type = AROS_BE2WORD(eth->h_proto);
+    dst = eth->h_dest;
+    if (*(ULONG *)dst == 0xffffffff && *(UWORD *)(dst + 4) == 0xffff)
+        bcast = TRUE;
+    else if (dst[0] & 0x01)
+        mcast = TRUE;
+
+    /* Held across the whole walk so a concurrent close()/CMD_FLUSH/AbortIO on
+     * another CPU cannot free a list node we are iterating over (SMP). */
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->openers, opener, onext)
+    {
+        ForeachNodeSafe(&opener->read_pending.mp_MsgList, req, rnext)
+        {
+            UBYTE *packet;
+
+            if (req->ios2_PacketType != (ULONG)packet_type)
+                continue;
+
+            req->ios2_Req.io_Flags &= ~(SANA2IOF_BCAST | SANA2IOF_MCAST);
+            if (bcast)
+                req->ios2_Req.io_Flags |= SANA2IOF_BCAST;
+            if (mcast)
+                req->ios2_Req.io_Flags |= SANA2IOF_MCAST;
+
+            CopyMem(eth->h_source, req->ios2_SrcAddr, ETH_ALEN);
+            CopyMem(eth->h_dest, req->ios2_DstAddr, ETH_ALEN);
+
+            if (req->ios2_Req.io_Flags & SANA2IOF_RAW)
+            {
+                req->ios2_DataLength = len;
+                packet = buf;
+            }
+            else
+            {
+                req->ios2_DataLength = len - ETH_HLEN;
+                packet = buf + ETH_HLEN;
+            }
+
+            /* opener packet filter: drop the frame for this request if it says no */
+            if (opener->filter != NULL &&
+                !CallHookPkt(opener->filter, req, packet))
+                continue;
+
+            if (opener->rx == NULL ||
+                !opener->rx(req->ios2_Data, packet, req->ios2_DataLength))
+            {
+                req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+                req->ios2_WireError = S2WERR_BUFF_ERROR;
+            }
+
+            Remove((struct Node *)req);
+            ReplyMsg(&req->ios2_Req.io_Message);
+            break;          /* one read per opener; keep offering to the rest */
+        }
+    }
+    ReleaseSemaphore(&unit->lock);
+}
+
+/*
+ * RX pump process: drains SDPCM frames from the chip and dispatches them.
+ * Data frames go to rx_deliver(); firmware events are logged for now (link /
+ * assoc handling arrives with join). Runs for the device's lifetime; the chip
+ * buffers frames, so when idle we poll on a coarse timer.
+ */
+static void bwfm_pump(void)
+{
+    LIBBASETYPEPTR LIBBASE = PumpBase;
+    struct bwfm_unit *unit = &LIBBASE->unit[0];
+    static UBYTE rxbuf[ETH_FRAME_LEN];
+    struct MsgPort *tport;
+    struct timerequest *tr = NULL;
+    ULONG irqsig, irqmask = 0, timersig = 0, woke = 0, delay = BWFM_POLL_MIN;
+    int use_irq = 0, idle = 0;
+
+    /* Card interrupt wakes us via BWFMSetRxSignal; the handler masks it in
+     * INT_ENABLE, we clear the chip's SDPCM int + re-arm after draining. */
+    irqsig = (ULONG)-1;
+    if (BWFM_USE_IRQ)
+        irqsig = AllocSignal(-1);
+    if (irqsig != (ULONG)-1)
+    {
+        irqmask = 1UL << irqsig;
+        BWFMSetRxSignal(FindTask(NULL), irqmask);
+        use_irq = 1;
+    }
+
+    /* Safety timeout so a missed interrupt can never stall RX. */
+    tport = CreateMsgPort();
+    if (tport)
+        tr = (struct timerequest *)CreateIORequest(tport, sizeof(struct timerequest));
+    if (tr && OpenDevice((CONST_STRPTR)"timer.device", UNIT_MICROHZ,
+                         (struct IORequest *)tr, 0) == 0)
+        timersig = 1UL << tport->mp_SigBit;
+
+    D(bug("[bwfm.device] RX pump running (irq %s, timer %s)\n",
+          use_irq ? "on" : "off", timersig ? "on" : "off"));
+
+    for (;;)
+    {
+        ULONG info, len;
+        int got = 0;
+
+        /* Drain everything in F2 (and the glom queue), THEN ack the chip's card
+         * interrupt: clearing HMB_FRAME_IND with F2 already empty deasserts DAT1,
+         * so the next frame re-triggers the edge-sensitive Arasan card interrupt
+         * (true per-frame IRQ rather than a one-shot + timer poll). */
+        while ((len = (ULONG)BWFMRxFrame(rxbuf, sizeof(rxbuf), &info)) > 0)
+        {
+            if (info & BWFM_RX_EVENT)
+            {
+                D(bug("[bwfm.device] RX event type %lu\n", (info >> 16) & 0xffff));
+                BWFMEventPost(rxbuf, len);  /* hand to a waiting join/scan */
+            }
+            else if (unit->online)
+                rx_deliver(LIBBASE, unit, rxbuf, len);
+            got = 1;
+        }
+
+        if (use_irq)
+            BWFMClearInt();
+
+        /*
+         * Spin guard: if the card interrupt keeps waking us with nothing to
+         * read (chip int not clearing), stop using it and fall back to timer
+         * polling - never worse than the old behaviour, never a busy loop.
+         */
+        if (use_irq && (woke & irqmask) && !got)
+        {
+            if (++idle >= 8)
+            {
+                use_irq = 0;
+                D(bug("[bwfm.device] card IRQ not self-clearing - polling\n"));
+            }
+        }
+        else
+            idle = 0;
+
+        /* Adaptive backoff: reset to the fast interval whenever a frame turned
+         * up, else double the wait up to the idle ceiling - low latency under
+         * load, low CPU when quiet (mirrors WiFiPi.device's poll strategy). */
+        if (got)
+            delay = BWFM_POLL_MIN;
+        else if ((delay <<= 1) > BWFM_POLL_MAX)
+            delay = BWFM_POLL_MAX;
+
+        if (timersig)
+        {
+            tr->tr_node.io_Command = TR_ADDREQUEST;
+            tr->tr_time.tv_secs = 0;
+            tr->tr_time.tv_micro = delay;
+            SendIO((struct IORequest *)tr);
+            if (use_irq)
+                BWFMAckRx();
+            woke = Wait(irqmask | timersig);
+            if (!CheckIO((struct IORequest *)tr))
+                AbortIO((struct IORequest *)tr);
+            WaitIO((struct IORequest *)tr);
+        }
+        else
+        {
+            Delay(1);
+            woke = 0;
+        }
+    }
+}
+
+/* Run a queued associate (defined below, near report_events). */
+static void do_associate(struct bwfm_unit *unit);
+
+/*
+ * Control worker: runs the blocking BWFMJoin for associate requests off the
+ * caller's task, so it never freezes wpa_supplicant's event loop (and so the RX
+ * pump - a separate task - stays free to feed BWFMJoin its association events).
+ * Woken by S2_SETOPTIONS via Signal(); also checks on entry in case a job was
+ * queued before this task armed its signal.
+ */
+static void bwfm_ctrl(void)
+{
+    LIBBASETYPEPTR LIBBASE = PumpBase;
+    struct bwfm_unit *unit = &LIBBASE->unit[0];
+    ULONG sig = AllocSignal(-1);
+
+    LIBBASE->ctrl_sig = (sig == (ULONG)-1) ? 0 : (1UL << sig);
+    LIBBASE->ctrl_task = FindTask(NULL);
+
+    D(bug("[bwfm.device] ctrl worker running (sig %s)\n",
+          LIBBASE->ctrl_sig ? "on" : "poll"));
+
+    for (;;)
+    {
+        do_associate(unit);             /* drain any pending job */
+        if (LIBBASE->ctrl_sig)
+            Wait(LIBBASE->ctrl_sig);
+        else
+            Delay(5);                   /* signal alloc failed: poll fallback */
+    }
+}
+
+/* Spawn the RX pump + control worker once the chip firmware is up. */
+static void start_pump(LIBBASETYPEPTR LIBBASE)
+{
+    if (LIBBASE->pump != NULL)
+        return;
+
+    PumpBase = LIBBASE;
+    LIBBASE->pump = CreateNewProcTags(
+        NP_Entry, (IPTR)bwfm_pump,
+        NP_Name,  (IPTR)"bwfm.rxpump",
+        NP_Priority, 5,
+        TAG_DONE);
+
+    /* Async associate worker (see bwfm_ctrl). */
+    LIBBASE->ctrl = CreateNewProcTags(
+        NP_Entry, (IPTR)bwfm_ctrl,
+        NP_Name,  (IPTR)"bwfm.ctrl",
+        NP_Priority, 4,
+        TAG_DONE);
+
+    /* The pump + ctrl worker reference LIBBASE for their whole life - keep the
+     * device from being expunged after the last CloseDevice by counting them
+     * as openers. */
+    if (LIBBASE->pump != NULL)
+        LIBBASE->device.dd_Library.lib_OpenCnt++;
+    if (LIBBASE->ctrl != NULL)
+        LIBBASE->device.dd_Library.lib_OpenCnt++;
+}
+
+/*
+ * Transmit one SANA-II write request: build the 802.3 header (unless RAW),
+ * copy the caller's payload through its tx buffer-management hook, and hand
+ * the frame to bwfm.resource. Modelled on tap.device's tap_send().
+ */
+static void tx_request(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    struct bwfm_opener *opener = (struct bwfm_opener *)req->ios2_BufferManagement;
+    UBYTE txbuf[ETH_FRAME_LEN];
+    struct bwfm_ethhdr *eth = (struct bwfm_ethhdr *)txbuf;
+    UBYTE *packet;
+    ULONG framelen;
+
+    if (!unit->online)
+    {
+        req->ios2_Req.io_Error = S2ERR_OUTOFSERVICE;
+        req->ios2_WireError = S2WERR_UNIT_OFFLINE;
+        return;
+    }
+
+    if (req->ios2_Req.io_Flags & SANA2IOF_RAW)
+    {
+        packet = txbuf;
+        framelen = req->ios2_DataLength;
+    }
+    else
+    {
+        CopyMem(unit->hwaddr, eth->h_source, ETH_ALEN);
+        CopyMem(req->ios2_DstAddr, eth->h_dest, ETH_ALEN);
+        eth->h_proto = AROS_WORD2BE(req->ios2_PacketType);
+        packet = txbuf + ETH_HLEN;
+        framelen = ETH_HLEN + req->ios2_DataLength;
+    }
+
+    if (framelen > sizeof(txbuf) ||
+        opener->tx == NULL ||
+        !opener->tx(packet, req->ios2_Data, req->ios2_DataLength))
+    {
+        req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+        req->ios2_WireError = S2WERR_BUFF_ERROR;
+        return;
+    }
+
+    if (BWFMTxData(txbuf, framelen) != 0)
+    {
+        req->ios2_Req.io_Error = S2ERR_TX_FAILURE;
+        req->ios2_WireError = S2WERR_GENERIC_ERROR;
+    }
+}
+
+/* One-time chip firmware bring-up. Returns TRUE on success. */
+static int load_firmware(LIBBASETYPEPTR LIBBASE)
+{
+    char name[64];
+    APTR fw = NULL, nvtxt = NULL, nvbin = NULL;
+    ULONG fwlen = 0, nvtxtlen = 0, nvbinlen = 0;
+    ULONG chip;
+    int ok = FALSE;
+
+    if (LIBBASE->fw_loaded)
+        return TRUE;
+    if (!BWFMBase || !DOSBase)
+        return FALSE;
+
+    /* Lazy chip bring-up: power the WiFi chip + enumerate it now (first open).
+     * No-op if a prior open already attached. */
+    if (!BWFMAttach())
+    {
+        D(bug("[bwfm.device] chip attach failed (no WiFi chip?)\n"));
+        return FALSE;
+    }
+
+    chip = BWFMChipID();
+    if (chip == 0 || fw_filename(name, chip, ".bin"))
+    {
+        D(bug("[bwfm.device] no firmware mapping for chip %x\n", chip));
+        return FALSE;
+    }
+
+    fw = read_file(name, &fwlen);
+    if (!fw)
+    {
+        D(bug("[bwfm.device] cannot read firmware '%s'\n", name));
+        goto out;
+    }
+
+    if (fw_filename(name, chip, ".txt") == 0)
+    {
+        nvtxt = read_file(name, &nvtxtlen);
+        if (nvtxt)
+            nvbin = nvram_convert(nvtxt, nvtxtlen, &nvbinlen);
+    }
+
+    D(bug("[bwfm.device] starting firmware (%u bytes, nvram %u bytes)\n",
+          fwlen, nvbinlen));
+
+    if (BWFMStartFirmware(fw, fwlen, nvbin, nvbinlen) == 0)
+    {
+        LIBBASE->fw_loaded = TRUE;
+        ok = TRUE;
+
+        /* Firmware is running: read the chip MAC into every unit. */
+        if (BWFMGetMAC(LIBBASE->unit[0].hwaddr) == 0)
+            D(bug("[bwfm.device] MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
+                  LIBBASE->unit[0].hwaddr[0], LIBBASE->unit[0].hwaddr[1],
+                  LIBBASE->unit[0].hwaddr[2], LIBBASE->unit[0].hwaddr[3],
+                  LIBBASE->unit[0].hwaddr[4], LIBBASE->unit[0].hwaddr[5]));
+        else
+            D(bug("[bwfm.device] failed to read chip MAC\n"));
+
+        /* Load the regulatory CLM blob if one ships for this chip. Without it
+         * the radio has no valid channels and scanning fails (NOTUP). The
+         * Pi 3 (43430) firmware has built-in regulatory and ships no blob, so
+         * a missing file is not an error. */
+        if (fw_filename(name, chip, ".clm_blob") == 0)
+        {
+            ULONG clmlen = 0;
+            APTR clm = read_file(name, &clmlen);
+
+            if (clm)
+            {
+                D(bug("[bwfm.device] loading CLM blob (%u bytes)\n", clmlen));
+                BWFMLoadCLM(clm, clmlen);
+                FreeVec(clm);
+            }
+            else
+                D(bug("[bwfm.device] no CLM blob at %s (IoErr %ld) - using"
+                      " built-in regulatory\n", name, IoErr()));
+        }
+
+        /* Bring the firmware MAC layer up */
+        if (BWFMIoctl(BWFM_C_UP, 1, NULL, 0) == 0)
+            D(bug("[bwfm.device] interface up\n"));
+        else
+            D(bug("[bwfm.device] BWFM_C_UP failed\n"));
+
+        /* Start the async RX pump now that the chip can deliver frames. */
+        start_pump(LIBBASE);
+    }
+
+out:
+    FreeVec(fw);
+    FreeVec(nvtxt);
+    FreeVec(nvbin);
+    return ok;
+}
+
+/*
+ * WiFi credentials for auto-join live in DEVS:bwfm.prefs: the first non-blank,
+ * non-comment line is the SSID, the second (optional) is the WPA2 passphrase
+ * (omit it for an open network). Whole-line values so SSIDs may contain spaces.
+ * Returns TRUE when at least an SSID was read.
+ */
+static int load_wifi_prefs(UBYTE *ssid, ULONG *ssidlen, UBYTE *key, ULONG *keylen)
+{
+    ULONG flen = 0, i = 0, line = 0;
+    UBYTE *buf = read_file("DEVS:bwfm.prefs", &flen);
+
+    *ssidlen = 0;
+    *keylen = 0;
+    if (buf == NULL)
+        return FALSE;
+
+    while (i < flen && line < 2)
+    {
+        ULONG s = i, e, n;
+
+        while (i < flen && buf[i] != '\n' && buf[i] != '\r')
+            i++;
+        e = i;
+        while (i < flen && (buf[i] == '\n' || buf[i] == '\r'))
+            i++;
+        if (e == s || buf[s] == '#')
+            continue;                       /* blank line or comment */
+
+        if (line == 0)
+        {
+            n = e - s;
+            if (n > 32)
+                n = 32;
+            CopyMem(buf + s, ssid, n);
+            *ssidlen = n;
+        }
+        else
+        {
+            n = e - s;
+            if (n > 63)
+                n = 63;
+            CopyMem(buf + s, key, n);
+            *keylen = n;
+        }
+        line++;
+    }
+
+    FreeVec(buf);
+    return (*ssidlen > 0);
+}
+
+/* Associate to the configured network once, when the interface goes online. */
+static void try_join(struct bwfm_unit *unit)
+{
+    UBYTE ssid[33], key[64];
+    ULONG ssidlen = 0, keylen = 0;
+
+    if (unit->joined)
+        return;
+    if (!load_wifi_prefs(ssid, &ssidlen, key, &keylen))
+    {
+        D(bug("[bwfm.device] no DEVS:bwfm.prefs - not auto-joining\n"));
+        return;
+    }
+
+    ssid[ssidlen] = '\0';
+    D(bug("[bwfm.device] auto-join \"%s\" (%s)\n", ssid, keylen ? "WPA2" : "open"));
+    if (BWFMJoin(ssid, ssidlen, keylen ? key : NULL, keylen) == 0)
+    {
+        unit->joined = TRUE;
+        D(bug("[bwfm.device] auto-join OK\n"));
+    }
+    else
+        D(bug("[bwfm.device] auto-join failed\n"));
+}
+
+/* SANA-II per-packet-type tracking (used by AROSTCP at interface setup). */
+static void track_type(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    struct bwfm_tracker *t, *tn;
+    ULONG type = req->ios2_PacketType;
+
+    /* Walk + insert under the lock so two concurrent S2_TRACKTYPE callers
+     * cannot both miss and then add a duplicate tracker (SMP). */
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->trackers, t, tn)
+        if (t->packet_type == type)
+        {
+            t->refcount++;
+            ReleaseSemaphore(&unit->lock);
+            return;
+        }
+
+    t = AllocVec(sizeof(struct bwfm_tracker), MEMF_PUBLIC | MEMF_CLEAR);
+    if (t == NULL)
+    {
+        ReleaseSemaphore(&unit->lock);
+        req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+        return;
+    }
+    t->refcount = 1;
+    t->packet_type = type;
+    AddTail((struct List *)&unit->trackers, (struct Node *)t);
+    ReleaseSemaphore(&unit->lock);
+}
+
+static void untrack_type(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    struct bwfm_tracker *t, *tn;
+    ULONG type = req->ios2_PacketType;
+
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->trackers, t, tn)
+        if (t->packet_type == type)
+        {
+            if (--t->refcount == 0)
+            {
+                Remove((struct Node *)t);
+                ReleaseSemaphore(&unit->lock);
+                FreeVec(t);
+                return;
+            }
+            ReleaseSemaphore(&unit->lock);
+            return;
+        }
+    ReleaseSemaphore(&unit->lock);
+}
+
+static void get_type_stats(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    struct bwfm_tracker *t, *tn;
+    ULONG type = req->ios2_PacketType;
+
+    if (req->ios2_StatData == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+        req->ios2_WireError = S2WERR_BAD_STATDATA;
+        return;
+    }
+
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->trackers, t, tn)
+        if (t->packet_type == type)
+        {
+            CopyMem(&t->stats, req->ios2_StatData, sizeof(struct Sana2PacketTypeStats));
+            ReleaseSemaphore(&unit->lock);
+            return;
+        }
+    ReleaseSemaphore(&unit->lock);
+
+    req->ios2_Req.io_Error = S2ERR_BAD_STATE;
+    req->ios2_WireError = S2WERR_NOT_TRACKED;
+}
+
+static int GM_UNIQUENAME(open)(LIBBASETYPEPTR LIBBASE, struct IOSana2Req *req,
+                               ULONG unitnum, ULONG flags)
+{
+    struct TagItem *tags;
+    struct bwfm_unit *unit;
+    struct bwfm_opener *opener = NULL;
+    BYTE error = 0;
+    int i;
+
+    req->ios2_Req.io_Unit = NULL;
+
+    tags = req->ios2_BufferManagement;
+    req->ios2_BufferManagement = NULL;
+
+    if (unitnum >= BWFM_MAX_UNITS)
+        error = IOERR_OPENFAIL;
+    else
+        unit = &LIBBASE->unit[unitnum];
+
+    if (error == 0)
+    {
+        opener = AllocVec(sizeof(struct bwfm_opener), MEMF_PUBLIC | MEMF_CLEAR);
+        if (opener == NULL)
+            error = IOERR_OPENFAIL;
+        req->ios2_BufferManagement = (APTR)opener;
+    }
+
+    if (error == 0)
+    {
+        NEWLIST(&opener->read_pending.mp_MsgList);
+        opener->read_pending.mp_Flags = PA_IGNORE;
+
+        for (i = 0; i < 2; i++)
+            opener->rx = (BOOL (*)(APTR, APTR, ULONG))
+                GetTagData(rx_tags[i], (IPTR)opener->rx, tags);
+        for (i = 0; i < 3; i++)
+            opener->tx = (BOOL (*)(APTR, APTR, ULONG))
+                GetTagData(tx_tags[i], (IPTR)opener->tx, tags);
+        opener->filter = (struct Hook *)GetTagData(S2_PacketFilter, 0, tags);
+    }
+
+    /* First open of this unit: initialise its SANA-II description */
+    if (error == 0 && unit->refcount == 0)
+    {
+        NEWLIST((struct List *)&unit->openers);
+        NEWLIST((struct List *)&unit->trackers);
+        NEWLIST((struct List *)&unit->event_pending);
+
+        unit->info.SizeAvailable = sizeof(struct Sana2DeviceQuery);
+        unit->info.SizeSupplied = sizeof(struct Sana2DeviceQuery);
+        unit->info.DevQueryFormat = 0;
+        unit->info.DeviceLevel = 0;
+        unit->info.AddrFieldSize = 8 * ETHER_ADDR_LEN;
+        unit->info.MTU = 1500;
+        unit->info.BPS = 0;                     /* unknown until associated */
+        unit->info.HardwareType = S2WireType_Ethernet;
+
+        /* hwaddr stays zero until firmware reports the chip MAC */
+
+        /* Bring the chip firmware up (one-time). A failure is logged but
+         * does not fail the open yet - query commands still work; the
+         * datapath is stubbed until firmware + SDPCM are in place. */
+        if (!load_firmware(LIBBASE))
+            D(bug("[bwfm.device] firmware not loaded (chip offline)\n"));
+    }
+
+    if (error == 0)
+    {
+        req->ios2_Req.io_Unit = (APTR)unit;
+        ObtainSemaphore(&unit->lock);
+        AddTail((struct List *)&unit->openers, (struct Node *)opener);
+        unit->refcount++;
+        ReleaseSemaphore(&unit->lock);
+    }
+    else
+        FreeVec(opener);
+
+    req->ios2_Req.io_Error = error;
+    return (error == 0) ? TRUE : FALSE;
+}
+
+static int GM_UNIQUENAME(close)(LIBBASETYPEPTR LIBBASE, struct IOSana2Req *req)
+{
+    struct bwfm_unit *unit = (struct bwfm_unit *)req->ios2_Req.io_Unit;
+    struct bwfm_opener *opener = (struct bwfm_opener *)req->ios2_BufferManagement;
+
+    if (unit && opener)
+    {
+        struct IOSana2Req *r, *rnext;
+
+        /* Reply any IO still queued against this opener before it is freed:
+         * otherwise the owner's WaitIO() blocks forever and the RX pump /
+         * CMD_FLUSH would later walk freed memory. Held under the unit lock so
+         * the pump cannot be mid-delivery to this opener on another CPU. */
+        ObtainSemaphore(&unit->lock);
+
+        while ((r = (struct IOSana2Req *)
+                RemHead(&opener->read_pending.mp_MsgList)) != NULL)
+        {
+            r->ios2_Req.io_Error = IOERR_ABORTED;
+            ReplyMsg(&r->ios2_Req.io_Message);
+        }
+
+        ForeachNodeSafe(&unit->event_pending, r, rnext)
+        {
+            if (r->ios2_BufferManagement != (APTR)opener)
+                continue;
+            Remove((struct Node *)r);
+            r->ios2_Req.io_Error = IOERR_ABORTED;
+            ReplyMsg(&r->ios2_Req.io_Message);
+        }
+
+        Remove((struct Node *)opener);
+        unit->refcount--;
+        ReleaseSemaphore(&unit->lock);
+
+        FreeVec(opener);
+    }
+    else
+    {
+        if (unit)
+            unit->refcount--;
+        if (opener)
+            FreeVec(opener);
+    }
+
+    req->ios2_Req.io_Unit = NULL;
+    req->ios2_BufferManagement = NULL;
+    return TRUE;
+}
+
+ADD2INITLIB(GM_UNIQUENAME(init), 0)
+ADD2OPENDEV(GM_UNIQUENAME(open), 0)
+ADD2CLOSEDEV(GM_UNIQUENAME(close), 0)
+
+/* ----------------------------------------------------------------------- */
+
+static void TermIO(struct IOSana2Req *req)
+{
+    if (!(req->ios2_Req.io_Flags & IOF_QUICK))
+        ReplyMsg(&req->ios2_Req.io_Message);
+}
+
+/* ----------------------------------------------------------------------- */
+/* SANA-II wireless extensions (scan / crypto query for WirelessManager)    */
+
+/*
+ * S2_GETNETWORKS: run a scan and return the results as an array of tag-lists,
+ * one per network, allocated from the caller-supplied memory pool (ios2_Data).
+ * Mirrors what wpa_supplicant's driver_sana2 get_scan_results() reads back.
+ *
+ * NOTE: synchronous (BWFMScan blocks ~5s, fed by the RX pump). Fine for a
+ * DoIO() caller; wpa_supplicant SendIO's this expecting an async reply, so a
+ * later step must move the scan to a worker. Good enough to bring the device
+ * side up and test via WiFiTest.
+ */
+static void get_networks(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    static struct bwfm_scanresult results[BWFM_MAX_SCAN];
+    APTR pool = req->ios2_Data;
+    struct TagItem **lists;
+    int n, i;
+
+    if (pool == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+        req->ios2_WireError = S2WERR_GENERIC_ERROR;
+        return;
+    }
+
+    req->ios2_DataLength = 0;        /* set to the network count only on success */
+    req->ios2_StatData = NULL;
+
+    n = BWFMScan(results, BWFM_MAX_SCAN);
+    if (n < 0)
+        n = 0;
+
+    lists = AllocPooled(pool, sizeof(struct TagItem *) * (n > 0 ? n : 1));
+    if (lists == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+        return;
+    }
+
+    for (i = 0; i < n; i++)
+    {
+        UBYTE iebuf[256];
+        ULONG ielen;
+        struct TagItem *tl = AllocPooled(pool, sizeof(struct TagItem) * 7);
+        UBYTE *bssid = AllocPooled(pool, ETH_ALEN);
+        UBYTE *ssid = AllocPooled(pool, results[i].ssid_len + 1);
+        int t = 0;
+
+        if (tl == NULL || bssid == NULL || ssid == NULL)
+        {
+            req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+            return;
+        }
+
+        CopyMem(results[i].bssid, bssid, ETH_ALEN);
+        CopyMem(results[i].ssid, ssid, results[i].ssid_len);
+        ssid[results[i].ssid_len] = '\0';
+
+        tl[t].ti_Tag = S2INFO_SSID;    tl[t++].ti_Data = (IPTR)ssid;
+        tl[t].ti_Tag = S2INFO_BSSID;   tl[t++].ti_Data = (IPTR)bssid;
+        tl[t].ti_Tag = S2INFO_Channel; tl[t++].ti_Data = results[i].chanspec & 0xff;
+        tl[t].ti_Tag = S2INFO_Signal;  tl[t++].ti_Data = (IPTR)(LONG)results[i].rssi;
+        tl[t].ti_Tag = S2INFO_Noise;   tl[t++].ti_Data = (IPTR)(LONG)-95;
+
+        /* Beacon IEs (incl. the RSN/WPA element) as S2INFO_InfoElements: a
+         * u16 byte-count followed by the IE bytes, which wpa_supplicant parses
+         * to match a WPA2 network. Without this it sees the BSS as open. */
+        ielen = (ULONG)BWFMScanIE(i, iebuf, sizeof(iebuf));
+        if (ielen > 0)
+        {
+            UBYTE *ie = AllocPooled(pool, 2 + ielen);
+            if (ie != NULL)
+            {
+                *(UWORD *)ie = (UWORD)ielen;
+                CopyMem(iebuf, ie + 2, ielen);
+                tl[t].ti_Tag = S2INFO_InfoElements; tl[t++].ti_Data = (IPTR)ie;
+            }
+        }
+
+        tl[t].ti_Tag = TAG_DONE;       tl[t].ti_Data = 0;
+        lists[i] = tl;
+    }
+
+    req->ios2_StatData = lists;
+    req->ios2_DataLength = n;
+}
+
+/* S2_GETCRYPTTYPES: report the cipher suites the firmware can do, as a byte
+ * array allocated from the caller's pool (ios2_Data). */
+static void get_crypttypes(struct IOSana2Req *req)
+{
+    APTR pool = req->ios2_Data;
+    UBYTE *list;
+
+    if (pool == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+        return;
+    }
+    list = AllocPooled(pool, 3);
+    if (list == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+        return;
+    }
+    list[0] = S2ENC_WEP;
+    list[1] = S2ENC_TKIP;
+    list[2] = S2ENC_CCMP;
+    req->ios2_StatData = list;
+    req->ios2_DataLength = 3;
+}
+
+/*
+ * Reply every queued S2_ONEVENT request whose wanted-event mask overlaps the
+ * events that just occurred. While queued, ios2_WireError holds the caller's
+ * mask; on reply it is narrowed to the events that fired. The matched requests
+ * are unlinked under the unit lock, then replied after the lock is dropped.
+ */
+static void report_events(struct bwfm_unit *unit, ULONG events)
+{
+    struct MinList done;
+    struct IOSana2Req *req, *next;
+    ULONG consumed = 0, pend_mask_or = 0;
+    int matched = 0, pend_count = 0;
+
+    NEWLIST((struct List *)&done);
+
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->event_pending, req, next)
+    {
+        ULONG hit;
+
+        pend_count++;                       /* DIAGNOSTIC: who is listening */
+        pend_mask_or |= req->ios2_WireError; /* and for which events */
+
+        hit = req->ios2_WireError & events;
+        if (hit)
+        {
+            Remove((struct Node *)req);
+            req->ios2_WireError = hit;
+            req->ios2_Req.io_Error = 0;
+            AddTail((struct List *)&done, (struct Node *)req);
+            consumed |= hit;
+            matched++;
+        }
+    }
+    /* Latch edge events (CONNECT/DISCONNECT) that no parked listener took, so a
+     * listener arming slightly later still sees them. The synchronous scan/
+     * associate blocks wpa_supplicant's event loop, so its S2_ONEVENT is often
+     * not parked at the instant the join fires CONNECT - without this the event
+     * is lost and wpa_supplicant times out and re-scans forever. */
+    unit->pending_events |= (events & ~consumed) &
+                            (S2EVENT_CONNECT | S2EVENT_DISCONNECT);
+    ReleaseSemaphore(&unit->lock);
+
+    /* DIAGNOSTIC: if CONNECT (0x200) fired but no parked mask wants it,
+     * wpa_supplicant is in soft-MAC mode => hard-MAC detection failed. */
+    D(bug("[bwfm.device] report_events 0x%lx -> %ld/%ld listener(s) masks 0x%lx latched 0x%lx\n",
+          (unsigned long)events, (long)matched, (long)pend_count,
+          (unsigned long)pend_mask_or, (unsigned long)unit->pending_events));
+
+    while ((req = (struct IOSana2Req *)RemHead((struct List *)&done)) != NULL)
+        ReplyMsg(&req->ios2_Req.io_Message);
+}
+
+/*
+ * S2_SETOPTIONS: WirelessManager (wpa_supplicant) drives association here. The
+ * request carries S2INFO_SSID + (with WPA_DRIVER_FLAGS_4WAY_HANDSHAKE)
+ * S2INFO_Passphrase. The join (BWFMJoin) takes seconds, so we MUST NOT run it
+ * inline: that blocks the caller's event loop (wpa_supplicant's), and the
+ * connect notification ends up lost (no S2_ONEVENT listener armed) -> auth
+ * timeout + endless re-scan. Instead copy the params, hand them to the
+ * bwfm.ctrl worker, and reply S2_SETOPTIONS at once (= "association initiated");
+ * the worker runs the join and raises S2EVENT_CONNECT on success, by which time
+ * the caller's loop is free and its S2_ONEVENT listener is armed. A non-associate
+ * S2_SETOPTIONS (no SSID) is just acknowledged.
+ */
+static void queue_associate(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    struct TagItem *tags = (struct TagItem *)req->ios2_Data;
+    UBYTE *ssid, *pass;
+    ULONG ssidlen = 0, passlen = 0;
+
+    if (tags == NULL)
+        return;
+
+    ssid = (UBYTE *)GetTagData(S2INFO_SSID, (IPTR)NULL, tags);
+    if (ssid == NULL || ssid[0] == '\0')
+        return;                         /* not an associate request - just ack */
+
+    while (ssid[ssidlen] && ssidlen < sizeof(unit->assoc_ssid) - 1)
+        ssidlen++;
+    pass = (UBYTE *)GetTagData(S2INFO_Passphrase, (IPTR)NULL, tags);
+    if (pass)
+        while (pass[passlen] && passlen < sizeof(unit->assoc_pass) - 1)
+            passlen++;
+
+    /* Copy the params out of the caller's tag list (freed once we return) and
+     * publish the job, then wake the worker. */
+    ObtainSemaphore(&unit->lock);
+    CopyMem(ssid, unit->assoc_ssid, ssidlen);
+    unit->assoc_ssid[ssidlen] = '\0';
+    unit->assoc_ssidlen = ssidlen;
+    if (passlen)
+        CopyMem(pass, unit->assoc_pass, passlen);
+    unit->assoc_pass[passlen] = '\0';
+    unit->assoc_passlen = passlen;
+    unit->assoc_pending = TRUE;
+    ReleaseSemaphore(&unit->lock);
+
+    D(bug("[bwfm.device] queued associate \"%s\" (%s) for ctrl worker\n",
+          unit->assoc_ssid, passlen ? "WPA2-PSK" : "open"));
+
+    if (PumpBase != NULL && PumpBase->ctrl_task != NULL)
+        Signal(PumpBase->ctrl_task, PumpBase->ctrl_sig);
+}
+
+/*
+ * Worker side of an associate (runs in the bwfm.ctrl task): pull the queued
+ * params and run the blocking BWFMJoin, then raise S2EVENT_CONNECT on success.
+ * Because this is off the caller's task, the RX pump stays free to feed the
+ * join its association events, and the caller's S2_ONEVENT listener is armed
+ * when CONNECT fires.
+ */
+static void do_associate(struct bwfm_unit *unit)
+{
+    UBYTE ssid[33], pass[64];
+    ULONG ssidlen, passlen;
+
+    ObtainSemaphore(&unit->lock);
+    if (!unit->assoc_pending)
+    {
+        ReleaseSemaphore(&unit->lock);
+        return;
+    }
+    unit->assoc_pending = FALSE;
+    ssidlen = unit->assoc_ssidlen;
+    passlen = unit->assoc_passlen;
+    CopyMem(unit->assoc_ssid, ssid, ssidlen + 1);
+    CopyMem(unit->assoc_pass, pass, passlen + 1);
+    ReleaseSemaphore(&unit->lock);
+
+    D(bug("[bwfm.device] ctrl worker: associate \"%s\" (%s)\n",
+          ssid, passlen ? "WPA2-PSK" : "open"));
+
+    if (BWFMJoin(ssid, ssidlen, passlen ? pass : NULL, passlen) == 0)
+    {
+        unit->joined = TRUE;
+        report_events(unit, S2EVENT_CONNECT);
+    }
+    else
+        D(bug("[bwfm.device] ctrl worker: associate failed\n"));
+}
+
+/*
+ * S2_GETNETWORKINFO: report the current association (at least the BSSID, which
+ * wpa_supplicant's get_bssid needs to confirm the connection and settle into
+ * COMPLETED instead of rescanning). The tag-list is allocated from the caller's
+ * pool (ios2_Data). Returns an error if not associated.
+ */
+static void get_networkinfo(struct bwfm_unit *unit, struct IOSana2Req *req)
+{
+    APTR pool = req->ios2_Data;
+    struct TagItem *tl;
+    UBYTE *bssid;
+
+    if (pool == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+        return;
+    }
+    tl = AllocPooled(pool, sizeof(struct TagItem) * 2);
+    bssid = AllocPooled(pool, ETH_ALEN);
+    if (tl == NULL || bssid == NULL)
+    {
+        req->ios2_Req.io_Error = S2ERR_NO_RESOURCES;
+        return;
+    }
+
+    if (BWFMIoctl(BWFM_C_GET_BSSID, 0, bssid, ETH_ALEN) != 0)
+    {
+        req->ios2_Req.io_Error = S2ERR_BAD_STATE;       /* not associated */
+        req->ios2_WireError = S2WERR_UNIT_OFFLINE;
+        return;
+    }
+
+    tl[0].ti_Tag = S2INFO_BSSID; tl[0].ti_Data = (IPTR)bssid;
+    tl[1].ti_Tag = TAG_DONE;     tl[1].ti_Data = 0;
+    req->ios2_StatData = tl;
+}
+
+/* Reply every queued CMD_READ across all openers (CMD_FLUSH, going offline). */
+static void flush_reads(struct bwfm_unit *unit, BYTE err, ULONG werr)
+{
+    struct bwfm_opener *opener, *onext;
+    struct IOSana2Req *r;
+
+    ObtainSemaphore(&unit->lock);
+    ForeachNodeSafe(&unit->openers, opener, onext)
+    {
+        while ((r = (struct IOSana2Req *)
+                RemHead(&opener->read_pending.mp_MsgList)) != NULL)
+        {
+            r->ios2_Req.io_Error = err;
+            r->ios2_WireError = werr;
+            ReplyMsg(&r->ios2_Req.io_Message);
+        }
+    }
+    ReleaseSemaphore(&unit->lock);
+}
+
+static void handle_request(struct IOSana2Req *req)
+{
+    struct bwfm_unit *unit = (struct bwfm_unit *)req->ios2_Req.io_Unit;
+    ULONG wanted = req->ios2_WireError;     /* S2_ONEVENT passes the wanted-event
+                                             * mask in ios2_WireError (input); save
+                                             * it before we clear the field for the
+                                             * common (output) case below. */
+
+    req->ios2_Req.io_Error = 0;
+    req->ios2_WireError = 0;
+
+    switch (req->ios2_Req.io_Command)
+    {
+    case S2_DEVICEQUERY:
+    {
+        struct Sana2DeviceQuery *q = (struct Sana2DeviceQuery *)req->ios2_StatData;
+        ULONG n;
+
+        if (q == NULL)
+        {
+            req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+            req->ios2_WireError = S2WERR_BAD_STATDATA;
+            break;
+        }
+        n = q->SizeAvailable;
+        if (n > sizeof(struct Sana2DeviceQuery))
+            n = sizeof(struct Sana2DeviceQuery);
+        CopyMem(&unit->info, q, n);
+        q->SizeSupplied = n;
+        break;
+    }
+
+    case S2_GETSTATIONADDRESS:
+        CopyMem(unit->hwaddr, req->ios2_SrcAddr, ETHER_ADDR_LEN);
+        CopyMem(unit->hwaddr, req->ios2_DstAddr, ETHER_ADDR_LEN);
+        break;
+
+    case S2_CONFIGINTERFACE:
+        /* SANA-II: configure the address AND bring the interface online. Don't
+         * associate here - that's S2_ONLINE's auto-join (AROSTCP) or
+         * S2_SETOPTIONS (wpa_supplicant). wpa_supplicant relies on this to go
+         * online (it only sends S2_ONLINE if we'd returned IS_CONFIGURED). */
+        CopyMem(req->ios2_SrcAddr, unit->hwaddr, ETHER_ADDR_LEN);
+        unit->online = TRUE;
+        report_events(unit, S2EVENT_ONLINE);
+        break;
+
+    case S2_ONLINE:
+        try_join(unit);                 /* associate to DEVS:bwfm.prefs network */
+        unit->online = TRUE;
+        report_events(unit, S2EVENT_ONLINE);
+        break;
+
+    case S2_OFFLINE:
+        unit->online = FALSE;
+        /* Reads queued while online can never complete now (the pump only
+         * delivers while online), so abort them instead of hanging WaitIO. */
+        flush_reads(unit, S2ERR_OUTOFSERVICE, S2WERR_UNIT_OFFLINE);
+        report_events(unit, S2EVENT_OFFLINE);
+        break;
+
+    case S2_ONEVENT:
+    {
+        /* S2EVENT_ONLINE/OFFLINE reflect the current state - reply at once if
+         * the wanted event already holds; otherwise queue the request until
+         * report_events() fires (e.g. CONNECT/DISCONNECT from association). */
+        const ULONG supported = S2EVENT_ONLINE | S2EVENT_OFFLINE |
+                                S2EVENT_CONNECT | S2EVENT_DISCONNECT;
+        ULONG mask = wanted;
+        ULONG cur = unit->online ? S2EVENT_ONLINE : S2EVENT_OFFLINE;
+        ULONG latched, ready;
+
+        /* A request for events this device can never raise can never complete;
+         * reject it now instead of parking it forever (SANA-II S2WERR_BAD_EVENT). */
+        if (mask & ~supported)
+        {
+            req->ios2_Req.io_Error = S2ERR_NOT_SUPPORTED;
+            req->ios2_WireError = S2WERR_BAD_EVENT;
+            break;
+        }
+
+        /* Deliver immediately for: ONLINE/OFFLINE that already holds (derivable
+         * from unit->online), OR a CONNECT/DISCONNECT edge that fired earlier
+         * with no listener parked (latched in report_events). Consuming the
+         * latched bit once means no spin even though wpa_supplicant keeps CONNECT
+         * in its mask permanently. */
+        ObtainSemaphore(&unit->lock);
+        latched = mask & unit->pending_events;
+        unit->pending_events &= ~latched;
+        ReleaseSemaphore(&unit->lock);
+        ready = (mask & cur) | latched;
+
+        D(bug("[bwfm.device] S2_ONEVENT mask 0x%lx (online=%d joined=%d) -> %s 0x%lx\n",
+              (unsigned long)mask, unit->online, unit->joined,
+              ready ? "immediate" : "queued", (unsigned long)ready));
+
+        if (ready)
+        {
+            req->ios2_WireError = ready;
+            break;                      /* immediate reply via TermIO */
+        }
+        req->ios2_Req.io_Flags &= ~IOF_QUICK;
+        req->ios2_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+        req->ios2_WireError = mask;     /* restore wanted mask: report_events()
+                                         * matches the queued request on it */
+        ObtainSemaphore(&unit->lock);
+        AddTail((struct List *)&unit->event_pending,
+                &req->ios2_Req.io_Message.mn_Node);
+        ReleaseSemaphore(&unit->lock);
+        return;                         /* replied later by report_events() */
+    }
+
+    case S2_TRACKTYPE:
+        track_type(unit, req);
+        break;
+
+    case S2_UNTRACKTYPE:
+        untrack_type(unit, req);
+        break;
+
+    case S2_GETTYPESTATS:
+        get_type_stats(unit, req);
+        break;
+
+    case S2_GETGLOBALSTATS:
+        if (req->ios2_StatData == NULL)
+        {
+            req->ios2_Req.io_Error = S2ERR_BAD_ARGUMENT;
+            req->ios2_WireError = S2WERR_BAD_STATDATA;
+            break;
+        }
+        CopyMem(&unit->stats, req->ios2_StatData, sizeof(struct Sana2DeviceStats));
+        break;
+
+    case S2_ADDMULTICASTADDRESS:
+    case S2_DELMULTICASTADDRESS:
+        /* Accept: in managed mode the firmware passes multicast through, so we
+         * don't program a hardware filter (yet). Stops AROSTCP's in6_addmulti
+         * from erroring and lets IPv4/IPv6 multicast through. */
+        break;
+
+    case S2_GETNETWORKS:
+        get_networks(unit, req);
+        break;
+
+    case S2_GETCRYPTTYPES:
+        get_crypttypes(req);
+        break;
+
+    case S2_SETOPTIONS:
+        queue_associate(unit, req);     /* hands the join to bwfm.ctrl; the
+                                         * request is replied now (TermIO) */
+        break;
+
+    case S2_GETNETWORKINFO:
+        get_networkinfo(unit, req);
+        break;
+
+    case S2_SETKEY:
+        /* The firmware does the 4-way handshake (driver advertises
+         * WPA_DRIVER_FLAGS_4WAY_HANDSHAKE), so host-installed PTK/GTK keys are
+         * a no-op here - just succeed so wpa_supplicant proceeds. */
+        break;
+
+    case NSCMD_DEVICEQUERY:
+    {
+        /* NewStyle command: the result buffer is in the IOStdReq io_Data field,
+         * NOT ios2_Data (a different struct offset). Reading ios2_Data wrote the
+         * result to a stale pointer and corrupted memory. */
+        struct IOStdReq *std = (struct IOStdReq *)req;
+        struct NSDeviceQueryResult *nsq =
+            (struct NSDeviceQueryResult *)std->io_Data;
+
+        if (nsq == NULL)
+        {
+            req->ios2_Req.io_Error = IOERR_BADADDRESS;
+            break;
+        }
+        nsq->DevQueryFormat = 0;
+        nsq->SizeAvailable = sizeof(struct NSDeviceQueryResult);
+        nsq->DeviceType = NSDEVTYPE_SANA2;
+        nsq->DeviceSubType = 0;
+        nsq->SupportedCommands = (UWORD *)supported_commands;
+        std->io_Actual = sizeof(struct NSDeviceQueryResult);
+        /* DIAGNOSTIC: wpa_supplicant calls this to detect hard-MAC (it scans
+         * SupportedCommands for S2_GETNETWORKS). If this never logs, the
+         * hard-MAC probe is not reaching us. */
+        D(bug("[bwfm.device] NSCMD_DEVICEQUERY -> %ld cmds (hard-MAC probe)\n",
+              (long)(sizeof(supported_commands)/sizeof(supported_commands[0]) - 1)));
+        break;
+    }
+
+    case CMD_READ:
+    {
+        struct bwfm_opener *opener = (struct bwfm_opener *)req->ios2_BufferManagement;
+
+        if (!unit->online)
+        {
+            D(bug("[bwfm.device] CMD_READ rejected: offline\n"));
+            req->ios2_Req.io_Error = S2ERR_OUTOFSERVICE;
+            req->ios2_WireError = S2WERR_UNIT_OFFLINE;
+            break;                          /* reply immediately with the error */
+        }
+
+        /* Queue the read; the RX pump replies it when a matching frame lands.
+         * SendIO() leaves ln_Type = 0, so mark the request NT_MESSAGE here or
+         * CheckIO() would treat the still-pending request as already done. */
+        req->ios2_Req.io_Flags &= ~IOF_QUICK;
+        req->ios2_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+        ObtainSemaphore(&unit->lock);
+        AddTail(&opener->read_pending.mp_MsgList,
+                &req->ios2_Req.io_Message.mn_Node);
+        ReleaseSemaphore(&unit->lock);
+        return;
+    }
+
+    case S2_BROADCAST:
+    {
+        static const UBYTE bcast[ETH_ALEN] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+        CopyMem((APTR)bcast, req->ios2_DstAddr, ETH_ALEN);
+    }
+    /* fall through */
+    case CMD_WRITE:
+    case S2_MULTICAST:
+        tx_request(unit, req);
+        break;
+
+    case CMD_FLUSH:
+        flush_reads(unit, IOERR_ABORTED, 0);
+        break;
+
+    default:
+        req->ios2_Req.io_Error = IOERR_NOCMD;
+        break;
+    }
+
+    TermIO(req);
+}
+
+AROS_LH1(void, begin_io, AROS_LHA(struct IOSana2Req *, req, A1),
+         LIBBASETYPEPTR, LIBBASE, 5, bwfm_device)
+{
+    AROS_LIBFUNC_INIT
+    handle_request(req);
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH1(long, abort_io, AROS_LHA(struct IOSana2Req *, req, A1),
+         LIBBASETYPEPTR, LIBBASE, 6, bwfm_device)
+{
+    AROS_LIBFUNC_INIT
+
+    struct bwfm_unit *unit = (struct bwfm_unit *)req->ios2_Req.io_Unit;
+
+    /* Pull a still-queued CMD_READ / S2_ONEVENT off its list and reply it
+     * aborted, so a caller's WaitIO() returns instead of blocking forever.
+     * Re-test ln_Type under the unit lock: the RX pump may have replied (and
+     * unlinked) the request between the caller's AbortIO() and us. */
+    if (unit)
+    {
+        ObtainSemaphore(&unit->lock);
+        if (req->ios2_Req.io_Message.mn_Node.ln_Type == NT_MESSAGE)
+        {
+            Remove((struct Node *)req);
+            ReleaseSemaphore(&unit->lock);
+            req->ios2_Req.io_Error = IOERR_ABORTED;
+            ReplyMsg(&req->ios2_Req.io_Message);
+            return 0;
+        }
+        ReleaseSemaphore(&unit->lock);
+    }
+    return -1;          /* not queued / already completed - nothing to abort */
+
+    AROS_LIBFUNC_EXIT
+}

--- a/workbench/devs/networks/bwfm/mmakefile.src
+++ b/workbench/devs/networks/bwfm/mmakefile.src
@@ -1,0 +1,9 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+%build_module mmake=workbench-devs-networks-bwfm \
+    modname=bwfm modtype=device \
+    files="bwfm_dev" \
+    moduledir=Devs/Networks
+
+%common

--- a/workbench/network/WirelessManager/src/drivers/driver_sana2.c
+++ b/workbench/network/WirelessManager/src/drivers/driver_sana2.c
@@ -392,6 +392,10 @@ static int wpa_driver_sana2_associate(
 		{S2INFO_WPAInfo, (params->wpa_ie_len > 0) ?
 			(UPINT)params->wpa_ie : (UPINT)NULL},
 		{S2INFO_AuthTypes, params->auth_alg},
+		/* PSK passphrase for the driver-side 4-way handshake (the firmware
+		 * does the handshake; see WPA_DRIVER_FLAGS_4WAY_HANDSHAKE). */
+		{(params->passphrase != NULL) ? S2INFO_Passphrase : TAG_IGNORE,
+			(UPINT)params->passphrase},
 		{TAG_END, 0}};
 
 	if (ssid == NULL) {
@@ -484,6 +488,11 @@ static int wpa_driver_sana2_get_capa(void *priv, struct wpa_driver_capa *capa)
 
 	if (!drv->hard_mac)
 		capa->flags = WPA_DRIVER_FLAGS_USER_SPACE_MLME;
+
+	/* The FullMAC firmware runs the WPA 4-way handshake itself. Tell
+	 * wpa_supplicant not to, so it hands us the passphrase/PSK in the
+	 * associate parameters instead of doing EAPOL in software. */
+	capa->flags |= WPA_DRIVER_FLAGS_4WAY_HANDSHAKE;
 
 	return 0;
 }

--- a/workbench/prefs/network/prefsdata.c
+++ b/workbench/prefs/network/prefsdata.c
@@ -437,7 +437,8 @@ BOOL WriteNetworkPrefs(CONST_STRPTR  destdir)
         }
         if (strstr(GetDevice(iface), "atheros5000.device") != NULL
             || strstr(GetDevice(iface), "prism2.device") != NULL
-            || strstr(GetDevice(iface), "realtek8180.device") != NULL)
+            || strstr(GetDevice(iface), "realtek8180.device") != NULL
+            || strstr(GetDevice(iface), "bwfm.device") != NULL)
         {
             SetWirelessDevice(GetDevice(iface));
             SetWirelessUnit(GetUnit(iface));


### PR DESCRIPTION
# Add WiFi support for Raspberry Pi 3 / 3B+ / 4 (Broadcom FullMAC)

This adds driver support for the on-board Broadcom WiFi chip on the
Raspberry Pi 3, 3B+ and 4.

## What it adds
- **sdio.resource** — a small SDIO host driver for the Pi's Arasan SDHCI
  controller (the bus the WiFi chip sits on, separate from the SD card).
  Generic CMD52/CMD53 API, usable by any SDIO client.
- **bwfm.resource** — brings the Broadcom chip to life: identifies it,
  loads its firmware, and speaks the chip's control/data protocol
  (scan, join, send/receive frames).
- **bwfm.device** — the SANA-II network device the TCP/IP stack and
  WirelessManager talk to, plus the disk-side firmware loading.

## Design choices
- **License-clean by construction.** The chip code is ported from
  OpenBSD's `bwfm` driver (ISC-licensed) and hardware documentation.
- **Layered, not monolithic.** The SDIO host is its own resource so it
  isn't tied to WiFi; the chip bring-up is its own resource so the
  firmware/protocol logic stays separate from the SANA-II plumbing.
- **Polled, no interrupts.** The Pi's Arasan card interrupt doesn't
  re-trigger reliably per frame, so the receive side uses adaptive
  polling (fast under load, idle when quiet).
- **FullMAC — let the firmware do the hard parts.** The chip firmware
  runs the 802.11 MAC and the WPA2 4-way handshake itself, so the host
  just hands it the SSID and passphrase. This keeps the driver small and
  avoids a host-side supplicant for the common case. A new
  `S2INFO_Passphrase` SANA-II tag carries the passphrase, and
  WirelessManager/wpa_supplicant are taught to use it.
- **Firmware from disk.** Broadcom firmware isn't redistributable
  in-tree, so it's fetched into `DEVS:Firmware` at build time; a failed
  fetch only warns (you get no WiFi, but the build still succeeds). The
  driver loads it on first open.
- **Two ways to connect.** Auto-join from `DEVS:bwfm.prefs` (handy for a
  headless AROSTCP setup) or interactively via WirelessManager.