### PR TITLE
dos: handle R_ARM_REL32 relocations in the ELF loader

### DIFF
--- a/compiler/include/dos/elf.h
+++ b/compiler/include/dos/elf.h
@@ -100,6 +100,7 @@
 #define R_ARM_NONE              0
 #define R_ARM_PC24              1
 #define R_ARM_ABS32             2
+#define R_ARM_REL32             3
 #define R_ARM_CALL              28
 #define R_ARM_JUMP24            29
 #define R_ARM_TARGET1           38

--- a/rom/dos/internalloadseg_elf.c
+++ b/rom/dos/internalloadseg_elf.c
@@ -720,6 +720,13 @@ static int relocate
                     *p = *p + s;  /* SHT_REL: addend is in *p */
                 break;
 
+            case R_ARM_REL32: /* PC-relative data (S + A - P), e.g. .eh_frame */
+                if (is_rela)
+                    *p = (ULONG)((struct rela *)rel)->addend + s - (ULONG)p;
+                else
+                    *p = *p + s - (ULONG)p;  /* SHT_REL: addend is in *p */
+                break;
+
             case R_ARM_NONE:
                 break;
             #elif defined(__riscv)


### PR DESCRIPTION
Clang emits R_ARM_REL32 for .eh_frame data in -fexceptions programs. The loader rejected the relocation, so such programs failed to load. Resolve it as S + A - P for both SHT_REL and SHT_RELA.