### PR TITLE
arm: build aeabi linklib as part of core-linklibs

### DIFF
--- a/arch/arm-all/arm-aeabi/mmakefile.src
+++ b/arch/arm-all/arm-aeabi/mmakefile.src
@@ -9,6 +9,7 @@ ASMFILES := uidivmod idivmod uldivmod ldivmod idiv0 ldiv0 unwind
 
 #MM- linklibs-arm : linklibs-aeabi
 #MM- linklibs-armeb : linklibs-aeabi
+#MM- core-linklibs : linklibs-aeabi
 
 #MM linklibs-aeabi : linklibs-softfloat includes-asm_h
 


### PR DESCRIPTION
Programs auto-link -laeabi via aros_c_libs, but libaeabi.a was only reachable through linklibs-arm, leaving the build order undefined. Hook it into core-linklibs so it exists before any program links.