### PR TITLE
Bugfixes: AHI/RPi: play audio at the correct speed and pitch on Raspberry Pi

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
@@ -5,10 +5,14 @@
 #ifndef VCMBOX_H
 #define VCMBOX_H
 
-#define VCMB_BASE               (ARM_PERIIOBASE + 0x00B880)
+#define VCMB_OFFSET             0x00B880
+#define VCMB_BASE               (ARM_PERIIOBASE + VCMB_OFFSET)
 
 #define VCMB_CHAN_MAX           8
 #define VCMB_CHAN_MASK          0xF
+
+/* Property tag channel (ARM -> VC) */
+#define VCMB_PROPCHAN           8
 
 /* Mailbox register offsets */
 #define VCMB_READ               0
@@ -38,6 +42,18 @@
 #define VCTAG_GETPOWER          0x00020001
 #define VCTAG_GETTIMING         0x00020002
 #define VCTAG_SETPOWER	        0x00028001
+
+/* Clock ids for the VCTAG_*CLK* tags */
+#define VCCLOCK_EMMC            1
+#define VCCLOCK_UART            2
+#define VCCLOCK_ARM             3
+#define VCCLOCK_CORE            4
+#define VCCLOCK_V3D             5
+#define VCCLOCK_H264            6
+#define VCCLOCK_ISP             7
+#define VCCLOCK_SDRAM           8
+#define VCCLOCK_PIXEL           9
+#define VCCLOCK_PWM             10
 
 #define VCTAG_GETCLKSTATE       0x00030001
 #define VCTAG_GETCLKRATE        0x00030002

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -9,7 +9,7 @@
  *  Software must provide fully formatted subframes (audio data,
  *  validity, user data, channel status, parity).
  *
- *  Register offsets taken from Linux vc4_hdmi_fields[] for BCM2835.
+ *  Register offsets are for the BCM2835 HD/HDMI core register blocks.
  *  No VCHIQ firmware interaction needed — HDMI link is already
  *  established by the VideoCore firmware at boot.
  */
@@ -20,6 +20,13 @@
 #include <aros/macros.h>
 
 #include "rpihdmi-hwaccess.h"
+
+/*
+ * HDMI State Machine (HSM) clock feeding the MAI sample-rate divider.
+ * Owned by the firmware and not queryable here; measured on Pi 3B+ at
+ * ~163.68 MHz (the 216 MHz assumed before gave 0.7578x playback speed).
+ */
+#define HDMI_HSM_CLOCK 163680000
 
 /*
  * Microsecond delay using a busy loop on the system timer.
@@ -344,11 +351,11 @@ static void hdmi_write_audio_infoframe(ULONG pb, ULONG samplerate)
 /*
  * Initialize the HDMI MAI for audio output.
  *
- * Based on Linux vc4_hdmi.c (BCM2835) and verified against
- * working bare-metal implementations.
+ * Programming sequence verified against working bare-metal
+ * implementations.
  *
  * Key points:
- * - Reset sequence from Linux vc4_hdmi: RESET, ERRORF, FLUSH (separate writes)
+ * - Reset sequence: RESET, ERRORF, FLUSH (separate writes)
  * - Software provides complete IEC958 subframes, including parity
  * - BIT_REVERSE | FORMAT_REVERSE required for correct serialization
  * - Channel map: 3-bit fields at bits 0-2 (ch0) and 4-6 (ch1)
@@ -361,7 +368,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     ULONG n_value = srate_to_n(dd->samplerate);
 
     /*
-     * Reset MAI — matches Linux vc4_hdmi_audio_reset() sequence.
+     * Reset MAI.
      * Three separate writes: RESET, then clear ERRORF, then FLUSH.
      * This resets the internal channel counter and FIFO state.
      */
@@ -375,7 +382,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     wr32le(HDMI_MAI_FMT(pb), MAI_FMT_FORMAT_PCM | MAI_FMT_RATE(srate_enum));
 
     /*
-     * FIFO thresholds — matches Linux vc4_hdmi values (all 0x10).
+     * FIFO thresholds (all 0x10).
      */
     wr32le(HDMI_MAI_THR(pb), MAI_THR_DREQL(0x10) | MAI_THR_DREQH(0x10) | MAI_THR_PANICL(0x10) | MAI_THR_PANICH(0x10));
 
