### PR TITLE
m68k: improve classic Shell and console compatibility

### DIFF
--- a/arch/m68k-all/utility/sdivmod32.s
+++ b/arch/m68k-all/utility/sdivmod32.s
@@ -50,7 +50,9 @@ nisneg:
     rts
 nispos:
     tst.l   %d1
-    bpl.l   AROS_SLIB_ENTRY(UDivMod32,Utility,26)
+    bmi.s   divisor_negative
+    jmp     AROS_SLIB_ENTRY(UDivMod32,Utility,26)
+divisor_negative:
     neg.l   %d1
     jsr     AROS_SLIB_ENTRY(UDivMod32,Utility,26)
     neg.l   %d0

--- a/rom/devs/console/cdinputhandler.c
+++ b/rom/devs/console/cdinputhandler.c
@@ -237,7 +237,11 @@ struct Interrupt *initCDIH(struct ConsoleBase *ConsoleDevice)
             cdihandler->is_Code =
                 (VOID_FUNC) AROS_SLIB_ENTRY(CDInputHandler, Console, 7);
             cdihandler->is_Data = ConsoleDevice;
-            cdihandler->is_Node.ln_Pri = 50;
+            /* Intuition runs at priority 50 and leaves the original event
+             * available to lower-priority handlers.  Run afterwards so its
+             * ActiveWindow is current before obtainconunit() routes the event,
+             * matching the classic console.device input chain. */
+            cdihandler->is_Node.ln_Pri = 0;
             cdihandler->is_Node.ln_Name = "console.device InputHandler";
 
             ReturnPtr("initCDIH", struct Interrupt *, cdihandler);

--- a/rom/devs/console/consoleclass.c
+++ b/rom/devs/console/consoleclass.c
@@ -446,6 +446,8 @@ static VOID console_getdefaultparams(Class *cl, Object *o,
     case C_CURSOR_BACKWARD:
     case C_CURSOR_NEXT_LINE:
     case C_CURSOR_PREV_LINE:
+    case C_INSERT_LINE:
+    case C_DELETE_LINE:
     case C_SET_TOP_OFFSET:
     case C_SET_PAGE_LENGTH:
         msg->Params[0] = 1;

--- a/rom/devs/console/consoletask.c
+++ b/rom/devs/console/consoletask.c
@@ -13,6 +13,7 @@
 #include <proto/console.h>
 #include <exec/io.h>
 #include <exec/alerts.h>
+#include <exec/rawfmt.h>
 #include <dos/dos.h>
 #include <devices/input.h>
 #include <devices/rawkeycodes.h>
@@ -77,6 +78,68 @@ static VOID answer_requests(APTR unit, struct ConsoleBase *ConsoleDevice)
             }
         }
     }
