### PR TITLE
nlist: fix 64-bit taglist crashes (int values in stack-spilled varargs)

### DIFF
--- a/workbench/classes/zune/nlist/nlist_mcc/NList_mcc.c
+++ b/workbench/classes/zune/nlist/nlist_mcc/NList_mcc.c
@@ -258,12 +258,15 @@ void obtain_pen(Object *obj, IPTR *pen, struct MUI_PenSpec *ps)
 
 #if !defined(__MORPHOS__)
 #ifdef __AROS__
-static __attribute__ ((noinline)) Object * VARARGS68K DoSuperNew(struct IClass *cl, Object *obj, Tag tag1, ...)
-{
-    AROS_SLOWSTACKTAGS_PRE_AS(tag1, Object *)
-    retval = (Object *)DoSuperMethod(cl, obj, OM_NEW, AROS_SLOWSTACKTAGS_ARG(tag1), NULL);
-    AROS_SLOWSTACKTAGS_POST
-}
+/* varargs cannot carry int-typed tag data on 64-bit targets; expand the
+   tag list into a full-width IPTR array at the call site instead */
+#include <aros/preprocessor/variadic/cast2iptr.hpp>
+#define DoSuperNew(cl, obj, ...)                                          \
+({                                                                        \
+    IPTR __args[] = { AROS_PP_VARIADIC_CAST2IPTR(__VA_ARGS__) };          \
+    struct opSet __ops = { OM_NEW, (struct TagItem *)__args, NULL };      \
+    (Object *)DoSuperMethodA((cl), (obj), (Msg)&__ops);                   \
+})
 #else
 static Object * VARARGS68K DoSuperNew(struct IClass *cl, Object *obj, ...)
 {
@@ -346,28 +349,31 @@ IPTR mNL_New(struct IClass *cl,Object *obj,struct opSet *msg)
   if(DragSortable)
     dropable = TRUE;
 
+  img_tr = MUI_NewObject(MUIC_Image,
+    MUIA_FillArea,FALSE,
+    MUIA_Image_Spec,img_name,
+/*
+ *   MUIA_Image_FontMatch, TRUE,
+ *   MUIA_Font, Topaz_8,
+ *   MUIA_Image_State, IDS_NORMAL,
+ */
+  End;
+
+  grp = NewObject(NGR_Class->mcc_Class,NULL,
+    MUIA_Group_LayoutHook, &NL_LayoutHookGroup,
+    MUIA_FillArea, FALSE,
+    NoFrame,
+    Child, img_tr,
+    /*Child, HVSpace,*/
+  End;
+
   obj = (Object *) DoSuperNew(cl,obj,
     MUIA_Group_LayoutHook, &NL_LayoutHookNList,
     MUIA_FillArea, FALSE,
     MUIA_Dropable, dropable,
     NoFrame,
-      Child, grp = NewObject(NGR_Class->mcc_Class,NULL,
-        MUIA_Group_LayoutHook, &NL_LayoutHookGroup,
-        MUIA_FillArea, FALSE,
-        NoFrame,
-        Child, img_tr = MUI_NewObject(MUIC_Image,
-          MUIA_FillArea,FALSE,
-          MUIA_Image_Spec,img_name,
-/*
- *         MUIA_Image_FontMatch, TRUE,
- *         MUIA_Font, Topaz_8,
- *         MUIA_Image_State, IDS_NORMAL,
- */
-        End,
-        /*Child, HVSpace,*/
-      End,
-    TAG_MORE, taglist
-  );
+    Child, grp,
+    TAG_MORE, taglist);
 
 
   if(obj == NULL || (data = INST_DATA(cl, obj)) == NULL)

--- a/workbench/classes/zune/nlist/nlistview_mcc/NListview.c
+++ b/workbench/classes/zune/nlist/nlistview_mcc/NListview.c
@@ -452,12 +452,9 @@ static void NLV_Scrollers(Object *obj, struct NLVData *data, LONG vert, LONG hor
 
 #if !defined(__MORPHOS__)
 #ifdef __AROS__
-static __attribute__ ((noinline)) Object * VARARGS68K DoSuperNew(struct IClass *cl, Object *obj, Tag tag1, ...)
-{
-    AROS_SLOWSTACKTAGS_PRE_AS(tag1, Object *)
-    retval = (Object *)DoSuperMethod(cl, obj, OM_NEW, AROS_SLOWSTACKTAGS_ARG(tag1), NULL);
-    AROS_SLOWSTACKTAGS_POST
-}
+/* varargs cannot carry int-typed tag data on 64-bit targets; expand the
+   tag list into a full-width IPTR array at the call site instead */
+#define DoSuperNew(cl, obj, ...) DoSuperNewTags((cl), (obj), NULL, __VA_ARGS__)
 #else
 static Object * VARARGS68K DoSuperNew(struct IClass *cl, Object *obj, ...)
 {
@@ -557,17 +554,18 @@ static IPTR mNLV_New(struct IClass *cl, Object *obj, struct opSet *msg)
     nlist = MUI_NewObject(MUIC_NList, MUIA_Dropable, dropable, TAG_MORE, msg->ops_AttrList);
   }
 
+  vgroup = VGroup,
+    MUIA_Group_Spacing, 0,
+    Child, nlist,
+  TAG_DONE);
+
   obj = (Object *)DoSuperNew(cl, obj,
     MUIA_Group_Horiz, TRUE,
     MUIA_Group_Spacing, 0,
     MUIA_CycleChain, cyclechain,
     NoFrame,
-    Child, vgroup = VGroup,
-      MUIA_Group_Spacing, 0,
-      Child, nlist,
-    TAG_DONE),
-    TAG_MORE, msg->ops_AttrList
-  );
+    Child, vgroup,
+    TAG_MORE, msg->ops_AttrList);
 
   if(obj)
   {

--- a/workbench/classes/zune/nlist/nlistviews_mcp/NListviews.c
+++ b/workbench/classes/zune/nlist/nlistviews_mcp/NListviews.c
@@ -120,12 +120,14 @@ Object *MakeCheck(STRPTR label, STRPTR help, ULONG check)
   return (obj);
 }
 
+/* MUIA_String_Contents carries a pointer; a bare int 0 vararg is not
+   pointer-sized on 64-bit targets, so cast it here */
 #define String2(contents,maxlen)\
   (void *)StringObject,\
     StringFrame,\
     MUIA_CycleChain, 1,\
     MUIA_String_MaxLen  , maxlen,\
-    MUIA_String_Contents, contents,\
+    MUIA_String_Contents, (STRPTR)(contents),\
     End
 
 #define LOAD_DATALONG(obj,attr,cfg_attr,defaultval) \


### PR DESCRIPTION
On 64-bit targets, a plain C int passed as a taglist tag or value in a variadic call is only stored as 32 bits when the argument spills to a stack vararg slot (the first 8 arguments travel in registers on AArch64 and are zero-extended for free, which is why small tag lists never trigger this). The tag walker then reads the full 64-bit slot, and the stale upper half of the stack turns a harmless 0 into a garbage pointer such as 0x100000000.

Three call sites in the NList classes hit this in practice:

- `NListviews.mcp`'s `String2(0,80)` macro passes int 0 as `MUIA_String_Contents`; `String__OM_NEW` strcmp's the garbage pointer. This crashes Zune prefs ("GUI Settings..." in Wanderer) as soon as the NListviews settings page loads.
- `NList_mcc.c` and `NListview.c` OM_NEW pass `NoFrame` (= `MUIA_Frame, MUIV_Frame_None`) past the 8th vararg of `DoSuperNew`; frame 0 becomes 0x100000000, which `Area--MUIM_Setup` treats as a frame-spec string and strlen's. This crashes SysExplorer at launch.

Fix: cast the affected tags and values to IPTR at the call sites. In the NList_mcc site the spilled tag words themselves (`MUIA_Frame`, `Child` are 32-bit unsigned int constants) are cast too, since a garbage upper half there makes the walker silently skip the tag.

Found and verified on aarch64 (hosted): before the fix, both Zune WANDERER and SysExplorer crashed deterministically at the exact same instructions; after it, both open and run cleanly. x86_64 is exposed to the same C-semantics issue since varargs spill to the stack after 6 integer registers there.