@@ -386,7 +393,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     wr32le(HDMI_MAI_CHANNEL_MAP(pb), 0x08);
 
     /*
-     * Audio packet config (matches Linux):
+     * Audio packet config:
      *   B_FRAME_IDENTIFIER = 0x8 at bits [13:10]
      *   CEA channel mask = 0x03 (channels 0 and 1 active)
      *   ZERO_DATA_ON_INACTIVE_CHANNELS
@@ -399,16 +406,17 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     /*
      * Sample rate clock divider.
      * MAI_SMP register: bits 31:8 = N (numerator), bits 7:0 = M (denominator-1).
-     * Clock ratio = N / (M+1) ≈ hsm_clock / samplerate.
+     * Clock ratio = N / (M+1) = hsm_clock / samplerate. Round N (rather than
+     * truncate) to halve the residual rate error.
      */
-    wr32le(HDMI_MAI_SMP(pb), (216000000 / dd->samplerate) << 8);
+    wr32le(HDMI_MAI_SMP(pb),
+           ((HDMI_HSM_CLOCK + dd->samplerate / 2) / dd->samplerate) << 8);
 
     /*
      * CTS/N audio clock recovery.
      * N is set from the HDMI spec standard values.
      * CTS is set to external mode — the hardware derives CTS from
      * the pixel clock automatically.
-     * Linux also writes CTS_0 and CTS_1 explicitly.
      * CTS = (pixel_clock * N) / (128 * samplerate)
      * RPi 3B+ default pixel clock ≈ 148500 kHz (1080p60) or 74250 kHz (720p60).
      * We read CTS_0 first to get the hardware-derived value, then write it back.
@@ -429,10 +437,11 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     hdmi_write_audio_infoframe(pb, dd->samplerate);
 
     /*
-     * Enable MAI (matches Linux vc4_hdmi_audio_prepare MAI_CTL write).
+     * Enable MAI.
      * WHOLSMP + CHALIGN: L/R pairs consumed atomically.
      * Parity is already encoded in software, so leave PAREN cleared.
-     * Note: Linux does NOT set DLATE/ERRORE/ERRORF at enable time.
+     * Note: DLATE/ERRORE/ERRORF are deliberately left cleared at
+     * enable time.
      */
     wr32le(HDMI_MAI_CTL(pb), MAI_CTL_CHALIGN | MAI_CTL_WHOLSMP | MAI_CTL_CHNUM(2) | MAI_CTL_ENABLE);
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
@@ -51,7 +51,7 @@ static inline void wr32le(ULONG addr, ULONG val)
 #define HDMI_MAI_SMP(pb)  ((pb) + HD_OFFSET + 0x2C)
 
 /*
- * HDMI register block — offsets from Linux vc4_hdmi_fields[] for BCM2835
+ * HDMI register block — BCM2835 offsets.
  * Bus address: 0x7E902000, ARM offset from peribase: 0x902000
  */
 #define HDMI_OFFSET                0x902000

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
@@ -154,25 +154,6 @@ void Slave(struct ExecBase *SysBase)
                 CallHookPkt(AudioCtrl->ahiac_MixerFunc, AudioCtrl, dd->mixbuffer);
 
                 /*
-                 * The mixer only writes ahiac_BuffSamples frames, but the
-                 * DMA buffer is sized for dmabuf_samples (MaxBuffSamples).
-                 * Zero the tail so the IEC958 encode produces silent (but
-                 * still valid) subframes there — leaving stale zero ULONGs
-                 * in the DMA buffer produces invalid subframes that put
-                 * the MAI into an error state.
-                 */
-                {
-                    ULONG mixed = AudioCtrl->ahiac_BuffSamples;
-                    if (mixed < dd->dmabuf_samples) {
-                        WORD *tail = (WORD *) dd->mixbuffer + mixed * 2;
-                        ULONG n = (dd->dmabuf_samples - mixed) * 2;
-                        ULONG i;
-                        for (i = 0; i < n; i++)
-                            tail[i] = 0;
-                    }
-                }
-
-                /*
                  * Convert mixed audio to SPDIF subframes and write
                  * to the DMA buffer that is NOT currently being read.
                  *
@@ -186,6 +167,11 @@ void Slave(struct ExecBase *SysBase)
                     ULONG dma_base = dd->periiobase + 0x007000 + dd->dma_channel * 0x100;
                     ULONG cbaddr = rd32le(dma_base + 0x04);
                     ULONG fillbuf;
+                    ULONG frames = AudioCtrl->ahiac_BuffSamples;
+
+                    /* The mix buffer holds at most MaxBuffSamples frames. */
+                    if (frames == 0 || frames > AudioCtrl->ahiac_MaxBuffSamples)
+                        frames = AudioCtrl->ahiac_MaxBuffSamples;
 
                     if (cbaddr == GPU_BUS_ADDR(dd->cb[0]))
                         fillbuf = 1; /* DMA on CB[0] → fill dmabuf[1] */
