### PR TITLE
m68k: improve Workbench 1.3 BCPL Shell compatibility

### DIFF
--- a/arch/m68k-all/dos/bcpl.S
+++ b/arch/m68k-all/dos/bcpl.S
@@ -523,8 +523,6 @@ BCPL doIO           /*  54, LONG, @IORequest */
 BCPL sendIO         /*  58, void, @IORequest */
     movem.l     %a0-%a1/%a6,%sp@-
     lsl.l       #2,%d1
-    moveq.l     #0,%d2
-    move.l      %d2,%a0@(ln_Name,%d1)    /* NULL dos packet */
     move.l      %d1, %a1
     move.l      SysBase,%a6
     jsr         %a6@(77 * -6)   /* Exec/SendIO */
@@ -744,8 +742,7 @@ BCPL readinput      /* a0, bytelength , &buf, bytelength */
      */
 BCPL taskwait       /* a4, DosPacket @,  */
     movem.l	%a0-%a1/%a6,%sp@-
-    move.l	%a2@(GV_DOSBase),%a6
-    jsr		%a6@(42 * -6)	/* Dos/WaitPkt() */
+    jsr		BCPL_TaskWait
     lsr.l	#2,%d0
     movem.l	%sp@+,%a0-%a1/%a6
     BRTS
@@ -870,7 +867,17 @@ BCPL returnPacket   /* c4, void, @DosPacket, res1, res2 */
 #define WA_Width	(WA_Dummy + 3)
 #define WA_Height	(WA_Dummy + 4)
 #define WA_Title	(WA_Dummy + 11)
+#define WA_MinWidth	(WA_Dummy + 15)
+#define WA_MinHeight	(WA_Dummy + 16)
+#define WA_MaxWidth	(WA_Dummy + 17)
+#define WA_MaxHeight	(WA_Dummy + 18)
 #define WA_PubScreen	(WA_Dummy + 22)
+#define WA_SizeGadget	(WA_Dummy + 30)
+#define WA_DragBar	(WA_Dummy + 31)
+#define WA_DepthGadget	(WA_Dummy + 32)
+#define WA_Activate	(WA_Dummy + 38)
+#define WA_SmartRefresh	(WA_Dummy + 42)
+#define WA_SizeBRight	(WA_Dummy + 43)
 #define WA_AutoAdjust	(WA_Dummy + 45)
 
 BCPL openWindow     /* c8, struct Window *, leftedge, topedge, width, height, @title */
@@ -878,11 +885,40 @@ BCPL openWindow     /* c8, struct Window *, leftedge, topedge, width, height, @t
 	move.l	%a2@(GV_DOSBase),%a6
 	move.l	%a6@(dl_IntuitionBase),%a6
 	move.l	#TAG_END, %sp@-
+	move.l	#32767, %sp@-
+	move.l	#WA_MaxHeight, %sp@-
+	move.l	#32767, %sp@-
+	move.l	#WA_MaxWidth, %sp@-
+	move.l	#70, %sp@-
+	move.l	#WA_MinHeight, %sp@-
+	move.l	#100, %sp@-
+	move.l	#WA_MinWidth, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_SizeBRight, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_SmartRefresh, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_DepthGadget, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_DragBar, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_SizeGadget, %sp@-
 	move.l	#-1, %sp@-
 	move.l	#WA_AutoAdjust, %sp@-
+	move.l	#-1, %sp@-
+	move.l	#WA_Activate, %sp@-
 	move.l	%a0, %sp@-
 	move.l	#WA_PubScreen, %sp@-
-	move.l	%a1@(4*4),%sp@-
+	/* NEWCON passes a BCPL word pointer to the first title character.
+	 * Convert it to the byte pointer required by WA_Title (BADDR), while
+	 * preserving a NULL title.  This is not an AmigaDOS length-prefixed
+	 * BSTR, so no byte is skipped after conversion.
+	 */
+	move.l	%a1@(4*4),%d0
+	beq.s	1f
+	lsl.l	#2,%d0
+1:
+	move.l	%d0,%sp@-
 	move.l	#WA_Title, %sp@-
 	move.l	%d4, %sp@-
 	move.l	#WA_Height, %sp@-
@@ -894,7 +930,7 @@ BCPL openWindow     /* c8, struct Window *, leftedge, topedge, width, height, @t
 	move.l	#WA_Left, %sp@-
 	move.l	%sp, %a1			/* a0 is still 0 here */
 	jsr		%a6@(101 * -6)		/* OpenWindowTagList */
-	lea.l	%sp@(15 * 4),%sp
+	lea.l	%sp@(35 * 4),%sp
 	movem.l	%sp@+,%a0-%a1/%a6
     BRTS
 

--- a/arch/m68k-all/dos/bcpl.h
+++ b/arch/m68k-all/dos/bcpl.h
@@ -10,6 +10,7 @@
 /* Our BCPL stub private data */
 
 #define GV_DEBUG_Result2	-0xac
+#define GV_IntuitionBase        0x170   /* Not a function, but a value */
 #define GV_DOSBase              0x204   /* Not a function, but a value */
 
 /* We can add private data up to -0x88 */

