### PR TITLE
Run: don't announce the background CLI number when output is redirected

### DIFF
--- a/workbench/c/shellcommands/Run.c
+++ b/workbench/c/shellcommands/Run.c
@@ -124,7 +124,7 @@ AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (argume
 
     /* All the 'noise' goes to cli_StandardError
      */
-    if (!SHArg(QUIET)) {
+    if (!SHArg(QUIET) && IsInteractive(Output())) {
         if (cli)
         {
             ces = cli->cli_StandardError;


### PR DESCRIPTION
`Run` sent the background CLI number (`[CLI n]`) to StandardError unless `QUIET` was given, so `Run >NIL: ...` still printed it. In a startup script that is noise, and it can interfere with early boot.

Only announce when the command's output is interactive. `Run cmd` still prints `[CLI n]`, `Run QUIET cmd` and `Run >NIL: cmd` are silent.

Verified on the hosted build via a script: `run >NIL: echo x` prints nothing, `run echo x` prints `[CLI n]`, `run QUIET echo x` is silent.

Fixes #40
