### PR TITLE
inttypes.h: fix printing of intmax_t values on 32-bit systems

### DIFF
--- a/compiler/crt/stdc/include/aros/stdc/inttypes.h
+++ b/compiler/crt/stdc/include/aros/stdc/inttypes.h
@@ -25,7 +25,7 @@
 #  define __PRIPTR_PREFIX	"l"
 # else
 #  define __PRI64_PREFIX	"ll"
-#  define __PRIMAX_PREFIX	"l"
+#  define __PRIMAX_PREFIX	"ll"
 #  define __PRIPTR_PREFIX
 # endif
 


### PR DESCRIPTION
This bug appeared during Mesa shader compilation on raspi. 

The PRIdMAX family of macros used the "l" length prefix on 32-bit systems, but intmax_t is 64 bits wide there. 