### PR TITLE
68k kickstart replacement: made some optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3063,3 +3063,8 @@
 
 # /workbench/utilities/Presenter/
 /workbench/utilities/Presenter/mmakefile
+
+# Build-generated mmakefiles (produced from mmakefile.src by the build).
+# Tracked, hand-written mmakefiles that predate mmakefile.src are unaffected,
+# since .gitignore does not untrack already-committed files.
+mmakefile

--- a/arch/m68k-amiga/boot/kobj-romtag.ld
+++ b/arch/m68k-amiga/boot/kobj-romtag.ld
@@ -1,0 +1,29 @@
+/*
+ * Partial-link (ld -Ur) section-ordering script for amiga-m68k kernel modules.
+ *
+ * Orders each module's contents as:
+ *   .text.romtag   - the Resident tag, at the module HEAD
+ *   .text          - the module body
+ *   .rodata        - folded in here (before the End marker) so it is covered by
+ *                    the tag->End leap; otherwise big-.rodata modules (e.g. icon's
+ *                    ~44KB of bitmaps) would still be walked word-by-word.
+ *   .text.moduleend - the End marker = rt_EndSkip target = TRUE module tail
+ * Combined with the ROM link emitting each module's .text before its .rodata
+ * (arch/m68k-amiga/boot/mmakefile.src), the romtag scanner finds the tag on the
+ * first read and leaps the whole module (body + rodata) to the next module's tag
+ * via rt_EndSkip - instead of walking every word of the ROM.
+ *
+ * NOTE: AROS linker-set sub-sections (__INITLIB_LIST__, __aros_set_*, etc.) stay
+ * in .rodata deliberately - the KOBJ link's OBJCOPY -L step collects/renames them,
+ * so they must not be folded away. They are only a few dozen bytes per module.
+ *
+ * Wired in via KERNEL_KOBJ_LDSCRIPT in config/make.cfg (amiga-m68k only).
+ */
+SECTIONS {
+  .text : {
+    *(.text.romtag)
+    *(.text .text.* .stub)
+    *(.rodata .rodata.*)
+    *(.text.moduleend)
+  }
+}

--- a/arch/m68k-amiga/boot/kobj-romtag.ld
+++ b/arch/m68k-amiga/boot/kobj-romtag.ld
@@ -17,13 +17,23 @@
  * in .rodata deliberately - the KOBJ link's OBJCOPY -L step collects/renames them,
  * so they must not be folded away. They are only a few dozen bytes per module.
  *
+ * The ALIGN(4) before .rodata is REQUIRED: folding .rodata after .text can leave
+ * it starting on an odd byte, and .rodata holds longword constants (e.g. the
+ * __aros_libreq_* library-version markers) that module code reads with CMP.L.
+ * A .L access to an odd address is an address error (0x80000003) on the 68000/010
+ * - it silently works on 68020+, which is why this only crashed on the A500.
+ *
  * Wired in via KERNEL_KOBJ_LDSCRIPT in config/make.cfg (amiga-m68k only).
  */
 SECTIONS {
   .text : {
+    . = ALIGN(2);
     *(.text.romtag)
+    . = ALIGN(2);
     *(.text .text.* .stub)
+    . = ALIGN(4);
     *(.rodata .rodata.*)
+    . = ALIGN(2);
     *(.text.moduleend)
   }
 }

--- a/arch/m68k-amiga/boot/mmakefile.src
+++ b/arch/m68k-amiga/boot/mmakefile.src
@@ -198,10 +198,17 @@ $(HOSTGENDIR)/tools/romcheck: romcheck.c
 # Resident tag at the module's head, so the boot-time romtag scanner finds it on
 # the first read and leaps to the next module via rt_EndSkip - instead of walking
 # every word of the ROM. Only the module's small .rodata is walked per module.
+#
+# ALIGN(4) before each part is REQUIRED: a module's .text can end on an odd byte,
+# and .rodata holds longword constants (e.g. __aros_libreq_* version markers) that
+# code reads with CMP.L. A .L read from an odd address is an address error on the
+# 68000/010 (fine on 68020+), so without this the A500 crashes booting from disk.
 $(GENDIR)/%_objs.ld: $(SRCDIR)/$(CURDIR)/mmakefile.src
 	$(Q)rm -f $@
 	$(Q)for file in $(OBJS_$*) $(KOBJS_$*); do \
+		echo ". = ALIGN(4);" >>$@; \
 		echo "$$file(.text)" >>$@; \
+		echo ". = ALIGN(4);" >>$@; \
 		echo "$$file(.rodata .rodata.*)" >>$@; \
 	done
 

--- a/arch/m68k-amiga/boot/mmakefile.src
+++ b/arch/m68k-amiga/boot/mmakefile.src
@@ -193,11 +193,16 @@ kernel-link-amiga-m68k-quick : $(GENDIR)/boot/aros-amiga-m68k-rom.bin $(GENDIR)/
 $(HOSTGENDIR)/tools/romcheck: romcheck.c
 	$(Q)$(HOST_CC) $(DEBUG_CFLAGS) -o $@ $<
 
+# Emit each module's .text BEFORE its .rodata. Combined with the romtag-first
+# KOBJ link (config/make.tmpl KERNEL_KOBJ_LDSCRIPT), this puts each module's
+# Resident tag at the module's head, so the boot-time romtag scanner finds it on
+# the first read and leaps to the next module via rt_EndSkip - instead of walking
+# every word of the ROM. Only the module's small .rodata is walked per module.
 $(GENDIR)/%_objs.ld: $(SRCDIR)/$(CURDIR)/mmakefile.src
 	$(Q)rm -f $@
 	$(Q)for file in $(OBJS_$*) $(KOBJS_$*); do \