@@ -193,20 +179,25 @@ void Slave(struct ExecBase *SysBase)
                         fillbuf = 0; /* DMA on CB[1] → fill dmabuf[0] */
 
                     /*
-                     * Encode fully-formed IEC958 subframes in software.
-                     * The MAI consumes L/R subframe pairs from the DMA buffer.
-                     * Encode the full DMA buffer width (dmabuf_samples), not
-                     * just BuffSamples — the tail was padded with silence above.
+                     * Encode exactly the frames the mixer produced (the
+                     * DMA length below is shortened to match) — padding
+                     * the tail with silence stretched playback.
+                     * frame_counter advances by 'frames', keeping the
+                     * 192-frame IEC958 block continuous.
                      */
                     convert_mix_to_iec958((WORD *) dd->mixbuffer,
                                           dd->dmabuf[fillbuf],
-                                          dd->dmabuf_samples,
+                                          frames,
                                           dd->channel_status_l,
                                           dd->channel_status_r,
                                           &dd->frame_counter);
 
                     /* Flush converted data to physical RAM for DMA */
-                    CacheClearE(dd->dmabuf[fillbuf], dd->dmabuf_size, CACRF_ClearD);
+                    CacheClearE(dd->dmabuf[fillbuf], frames * 2 * sizeof(ULONG), CACRF_ClearD);
+
+                    /* Play exactly the encoded frames (see PWM driver notes). */
+                    dd->cb[fillbuf]->txfr_len = frames * 2 * sizeof(ULONG);
+                    CacheClearE(dd->cb[fillbuf], sizeof(struct BCM2708DMACB), CACRF_ClearD);
                 }
             }
         }

--- a/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-hwaccess.c
@@ -10,9 +10,23 @@
 #include <config.h>
 
 #include <exec/types.h>
+#include <exec/memory.h>
 #include <aros/macros.h>
+#include <aros/debug.h>
+#include <proto/exec.h>
+#include <proto/mbox.h>
+
+#include <hardware/videocore.h>
 
 #include "rpipwm-hwaccess.h"
+
+APTR MBoxBase = NULL;
+
+/*
+ * TRUE while the firmware owns the PWM clock. AHI serialises
+ * AHIsub_Start/Stop, so a plain flag is enough.
+ */
+static BOOL pwm_fw_owned = FALSE;
 
 /*
  * Microsecond delay using a busy loop on the system timer.
@@ -78,7 +92,8 @@ void pwm_gpio_restore(ULONG peribase)
 ******************************************************************************/
 
 /*
- * Configure the PWM clock from PLLD (500 MHz) for the desired sample rate.
+ * Fallback: configure the PWM clock directly from PLLD for the desired
+ * sample rate, assuming PLLD == PLLD_FREQ (500 MHz).
  *
  * The PWM runs at: clock_freq / range samples per second.
  * So we need: clock_freq = samplerate * range
@@ -86,11 +101,14 @@ void pwm_gpio_restore(ULONG peribase)
  *
  * We use MASH=1 (1-stage MASH noise-shaping) for fractional division,
  * which gives better audio quality than integer-only division.
+ *
+ * NOTE: drifts if the firmware retunes PLLD (display-mode changes);
+ * pwm_clock_setup() therefore prefers the firmware path.
  */
