### PR TITLE
graphics: ScrollRaster/ScrollRasterBF drop negative deltas on AAPCS64

### DIFF
--- a/rom/graphics/scrollraster.c
+++ b/rom/graphics/scrollraster.c
@@ -18,12 +18,12 @@
 
 /*  SYNOPSIS */
         AROS_LHA(struct RastPort *, rp, A1),
-        AROS_LHA(LONG             , dx, D0),
-        AROS_LHA(LONG             , dy, D1),
-        AROS_LHA(LONG             , xMin, D2),
-        AROS_LHA(LONG             , yMin, D3),
-        AROS_LHA(LONG             , xMax, D4),
-        AROS_LHA(LONG             , yMax, D5),
+        AROS_LHA(WORD             , dx, D0),
+        AROS_LHA(WORD             , dy, D1),
+        AROS_LHA(WORD             , xMin, D2),
+        AROS_LHA(WORD             , yMin, D3),
+        AROS_LHA(WORD             , xMax, D4),
+        AROS_LHA(WORD             , yMax, D5),
 
 /*  LOCATION */
         struct GfxBase *, GfxBase, 66, Graphics)

--- a/rom/graphics/scrollrasterbf.c
+++ b/rom/graphics/scrollrasterbf.c
@@ -18,12 +18,12 @@
 
 /*  SYNOPSIS */
         AROS_LHA(struct RastPort *, rp, A1),
-        AROS_LHA(LONG             , dx, D0),
-        AROS_LHA(LONG             , dy, D1),
-        AROS_LHA(LONG             , xMin, D2),
-        AROS_LHA(LONG             , yMin, D3),
-        AROS_LHA(LONG             , xMax, D4),
-        AROS_LHA(LONG             , yMax, D5),
+        AROS_LHA(WORD             , dx, D0),
+        AROS_LHA(WORD             , dy, D1),
+        AROS_LHA(WORD             , xMin, D2),
+        AROS_LHA(WORD             , yMin, D3),
+        AROS_LHA(WORD             , xMax, D4),
+        AROS_LHA(WORD             , yMax, D5),
 
 /*  LOCATION */
         struct GfxBase *, GfxBase, 167, Graphics)


### PR DESCRIPTION
## The bug

graphics.conf declares ScrollRaster and ScrollRasterBF with WORD parameters, so every generated caller stub passes 16-bit arguments, but the two implementations declare them `AROS_LHA(LONG, ...)`.

On aarch64 the libcall macros expand to plain C calls, and under AAPCS64 the caller is not required to extend sub-32-bit arguments: the upper register bits are the callee's problem. In practice the caller loads a WORD field with `ldrh` (zero-extend), so a callee compiled with LONG parameters sees `dy = -30` arrive as `65506` (0xFFE2). The huge magnitude then takes the "scrolled beyond the rectangle" early-out (EraseRect and return) and the blit never happens. Since Zune windows install a no-op backfill, the erase paints nothing either, so any upward or leftward scroll does nothing except the caller's exposed-strip redraw.

Visible result on aarch64 hosted builds: scrolling a Wanderer drawer window up or left duplicates icon rows and leaves stale bands, compounding with every step (subsequent downward scrolls faithfully blit the accumulated mess). Verified by logging the delta on both sides of the LVO boundary: `d=(0,-30)` leaves iconlist.c, `d=(0,65506)` arrives in ScrollRasterBF.

## The fix

Make the implementation parameter types match the .conf (WORD), so the callee sign-extends the low 16 bits itself.

Fixing the callee rather than widening the .conf keeps the ABI exactly as every already-built binary and the AmigaOS NDK prototype expect. Other platforms are unaffected:

- x86: the caller pushes a sign-extended 32-bit slot; reading it as short yields the same value.
- arm 32-bit: AAPCS requires the caller to extend narrow arguments; low 16 bits are the value either way.
- x86_64: compilers extend narrow arguments at the call site in practice; same reasoning.
- m68k: the original ABI passes these in the low word of D0-D5 and classic callers leave garbage in the upper half, so reading the registers as LONG was wrong there too; WORD matches the historical contract.

Inside the functions nothing changes: the bodies immediately promote into LONG locals, and the rastport coordinate space is 16-bit signed by design, so no legitimate caller loses range (callers were already truncating to WORD in the stubs).

Tested on darwin-aarch64 hosted: wheel and scrollbar scrolling in both directions, horizontal scrolling, and repeated window resize cycles are all artifact-free; previously any negative delta corrupted the window.

## Scope note

A sweep found the same latent WORD (.conf) vs LONG (implementation) pattern in BltBitMap, RectFill, EraseRect, Flood, Read/WritePixelLine8, WriteChunkyPixels and WritePixelArray8 coordinates. Those values are essentially always non-negative, so they are left untouched here to keep this change surgical; happy to follow up separately if there is interest.