--- a/arch/m68k-all/dos/bcpl_support.c
+++ b/arch/m68k-all/dos/bcpl_support.c
@@ -7,6 +7,7 @@
 #include <aros/debug.h>
 #include <aros/asmcall.h>
 
+#include <devices/console.h>
 #include <dos/dosextens.h>
 #include <dos/filehandler.h>
 #include <dos/dostags.h>
@@ -35,6 +36,38 @@ const ULONG BCPL_GlobVec[(BCPL_GlobVec_NegSize + BCPL_GlobVec_PosSize) >> 2] = {
 #undef BCPL
 
 #define BCPL_ENTRY(proc)        (((APTR *)(proc)->pr_GlobVec)[1])
+
+/* Wait for either a DOS packet or an asynchronous IO completion on a
+ * legacy BCPL process port.  AmigaDOS exposed console read/write completions
+ * to BCPL handlers as private actions 1001/1002.  Provide a packet-shaped
+ * view backed by the completed IORequest; dp_Type aliases io_Actual, matching
+ * the layout expected by the original handlers.  The device has completed
+ * the request and BCPL setIO initializes it before the next submission.
+ */
+APTR BCPL_TaskWait(void)
+{
+    struct Process *me = (struct Process *)FindTask(NULL);
+    struct Message *msg;
+
+    while ((msg = GetMsg(&me->pr_MsgPort)) == NULL)
+        Wait(1L << me->pr_MsgPort.mp_SigBit);
+
+    if (msg->mn_Node.ln_Name != NULL)
+        return msg->mn_Node.ln_Name;
+
+    {
+        struct IOStdReq *io = (struct IOStdReq *)msg;
+
+        if (io->io_Command == CMD_READ || io->io_Command == CMD_WRITE)
+        {
+            io->io_Actual = (io->io_Command == CMD_READ) ? 1001 : 1002;
+            return &io->io_Unit;
+        }
+    }
+
+    return NULL;
+}
+
 /*
  * Set up the process's initial global vector
  */
@@ -49,6 +82,7 @@ ULONG BCPL_InstallSeg(BPTR seg, ULONG *globvec)
     }
 
     if (seg == (ULONG)-1) {
+        struct DosLibrary *DOSBase;
         ULONG slots = globvec[0];
         int i;
         if (slots > (BCPL_GlobVec_PosSize>>2))
@@ -66,8 +100,11 @@ ULONG BCPL_InstallSeg(BPTR seg, ULONG *globvec)
             globvec[i] = gv;
         }
 
-        D(bug("BCPL_InstallSeg: Inserting DOSBase global\n"));
-        globvec[GV_DOSBase >> 2] = (IPTR)OpenLibrary("dos.library",0);
+        D(bug("BCPL_InstallSeg: Inserting library-base globals\n"));
+        DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
+        globvec[GV_DOSBase >> 2] = (IPTR)DOSBase;
+        if (DOSBase != NULL)
+            globvec[GV_IntuitionBase >> 2] = (IPTR)DOSBase->dl_IntuitionBase;
 
         return DOSTRUE;
     }
@@ -262,4 +299,3 @@ void bcpl_command_name(void)
     else
         bug("%b: ", cli->cli_CommandName);
 }
-

--- a/rom/dos/newcliproc.c
+++ b/rom/dos/newcliproc.c
@@ -61,6 +61,13 @@ ULONG internal_CliInitAny(struct DosPacket *dp, APTR DOSBase)
                 AROS_UFCA(APTR, &me->pr_ReturnAddr, A3),
                 AROS_UFCA(LONG_FUNC, (IPTR)Type, A4));
         D(bug("%s: Called custom BCPL CliInit routine @%p => 0x%08x\n",__func__, Type, ret));
+        /* An interactive BCPL Shell-Seg expects zero after CliInit has
+         * installed caller-supplied input and output streams.  AROS tags
+         * that state for native shells; translate it at the BCPL boundary.
+         */
+        if ((ULONG)ret == (FNF_VALIDFLAGS | FNF_SYSTEM |
+                           FNF_USERINPUT | FNF_RUNOUTPUT))
+            ret = 0;
         if (ret > 0) {
             D(bug("%s: Calling custom BCPL reply routine @%p\n",__func__, ret));
             ret = AROS_UFC8(ULONG, BCPL_thunk,


### PR DESCRIPTION
Improves compatibility with the original Workbench 1.3 BCPL Shell and Newcon-Handler on m68k:

  - Fixes keyboard input and asynchronous console I/O handling.
  - Corrects the Shell window title and restores resize, drag, and depth gadgets.
  - Handles legacy BCPL CLI initialization correctly.
  - Initializes the standard BCPL IntuitionBase global-vector slot, fixing the crash when running EndCLI.

  Tested with Workbench 1.3 in Copperline on an A500 configuration.

<img width="1320" height="936" alt="image" src="https://github.com/user-attachments/assets/c2e6d369-810c-4670-8a00-360206d70e71" />
