### PR TITLE
Fix OCS screen dragging and classic Workbook icon layout

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -239,6 +239,18 @@ VOID AmigaVideoBM__Root__Set(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg
     if (newyoffset >= data->height)
         newyoffset = data->height - 1;
 
+    /*
+     * OCS cannot switch a display fragment cleanly on the vertical-counter
+     * rollover itself.  Round that single position to the following line;
+     * Root::Get then reports the actual hardware position to graphics and
+     * Intuition, as for other chipset positioning constraints.
+     */
+    if (data->disp && !csd->ecs_denise &&
+        newyoffset == ((256 - csd->starty) << data->interlace))
+    {
+        newyoffset += 1 << data->interlace;
+    }
+
     if ((newxoffset != data->leftedge) || (newyoffset != data->topedge))
     {
         struct pHidd_Compositor_BitMapPositionChanged bpcmsg =

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -259,6 +259,11 @@ static VOID setcopperscroll2(struct amigavideo_staticdata *csd, struct amigabm_d
     yend = y + (bm->displayheight >> bm->interlace);
     yend = limitheight(csd, yend, FALSE, TRUE);
     ystart = y - c2d->extralines;
+    if (y >= (REZ_Y_MIN + REZ_PAL_LINES) &&
+        ystart < (REZ_Y_MIN + REZ_PAL_LINES))
+    {
+        ystart = REZ_Y_MIN + REZ_PAL_LINES;
+    }
 
     modulo = (bm->interlace ? bm->bytesperrow : 0) + bm->modulo;
     ddfstrt = bm->ddfstrt;
@@ -318,6 +323,11 @@ static VOID setcopperscroll2(struct amigavideo_staticdata *csd, struct amigabm_d
     else
         copptr[0] = 0x01fe;  // NOP
     copptr[2] = (ystart << 8) | 0x05;
+
+    /* Do not enable DMA before the screen's exact first scanline. */
+    copptr = c2d->copper2_bplstart;
+    copptr[0] = 0x01fe;
+    copptr[2] = (y << 8) | 0x05;
 
     copptr = c2d->copper2_tail;
     if (copptr[0] != 0x0084)
@@ -489,6 +499,10 @@ UWORD *populatebmcopperlist(struct amigavideo_staticdata *csd, struct amigabm_da
     c2d->copper2_scroll = c;
 
     COPPEROUT(c, 0x008e, 0)                     // Push (DIWSTRT) Display window start
+
+    c2d->copper2_bplstart = c;
+    COPPEROUT(c, 0x01fe, 0xfffe)                // Rollover marker or NOP
+    COPPEROUT(c, 0xffff, 0xfffe)                // Exact screen start WAIT
 
     COPPEROUT(c, 0x0100, bplcon0)               // Push the screens bplcon0
     COPPEROUT(c, 0x0104, csd->bplcon2 | ((csd->aga && !(bm->modeid & EXTRAHALFBRITE_KEY)) ? 0x0200 : 0))  // Push the screens bplcon2

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
@@ -22,6 +22,7 @@ struct copper2data
     UWORD                       *copper2_palette_aga_lo;
     UWORD                       *copper2_scroll;
     UWORD                       *copper2_diwstop;
+    UWORD                       *copper2_bplstart;
     UWORD                       *copper2_bpl;
     UWORD                       *copper2_fmode;
     UWORD                       *copper2_tail;

--- a/arch/m68k-amiga/hidd/amigavideo/chipset.h
+++ b/arch/m68k-amiga/hidd/amigavideo/chipset.h
@@ -58,6 +58,8 @@ static inline VOID initvpicopper(struct ViewPort  *vp, struct amigabm_data *bm, 
     /* copy adjusted pointers ... */
     bm->copsd.copper2_palette = vp->DspIns->CopSStart + (bm->copld.copper2_palette - vp->DspIns->CopLStart);
     bm->copsd.copper2_scroll = vp->DspIns->CopSStart + (bm->copld.copper2_scroll - vp->DspIns->CopLStart);
+    bm->copsd.copper2_diwstop = vp->DspIns->CopSStart + (bm->copld.copper2_diwstop - vp->DspIns->CopLStart);
+    bm->copsd.copper2_bplstart = vp->DspIns->CopSStart + (bm->copld.copper2_bplstart - vp->DspIns->CopLStart);
     bm->copsd.copper2_bpl = vp->DspIns->CopSStart + (bm->copld.copper2_bpl - vp->DspIns->CopLStart);
     bm->copsd.copper2_tail = vp->DspIns->CopSStart + (bm->copld.copper2_tail - vp->DspIns->CopLStart);
     bm->copsd.extralines = bm->copld.extralines;

--- a/rom/intuition/scrdecorclass.c
+++ b/rom/intuition/scrdecorclass.c
@@ -418,6 +418,8 @@ IPTR ScrDecorClass__SDM_DRAW_SCREENBAR(Class *cl, Object *obj, struct sdpDrawScr
     BOOL                  atomicTitle = FALSE;
     TEXT                  titleLine[128];
     ULONG                 titleChars = 0;
+    ULONG                 len;
+    LONG                  titleWidth;
 
     D(bug("[SCRDECOR] %s()\n", __func__));
 
@@ -426,6 +428,14 @@ IPTR ScrDecorClass__SDM_DRAW_SCREENBAR(Class *cl, Object *obj, struct sdpDrawScr
 #endif
 
     findtitlearea(msg->sdp_Screen, &left, &right);
+
+    titleWidth = right - msg->sdp_Screen->BarHBorder;
+    if (titleWidth >= 8)
+    {
+        titleChars = titleWidth / 8;
+        if (titleChars > sizeof(titleLine))
+            titleChars = sizeof(titleLine);
+    }
 
     D(bug("[SCRDECOR] %s: Title_Left = %d, Title_Right = %d\n", __func__, left, right));
 
@@ -438,22 +448,14 @@ IPTR ScrDecorClass__SDM_DRAW_SCREENBAR(Class *cl, Object *obj, struct sdpDrawScr
         rp->Font->tf_XSize == 8 && rp->TxSpacing == 0 &&
         !(rp->AlgoStyle & (FSF_BOLD | FSF_ITALIC | FSF_UNDERLINED)))
     {
-        LONG titleWidth = right - msg->sdp_Screen->BarHBorder;
-
-        if (titleWidth >= 8)
+        if (titleChars)
         {
-            ULONG len;
-
-            titleChars = titleWidth / 8;
-            if (titleChars > sizeof(titleLine))
-                titleChars = sizeof(titleLine);
-
             memset(titleLine, ' ', titleChars);
             if (msg->sdp_Screen->Title)
             {
-                len = strlen(msg->sdp_Screen->Title);
-                if (len > titleChars)
-                    len = titleChars;
+                len = 0;
+                while ((len < titleChars) && msg->sdp_Screen->Title[len])
+                    len++;
                 memcpy(titleLine, msg->sdp_Screen->Title, len);
             }
             atomicTitle = TRUE;
@@ -495,7 +497,11 @@ IPTR ScrDecorClass__SDM_DRAW_SCREENBAR(Class *cl, Object *obj, struct sdpDrawScr
         if (atomicTitle)
             Text(rp, titleLine, titleChars);
         else
-            Text(rp, msg->sdp_Screen->Title, strlen(msg->sdp_Screen->Title));
+        {
+            for (len = 0; (len < titleChars) && msg->sdp_Screen->Title[len]; len++)
+                ;
+            Text(rp, msg->sdp_Screen->Title, len);
+        }
 
         D(bug("[SCRDECOR] %s: Text Rendered\n", __func__));
     }

--- a/workbench/system/Workbook/classes.h
+++ b/workbench/system/Workbook/classes.h
@@ -121,6 +121,9 @@ Class *WBSet_MakeClass(struct WorkbookBase *wb);
 #define WBIA_Label               (WBIA_Dummy+3)	/* CONST_STRPTR */
 #define WBIA_Screen              (WBIA_Dummy+4)	/* struct Screen * */
 
+/* Internal attributes */
+#define WBIA_Positioned          (WBIA_Dummy+128) /* BOOL */
+
 /* Methods */
 #define WBIM_Dummy               (TAG_USER | 0x40440100)
 #define WBIM_Open                (WBIM_Dummy + 1)	/* N/A */

--- a/workbench/system/Workbook/wbicon.c
+++ b/workbench/system/Workbook/wbicon.c
@@ -31,6 +31,7 @@ struct wbIcon {
     struct Screen     *Screen;
     WORD               DrawOffsetX;
     WORD               DrawOffsetY;
+    BOOL               Positioned;
 
     struct timeval LastActive;
 };
@@ -75,6 +76,8 @@ void wbIcon_Update(Class *cl, Object *obj)
     }
 
     D(bug("%s: %dx%d @%d,%d (%s)\n", my->File, (int)w, (int)h, (WORD)my->Icon->do_CurrentX, (WORD)my->Icon->do_CurrentY, my->Label));
+    my->Positioned = my->Icon->do_CurrentX != NO_ICON_POSITION &&
+                     my->Icon->do_CurrentY != NO_ICON_POSITION;
     SetAttrs(obj,
         GA_Left, (my->Icon->do_CurrentX == NO_ICON_POSITION) ? ~0 : my->Icon->do_CurrentX + rect.MinX,
         /* Classic Workbench leaves one pixel between Y=0 icons and the
@@ -184,6 +187,9 @@ static IPTR wbIconGet(Class *cl, Object *obj, struct opGet *opg)
         break;
     case WBIA_Label:
         *(opg->opg_Storage) = (IPTR)my->Label;
+        break;
+    case WBIA_Positioned:
+        *(opg->opg_Storage) = my->Positioned;
         break;
     default:
         rc = DoSuperMethodA(cl, obj, (Msg)opg);

--- a/workbench/system/Workbook/wbset.c
+++ b/workbench/system/Workbook/wbset.c
@@ -101,6 +101,7 @@ static IPTR WBSetAddMember(Class *cl, Object *obj, struct opMember *opm)
     struct IBox ibox;
     struct wbSet *my = INST_DATA(cl, obj);
     struct wbSetNode *node;
+    IPTR positioned = FALSE;
     IPTR rc;
 
     node = AllocMem(sizeof(*node), MEMF_ANY);
@@ -109,8 +110,8 @@ static IPTR WBSetAddMember(Class *cl, Object *obj, struct opMember *opm)
     /* Get bounding box of item to add */
     wbGABox(wb, iobj, &ibox);
 
-    if (ibox.Left == ~0 ||
-        ibox.Top == ~0) {
+    GetAttr(WBIA_Positioned, iobj, &positioned);
+    if (!positioned) {
         AddTail(&my->AutoObjects, (struct Node *)&node->sn_Node);
     } else {
         AddHead(&my->FixedObjects, (struct Node *)&node->sn_Node);


### PR DESCRIPTION
 Description:

  This second round of classic Amiga fixes improves screen dragging, title rendering, and compatibility with saved Workbench icon positions.

  Key changes:

  - Fix display corruption when dragging an OCS screen across the vertical counter’s line-255 rollover.
  - Restore an exact Copper wait before enabling bitplane DMA.
  - Avoid the single invalid display position directly on the OCS counter rollover.
  - Preserve valid saved icon positions when a wide icon label gives its bounding box a negative coordinate.
  - Prevent affected icons from being incorrectly auto-positioned and leaving stale progressive-rendering artifacts.
  - Bound screen-title processing to the available title-bar area instead of scanning or drawing beyond it.

  The icon-positioning fix notably corrects the Workbench 3.1 disk layout, including the misplaced Expansion icon, while retaining progressive drawer loading.


Before
<img width="679" height="125" alt="Capture d’écran 2026-07-20 à 10 55 58" src="https://github.com/user-attachments/assets/147d34fb-802e-421b-8c47-f4298c64b9cc" />

After
<img width="672" height="78" alt="Capture d’écran 2026-07-20 à 11 37 12" src="https://github.com/user-attachments/assets/6499d0e4-937c-49b5-952b-737181f29c05" />
