### PR TITLE
console.device: fix whole-GUI deadlock when resizing a console window

### DIFF
--- a/rom/devs/console/cdinputhandler.c
+++ b/rom/devs/console/cdinputhandler.c
@@ -59,10 +59,8 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
     struct ConsoleBase *ConsoleDevice = (struct ConsoleBase *)consoleDevice;
 
     struct InputEvent *ie;
-    BOOL send_message = FALSE;
 
     struct cdihData *cdihdata = (struct cdihData *)&ConsoleDevice->consIHData;
-    struct cdihMessage *message = cdihdata->cdihMsg;
 
     D(bug("CDInputHandler(events=%p, cdihdata=%p)\n", events, cdihdata));
 
@@ -87,11 +85,28 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
             unit = obtainconunit(ConsoleDevice);
             if (unit)
             {
-                message->unit = unit;
-                message->ie = *ie;
-                send_message = TRUE;
+                /* Hand the event to the console task asynchronously: one
+                   message per event, freed by the task after processing.
+                   NEVER wait for the console task here. This handler runs
+                   in the input.device task, and the console task renders
+                   (RectFill obtains the window's layer lock). During an
+                   interactive size/drag intuition holds LockLayers() across
+                   many input events, so waiting for the console task while
+                   it waits for the layer lock deadlocks all input. Under
+                   memory pressure the event is dropped instead. */
+                struct cdihMessage *message =
+                    AllocMem(sizeof(struct cdihMessage),
+                    MEMF_PUBLIC | MEMF_CLEAR);
 
                 D(bug("Event should be passed to unit %p\n", unit));
+
+                if (message)
+                {
+                    message->msg.mn_Length = sizeof(struct cdihMessage);
+                    message->unit = unit;
+                    message->ie = *ie;
+                    PutMsg(cdihdata->inputPort, (struct Message *)message);
+                }
 
                 /* deletion of unit is now allowed */
                 releaseconunit(unit, ConsoleDevice);
@@ -101,28 +116,6 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
         else
         {
             D(bug("Ignoring event of ie_Class %d\n", ie->ie_Class));
-        }
-
-        if (send_message)
-        {
-            /* This function might be called by any task, not only
-               by the input.device, so it is important that
-               we initialize the replyport's task each time.
-             */
-            struct MsgPort *replyport;
-
-            replyport = message->msg.mn_ReplyPort;
-
-            replyport->mp_SigTask = FindTask(NULL);
-            PutMsg(cdihdata->inputPort, (struct Message *)message);
-
-            /* Wait for reply */
-            WaitPort(replyport);
-
-            /* Remove it from the replyport's msgqueue */
-            GetMsg(replyport);
-
-            send_message = FALSE;
         }
     } /* for (each event in the chain) */
 
@@ -237,56 +230,17 @@ struct Interrupt *initCDIH(struct ConsoleBase *ConsoleDevice)
     if (cdihandler)
     {
         cdihdata = &ConsoleDevice->consIHData;
+        cdihdata->inputPort = CreateMsgPort();
+        if (cdihdata->inputPort)
         {
-            cdihdata->inputPort = CreateMsgPort();
-            if (cdihdata->inputPort)
-            {
-                struct cdihMessage *msg;
+            /* Initialize Interrupt struct */
+            cdihandler->is_Code =
+                (VOID_FUNC) AROS_SLIB_ENTRY(CDInputHandler, Console, 7);
+            cdihandler->is_Data = ConsoleDevice;
+            cdihandler->is_Node.ln_Pri = 50;
+            cdihandler->is_Node.ln_Name = "console.device InputHandler";
 
-                msg =
-                    AllocMem(sizeof(struct cdihMessage),
-                    MEMF_PUBLIC | MEMF_CLEAR);
-                if (msg)
-                {
-                    struct MsgPort *port;
-                    port =
-                        CreateMsgPort();
-                    if (port)
-                    {
-                        /* Free the signal allocated for msgport by exec */
-                        FreeSignal(port->mp_SigBit);
-
-                        /* Initialize port */
-                        port->mp_Flags = PA_SIGNAL;
-                        port->mp_SigBit = SIGB_INTUITION;
-
-                        /* The task of the replyport must be initialized each
-                           time used, because the CDInputHandler might be
-                           called by an app
-                         */
-                        cdihdata->cdihReplyPort = port;
-
-                        /* Initialize Message struct */
-                        cdihdata->cdihMsg = msg;
-                        msg->msg.mn_ReplyPort = cdihdata->cdihReplyPort;
-                        msg->msg.mn_Length = sizeof(struct cdihMessage);
-
-                        /* Initialize Interrupt struct */
-                        cdihandler->is_Code =
-                            (VOID_FUNC) AROS_SLIB_ENTRY(CDInputHandler,
-                            Console, 7);
-                        cdihandler->is_Data = ConsoleDevice;
-                        cdihandler->is_Node.ln_Pri = 50;
-                        cdihandler->is_Node.ln_Name =
-                            "console.device InputHandler";
-
-                        ReturnPtr("initCDIH", struct Interrupt *,
-                            cdihandler);
-                    }
-                    FreeMem(cdihdata->cdihMsg, sizeof(struct cdihMessage));
-                }
-                DeleteMsgPort(cdihdata->inputPort);
-            }
+            ReturnPtr("initCDIH", struct Interrupt *, cdihandler);
         }
         FreeMem(cdihandler, sizeof(struct Interrupt));
     }
