### PR TITLE
ram.handler: allow case-only rename of an object

### DIFF
--- a/rom/filesys/ram/commands.c
+++ b/rom/filesys/ram/commands.c
@@ -1854,13 +1854,8 @@ BOOL CmdRenameObject(struct Handler *handler, struct Lock *old_lock,
       the target name */
 
    duplicate = GetHardObject(handler, new_lock, new_name, &parent);
-   if(duplicate)
-   {
-      if (duplicate != object)
-         error = ERROR_OBJECT_EXISTS;
-      else
-         error = ERROR_INVALID_COMPONENT_NAME;
-   }
+   if(duplicate && duplicate != object)
+      error = ERROR_OBJECT_EXISTS;
    if(parent == NULL)
       error = IoErr();
 


### PR DESCRIPTION
`CmdRenameObject()` rejected renaming an object to a different-case form of its own name (e.g. `rename ram:ct ram:CT`) with "object name invalid". Because the handler compares names case-insensitively, the target resolves to the same object, and the code treated that as `ERROR_INVALID_COMPONENT_NAME`.

Only reject when the target is a *different* existing object (`ERROR_OBJECT_EXISTS`); otherwise fall through to `SetName()`, which applies the new spelling.

Reproduced and verified on the hosted build: `makedir ram:ct` then `rename ram:ct ram:CT` now succeeds and the directory lists as `CT`.

Fixes #665