-		echo "$$file(.rodata .rodata.*)" >>$@; \
 		echo "$$file(.text)" >>$@; \
+		echo "$$file(.rodata .rodata.*)" >>$@; \
 	done
 
 $(GENDIR)/boot/aros-amiga-m68k-reloc.elf : $(DEPLIBS) $(SRCDIR)/$(CURDIR)/mmakefile.src \

--- a/arch/m68k-amiga/boot/start.c
+++ b/arch/m68k-amiga/boot/start.c
@@ -562,6 +562,15 @@ void doColdCapture(void)
           "a0", "a1", "a2", "a3", "a4", "a5", "a6");
 }
 
+/* Returns TRUE if a Kickstart-format ROM image is present at 'rom'.
+ * Uses the standard ROM header signature (top 12 bits == 0x111), the same
+ * check as AMiGAROM_IsValid(). Lets us skip the romtag scan of the
+ * 0xF00000 window when no expansion/diagnostic ROM is mapped there. */
+static BOOL rom_present(IPTR rom)
+{
+    return (*(volatile ULONG *)rom & 0xFFF00000) == 0x11100000;
+}
+
 static void RomInfo(IPTR rom)
 {
 #if AROS_SERIAL_DEBUG && (DEBUG > 0)
@@ -793,26 +802,33 @@ void exec_boot(ULONG *membanks, ULONG *cpupcr)
 
     Early_ScreenCode(CODE_RAM_CHECK);
 
-    if (arosbootstrapmode) {
-        /* Scan only first rom image.
-         * The rest is in BootStruct resident list
+    {
+        /*
+         * Build the romtag scan ranges. The main ROM (and, when not in
+         * bootstrap mode, the ext ROM) are always scanned. The 0xF00000
+         * window is only scanned if a ROM image is actually mapped there
+         * (expansion/diagnostic ROM). On stock machines and emulators that
+         * window is empty, so scanning its 512K word-by-word is pure waste
+         * and dominates boot time - skip it unless a ROM signature is found.
          */
-        kickrom[0] = (UWORD*)&_rom_start;
-        kickrom[1] = (UWORD*)&_rom_end;
-        kickrom[2] = (UWORD*)0x00f00000;
-        kickrom[3] = (UWORD*)0x00f80000;
-        kickrom[4] = (UWORD*)~0;
-        kickrom[5] = (UWORD*)~0;
-        resetKickMem (BootS);
-    } else {
-        kickrom[0] = (UWORD*)&_rom_start;
-        kickrom[1] = (UWORD*)&_rom_end;
-        kickrom[2] = (UWORD*)0x00f00000;
-        kickrom[3] = (UWORD*)0x00f80000;
-        kickrom[4] = (UWORD*)&_ext_start;
-        kickrom[5] = (UWORD*)&_ext_end;
-        kickrom[6] = (UWORD*)~0;
-        kickrom[7] = (UWORD*)~0;
+        i = 0;
+        kickrom[i++] = (UWORD*)&_rom_start;
+        kickrom[i++] = (UWORD*)&_rom_end;
+        if (rom_present(0x00f00000)) {
+            kickrom[i++] = (UWORD*)0x00f00000;
+            kickrom[i++] = (UWORD*)0x00f80000;
+        }
+        if (arosbootstrapmode) {
+            /* Scan only first rom image.
+             * The rest is in BootStruct resident list
+             */
+            resetKickMem (BootS);
+        } else {
+            kickrom[i++] = (UWORD*)&_ext_start;
+            kickrom[i++] = (UWORD*)&_ext_end;
+        }
+        kickrom[i++] = (UWORD*)~0;
+        kickrom[i++] = (UWORD*)~0;
     }
 
     mh = addmemoryregion(membanks[0], membanks[1],

--- a/arch/m68k-amiga/cia/cia_init.c
+++ b/arch/m68k-amiga/cia/cia_init.c
@@ -82,7 +82,9 @@ static AROS_UFP3 (APTR, Cia_Init,
 
 extern void Cia_End(void);
 
-struct Resident const Cia_ROMTag =
+/* In .text.romtag so the m68k ROM link places this tag at the module head,
+ * letting the romtag scanner find it on the first read and leap via rt_EndSkip. */
+__attribute__((section(".text.romtag"))) struct Resident const Cia_ROMTag =
 {
     RTC_MATCHWORD,
     &Cia_ROMTag,

--- a/arch/m68k-amiga/cia/resident_end.c
+++ b/arch/m68k-amiga/cia/resident_end.c
@@ -2,4 +2,6 @@
     Copyright (C) 1995-2014, The AROS Development Team. All rights reserved.
 */
 
-void Cia_End(void) { }
+/* In .text.moduleend so it links at the module tail: rt_EndSkip = &Cia_End then
+ * marks the true module end for the romtag scanner's leap to the next module. */
+__attribute__((section(".text.moduleend"))) void Cia_End(void) { }

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
@@ -885,10 +885,26 @@ VOID AmigaVideoCl__Hidd_Gfx__CopyBox(OOP_Class *cl, OOP_Object *o, struct pHidd_
  
     OOP_GetAttr(msg->src,  aHidd_BitMap_AmigaVideo_Drawable, &src);
     OOP_GetAttr(msg->dest, aHidd_BitMap_AmigaVideo_Drawable, &dst);
-    if (src && dst) {
-        struct amigabm_data *sdata = OOP_INST_DATA(OOP_OCLASS(msg->src), msg->src);
+    if (dst) {
         struct amigabm_data *ddata = OOP_INST_DATA(OOP_OCLASS(msg->dest), msg->dest);
-        ok = blit_copybox(csd, sdata->pbm, ddata->pbm, msg->srcX, msg->srcY, msg->width, msg->height, msg->destX, msg->destY, mode);
+        struct BitMap *srcpbm = NULL;
+
+        if (src) {
+            /* Source is an AmigaVideo bitmap. */
+            struct amigabm_data *sdata = OOP_INST_DATA(OOP_OCLASS(msg->src), msg->src);
+            srcpbm = sdata->pbm;
+        } else {
+            /* Source is a generic planar bitmap (e.g. a plain struct BitMap
+             * wrapped by get_planarbm_object). Its planes can be blitted from
+             * directly as long as they live in Chip RAM (checked by canblit).
+             * This lets callers BltBitMap a hand-built planar BitMap - such as
+             * the dosboot animation image - straight to the screen with the
+             * hardware blitter instead of falling back to per-pixel C2P. */
+            OOP_GetAttr(msg->src, aHidd_PlanarBM_BitMap, (IPTR *)&srcpbm);
+        }
+
+        if (srcpbm)
+            ok = blit_copybox(csd, srcpbm, ddata->pbm, msg->srcX, msg->srcY, msg->width, msg->height, msg->destX, msg->destY, mode);
     }
     if (!ok)
         OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);

--- a/compiler/crt/stdc/memset.c
+++ b/compiler/crt/stdc/memset.c
@@ -59,6 +59,36 @@
         fill = (fill <<  8) | fill;
         fill = (fill << 16) | fill;
 
+#if defined(__mc68000__)
+        /*
+         * On 68000, GCC -Os compiles the plain long-fill loop to ~6 instructions
+         * per 4 bytes (~18 cycles/byte), which dominates ROM boot time clearing
+         * MEMF_CLEAR allocations. Fill 32 bytes per iteration with movem.l (the
+         * fastest 68000 memory fill) instead.
+         */
+        {
+            /*
+             * Fill 16 bytes per iteration with movem.l (d3-d6). We pin only four
+             * data registers so the allocator still has registers for the loop
+             * counter and pointer; that is enough to beat the plain long loop by
+             * a wide margin while staying well within the 68000's register file.
+             */
+            register ULONG f3 asm("d3") = fill;
+            register ULONG f4 asm("d4") = fill;
+            register ULONG f5 asm("d5") = fill;
+            register ULONG f6 asm("d6") = fill;
+
+            while (count >= 16)
+            {
+                asm volatile ("movem.l %%d3-%%d6,%0@\n\tlea %0@(16),%0"
+                              : "+a" (ulptr)
+                              : "d"(f3),"d"(f4),"d"(f5),"d"(f6)
+                              : "memory");
+                count -= 16;
+            }
+        }
+#endif
+
         while (count > sizeof(ULONG))
         {
             *ulptr ++ = fill;

--- a/config/make.cfg.in
+++ b/config/make.cfg.in
@@ -204,6 +204,17 @@ AROS_CXXEXTS                  := cpp cxx cc c++
 AROS_AS                       := $(TARGET_AS)
 AROS_LD                       := $(TARGET_LD)
 
+# Optional -T linker script for the kernel-module partial link (AROS_LD -Ur), used
+# to order each module's sections so its Resident romtag lands at the module head
+# (see arch/m68k-amiga/boot/kobj-romtag.ld). Empty for every target except
+# amiga-m68k, so all other builds pass the identical -Ur command as before.
+KERNEL_KOBJ_LDSCRIPT          :=
+ifeq ($(AROS_TARGET_ARCH),amiga)
+ifeq ($(AROS_TARGET_CPU),m68k)
+KERNEL_KOBJ_LDSCRIPT          := -T $(SRCDIR)/arch/m68k-amiga/boot/kobj-romtag.ld
+endif
+endif
+
 STRIP                         := $(TARGET_STRIP)
 
 CALL                          := env AROS_HOST_ARCH=$(AROS_HOST_ARCH) \

--- a/config/make.tmpl
+++ b/config/make.tmpl
@@ -2162,7 +2162,7 @@ $(%(mmake)_KOBJ) : FILTBASES:=$(addprefix -L ,$(%(mmake)_SYMBOLS))
 $(%(mmake)_KOBJ) : USER_LDFLAGS := $(USER_LDFLAGS)
 $(%(mmake)_KOBJ) : $(%(mmake)_OBJS) $(%(mmake)_ENDOBJS)
 	$(Q)$(ECHO) "Linking    $(subst $(TARGETDIR)/,,$@)"
-	$(Q)$(AROS_LD) -Ur -o $@ $^ $(USER_LDFLAGS) -L$(AROS_LIB) $(addprefix -l,$(LINKLIBS))
+	$(Q)$(AROS_LD) -Ur $(KERNEL_KOBJ_LDSCRIPT) -o $@ $^ $(USER_LDFLAGS) -L$(AROS_LIB) $(addprefix -l,$(LINKLIBS))
 	$(Q)$(OBJCOPY) $@ $(FILTBASES) `$(NM_PLAIN) $@ | $(AWK) '($$3 ~ /^__.*_(LIST|END)__\r?$$/) || ($$3 ~ /^__aros_lib.*\r?$$/) {print "-L " $$3;}'`
 
 ## Dependency fine-tuning
@@ -2752,7 +2752,7 @@ $(%(mmake)%(flavour)_KOBJ) : FILTBASES:=$(addprefix -L ,$(%(mmake)%(flavour)_SYM
 $(%(mmake)%(flavour)_KOBJ) : USER_LDFLAGS:=$(USER_LDFLAGS)
 $(%(mmake)%(flavour)_KOBJ) : $(%(mmake)%(flavour)_OBJS) $(USER_OBJS) $(%(mmake)%(flavour)_ENDOBJS)
 	$(Q)$(ECHO) "Linking    $(subst $(TARGETDIR)/,,$@)"
-	$(Q)$(AROS_LD) -Ur -o $@ $^ $(USER_LDFLAGS) -L$(AROS_LIB) $(addprefix -l,$(LINKLIBS))
+	$(Q)$(AROS_LD) -Ur $(KERNEL_KOBJ_LDSCRIPT) -o $@ $^ $(USER_LDFLAGS) -L$(AROS_LIB) $(addprefix -l,$(LINKLIBS))
 	$(Q)$(OBJCOPY) $@ $(FILTBASES) `$(NM_PLAIN) $@ | $(AWK) '($$3 ~ /^__.*_(LIST|END)__\r?$$/) || ($$3 ~ /^__aros_lib.*\r?$$/) {print "-L " $$3;}'`
 endif
 

--- a/rom/alerthook/resident_end.c
+++ b/rom/alerthook/resident_end.c
@@ -2,4 +2,6 @@
     Copyright (C) 1995-2014, The AROS Development Team. All rights reserved.
 */
 
-void Alerthook_end(void) { }
+/* In .text.moduleend so it links at the module tail: rt_EndSkip = &Alerthook_end
+ * then marks the true module end for the romtag scanner's leap to the next module. */
+__attribute__((section(".text.moduleend"))) void Alerthook_end(void) { }

--- a/rom/dos/dos_init.c
+++ b/rom/dos/dos_init.c
@@ -32,7 +32,9 @@ AROS_UFP3S(struct DosLibrary *, DosInit,
     AROS_UFPA(BPTR, segList, A0),
     AROS_UFPA(struct ExecBase *, SysBase, A6));
 
-const struct Resident Dos_resident =
+/* In .text.romtag so the m68k ROM link places this tag at the module head,
+ * letting the romtag scanner find it on the first read and leap via rt_EndSkip. */
+__attribute__((section(".text.romtag"))) const struct Resident Dos_resident =
 {
     RTC_MATCHWORD,
     (struct Resident *)&Dos_resident,

--- a/rom/dosboot/bootanim.c
+++ b/rom/dosboot/bootanim.c
@@ -26,6 +26,20 @@ void WriteChunkRegion(struct DOSBootBase *DOSBootBase,
                                     struct RastPort *rp, UWORD x, UWORD y, UWORD width,
                                     UBYTE *data, UWORD regx, UWORD regy, UWORD regwidth, UWORD regheight)
 {
+    /* Native planar: blit the region straight from the planar source bitmap.
+     * The blitter does planar->planar in hardware - no per-pixel CPU C2P.
+     * srcbm is only set up when the image was emitted planar (m68k); otherwise
+     * it is NULL and we fall through to the chunky path. */
+    struct AnimData *ad = DOSBootBase->animData;
+
+    if (ad && ad->srcbm)
+    {
+        BltBitMap(ad->srcbm, regx, regy,
+                  rp->BitMap, x + regx, y + regy,
+                  regwidth, regheight, 0xC0 /* copy */, 0xFF, NULL);
+        return;
+    }
+
     WriteChunkyPixels(rp, x + regx, y + regy,
                                     x + regx + regwidth - 1, y + regy + regheight - 1,
                                     data + regx + (regy * width), width);

--- a/rom/dosboot/bootanim.c
+++ b/rom/dosboot/bootanim.c
@@ -55,9 +55,8 @@ APTR anim_Init(struct Screen *scr, struct DOSBootBase *DOSBootBase)
     if (ad)
     {
         D(bug("[dosboot] %s: ad @ 0x%p\n", __func__, ad);)
-        DOSBootBase->blank_pointer = AllocMem(6*2, MEMF_CHIP | MEMF_CLEAR);
-        SetPointer(DOSBootBase->bm_Window, DOSBootBase->blank_pointer,
-                   1, 16, 0, 0);
+        /* The mouse pointer is blanked earlier (right after OpenWindow in
+           NoBootMediaScreen) so it doesn't linger during animation setup. */
         ad->ad_State |= STATEF_POINTERHIDE;
         SetAPen(&scr->RastPort, 0);
         RectFill(&scr->RastPort, 0, 0, scr->Width, scr->Height);

--- a/rom/dosboot/bootanim.h
+++ b/rom/dosboot/bootanim.h
@@ -8,6 +8,7 @@ struct AnimData
     struct Library      *OOPBase;
     OOP_Object          *gfxhidd;
     UBYTE               **framedata;
+    struct BitMap       *srcbm;         /* planar source bitmap (NOMEDIA_PLANAR only) */
 
     IPTR                ad_State;
     UWORD               x;

--- a/rom/dosboot/bootanim_nomedia.c
+++ b/rom/dosboot/bootanim_nomedia.c
@@ -69,6 +69,46 @@ struct AnimData *banm_Init(struct Screen *scr, struct DOSBootBase *DOSBootBase)
 
             /* set up the date for the frames of the animation ..*/
             ad->framedata = (APTR)(IPTR)ad + sizeof(struct AnimData);
+#if defined(NOMEDIA_PLANAR)
+            /*
+             * Native planar: build a struct BitMap over the image bitplanes and
+             * let WriteChunkRegion() blit regions from it with the hardware
+             * blitter (BltBitMap -> amigavideo CopyBox -> blit_copybox), avoiding
+             * per-pixel chunky->planar conversion entirely. The planes must live
+             * in Chip RAM so the blitter can read them.
+             */
+            {
+                ULONG i;
+                UBYTE *planebuf = AllocMem(NOMEDIA_PLANESIZE * NOMEDIA_PLANES,
+                                           MEMF_CHIP);
+
+                ad->srcbm = AllocMem(sizeof(struct BitMap), MEMF_ANY | MEMF_CLEAR);
+                /* planebuf is reachable via srcbm->Planes[0]; keep framedata as
+                 * sentinels so banm_Dispose's FreeVec loop skips them. */
+                ad->framedata[0] = (APTR)(IPTR)-1;
+                ad->framedata[1] = (APTR)(IPTR)-1;
+
+                if (ad->srcbm && planebuf)
+                {
+                    /* Unpack the RLE planar blob ONCE (linear decode, not C2P). */
+#if NOMEDIA_PACKED
+                    unpack_byterun1(nomedia_data, planebuf,
+                                    NOMEDIA_PLANESIZE * NOMEDIA_PLANES);
+#else
+                    CopyMem((APTR)nomedia_data, planebuf,
+                            NOMEDIA_PLANESIZE * NOMEDIA_PLANES);
+#endif
+                    InitBitMap(ad->srcbm, NOMEDIA_PLANES, NOMEDIA_WIDTH, NOMEDIA_HEIGHT);
+                    for (i = 0; i < NOMEDIA_PLANES; i++)
+                        ad->srcbm->Planes[i] = (PLANEPTR)(planebuf + i * NOMEDIA_PLANESIZE);
+                }
+
+                for (i = 0; i < NOMEDIA_COLORS; i++)
+                    SetRGB32(&scr->ViewPort, i, (nomedia_pal[i] << 8) & 0xFF000000,
+                                                (nomedia_pal[i] << 16) & 0xFF000000, (nomedia_pal[i] << 24) & 0xFF000000);
+            }
+#else
+            ad->srcbm = NULL;
             ad->framedata[0] = AllocVec(size, MEMF_ANY);
 
             if (ad->framedata[0])
@@ -83,6 +123,7 @@ struct AnimData *banm_Init(struct Screen *scr, struct DOSBootBase *DOSBootBase)
                     SetRGB32(&scr->ViewPort, i, (nomedia_pal[i] << 8) & 0xFF000000,
                                                 (nomedia_pal[i] << 16) & 0xFF000000, (nomedia_pal[i] << 24) & 0xFF000000);
             }
+#endif
         }
     }
     return ad;
@@ -98,6 +139,14 @@ void banm_Dispose(struct DOSBootBase *DOSBootBase)
     {
         int frame;
         DOSBootBase->animData = NULL;
+#if defined(NOMEDIA_PLANAR)
+        if (ad->srcbm)
+        {
+            if (ad->srcbm->Planes[0])
+                FreeMem(ad->srcbm->Planes[0], NOMEDIA_PLANESIZE * NOMEDIA_PLANES);
+            FreeMem(ad->srcbm, sizeof(struct BitMap));
+        }
+#endif
         for (frame = 0; frame < ad->framecnt; frame ++)
         {
             if (ad->framedata[frame] != (APTR)(IPTR)-1)

--- a/rom/dosboot/bootanim_nomedia.c
+++ b/rom/dosboot/bootanim_nomedia.c
@@ -15,32 +15,46 @@
 
 static const UBYTE *unpack_byterun1(const UBYTE *source, UBYTE *dest, LONG unpackedsize)
 {
-    UBYTE r;
     BYTE c;
 
-    for(;;)
+    /*
+     * byterun1 (ILBM/PackBits): most of this image's output (~88%) comes from
+     * replicate runs (avg ~30 bytes each), so fill those with long-word stores
+     * instead of one byte per loop. dest may be odd after a literal run and the
+     * 68000 faults on odd-address long access, so align to a longword first.
+     */
+    while (unpackedsize > 0)
     {
+        LONG n;
+
         c = (BYTE)(*source++);
         if (c >= 0)
         {
-            while(c-- >= 0)
-            {
-                *dest++ = *source++;
-                if (--unpackedsize <= 0) return source;
-            }
+            n = (LONG)c + 1;
+            if (n > unpackedsize) n = unpackedsize;
+            unpackedsize -= n;
+            do { *dest++ = *source++; } while (--n);
         }
         else if (c != -128)
         {
-            c = -c;
-            r = *source++;
+            UBYTE r = *source++;
 
-            while(c-- >= 0)
+            n = (LONG)(-c) + 1;
+            if (n > unpackedsize) n = unpackedsize;
+            unpackedsize -= n;
+
+            if (n >= 8)
             {
-                *dest++ = r;
-                if (--unpackedsize <= 0) return source;
+                ULONG rr = r;
+                rr |= rr << 8;
+                rr |= rr << 16;
+                while (((IPTR)dest & 3) && n) { *dest++ = r; n--; }
+                while (n >= 4) { *(ULONG *)dest = rr; dest += 4; n -= 4; }
             }
+            while (n--) *dest++ = r;
         }
     }
+    return source;
 }
 
 struct AnimData *banm_Init(struct Screen *scr, struct DOSBootBase *DOSBootBase)

--- a/rom/dosboot/bootscreen.c
+++ b/rom/dosboot/bootscreen.c
@@ -53,7 +53,8 @@ static struct Screen *OpenBootScreenType(struct DOSBootBase *DOSBootBase, BYTE M
     if (mode != INVALID_ID)
     {
         struct Screen *scr = OpenScreenTags(NULL, SA_DisplayID, mode, SA_Draggable, FALSE,
-                                            SA_Quiet, TRUE, SA_Depth, MinDepth, TAG_DONE);
+                                            SA_Quiet, TRUE, SA_ShowTitle, FALSE,
+                                            SA_Depth, MinDepth, TAG_DONE);
 
         if (scr)
             return scr;
@@ -96,6 +97,15 @@ struct Screen *NoBootMediaScreen(struct DOSBootBase *DOSBootBase)
         };
 
         DOSBootBase->bm_Window = OpenWindow(&nw);
+
+        /* Hide the mouse pointer immediately, before the (slower) animation
+           setup runs, so the default arrow doesn't linger over the screen. */
+        if (DOSBootBase->bm_Window)
+        {
+            DOSBootBase->blank_pointer = AllocMem(6 * 2, MEMF_CHIP | MEMF_CLEAR);
+            if (DOSBootBase->blank_pointer)
+                SetPointer(DOSBootBase->bm_Window, DOSBootBase->blank_pointer, 1, 16, 0, 0);
+        }
 
         if (!anim_Init(scr, DOSBootBase))
         {

--- a/rom/dosboot/mmakefile.src
+++ b/rom/dosboot/mmakefile.src
@@ -3,6 +3,19 @@ include $(SRCDIR)/config/aros.cfg
 
 NOMEDIA_IMAGE := nomedia
 
+# Match the asset format to the target's display hardware:
+#  - m68k / native Amiga has PLANAR display hardware. Emit native planar bitplanes
+#    so the image can be drawn with BltBitMap (blitter, planar->planar). The
+#    alternative - per-pixel chunky->planar C2P on a 7MHz 68000 - is prohibitively
+#    slow (~seconds per full-image draw).
+#  - other targets (x86/x64 etc.) have a CHUNKY framebuffer, so keep the chunky
+#    emit: WriteChunkyPixels writes chunky->chunky with no planar conversion at all.
+ifeq ($(AROS_TARGET_CPU),m68k)
+NOMEDIA_ILBMTOC_FLAGS := -p
+else
+NOMEDIA_ILBMTOC_FLAGS :=
+endif
+
 FILES := dosboot_init bootstrap bootscan \
          menu bootscreen bootanim bootanim_nomedia cleanup
 
@@ -25,6 +38,6 @@ $(GENDIR)/$(CURDIR)/dosboot/bootanim_nomedia.d : $(GENDIR)/$(CURDIR)/dosboot/nom
 
 $(GENDIR)/$(CURDIR)/dosboot/nomedia_image.h : $(NOMEDIA_IMAGE).ilbm
 	@$(ECHO) "Creating   $@..."
-	@$(ILBMTOC) $< >$@
+	@$(ILBMTOC) $(NOMEDIA_ILBMTOC_FLAGS) $< >$@
 
 %common

--- a/rom/exec/exec_init.c
+++ b/rom/exec/exec_init.c
@@ -64,7 +64,9 @@ AROS_UFP3S(struct ExecBase *, GM_UNIQUENAME(init),
  *
  * WARNING: the CPU privilege level must be set to user before calling InitCode(RTF_COLDSTART)!
  */
-const struct Resident Exec_resident =
+/* In .text.romtag so the m68k ROM link places this tag at the module head,
+ * letting the romtag scanner find it on the first read and leap via rt_EndSkip. */
+__attribute__((section(".text.romtag"))) const struct Resident Exec_resident =
 {
     RTC_MATCHWORD,
     (struct Resident *)&Exec_resident,

--- a/rom/hidds/gfx/gfx_planarbitmapclass.c
+++ b/rom/hidds/gfx/gfx_planarbitmapclass.c
@@ -169,10 +169,21 @@ OOP_Object *PBM__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
         if (displayable)
             data->bitmap->Flags |= BMF_DISPLAYABLE;
 
-        /* Allocate memory for all the planes. Use chip memory. */
+        /*
+         * Allocate memory for all the planes. Use chip memory.
+         *
+         * Displayable bitmaps (screens, framebuffers) are always fully painted
+         * before/at display, and graphics.library's AllocBitMap() blit-clears
+         * them itself when the caller passes BMF_CLEAR, so zeroing the planes
+         * here with a CPU memset is redundant work on the boot path. Only clear
+         * offscreen bitmaps, whose fresh contents a caller may read before any
+         * draw. (MEMF_CLEAR is expensive on the 68000; skipping the full-screen
+         * clear saves a large memset at boot.)
+         */
+        ULONG planeflags = MEMF_CHIP | (displayable ? 0 : MEMF_CLEAR);
         for (i = 0; i < depth; i++)
         {
-            data->bitmap->Planes[i] = AllocMem(height * bytesperrow, MEMF_CHIP | MEMF_CLEAR);
+            data->bitmap->Planes[i] = AllocMem(height * bytesperrow, planeflags);
 
             if (NULL == data->bitmap->Planes[i])
             {

--- a/rom/kernel/kernel_init.c
+++ b/rom/kernel/kernel_init.c
@@ -32,7 +32,9 @@ AROS_UFP3S(struct KernelBase *, Kernel_Init,
     AROS_UFPA(BPTR, segList, A0),
     AROS_UFPA(struct ExecBase *, sysBase, A6));
 
-const struct Resident Kernel_resident =
+/* In .text.romtag so the m68k ROM link places this tag at the module head,
+ * letting the romtag scanner find it on the first read and leap via rt_EndSkip. */
+__attribute__((section(".text.romtag"))) const struct Resident Kernel_resident =
 {
     RTC_MATCHWORD,
     (struct Resident *)&Kernel_resident,

--- a/rom/kernel/kernel_romtags.c
+++ b/rom/kernel/kernel_romtags.c
@@ -24,14 +24,23 @@
 
 /* The following define prevents the initial
  * scan to count residents */
-//#define ROMTAG_FLATALLOC
+#if defined(__mc68000__)
+/* On the 7MHz 68000 the ROM scan is a major boot cost, and it runs TWICE
+ * (a count pass to size the array, then a register pass). Skip the count
+ * pass: krnSysMemAlloc() grabs a whole free MemChunk anyway and the unused
+ * tail is returned by krnReleaseSysMem(), so this is memory-equivalent to the
+ * count path but scans ~1MB of ROM once instead of twice. */
+#define ROMTAG_FLATALLOC
+#endif
 
 /*
- * Currently the ROMTag code tries to allocate a 1MB
- * chunk to store the Resident info.
- * TODO: 1MB seems a bit excessive .. look at using a more conservative value
+ * FLATALLOC over-allocates before the resident count is known. This is the
+ * minimum free-chunk size krnGetSysMem() will look for; the whole chunk found
+ * is used and its unused tail released afterwards. Keep it small enough to be
+ * satisfiable on a 512KB Amiga (the old 1MB value could not be met there),
+ * but large enough to hold far more resident pointers than any ROM has.
  */
-#define ROMTAG_CHUNKSIZE    (1024 * 1024)
+#define ROMTAG_CHUNKSIZE    (8 * 1024)
 
 static LONG findname(struct Resident **list, ULONG len, CONST_STRPTR name)
 {

--- a/tools/genmodule/writeend.c
+++ b/tools/genmodule/writeend.c
@@ -33,8 +33,16 @@ void writeend(struct config *cfg)
         );
     }
 
+    /*
+     * The module's Resident rt_EndSkip points at this End marker so the romtag
+     * scanner can leap from a module's tag to its end in one step. For that the
+     * marker must be the LAST thing in the module. It is emitted into its own
+     * ".text.moduleend" section; the m68k ROM link (see arch/m68k-amiga/boot,
+     * config/make.tmpl KERNEL_KOBJ_LDSCRIPT) orders sections so .text.moduleend
+     * comes last, making &End the true module end.
+     */
     fprintf(out,
-            "int GM_UNIQUENAME(End)(void) {return 0;}\n"
+            "__section(\".text.moduleend\") const char GM_UNIQUENAME(End)[] = { 0 };\n"
     );
     fclose(out);
 }

--- a/tools/genmodule/writestart.c
+++ b/tools/genmodule/writestart.c
@@ -617,7 +617,7 @@ static void writeresident(FILE *out, struct config *cfg)
     else
     {
         rt_skip = "GM_UNIQUENAME(End)";
-        fprintf(out, "extern int %s(void);\n", rt_skip);
+        fprintf(out, "extern const char %s[];\n", rt_skip);
     }
     fprintf(out,
             "extern const APTR GM_UNIQUENAME(FuncTable)[];\n"

--- a/tools/ilbmtoc/ilbmtoc.c
+++ b/tools/ilbmtoc/ilbmtoc.c
@@ -79,6 +79,7 @@ static char                 imagename[1000];
 static char                 bigimagename[1000];
 static BOOL                 brush2c;    // compatibility with brush2c from MUI SDK
 static BOOL                 brush2pix;  // compatibility with brush2pix from JabberWocky
+static BOOL                 planar;     // emit deinterleaved planar planes (for direct BltBitMap)
 
 /****************************************************************************************/
 
@@ -115,11 +116,16 @@ static void getarguments(int argc, char **argv)
         brush2pix = 1;
         narg++;
     }
-    
+    else if (!strcasecmp(argv[1], "-p"))
+    {
+        planar = 1;
+        narg++;
+    }
+
     if (argc > narg)
         filename = argv[narg++];
     else
-        cleanup("Usage: ilbmtoc [-b2c|-b2p] filename [imagename]", 1);
+        cleanup("Usage: ilbmtoc [-b2c|-b2p|-p] filename [imagename]", 1);
     
     if (argc > narg)
         imagenamestart = argv[narg];
@@ -648,6 +654,91 @@ static void gensource(void)
 
 /****************************************************************************************/
 
+/*
+ * Emit the image as native planar bitplanes so the target can point a struct
+ * BitMap at them and BltBitMap directly - no chunky<->planar conversion at
+ * runtime. Used for m68k/native Amiga where per-pixel C2P on the CPU is
+ * prohibitively slow.
+ *
+ * The ILBM body (planarbuffer) is line-interleaved (per row: plane0 row,
+ * plane1 row, ...). We deinterleave it into a single contiguous planar buffer
+ * (all of plane0, then all of plane1, ...), then byterun1-RLE-pack the whole
+ * thing so it stays small in ROM. At runtime the target unpacks it ONCE into an
+ * allocated buffer (a cheap linear RLE decode, NOT per-pixel C2P) and points the
+ * bitplanes at plane-sized offsets.
+ */
+static void gensourceplanar(void)
+{
+    LONG p, y, i;
+    LONG planesize = bpr * bmh.bmh_Height;
+    LONG totalsize = planesize * bmh.bmh_Depth;
+    unsigned char *deint, *packed, *emit;
+    LONG emitsize, packedsize = 0;
+    BOOL packok;
+
+    /* Deinterleave into contiguous per-plane layout. */
+    deint = malloc(totalsize);
+    if (!deint) cleanup("Memory allocation for deinterleave buffer failed!", 1);
+    for (p = 0; p < bmh.bmh_Depth; p++)
+        for (y = 0; y < bmh.bmh_Height; y++)
+            memcpy(deint + p * planesize + y * bpr,
+                   planarbuffer + (y * totdepth + p) * bpr, bpr);
+
+    /* Try to RLE-pack the whole planar buffer. */
+    packed = malloc(totalsize);
+    if (!packed) cleanup("Memory allocation for packed planar buffer failed!", 1);
+    packok = pack_byterun1(deint, packed, totalsize, totalsize, &packedsize);
+    if (packok)
+    {
+        emit = packed; emitsize = packedsize;
+    }
+    else
+    {
+        emit = deint; emitsize = totalsize;
+    }
+
+    printf("#include <exec/types.h>\n");
+    printf("\n");
+    printf("#define %s_PLANAR       1\n", bigimagename);
+    printf("#define %s_PACKED       %d\n", bigimagename, packok ? 1 : 0);
+    printf("#define %s_WIDTH  %d\n", bigimagename, bmh.bmh_Width);
+    printf("#define %s_HEIGHT %d\n", bigimagename, bmh.bmh_Height);
+    printf("#define %s_PLANES %d\n", bigimagename, bmh.bmh_Depth);
+    printf("#define %s_BYTESPERROW %ld\n", bigimagename, (long)bpr);
+    printf("#define %s_PLANESIZE %ld\n", bigimagename, (long)planesize);
+    printf("#define %s_DATASIZE %ld\n", bigimagename, (long)emitsize);
+    if (have_cmap)
+        printf("#define %s_COLORS %ld\n", bigimagename, cmapentries);
+    printf("\n");
+
+    if (have_cmap)
+    {
+        printf("const ULONG %s_pal[%ld] =\n{\n", imagename, cmapentries);
+        for (i = 0; i < cmapentries; i++)
+        {
+            ULONG col = (((ULONG)red[i]) << 16) +
+                        (((ULONG)green[i]) << 8) +
+                        ((ULONG)blue[i]);
+            printf("    0x%06lx%s\n", col, (i == cmapentries - 1) ? "" : ",");
+        }
+        printf("};\n\n");
+    }
+
+    printf("const UBYTE %s_data[%ld] =\n{", imagename, (long)emitsize);
+    for (i = 0; i < emitsize; i++)
+    {
+        if ((i % 20) == 0) printf("\n    ");
+        printf("0x%02x", emit[i]);
+        if (i != emitsize - 1) printf(",");
+    }
+    printf("\n};\n");
+
+    free(packed);
+    free(deint);
+}
+
+/****************************************************************************************/
+
 static void genbrush2csource(void)
 {
     int i;
@@ -759,6 +850,11 @@ int main(int argc, char **argv)
     else if (brush2pix)
     {
         genbrush2pixsource();
+    }
+    else if (planar)
+    {
+        convertbody();
+        gensourceplanar();
     }
     else
     {


### PR DESCRIPTION
The 68k replacement kickstart ROM took a very long time to display the "insert disk" screen, which was also very slow to refresh.

This PR adds some optimizations so that it now takes about 7 seconds to start showing the "insert disk" screen compared to 25-30 seconds before.

Summary of the optimizations:

- Boot-time resident discovery on m68k was heavily reduced by restructuring ROM tags so modules are found immediately and by switching the ROM scan to a single-pass FLATALLOC path. Together, this cut resident scanning on an A500 from about 9.8s to 1.13s.
 - Early boot memory clearing was optimized with a 68000-specific memset fast path using movem.l, reducing the cost of clearing roughly 700KB of MEMF_CLEAR allocations from about 1.85s to 516ms.
 - The DOS boot animation was reworked to use native planar bitplanes and hardware blits instead of per-pixel chunky-to-planar conversion, eliminating the major PutImageLUT bottleneck. Its compressed asset unpacking was also optimized with longword fills, cutting decode time from 610ms to 278ms.
 - Graphics startup avoids redundant clearing of displayable planar bitmaps, so framebuffers are no longer zeroed before being fully repainted anyway. That removes an unnecessary full-screen clear and saves about 110ms during display bring-up.

This individual commits for more details.

This video was made booting the previous kickstart ROM vs Optimized kickstart ROM on Copperline emulating an Amiga 500 at real speed:


https://github.com/user-attachments/assets/2ede69f2-4e90-4d8b-92d3-c5b81f0b3caf

Note: Claude was used to help me write these optimizations