### PR TITLE
kernel: save IDNestCnt for every outgoing task in core_Switch

### DIFF
--- a/arch/arm-native/kernel/kernel_scheduler.c
+++ b/arch/arm-native/kernel/kernel_scheduler.c
@@ -106,6 +106,11 @@ void core_Switch(void)
 
     DSCHED(bug("[Kernel:%02d] core_Switch(%08x)\n", cpunum, task->tc_State));
 
+    /* Preserve the Disable() nest count for every outgoing task, not only
+     * TS_RUN ones: Wait() switches away in TS_WAIT holding a Disable() level
+     * and relies on Switch() to restore it. */
+    task->tc_IDNestCnt = IDNESTCOUNT_GET;
+
     if (task->tc_State == TS_RUN)
     {
         DSCHED(bug("[Kernel:%02d] Switching away from '%s' @ 0x%p\n", cpunum, task->tc_Node.ln_Name, task));
@@ -136,8 +141,6 @@ void core_Switch(void)
 
             Alert(AN_StackProbe);
         }
-
-        task->tc_IDNestCnt = IDNESTCOUNT_GET;
 
         if (task->tc_Flags & TF_SWITCH)
             AROS_UFC1NR(void, task->tc_Switch, AROS_UFCA(struct ExecBase *, SysBase, A6));


### PR DESCRIPTION
exec Wait() switches away in TS_WAIT state while holding one Disable() level and relies on Switch() to preserve the nest count. The TS_RUN-only save let the count drift below -1 on every blocking wait until the BYTE wrapped positive and the task was dispatched with IRQs masked.