@@ -304,12 +258,12 @@ VOID cleanupCDIH(struct Interrupt *cdihandler,
 
     cdihdata = &ConsoleDevice->consIHData;
 
-    /* Reset mp_SigBit, since we were not using it */
-    cdihdata->cdihReplyPort->mp_SigBit = -1;
-    DeleteMsgPort(cdihdata->cdihReplyPort);
-
-    FreeMem(cdihdata->cdihMsg, sizeof(struct cdihMessage));
-
+    /* Drop any events still queued for the console task */
+    {
+        struct Message *msg;
+        while ((msg = GetMsg(cdihdata->inputPort)))
+            FreeMem(msg, sizeof(struct cdihMessage));
+    }
     DeleteMsgPort(cdihdata->inputPort);
 
     FreeMem(cdihandler, sizeof(struct Interrupt));

--- a/rom/devs/console/console_gcc.h
+++ b/rom/devs/console/console_gcc.h
@@ -228,17 +228,15 @@ struct cdihData
 {
     /* Port to which we send input to the console device
        from the console device input handler.
+
+       The handoff is asynchronous: one cdihMessage is allocated per
+       forwarded event and the console task frees it after processing.
+       The input handler must never wait for the console task: the task
+       renders (RectFill needs the layer lock), and during an interactive
+       window drag intuition holds LockLayers() across many input events,
+       so a synchronous round-trip deadlocks the whole input chain.
      */
     struct MsgPort *inputPort;
-
-    /* The port the console.device task replies to telling
-       the console.device input handler that it is finished
-       with the output.
-     */
-    struct MsgPort *cdihReplyPort;
-
-    /* The message struct used to pass user input to the console device */
-    struct cdihMessage *cdihMsg;
 };
 
 

--- a/rom/devs/console/consoletask.c
+++ b/rom/devs/console/consoletask.c
@@ -359,8 +359,9 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                     } /* switch(cdihmsg->ie.ie_Class) */
                 } /* if (checkconunit(cdihmsg->unit, ConsoleDevice)) */
 
-                /* Tell the input handler we're done */
-                ReplyMsg((struct Message *)cdihmsg);
+                /* The input handler sent this asynchronously (it must never
+                   wait for us, see CDInputHandler); we own the message. */
+                FreeMem(cdihmsg, sizeof(struct cdihMessage));
             } /* while ((cdihmsg = (struct cdihMessage *)GetMsg(inputport))) */
         } /* if (wakeupsig & inputsig) */
 


### PR DESCRIPTION
Drag a Shell window's size gadget, release, then immediately drag again, and all input deadlocks.

CDInputHandler forwarded every event to the console task through a single static message, then blocked in WaitPort() for the reply. An input handler must never wait on a task that renders: the console task redraws with RectFill, which obtains the window's layer lock, and intuition's gadget classes hold LockLayers() across the whole interactive drag. The cycle:

- input.device: holds the layer locks (drag in progress), waits in CDInputHandler for the console task's reply
- console task: still processing the previous SIZEWINDOW redraw, waits in RectFill for the layer lock

It takes the second drag because the first drag's release posts a redraw (a long burst of RectFills, each taking and releasing the layer lock); an immediately following grab wins the layer lock between two of them.

Fix: hand events over asynchronously. One cdihMessage is allocated per forwarded event, PutMsg without waiting, and the console task frees the message after processing (event order is preserved by the port FIFO). Under memory pressure the event is dropped rather than blocking the input chain. The static message, its reply port and the SIGB_INTUITION reply hack are removed.

Diagnosed on aarch64-darwin hosted with a task-dump tool that names semaphore owners from blocked tasks' saved contexts; the defect itself is platform independent. Verified there: 10/10 resize torture cycles pass where the deadlock previously hit on cycle 1, and console typing/rendering behave as before.