### PR TITLE
crosstools/llvm: default to emulated TLS and auto-link compiler-rt

### DIFF
--- a/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
+++ b/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
@@ -229,7 +229,7 @@ diff -ruN clang-11.0.0.src/lib/Driver/Driver.cpp clang-11.0.0.src.aros/lib/Drive
 diff -ruN clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp clang-11.0.0.src.aros/lib/Driver/ToolChains/AROS.cpp
 --- clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp	1970-01-01 00:00:00.000000000 +0000
 +++ clang-11.0.0.src.aros/lib/Driver/ToolChains/AROS.cpp	2025-07-15 20:21:11.609706173 +0000
-@@ -0,0 +1,432 @@
+@@ -0,0 +1,439 @@
 +//===--- AROS.cpp - AROS Tool Chain -------------===//
 +//
 +//                     The LLVM Compiler Infrastructure
@@ -407,10 +407,10 @@ diff -ruN clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp clang-11.0.0.src.aros/
 +        CmdArgs.push_back(Args.MakeArgString(StringRef("-L") + LibPath));
 +
 +        CmdArgs.push_back("--start-group");
-+        if ((jobWantsPThread) ||
-+           (Args.hasArg(options::OPT_pthreads, options::OPT_pthread))) {
-+            CmdArgs.push_back("-lpthread");
-+        }
++        /* Emulated TLS is the AROS default and __emutls_get_address pulls
++         * pthread; -lpthread is pull-on-demand, so this is free unless TLS
++         * or threads are actually used. */
++        CmdArgs.push_back("-lpthread");
 +        CmdArgs.push_back("-lmui");
 +        CmdArgs.push_back("-larossupport");
 +        CmdArgs.push_back("-lamiga");
@@ -474,6 +474,10 @@ diff -ruN clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp clang-11.0.0.src.aros/
 +                }
 +            }
 +        }// 2nd OPT_nostartfiles endif
++        // Pull in the compiler runtime (compiler-rt, builtins, including 
++        // the emutls helpers).  Kept inside the group so its pthread 
++        // references resolve against the -lpthread above.
++        AddRunTimeLibs(AROSTC, D, CmdArgs, Args);
 +        CmdArgs.push_back("--end-group");
 +    }
 +
@@ -567,6 +571,9 @@ diff -ruN clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp clang-11.0.0.src.aros/
 +    if (DriverArgs.hasArg(options::OPT_nix)) {
 +        CC1Args.push_back("-D__NIX__");
 +    }
++    // AROS has no usable hardware TLS; force emulated TLS (compiler-rt
++    // emutls + pthread keys).  A later -fno-emulated-tls still overrides.
++    CC1Args.push_back("-femulated-tls");
 +}
 +
 +

--- a/tools/crosstools/llvm/mmakefile.src
+++ b/tools/crosstools/llvm/mmakefile.src
@@ -350,8 +350,8 @@ LLVM_COMPILER_RT_CMAKEBASE :=                                                   
   -DCOMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=OFF                                                                                              \
   -DBUILD_SHARED_LIBS=OFF                                                                                                               \
   -DAROS_BUILD=ON \
-  -DCOMPILER_RT_LIBRARY_INSTALL_DIR="lib/clang/$(LLVM_VERSION)/lib/aros" \
-  -DCOMPILER_RT_LIBRARY_OUTPUT_DIR="$(CROSSTOOLSDIR)/lib/clang/$(LLVM_VERSION)/lib/aros"
+  -DCOMPILER_RT_INSTALL_PATH="$(CROSSTOOLSDIR)/lib/clang/$(LLVM_VERSION)" \
+  -DCOMPILER_RT_OS_DIR="aros"
 
 # Without COMPILER_RT_ARMHF_TARGET, compiler-rt tags its builtins with
 # __pcs__("aapcs"), forcing the soft-float return ABI even under
@@ -375,14 +375,15 @@ LLVM_COMPILER_RT_CMAKEOPTIONS :=                                                
     prefix="$(CROSSTOOLSDIR)" extraoptions="$(LLVM_COMPILER_RT_CMAKEOPTIONS)" compiler=host usecppflags=no
 
 # Clang's driver looks for libclang_rt.builtins-armhf.a on hard-float targets,
-# but compiler-rt builds it as builtins-arm.a. Create a symlink.
+# but compiler-rt builds it as builtins-arm.a. Provide it under both names
+# (copied, not symlinked, as AROS' build tools define no $(LN)).
 COMPILER_RT_CLANG_LIBDIR := $(CROSSTOOLSDIR)/lib/clang/$(LLVM_VERSION)/lib/aros
 
 #MM crosstools-compiler-rt-fixup : crosstools-compiler-rt
 crosstools-compiler-rt-fixup :
 	$(Q)$(IF) $(TEST) -f $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-arm.a -a \
 	    ! -e $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-armhf.a ; then \
-	    $(LN) -sf libclang_rt.builtins-arm.a $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-armhf.a ; \
+	    $(CP) $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-arm.a $(COMPILER_RT_CLANG_LIBDIR)/libclang_rt.builtins-armhf.a ; \
 	fi
 
 ifneq ($(AROS_TARGET_CPU32),)


### PR DESCRIPTION
AROS has no hardware TLS, so the clang driver now forces -femulated-tls and links compiler-rt builtins (with the emutls helpers) plus -lpthread inside the link group. Install compiler-rt via COMPILER_RT_INSTALL_PATH/OS_DIR and copy the armhf builtins alias instead of symlinking (no $(LN) in the build tools).