+}
+
+static BOOL report_raw_event(Object *unit, const struct InputEvent *event,
+    struct ConsoleBase *ConsoleDevice)
+{
+    struct intConUnit *icu = ICU(unit);
+    UBYTE report[128];
+    LONG fields[8];
+    LONG x, y;
+    ULONG len;
+
+    if (!CHECK_RAWEVENT(unit, event->ie_Class))
+        return FALSE;
+
+    /* The classic console.device reports mouse button transitions but not
+     * IECODE_NOBUTTON movement events through this raw-event byte stream.
+     * Consumers such as Ed read the mouse coordinates maintained by
+     * Intuition when processing the press and release reports. */
+    if (event->ie_Class == IECLASS_RAWMOUSE &&
+        event->ie_Code == IECODE_NOBUTTON)
+        return TRUE;
+
+    if (event->ie_Class == IECLASS_RAWKEY)
+    {
+        x = ((ULONG)event->ie_Prev1DownCode << 8) |
+            event->ie_Prev1DownQual;
+        y = ((ULONG)event->ie_Prev2DownCode << 8) |
+            event->ie_Prev2DownQual;
+    }
+    else
+    {
+        x = event->ie_X;
+        y = event->ie_Y;
+    }
+
+    fields[0] = event->ie_Class;
+    fields[1] = event->ie_SubClass;
+    fields[2] = event->ie_Code;
+    fields[3] = event->ie_Qualifier;
+    fields[4] = x;
+    fields[5] = y;
+    fields[6] = event->ie_TimeStamp.tv_secs;
+    fields[7] = event->ie_TimeStamp.tv_micro;
+
+    /* RawDoFmt's explicit data stream is ABI-safe on m68k.  Passing this
+     * many values through NewRawDoFmt's varargs interface corrupts the
+     * stream there, producing more than the eight fields mandated by the
+     * console.device input-event report protocol. */
+    RawDoFmt("\x9b%ld;%ld;%ld;%ld;%ld;%ld;%ld;%ld|", fields,
+        RAWFMTFUNC_STRING, report);
+    len = strnlen(report, sizeof(report));
+    if (len == sizeof(report))
+        return TRUE;
+
+    if (len <= CON_INPUTBUF_SIZE - icu->numStoredChars)
+    {
+        CopyMem(report, icu->inputBuf + icu->numStoredChars, len);
+        icu->numStoredChars += len;
+        answer_requests(unit, ConsoleDevice);
+    }
+
+    return TRUE;
 }
 
 static ULONG pasteData(struct intConUnit *icu,
@@ -221,6 +284,9 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                  */
                 if (checkconunit(cdihmsg->unit, ConsoleDevice))
                 {
+                    BOOL rawEvent = report_raw_event(cdihmsg->unit,
+                        &cdihmsg->ie, ConsoleDevice);
+
                     switch (cdihmsg->ie.ie_Class)
                     {
                     case IECLASS_CLOSEWINDOW:
@@ -239,6 +305,9 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                             LONG actual;
                             ULONG tocopy;
                             struct InputEvent e;
+
+                            if (rawEvent)
+                                break;
 
                             /* Mouse wheel support */
                             if (cdihmsg->ie.ie_Code == RAWKEY_NM_WHEEL_UP ||

--- a/rom/devs/console/stdconclass.c
+++ b/rom/devs/console/stdconclass.c
@@ -504,7 +504,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
 
             ScrollRaster(rp,
                 0,
-                -YRSIZE,
+                -YRSIZE * params[0],
                 GFX_XMIN(o), GFX_Y(o, YCP), GFX_XMAX(o), GFX_YMAX(o));
 
             SetAPen(rp, oldpen);
@@ -522,7 +522,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
 
             ScrollRaster(rp,
                 0,
-                YRSIZE,
+                YRSIZE * params[0],
                 GFX_XMIN(o), GFX_Y(o, YCP), GFX_XMAX(o), GFX_YMAX(o));
 
             SetAPen(rp, oldpen);
@@ -614,7 +614,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
         {
             UBYTE reply[32];
             NewRawDoFmt("\x9b" "1;1;%d;%d r", RAWFMTFUNC_STRING, reply,
-                CU(o)->cu_YMax, CU(o)->cu_XMax);
+                CU(o)->cu_YMax + 1, CU(o)->cu_XMax + 1);
             con_inject((struct ConsoleBase *)cl->cl_UserData, CU(o), reply,
                 -1);
             break;
@@ -624,7 +624,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
         {
             UBYTE reply[32];
             NewRawDoFmt("\x9b" "%d;%dR", RAWFMTFUNC_STRING, reply,
-                CU(o)->cu_YCP, CU(o)->cu_XCP);
+                CU(o)->cu_YCP + 1, CU(o)->cu_XCP + 1);
             con_inject((struct ConsoleBase *)cl->cl_UserData, CU(o), reply,
                 -1);
             break;

--- a/rom/devs/console/support.c
+++ b/rom/devs/console/support.c
@@ -504,9 +504,9 @@ static const struct Command
     {C_CURSOR_POS,               2},                     /* 0x48 H */
     {C_CURSOR_HTAB,              1},                     /* 0x49 I */
     {C_ERASE_IN_DISPLAY,         0},                     /* 0x4A J */
-    {C_ERASE_IN_LINE,            0},                     /* 0x4B K */
-    {C_INSERT_LINE,              0},                     /* 0x4C L */
-    {C_DELETE_LINE,              0},                     /* 0x4D M */
+    {C_ERASE_IN_LINE,            1},                     /* 0x4B K */
+    {C_INSERT_LINE,              1},                     /* 0x4C L */
+    {C_DELETE_LINE,              1},                     /* 0x4D M */
     {-1,                         },                      /* 0x4E N */
     {-1,                         },                      /* 0x4F O */
     {C_DELETE_CHAR,              1},                     /* 0x50 P */

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -500,6 +500,33 @@ static void startread(struct filehandle *fh)
     fh->flags |= FHFLG_ASYNCCONSOLEREAD;
 }
 
+static void pump_raw_input(struct filehandle *fh)
+{
+    while (fh->conbufferpos < fh->conbuffersize)
+    {
+        LONG available = fh->conbuffersize - fh->conbufferpos;
+        LONG space = INPUTBUFFER_SIZE - fh->inputsize;
+        LONG copylen;
+
+        if (space <= 0)
+            break;
+
+        copylen = available < space ? available : space;
+        CopyMem(fh->consolebuffer + fh->conbufferpos,
+            fh->inputbuffer + fh->inputsize, copylen);
+        fh->conbufferpos += copylen;
+        fh->inputsize += copylen;
+        fh->inputpos = fh->inputstart = fh->inputsize;
+
+        HandlePendingReads(fh);
+
+        /* Without a pending application read, keep the remaining device
+         * bytes in consolebuffer until space is made by ACTION_READ. */
+        if (fh->inputsize != 0)
+            break;
+    }
+}
+
 static void stopwait(struct filehandle *fh, struct DosPacket *waitingdp, ULONG result)
 {
     if (waitingdp) {
@@ -727,14 +754,9 @@ LONG CONMain(struct ExecBase *SysBase)
                 /* terminate with 0 char */
                 fh->consolebuffer[fh->conbuffersize] = '\0';
                 if (fh->flags & FHFLG_RAW) {
-                    LONG inp;
                     /* raw mode */
                     DREAD(bug("[con:handler] %s: FHFLG_RAW\n", __func__));
-                    for (inp = 0; (inp < fh->conbuffersize) && (fh->inputpos < INPUTBUFFER_SIZE);) {
-                        fh->inputbuffer[fh->inputpos++] = fh->consolebuffer[inp++];
-                    }
-                    fh->inputsize = fh->inputstart = fh->inputpos;
-                    HandlePendingReads(fh);
+                    pump_raw_input(fh);
                 } /* if (fh->flags & FHFLG_RAW) */
                 else {
                     DREAD(bug("[con:handler] %s: COOKED\n", __func__));
@@ -749,7 +771,9 @@ LONG CONMain(struct ExecBase *SysBase)
                     }
                 } /* if (fh->flags & FHFLG_RAW) else ... */
 
-                if (fh->flags & FHFLG_CONSOLEDEVICEOPEN) /* device could have been closed */
+                if ((fh->flags & FHFLG_CONSOLEDEVICEOPEN) &&
+                    (!(fh->flags & FHFLG_RAW) ||
+                        fh->conbufferpos >= fh->conbuffersize))
                     startread(fh);
             }
 
@@ -835,8 +859,15 @@ LONG CONMain(struct ExecBase *SysBase)
                         break;
                     }
                     fh->breaktask = dp->dp_Port->mp_SigTask;
-                    startread(fh);
-                    con_read(fh, dp);
+                    if (fh->flags & FHFLG_RAW) {
+                        con_read(fh, dp);
+                        pump_raw_input(fh);
+                        if (fh->conbufferpos >= fh->conbuffersize)
+                            startread(fh);
+                    } else {
+                        startread(fh);
+                        con_read(fh, dp);
+                    }
                     break;
                 case ACTION_WRITE:
                     DACTION(bug("[con:handler] ACTION_WRITE\n"));

--- a/workbench/c/Shell/readLine.c
+++ b/workbench/c/Shell/readLine.c
@@ -19,15 +19,21 @@ static BOOL checkPipe(STRPTR pchar, STRPTR mchar, STRPTR in, LONG inlen)
 {
     LONG c, n;
     BOOL quoted = FALSE;
+    BOOL escaped = FALSE;
     int mcharn = strlen(mchar), pcharn = strlen(pchar);
 
     for (n = 0; n < inlen; n++)
     {
         c = in[n];
-        if (c == '"')
+        if (c == '"' && !escaped)
         {
             quoted = !quoted;
         }
+
+        if (c == '*' && !escaped)
+            escaped = TRUE;
+        else
+            escaped = FALSE;
 
         if (quoted)
             continue;
@@ -47,6 +53,7 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
     STRPTR buf = out->buf; /* pre-allocated by caller */
     BOOL comment = FALSE;
     BOOL quoted = FALSE;
+    BOOL escaped = FALSE;
     LONG c, i, j, len;
     TEXT pchar[3], mchar[3];
 
@@ -69,8 +76,13 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
         if (c == ENDSTREAMCH)
             break;
 
-        if (c == '"')
+        if (c == '"' && !escaped)
             quoted = !quoted;
+
+        if (c == '*' && !escaped)
+            escaped = TRUE;
+        else
+            escaped = FALSE;
  
         if (!quoted && c == ';' && c != mchar[0] ) /* comment line */
         {
@@ -115,4 +127,3 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
     )
     return 0;
 }
-


### PR DESCRIPTION
This PR fixes some console/Shell related compatibility problems with Workbench 3.1:

 - Preserve escaped quotes when parsing Shell command lines, fixing Workbench 3.1 aliases (warning when executing Workbench 3.1 shell-startup)
 - Avoid generating a 68020-only branch instruction in SDivMod32, allowing classic applications such as List to run on a 68000 (crash when running `list` from WB 3.1 on a 68000)
 - Implement classic console raw-event reports used by applications such as Ed.
 - Match Kickstart 3.1 mouse reporting by forwarding button transitions without flooding applications with movement-only events.
 - Prevent raw console input from being silently discarded when intermediate buffers are full.
 - Correct console escape-sequence defaults, line insertion/deletion, scrolling, and cursor-position replies (visible escape characters when opening an empty file in Ed)
 - Route console input after Intuition has updated the active window.

Ed mouse selection now works! (but there are more problems to fix...):

<img width="331" height="211" alt="Capture d’écran 2026-07-21 à 02 23 48" src="https://github.com/user-attachments/assets/e5a025e3-1621-4180-815f-b5174afaa0e2" />
