### PR TITLE
keymap: copy raw bytes with CopyMem() in WriteToBuffer()

### DIFF
--- a/rom/keymap/support.c
+++ b/rom/keymap/support.c
@@ -6,6 +6,8 @@
 
 /****************************************************************************************/
 
+#include <proto/exec.h>
+
 #include <devices/inputevent.h>
 #include <aros/crt_replacement.h>
 
@@ -29,8 +31,7 @@ BOOL WriteToBuffer(struct BufInfo *bufinfo, UBYTE *string, LONG numchars)
     if (bufinfo->CharsWritten + numchars > bufinfo->BufLength)
         return (FALSE);
 
-    /* TODO: check if we can use utility.library/Strlcpy() */
-    Strncpy(bufinfo->Buffer, string, numchars);
+    CopyMem(string, bufinfo->Buffer + bufinfo->CharsWritten, numchars);
     bufinfo->CharsWritten += numchars;
 
     return (TRUE);


### PR DESCRIPTION
Resolves the TODO in `rom/keymap/support.c`.

`WriteToBuffer()` appends a fixed number of raw output bytes to a packed buffer whose length is the `MapRawKey()` return value. It is not a NUL-terminated string, so `utility.library/Strlcpy()` is not applicable. Replace the local `Strncpy()` helper with `CopyMem()` of the requested byte count, written at the running `CharsWritten` offset.

Fixes #148