-void pwm_clock_setup(ULONG peribase, ULONG samplerate, ULONG range)
+static void pwm_clock_setup_cm(ULONG peribase, ULONG samplerate, ULONG range)
 {
-    ULONG cm_ctl_addr = peribase + 0x1010A0; /* CM_PWMCTL */
-    ULONG cm_div_addr = peribase + 0x1010A4; /* CM_PWMDIV */
+    ULONG cm_ctl_addr = CM_PWMCTL_ADDR(peribase);
+    ULONG cm_div_addr = CM_PWMDIV_ADDR(peribase);
     ULONG target_freq;
     ULONG divi, divf;
 
@@ -123,12 +141,211 @@ void pwm_clock_setup(ULONG peribase, ULONG samplerate, ULONG range)
 }
 
 /*
+ * Single-tag VideoCore property transaction. Request values in vals[]
+ * are replaced with the firmware's response on success.
+ *
+ * Must use MBoxCall (atomic request/response) — a split MBoxWrite +
+ * MBoxRead can lose the reply to concurrent mailbox users. The message
+ * is confined to one 64-byte cache line so the reply invalidate cannot
+ * clash with dirty neighbouring heap data.
+ */
+#define PWM_FW_MSG_BYTES 64 /* one full cache line, >= 6+3 message words */
+
+static BOOL pwm_fw_property(struct DriverBase *AHIsubBase, ULONG peribase, ULONG tag, ULONG *vals, ULONG nvals)
+{
+    APTR mbox = (APTR) (peribase + VCMB_OFFSET);
+    ULONG msgwords = 6 + nvals; /* header 2, tag header 3, values, end tag */
+    ULONG allocsz = PWM_FW_MSG_BYTES + 63;
+    ULONG *raw, *m;
+    ULONG i;
+    BOOL ok = FALSE;
+
+    if (MBoxBase == NULL)
+        MBoxBase = OpenResource("mbox.resource");
+    if (MBoxBase == NULL || msgwords * 4 > PWM_FW_MSG_BYTES)
+        return FALSE;
+
+    raw = AllocMem(allocsz, MEMF_PUBLIC | MEMF_CLEAR);
+    if (raw == NULL)
+        return FALSE;
+
+    m = (ULONG *) (((IPTR) raw + 63) & ~63);
+
+    m[0] = AROS_LONG2LE(msgwords * 4);
+    m[1] = AROS_LONG2LE(VCTAG_REQ);
+    m[2] = AROS_LONG2LE(tag);
+    m[3] = AROS_LONG2LE(nvals * 4);
+    m[4] = AROS_LONG2LE(nvals * 4);
+    for (i = 0; i < nvals; i++)
+        m[5 + i] = AROS_LONG2LE(vals[i]);
+    m[5 + nvals] = 0; /* end tag */
+
+    /*
+     * Require our buffer back, a success response code and the
+     * tag-processed bit — an error reply leaves the request values
+     * in place, spoofing a result.
+     */
+    if ((APTR) MBoxCall(mbox, VCMB_PROPCHAN, m) == (APTR) m
+        && AROS_LE2LONG(m[1]) == VCTAG_RESP
+        && (AROS_LE2LONG(m[4]) & VCTAG_RESP)) {
+        for (i = 0; i < nvals; i++)
+            vals[i] = AROS_LE2LONG(m[5 + i]);
+        ok = TRUE;
+    }
+
+    FreeMem(raw, allocsz);
+    return ok;
+}
+
+/* Tell the firmware to turn the PWM clock off. */
+static void pwm_fw_release_clock(struct DriverBase *AHIsubBase, ULONG peribase)
+{
+    ULONG vals[2];
+
+    vals[0] = VCCLOCK_PWM;
+    vals[1] = 0; /* bit0 clear = off */
+    pwm_fw_property(AHIsubBase, peribase, VCTAG_SETCLKSTATE, vals, 2);
+}
+
+/*
+ * Have the firmware enable and program the PWM clock. Returns the rate
+ * it programmed, or 0 on failure. A firmware-owned clock is re-derived
+ * when the parent PLL is retuned, so the rate survives display-mode
+ * changes.
+ */
+static ULONG pwm_fw_set_clock(struct DriverBase *AHIsubBase, ULONG peribase, ULONG rate)
+{
+    ULONG vals[3];
+
+    /* Enable the clock (only bit0 may be set in a request) */
+    vals[0] = VCCLOCK_PWM;
+    vals[1] = 1;
+    if (!pwm_fw_property(AHIsubBase, peribase, VCTAG_SETCLKSTATE, vals, 2))
+        return 0;
+
+    /* Program the clock rate */
+    vals[0] = VCCLOCK_PWM;
+    vals[1] = rate;
+    vals[2] = 0; /* do not skip turbo handling */
+    if (!pwm_fw_property(AHIsubBase, peribase, VCTAG_SETCLKRATE, vals, 3)) {
+        pwm_fw_release_clock(AHIsubBase, peribase); /* undo the enable above */
+        return 0;
+    }
+
+    return vals[1]; /* the rate the firmware actually programmed */
+}
+
+/*
+ * PWM clock rate read back from the CM registers — the mailbox response
+ * cannot be trusted (SETCLKRATE on a running clock echoes the new rate
+ * while CM_PWMDIV keeps the old divisor). Returns 0 if unverifiable.
+ */
+static ULONG pwm_cm_actual_clock(ULONG peribase)
+{
+    ULONG ctl = rd32le(CM_PWMCTL_ADDR(peribase));
+    ULONG div = rd32le(CM_PWMDIV_ADDR(peribase)) & 0xFFFFFF; /* 12.12 */
+
+    if ((ctl & 0xF) != CM_SRC_PLLD || div == 0)
+        return 0;
+
+    if (((ctl >> 9) & 3) == 0) {
+        /* MASH 0: integer division, the fractional field is ignored */
+        ULONG divi = div >> 12;
+        return divi ? PLLD_FREQ / divi : 0;
+    }
+
+    return (ULONG) (((unsigned long long) PLLD_FREQ << 12) / div);
+}
+
+/*
+ * Accept the firmware rate within 1% — it divides with MASH off, which
+ * costs up to ~1% (measured +0.66% at 44100 Hz).
+ */
+static BOOL pwm_rate_ok(ULONG real, ULONG target)
+{
+    ULONG diff = (real > target) ? (real - target) : (target - real);
+    return real != 0 && diff <= target / 100;
+}
+
+/*
+ * Configure the PWM clock: prefer the firmware path (stable across
+ * display-mode changes), fall back to direct CM programming from PLLD.
+ */
+void pwm_clock_setup(struct DriverBase *AHIsubBase, ULONG peribase, ULONG samplerate, ULONG range)
+{
+    ULONG target_freq = samplerate * range;
+    ULONG cm_ctl_addr = CM_PWMCTL_ADDR(peribase);
+    ULONG got;
+    ULONG real = 0;
+
+    /*
+     * Stop the clock first: the CM does not latch a divisor written
+     * while running, and the firmware's SETCLKRATE does not stop a
+     * clock it believes is enabled. SETCLKSTATE(off) also syncs the
+     * firmware's cached state.
+     */
+    wr32le(cm_ctl_addr, CM_PASSWORD | (rd32le(cm_ctl_addr) & ~CM_ENAB));
+    while (rd32le(cm_ctl_addr) & CM_BUSY)
+        udelay(peribase, 1);
+    pwm_fw_release_clock(AHIsubBase, peribase);
+
+    got = pwm_fw_set_clock(AHIsubBase, peribase, target_freq);
+
+    if (got != 0) {
+        real = pwm_cm_actual_clock(peribase);
+
+        /*
+         * Verify against the registers (see pwm_cm_actual_clock); on
+         * mismatch retry once with a full off -> on cycle, giving the
+         * firmware a real state transition to act on.
+         */
+        if (!(rd32le(CM_PWMCTL_ADDR(peribase)) & CM_BUSY) || !pwm_rate_ok(real, target_freq)) {
+            bug("[RPiPWM] firmware left PWM clock at %u Hz (want %u); retrying with off/on cycle\n",
+                real, target_freq);
+            pwm_fw_release_clock(AHIsubBase, peribase);
+            got = pwm_fw_set_clock(AHIsubBase, peribase, target_freq);
+            real = (got != 0) ? pwm_cm_actual_clock(peribase) : 0;
+        }
+    }
+
+    if (got != 0 && (rd32le(CM_PWMCTL_ADDR(peribase)) & CM_BUSY)
+        && pwm_rate_ok(real, target_freq)) {
+        pwm_fw_owned = TRUE;
+        return;
+    }
+
+    if (got != 0)
+        bug("[RPiPWM] firmware path unusable (claimed %u Hz, registers say %u, want %u); using direct PLLD path\n",
+            got, real, target_freq);
+
+    /*
+     * Release any firmware claim before programming the CM directly, or
+     * the firmware would reprogram our divisor on the next PLL retune.
+     */
+    if (got != 0 || pwm_fw_owned)
+        pwm_fw_release_clock(AHIsubBase, peribase);
+    pwm_fw_owned = FALSE;
+
+    pwm_clock_setup_cm(peribase, samplerate, range);
+}
+
+/*
  * Stop the PWM clock.
  */
-void pwm_clock_stop(ULONG peribase)
+void pwm_clock_stop(struct DriverBase *AHIsubBase, ULONG peribase)
 {
-    ULONG cm_ctl_addr = peribase + 0x1010A0;
+    ULONG cm_ctl_addr = CM_PWMCTL_ADDR(peribase);
 
+    /*
+     * Leave a firmware-owned clock running: releasing it makes the next
+     * session's identical enable+rate request be answered from the
+     * firmware's cache without the clock actually starting (observed on
+     * Pi 3B+). The PWM peripheral itself is stopped, so this is harmless.
+     */
+    if (pwm_fw_owned)
+        return;
+
+    /* Direct disable for the direct-programming path. */
     wr32le(cm_ctl_addr, CM_PASSWORD | (rd32le(cm_ctl_addr) & ~CM_ENAB));
 
     while (rd32le(cm_ctl_addr) & CM_BUSY)

--- a/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-hwaccess.h
+++ b/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-hwaccess.h
@@ -86,6 +86,10 @@ static inline void wr32le(ULONG addr, ULONG val)
 #define PWM_DMAC_PANIC(x) (((x) & 0xFF) << 8)
 #define PWM_DMAC_DREQ(x)  (((x) & 0xFF) << 0)
 
+/* Clock Manager PWM clock registers */
+#define CM_PWMCTL_ADDR(peribase) ((peribase) + 0x1010A0)
+#define CM_PWMDIV_ADDR(peribase) ((peribase) + 0x1010A4)
+
 /* Clock Manager bits */
 #define CM_PASSWORD 0x5A000000
 #define CM_SRC_PLLD 6
@@ -102,8 +106,8 @@ static inline void wr32le(ULONG addr, ULONG val)
 /* Hardware setup/teardown functions */
 void pwm_gpio_setup(ULONG peribase);
 void pwm_gpio_restore(ULONG peribase);
-void pwm_clock_setup(ULONG peribase, ULONG samplerate, ULONG range);
-void pwm_clock_stop(ULONG peribase);
+void pwm_clock_setup(struct DriverBase *AHIsubBase, ULONG peribase, ULONG samplerate, ULONG range);
+void pwm_clock_stop(struct DriverBase *AHIsubBase, ULONG peribase);
 void pwm_init(ULONG peribase, ULONG range);
 void pwm_stop(ULONG peribase);
 void dma_setup(ULONG peribase, ULONG channel, ULONG cb_bus_addr);

--- a/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-main.c
+++ b/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-main.c
@@ -144,6 +144,35 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
         dd->samplerate = AudioCtrl->ahiac_MixFreq;
 
         /*
+         * Pick a PWM range near PWM_AUDIO_RANGE so samplerate * range
+         * lands close to an integer division of PLLD — the firmware
+         * programs the clock with MASH off, so PLLD/divi are the only
+         * rates it can hit (e.g. 48000: range 1042 is -0.03% off vs
+         * 1024 at +1.7%).
+         */
+        {
+            ULONG best_ppm = ~0UL;
+            ULONG R;
+
+            dd->pwm_range = PWM_AUDIO_RANGE;
+            for (R = PWM_AUDIO_RANGE - 64; R <= PWM_AUDIO_RANGE + 64; R++) {
+                ULONG clk = dd->samplerate * R;
+                ULONG d = (PLLD_FREQ + clk / 2) / clk;
+                ULONG actual, err, ppm;
+
+                if (d == 0)
+                    continue;
+                actual = PLLD_FREQ / d;
+                err = (actual > clk) ? actual - clk : clk - actual;
+                ppm = (ULONG) (((unsigned long long) err * 1000000ULL) / clk);
+                if (ppm < best_ppm) {
+                    best_ppm = ppm;
+                    dd->pwm_range = R;
+                }
+            }
+        }
+
+        /*
          * Calculate DMA buffer size.
          * Use the AHI-requested buffer size in sample frames.
          * Each frame = 2 channels * 4 bytes (32-bit PWM words) = 8 bytes.
@@ -199,7 +228,7 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         /* Configure hardware (but don't start DMA yet) */
         pwm_gpio_setup(dd->periiobase);
-        pwm_clock_setup(dd->periiobase, dd->samplerate, dd->pwm_range);
+        pwm_clock_setup(AHIsubBase, dd->periiobase, dd->samplerate, dd->pwm_range);
         pwm_init(dd->periiobase, dd->pwm_range);
 
         /*
@@ -283,7 +312,7 @@ void _AHIsub_Stop(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverB
         /* Stop hardware */
         dma_stop(dd->periiobase, dd->dma_channel);
         pwm_stop(dd->periiobase);
-        pwm_clock_stop(dd->periiobase);
+        pwm_clock_stop(AHIsubBase, dd->periiobase);
         pwm_gpio_restore(dd->periiobase);
 
         dd->slavesignal = -1;

--- a/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiPWM/rpipwm-playslave.c
@@ -193,6 +193,15 @@ void Slave(struct ExecBase *SysBase)
                     ULONG dma_base = dd->periiobase + 0x007000 + dd->dma_channel * 0x100;
                     ULONG cbaddr = rd32le(dma_base + 0x04);
                     ULONG fillbuf;
+                    ULONG frames = AudioCtrl->ahiac_BuffSamples;
+
+                    /*
+                     * The mix buffer holds at most MaxBuffSamples frames,
+                     * which can be less than the (min. 256 frame) DMA
+                     * buffer.
+                     */
+                    if (frames == 0 || frames > AudioCtrl->ahiac_MaxBuffSamples)
+                        frames = AudioCtrl->ahiac_MaxBuffSamples;
 
                     if (cbaddr == GPU_BUS_ADDR(dd->cb[0]))
                         fillbuf = 1; /* DMA on CB[0] → fill dmabuf[1] */
@@ -200,10 +209,21 @@ void Slave(struct ExecBase *SysBase)
                         fillbuf = 0; /* DMA on CB[1] → fill dmabuf[0] */
 
                     convert_mix_to_pwm(
-                        (WORD *) dd->mixbuffer, dd->dmabuf[fillbuf], AudioCtrl->ahiac_BuffSamples, dd->pwm_range);
+                        (WORD *) dd->mixbuffer, dd->dmabuf[fillbuf], frames, dd->pwm_range);
 
                     /* Flush converted data to physical RAM for DMA */
-                    CacheClearE(dd->dmabuf[fillbuf], dd->dmabuf_size, CACRF_ClearD);
+                    CacheClearE(dd->dmabuf[fillbuf], frames * 2 * sizeof(ULONG), CACRF_ClearD);
+
+                    /*
+                     * Play exactly the frames the mixer produced —
+                     * playing the full (MaxBuffSamples-sized) DMA buffer
+                     * would stretch playback and shift the pitch. The DMA
+                     * re-reads the CB from RAM on each chain; we only
+                     * touch the CB that is not playing, which assumes the
+                     * refill completes within one buffer period.
+                     */
+                    dd->cb[fillbuf]->txfr_len = frames * 2 * sizeof(ULONG);
+                    CacheClearE(dd->cb[fillbuf], sizeof(struct BCM2708DMACB), CACRF_ClearD);
                 }
             }
         }

--- a/workbench/devs/AHI/mmakefile.src
+++ b/workbench/devs/AHI/mmakefile.src
@@ -8,8 +8,8 @@ include $(SRCDIR)/config/aros.cfg
 #MM- workbench-devs-AHI : workbench-devs-AHI-subsystem AHI-drivers
 #MM- workbench-devs-AHI-quick : workbench-devs-AHI-subsystem-quick AHI-drivers-quick
 
-#MM- AHI-raspi-armhf :  kernel-dma-bcm2708-includes
-#MM- AHI-raspi-arm :  kernel-dma-bcm2708-includes
+#MM- AHI-raspi-armhf :  kernel-dma-bcm2708-includes kernel-mbox-bcm2708-includes
+#MM- AHI-raspi-arm :  kernel-dma-bcm2708-includes kernel-mbox-bcm2708-includes
 
 #MM- AHI-standalone-prereqs : \
 #MM                         AHI-$(AROS_TARGET_ARCH)-$(AROS_TARGET_CPU)


### PR DESCRIPTION
Sound over HDMI and the 3.5mm jack could play too fast or too slow, and could drift when the screen mode changed. The drivers now use the correct audio clocks and play exactly what the mixer produces.