### PR TITLE
m68k: Workbench & console improvements

### DIFF
--- a/arch/m68k-amiga/graphics/bltclear.c
+++ b/arch/m68k-amiga/graphics/bltclear.c
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Amiga hardware implementation of graphics.library/BltClear().
+*/
+
+#include <hardware/custom.h>
+#include <proto/graphics.h>
+
+#include "graphics_intern.h"
+
+/* See rom/graphics/bltclear.c for documentation. */
+
+AROS_LH3(void, BltClear,
+    AROS_LHA(void *, memBlock, A1),
+    AROS_LHA(ULONG, bytecount, D0),
+    AROS_LHA(ULONG, flags, D1),
+    struct GfxBase *, GfxBase, 50, Graphics)
+{
+    AROS_LIBFUNC_INIT
+
+    volatile struct Custom *custom = (struct Custom *)0xdff000;
+    UBYTE *dst = memBlock;
+    ULONG words;
+
+    if (flags & 2)
+        bytecount = (bytecount & 0xffff) * (bytecount >> 16);
+
+    words = bytecount >> 1;
+    if (!words)
+        return;
+
+    OwnBlitter();
+
+    while (words)
+    {
+        UWORD width;
+        UWORD height;
+        ULONG count;
+
+        if (words >= 64)
+        {
+            width = 64;
+            height = words / 64;
+            if (height > 1024)
+                height = 1024;
+        }
+        else
+        {
+            width = words;
+            height = 1;
+        }
+
+        count = (ULONG)width * height;
+
+        WaitBlit();
+        custom->bltcon0 = 0x0100; /* D = 0, D channel enabled. */
+        custom->bltcon1 = 0;
+        custom->bltdmod = 0;
+        custom->bltdpt = dst;
+        custom->bltsize = (height << 6) | (width & 63);
+
+        dst += count * 2;
+        words -= count;
+    }
+
+    WaitBlit();
+    DisownBlitter();
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/m68k-amiga/graphics/mmakefile.src
+++ b/arch/m68k-amiga/graphics/mmakefile.src
@@ -1,7 +1,7 @@
 
 include $(SRCDIR)/config/aros.cfg
 
-CFILES  := changeextspritea movesprite setchiprev vbeampos
+CFILES  := bltclear changeextspritea movesprite setchiprev vbeampos
 AFILES  := attemptlocklayerrom locklayerrom unlocklayerrom waitblit
 
 #MM kernel-graphics-amiga-m68k : kernel-hidd-includes kernel-graphics-includes includes-asm_h kernel-hidd-graphics-includes

--- a/rom/devs/console/charmap.c
+++ b/rom/devs/console/charmap.c
@@ -18,14 +18,10 @@ struct charmap_line *charmap_dispose_line(struct charmap_line *line)
     if (line)
     {
         next = line->next;
-        if (line->size)
+        if (line->capacity)
         {
             if (line->text)
-                FreeMem(line->text, line->size);
-            if (line->fgpen)
-                FreeMem(line->fgpen, line->size);
-            if (line->bgpen)
-                FreeMem(line->bgpen, line->size);
+                FreeMem(line->text, line->capacity * 4);
         }
         FreeMem(line, sizeof(struct charmap_line));
     }
@@ -54,12 +50,11 @@ struct charmap_line *charmap_newline(struct charmap_line *next,
     newline->bgpen = 0;
     newline->flags = 0;
     newline->size = 0;
+    newline->capacity = 0;
     return newline;
 }
 
 
-// FIXME: **much** faster if add capacity to charmap_line and allocate
-// a few characters at a time
 VOID charmap_resize(struct ConsoleBase *ConsoleDevice, struct charmap_line *line, ULONG newsize)
 {
     char *text = line->text;
@@ -67,22 +62,51 @@ VOID charmap_resize(struct ConsoleBase *ConsoleDevice, struct charmap_line *line
     BYTE *bgpen = line->bgpen;
     BYTE *flags = line->flags;
     ULONG size = line->size;
+    ULONG capacity = line->capacity;
+
+    if (newsize && newsize <= capacity)
+    {
+        if (newsize > size)
+        {
+            SetMem(line->text + size, 0, newsize - size);
+            SetMem(line->fgpen + size, 0, newsize - size);
+            SetMem(line->bgpen + size, 0, newsize - size);
+            SetMem(line->flags + size, 0, newsize - size);
+        }
+        line->size = newsize;
+        return;
+    }
 
     if (newsize)
     {
-        line->text = (char *)AllocMem(newsize, MEMF_ANY);
-        if (line->text)
-            SetMem(line->text, 0, newsize);
-        line->fgpen = (BYTE *) AllocMem(newsize, MEMF_ANY);
-        if (line->fgpen)
-            SetMem(line->fgpen, 0, newsize);
-        line->bgpen = (BYTE *) AllocMem(newsize, MEMF_ANY);
-        if (line->bgpen)
-            SetMem(line->bgpen, 0, newsize);
-        line->flags = (BYTE *) AllocMem(newsize, MEMF_ANY);
-        if (line->flags)
-            SetMem(line->flags, 0, newsize);
+        ULONG growth = capacity / 2;
+        ULONG newcapacity;
+        UBYTE *buffer;
+
+        if (newsize > 0xffff)
+            return;
+        if (growth < 8)
+            growth = 8;
+        newcapacity = capacity + growth;
+        if (newcapacity < newsize)
+            newcapacity = newsize;
+        if (newcapacity > 0xffff)
+            newcapacity = 0xffff;
+
+        buffer = AllocMem(newcapacity * 4, MEMF_ANY);
+        if (!buffer)
+            return;
+
+        line->text = (char *)buffer;
+        line->fgpen = (BYTE *)(buffer + newcapacity);
+        line->bgpen = (BYTE *)(buffer + newcapacity * 2);
+        line->flags = (BYTE *)(buffer + newcapacity * 3);
+        SetMem(line->text, 0, newsize);
+        SetMem(line->fgpen, 0, newsize);
+        SetMem(line->bgpen, 0, newsize);
+        SetMem(line->flags, 0, newsize);
         line->size = newsize;
+        line->capacity = newcapacity;
     }
     else
     {
@@ -91,6 +115,7 @@ VOID charmap_resize(struct ConsoleBase *ConsoleDevice, struct charmap_line *line
         line->bgpen = 0;
         line->flags = 0;
         line->size = 0;
+        line->capacity = 0;
     }
 
     if (text && line->text)
@@ -103,11 +128,5 @@ VOID charmap_resize(struct ConsoleBase *ConsoleDevice, struct charmap_line *line
         memcpy(line->flags, flags, size);
 
     if (text)
-        FreeMem(text, size);
-    if (fgpen)
-        FreeMem(fgpen, size);
-    if (bgpen)
-        FreeMem(bgpen, size);
-    if (flags)
-        FreeMem(flags, size);
+        FreeMem(text, capacity * 4);
 }

--- a/rom/devs/console/charmap.h
+++ b/rom/devs/console/charmap.h
@@ -17,7 +17,8 @@ struct charmap_line
     struct charmap_line *next;
     struct charmap_line *prev;
 
-    ULONG size;
+    UWORD size;
+    UWORD capacity;
     char *text;
     BYTE *fgpen;
     BYTE *bgpen;

--- a/rom/devs/console/charmapconclass.c
+++ b/rom/devs/console/charmapconclass.c
@@ -884,6 +884,12 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
     struct RastPort *rp = w->RPort;
     struct charmapcondata *data = INST_DATA(cl, o);
     struct Library *GfxBase = data->ccd_GfxBase;
+    struct TmpRas localTmpRas;
+    struct TmpRas *savedTmpRas = rp->TmpRas;
+    PLANEPTR scratch = NULL;
+    UWORD scratchWidth = GFX_XMAX(o) - GFX_XMIN(o) + 1;
+    UWORD scratchHeight = rp->Font->tf_YSize;
+    ULONG scratchSize = RASSIZE(scratchWidth, scratchHeight);
 
     if (fromLine < CHAR_YMIN(o))
         fromLine = CHAR_YMIN(o);
@@ -895,6 +901,13 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
 
     if (toLine < fromLine)
         return;
+
+    if (!savedTmpRas || savedTmpRas->Size < scratchSize)
+    {
+        scratch = AllocRaster(scratchWidth, scratchHeight);
+        if (scratch)
+            rp->TmpRas = InitTmpRas(&localTmpRas, scratch, scratchSize);
+    }
 
     Console_UnRenderCursor(o);
 
@@ -1045,6 +1058,13 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
     }
 
     Console_RenderCursor(o);
+
+    if (scratch)
+    {
+        rp->TmpRas = savedTmpRas;
+        FreeRaster(scratch, scratchWidth, scratchHeight);
+    }
+
 }
 
 

--- a/rom/devs/console/charmapconclass.c
+++ b/rom/devs/console/charmapconclass.c
@@ -692,17 +692,20 @@ static VOID charmap_swap_line_contents(struct charmap_line *a,
     struct charmap_line *b)
 {
     ULONG size = a->size;
+    ULONG capacity = a->capacity;
     char *text = a->text;
     BYTE *fgpen = a->fgpen;
     BYTE *bgpen = a->bgpen;
     BYTE *flags = a->flags;
 
     a->size = b->size;
+    a->capacity = b->capacity;
     a->text = b->text;
     a->fgpen = b->fgpen;
     a->bgpen = b->bgpen;
     a->flags = b->flags;
     b->size = size;
+    b->capacity = capacity;
     b->text = text;
     b->fgpen = fgpen;
     b->bgpen = bgpen;

--- a/rom/devs/console/stdconclass.c
+++ b/rom/devs/console/stdconclass.c
@@ -31,6 +31,9 @@ struct stdcondata
     UWORD pens[CONUNIT_PEN_MAX];
     UWORD *penmap[CONUNIT_PEN_MAX];
 
+    PLANEPTR charScratch;
+    UWORD charScratchHeight;
+
     /* Libraries */
     struct Library *scd_GfxBase;
 };
@@ -67,11 +70,16 @@ static Object *stdcon_new(Class *cl, Object *o, struct opSet *msg)
             data->dri = GetScreenDrawInfo(CU(o)->cu_Window->WScreen);
             if (data->dri)
             {
+                struct Library *GfxBase = data->scd_GfxBase;
+
                 data->penmap[0] = &data->dri->dri_Pens[BACKGROUNDPEN];
                 data->penmap[1] = &data->dri->dri_Pens[TEXTPEN];
 
                 CU(o)->cu_BgPen = (BYTE)*(data->penmap[0]);
                 CU(o)->cu_FgPen = (BYTE)*(data->penmap[1]);
+
+                data->charScratchHeight = RASTPORT(o)->Font->tf_YSize;
+                data->charScratch = AllocRaster(8, data->charScratchHeight);
 
                 data->cursorvisible = TRUE;
                 Console_RenderCursor(o);
@@ -90,6 +98,10 @@ static Object *stdcon_new(Class *cl, Object *o, struct opSet *msg)
 static VOID stdcon_dispose(Class *cl, Object *o, Msg msg)
 {
     struct stdcondata *data = INST_DATA(cl, o);
+    struct Library *GfxBase = data->scd_GfxBase;
+
+    if (data->charScratch)
+        FreeRaster(data->charScratch, 8, data->charScratchHeight);
 
     if (data->scd_GfxBase)
         CloseLibrary(data->scd_GfxBase);
@@ -124,6 +136,22 @@ static void setstyle(struct Library *GfxBase, struct RastPort *rp,
     SetSoftStyle(rp, tflags, CON_TXTFLAGS_MASK);
 }
 
+static void stdcon_text(struct stdcondata *data, struct RastPort *rp,
+    CONST_STRPTR text, ULONG len)
+{
+    struct TmpRas *savedTmpRas = rp->TmpRas;
+    struct TmpRas charTmpRas;
+    struct Library *GfxBase = data->scd_GfxBase;
+    ULONG scratchSize = RASSIZE(8, data->charScratchHeight);
+
+    if (len == 1 && data->charScratch &&
+        (!savedTmpRas || savedTmpRas->Size < scratchSize))
+        rp->TmpRas = InitTmpRas(&charTmpRas, data->charScratch, scratchSize);
+
+    Text(rp, text, len);
+    rp->TmpRas = savedTmpRas;
+}
+
 /*********  StdCon::DoCommand()  ****************************/
 
 static VOID stdcon_docommand(Class *cl, Object *o,
@@ -155,7 +183,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
         Move(rp, CP_X(o), CP_Y(o) + rp->Font->tf_Baseline);
         {
             UBYTE c = params[0];
-            Text(rp, &c, 1);
+            stdcon_text(data, rp, &c, 1);
         }
 
         Console_Right(o, 1);
@@ -185,7 +213,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
                     len < remaining_space ? len : remaining_space;
 
                 Move(rp, CP_X(o), CP_Y(o) + rp->Font->tf_Baseline);
-                Text(rp, str, line_len);
+                stdcon_text(data, rp, str, line_len);
 
                 Console_Right(o, line_len);
 

--- a/rom/graphics/allocbitmap.c
+++ b/rom/graphics/allocbitmap.c
@@ -500,7 +500,8 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
                 if(flags & BMF_INTERLEAVED) {
                     if((nbm->Planes[plane++] = AllocRaster(sizex * depth, sizey)) != NULL) {
                         if(clear)
-                            SetMem(nbm->Planes[0], 0, RASSIZE(sizex * depth, sizey));
+                            BltClear(nbm->Planes[0],
+                                RASSIZE(sizex * depth, sizey), 1);
 
                         /* Set the plane pointers, and clear remaining entries.. */
                         for(; plane < depth; plane++) {
@@ -522,7 +523,8 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
                             break;
 
                         if(clear)
-                            SetMem(nbm->Planes[plane], 0, RASSIZE(sizex, sizey));
+                            BltClear(nbm->Planes[plane],
+                                RASSIZE(sizex, sizey), 1);
                     }
                     if(plane != depth) {
                         for(--plane; plane >= 0; plane--)

--- a/rom/graphics/flood.c
+++ b/rom/graphics/flood.c
@@ -172,14 +172,8 @@ static int pix_written;
 
     /* Clear the needed part of tmpras */
 
-    /*
-
-    !!! Maybe we should use BltClear() here, since
-    !!! tmpras allways reside in CHIP RAM
-         */
-
     D(bug("Clearing tmpras\n"));
-    SetMem(tmpras->RasPtr, 0,  needed_size);
+    BltClear(tmpras->RasPtr, needed_size, 1);
 
     if(mode == 0) {
         /* Outline mode */

--- a/rom/graphics/text.c
+++ b/rom/graphics/text.c
@@ -102,47 +102,70 @@ void BltTemplateBasedText(struct RastPort *rp, CONST_STRPTR text, ULONG len,
     WORD                 raswidth, raswidth16, raswidth_bpr, rasheight, x, y, gx;
     UBYTE               *raster;
     BOOL                 is_bold, is_italic, fastfont;
+    BOOL                 allocated = FALSE;
+    ULONG                rassize;
 
-    TextExtent(rp, text, len, &te);
+    tf = rp->Font;
+    is_bold = (rp->AlgoStyle & FSF_BOLD) != 0;
+    is_italic = (rp->AlgoStyle & FSF_ITALIC) != 0;
+    fastfont = !is_bold && !is_italic && tf->tf_XSize == 8 &&
+               rp->TxSpacing == 0;
+
+    if (fastfont)
+    {
+        ULONG i;
+
+        for (i = 0; i < len; i++)
+        {
+            UBYTE c = text[i];
+            ULONG idx = (c < tf->tf_LoChar || c > tf->tf_HiChar) ?
+                        NUMCHARS(tf) - 1 : c - tf->tf_LoChar;
+            ULONG charloc = ((ULONG *)tf->tf_CharLoc)[idx];
+
+            if ((charloc & 0xFFFF) != 8 || ((charloc >> 16) & 7) ||
+                (tf->tf_CharKern &&
+                    ((WORD *)tf->tf_CharKern)[idx] != 0) ||
+                (tf->tf_CharSpace &&
+                    ((WORD *)tf->tf_CharSpace)[idx] != 8))
+            {
+                fastfont = FALSE;
+                break;
+            }
+        }
+    }
+
+    if (fastfont)
+    {
+        te.te_Width = len * 8;
+        te.te_Height = tf->tf_YSize;
+        te.te_Extent.MinX = 0;
+        te.te_Extent.MaxX = te.te_Width - 1;
+        te.te_Extent.MinY = -tf->tf_Baseline;
+        te.te_Extent.MaxY = te.te_Height - 1 - tf->tf_Baseline;
+    }
+    else
+        TextExtent(rp, text, len, &te);
 
     raswidth  = te.te_Extent.MaxX - te.te_Extent.MinX + 1;
     rasheight = te.te_Extent.MaxY - te.te_Extent.MinY + 1;
 
     raswidth16 = (raswidth + 15) & ~15;
     raswidth_bpr = raswidth16 / 8;
+    rassize = RASSIZE(raswidth, rasheight);
 
-    if((raster = AllocRaster(raswidth, rasheight))) {
-        SetMem(raster, 0, RASSIZE(raswidth, rasheight));
+    if (rp->TmpRas && rp->TmpRas->RasPtr && rp->TmpRas->Size >= rassize)
+        raster = rp->TmpRas->RasPtr;
+    else
+    {
+        raster = AllocRaster(raswidth, rasheight);
+        allocated = raster != NULL;
+    }
 
-        tf = rp->Font;
+    if(raster) {
+        if (!fastfont)
+            SetMem(raster, 0, rassize);
 
         x = -te.te_Extent.MinX;
-
-        is_bold   = (rp->AlgoStyle & FSF_BOLD) != 0;
-        is_italic = (rp->AlgoStyle & FSF_ITALIC) != 0;
-
-        fastfont = !is_bold && !is_italic && !tf->tf_CharKern &&
-                   !tf->tf_CharSpace && tf->tf_XSize == 8 &&
-                   rp->TxSpacing == 0 && x == 0;
-
-        if (fastfont)
-        {
-            ULONG i;
-
-            for (i = 0; i < len; i++)
-            {
-                UBYTE c = text[i];
-                ULONG idx = (c < tf->tf_LoChar || c > tf->tf_HiChar) ?
-                            NUMCHARS(tf) - 1 : c - tf->tf_LoChar;
-                ULONG charloc = ((ULONG *)tf->tf_CharLoc)[idx];
-
-                if ((charloc & 0xFFFF) != 8 || ((charloc >> 16) & 7))
-                {
-                    fastfont = FALSE;
-                    break;
-                }
-            }
-        }
 
         /* The standard Amiga screen font is an unstyled, fixed-width,
          * byte-aligned 8-pixel font. Build its template a byte at a time
@@ -150,30 +173,60 @@ void BltTemplateBasedText(struct RastPort *rp, CONST_STRPTR text, ULONG len,
         if (fastfont)
         {
             UBYTE *dst = raster;
+            ULONG remaining = len;
 
-            while (len--)
+            if (raswidth_bpr > len)
             {
-                UBYTE c = *text++;
-                ULONG idx;
-                ULONG charloc;
-                UWORD glyphpos;
-                UBYTE *glyphdata;
+                for (y = 0; y < rasheight; y++)
+                    raster[y * raswidth_bpr + len] = 0;
+            }
 
-                if (c < tf->tf_LoChar || c > tf->tf_HiChar)
-                    idx = NUMCHARS(tf) - 1;
-                else
-                    idx = c - tf->tf_LoChar;
+            while (remaining)
+            {
+                UBYTE *glyphdata[4];
+                ULONG batch = remaining >= 4 ? 4 :
+                              remaining >= 2 ? 2 : 1;
+                ULONG i;
 
-                charloc = ((ULONG *)tf->tf_CharLoc)[idx];
-                glyphpos = charloc >> 16;
+                for (i = 0; i < batch; i++)
+                {
+                    UBYTE c = text[i];
+                    ULONG idx = (c < tf->tf_LoChar || c > tf->tf_HiChar) ?
+                                NUMCHARS(tf) - 1 : c - tf->tf_LoChar;
+                    ULONG charloc = ((ULONG *)tf->tf_CharLoc)[idx];
 
-                glyphdata = (UBYTE *)tf->tf_CharData + glyphpos / 8;
+                    glyphdata[i] = (UBYTE *)tf->tf_CharData +
+                                   (charloc >> 16) / 8;
+                }
+
                 for (y = 0; y < rasheight; y++)
                 {
-                    dst[y * raswidth_bpr] = glyphdata[y * tf->tf_Modulo];
+                    UBYTE *row = dst + y * raswidth_bpr;
+
+                    if (batch == 4)
+                    {
+                        ULONG value =
+                            ((ULONG)glyphdata[0][y * tf->tf_Modulo] << 24) |
+                            ((ULONG)glyphdata[1][y * tf->tf_Modulo] << 16) |
+                            ((ULONG)glyphdata[2][y * tf->tf_Modulo] << 8) |
+                            glyphdata[3][y * tf->tf_Modulo];
+                        *(ULONG *)row = AROS_LONG2BE(value);
+                    }
+                    else if (batch == 2)
+                    {
+                        UWORD value =
+                            ((UWORD)glyphdata[0][y * tf->tf_Modulo] << 8) |
+                            glyphdata[1][y * tf->tf_Modulo];
+                        *(UWORD *)row = AROS_WORD2BE(value);
+                    }
+                    else
+                        *row = glyphdata[0][y * tf->tf_Modulo];
                 }
-                dst++;
-                x += 8;
+
+                text += batch;
+                dst += batch;
+                remaining -= batch;
+                x += batch * 8;
             }
         }
         else while(len--) {
@@ -334,7 +387,8 @@ void BltTemplateBasedText(struct RastPort *rp, CONST_STRPTR text, ULONG len,
                     raswidth,
                     rasheight);
 
-        FreeRaster(raster, raswidth, rasheight);
+        if (allocated)
+            FreeRaster(raster, raswidth, rasheight);
 
     } /* if ((raster = AllocRaster(raswidth, rasheight))) */
 

--- a/rom/intuition/intuition_init.c
+++ b/rom/intuition/intuition_init.c
@@ -77,6 +77,32 @@ const ULONG coltab[] =
     0xeeeeeeee, 0x00000000, 0x00000000
 };
 
+/* Built-in busy pointer in the classic two-plane sprite format. Keep this
+ * distinct from Preferences.PointerMatrix: the latter is the normal pointer
+ * and using it for both shapes makes WA_BusyPointer visually ambiguous.
+ * IPrefs may still replace this through IPREFS_TYPE_POINTER_V39. */
+static CONST UWORD IntuitionBusyPointer[] =
+{
+    0x0000, 0x0000,             /* sprite control words */
+    0x0000, 0x07c0,
+    0x07c0, 0x1ff0,
+    0x1ff0, 0x3ff8,
+    0x3078, 0x7ffc,
+    0x7efc, 0xfffe,
+    0x7dfc, 0xfffe,
+    0x707e, 0xffff,
+    0x7fc2, 0xffff,
+    0x3ff4, 0x7ffe,
+    0x1fc0, 0x3ffc,
+    0x07c0, 0x1ff0,
+    0x0000, 0x07c0,
+    0x00c0, 0x01e0,
+    0x0000, 0x01cc,
+    0x0004, 0x000e,
+    0x0000, 0x000e,
+    0x0000, 0x0000              /* sprite terminator words */
+};
+
 static int IntuitionInit(LIBBASETYPEPTR LIBBASE)
 {
     struct Library *OOPBase;
@@ -265,9 +291,9 @@ static int IntuitionInit(LIBBASETYPEPTR LIBBASE)
     (
         GetPubIBase(LIBBASE), &GetPrivIBase(LIBBASE)->ActivePreferences
     );
-    GetPrivIBase(LIBBASE)->BusyPointer = MakePointerFromPrefs
+    GetPrivIBase(LIBBASE)->BusyPointer = MakePointerFromData
     (
-        GetPubIBase(LIBBASE), &GetPrivIBase(LIBBASE)->ActivePreferences
+        GetPubIBase(LIBBASE), IntuitionBusyPointer, 0, 0, 16, 16
     );
 
     if
@@ -495,4 +521,3 @@ DECLARESET(CLASSESINIT)
 ADD2SET(InitRootClass, CLASSESINIT, -20)
 ADD2INITLIB(IntuitionInit, 0)
 ADD2OPENLIB(IntuitionOpen, 0)
-

--- a/rom/intuition/intuition_intern.h
+++ b/rom/intuition/intuition_intern.h
@@ -271,7 +271,7 @@ void * memclr(APTR, ULONG);
 
    Unfortunately this can fail with some programs, like DOpus 4.x text viewer */
 
-#define PROP_RENDER_OPTIMIZATION    	    0
+#define PROP_RENDER_OPTIMIZATION    	    1
 
 #define SINGLE_SETPOINTERPOS_PER_EVENTLOOP  1
 

--- a/rom/intuition/newmodifyprop.c
+++ b/rom/intuition/newmodifyprop.c
@@ -78,6 +78,9 @@
     struct PropInfo *pi;
     struct BBox      old, new;
     BOOL             knobok1, knobok2;
+#if PROP_RENDER_OPTIMIZATION
+    BOOL             fullrefresh;
+#endif
 
     if ((gadget->GadgetType & GTYP_GTYPEMASK) != GTYP_PROPGADGET
         || !gadget->SpecialInfo || !window)
@@ -101,7 +104,19 @@
 
     new = old;
 #if PROP_RENDER_OPTIMIZATION
-    knobok1 = CalcKnobSize (gadget, &old);
+    /* Some legacy programs update PropInfo before calling NewModifyProp().
+     * Only use the partial renderer when an active pot actually moves. A
+     * call with no detectable movement may have changed the knob geometry
+     * already and therefore needs the complete gadget renderer. */
+    fullrefresh = pi->HorizBody != horizBody ||
+                  pi->VertBody != vertBody ||
+                  ((pi->Flags ^ flags) &
+                   (AUTOKNOB | FREEHORIZ | FREEVERT |
+                    PROPBORDERLESS | PROPNEWLOOK)) ||
+                  (!(flags & AUTOKNOB) && gadget->GadgetRender) ||
+                  !(((flags & FREEHORIZ) && pi->HorizPot != horizPot) ||
+                    ((flags & FREEVERT) && pi->VertPot != vertPot));
+    knobok1 = fullrefresh ? TRUE : CalcKnobSize (gadget, &old);
 #else
     knobok1 = TRUE;
 #endif
@@ -125,11 +140,20 @@
 
         // Permit(); stegerg: CHECKME, commented out!
 #endif
-        knobok2 = CalcKnobSize (gadget, &new);
-
-        if (knobok2)
+    #if PROP_RENDER_OPTIMIZATION
+        if (fullrefresh)
         {
-            RefreshPropGadgetKnob (gadget, knobok1 ? &old : 0, &new, window, requester, IntuitionBase);
+            RefreshPropGadget(gadget, window, requester, IntuitionBase);
+        }
+        else
+    #endif
+        {
+            knobok2 = CalcKnobSize (gadget, &new);
+
+            if (knobok2)
+            {
+                RefreshPropGadgetKnob (gadget, knobok1 ? &old : 0, &new, window, requester, IntuitionBase);
+            }
         }
 
 #ifdef PROPHACK

--- a/workbench/system/Workbook/wbset.c
+++ b/workbench/system/Workbook/wbset.c
@@ -45,13 +45,45 @@ static void wbGABox(struct WorkbookBase *wb, Object *obj, struct IBox *box)
     box->Height = gadget->Height;
 }
 
+static BOOL wbFixedCollision(struct WorkbookBase *wb, struct wbSet *my,
+    const struct IBox *setbox, const struct IBox *candidate,
+    WORD *nextLeft, WORD *nextTop)
+{
+    struct wbSetNode *node;
+    BOOL collision = FALSE;
+
+    ForeachNode(&my->FixedObjects, node) {
+        struct IBox fixed;
+
+        wbGABox(wb, node->sn_Object, &fixed);
+        fixed.Left -= setbox->Left;
+        fixed.Top -= setbox->Top;
+
+        if (candidate->Left < fixed.Left + fixed.Width &&
+            candidate->Left + candidate->Width > fixed.Left &&
+            candidate->Top < fixed.Top + fixed.Height &&
+            candidate->Top + candidate->Height > fixed.Top) {
+            WORD right = fixed.Left + fixed.Width;
+            WORD bottom = fixed.Top + fixed.Height;
+
+            if (right > *nextLeft)
+                *nextLeft = right;
+            if (bottom > *nextTop)
+                *nextTop = bottom;
+            collision = TRUE;
+        }
+    }
+
+    return collision;
+}
+
 static void rearrange(Class *cl, Object *obj)
 {
     struct WorkbookBase *wb = (APTR)cl->cl_UserData;
     struct wbSet *my = INST_DATA(cl, obj);
     struct wbSetNode *node;
     struct IBox sbox;
-    WORD CurrRight, CurrBottom;
+    WORD CurrRight, CurrBottom, RowHeight;
 
     /* First, remove all autoobjects from the superclass */
     ForeachNode(&my->AutoObjects, node) {
@@ -61,29 +93,53 @@ static void rearrange(Class *cl, Object *obj)
     /* Find the set size with just the fixed objects */
     wbGABox(wb, obj, &sbox);
 
-    /* Set the start of the auto area to be
-     * immediately below the fixed objects.
-     */
+    /* Pack automatic icons from the top-left. Positioned icons are obstacles,
+     * not a horizontal band: an icon saved low on the desktop must not force
+     * every automatic disk icon beneath it. */
     CurrRight = 0;
-    CurrBottom = sbox.Height;
+    CurrBottom = 0;
+    RowHeight = 0;
 
     /* For each item in the auto list, add it to the right */
     ForeachNode(&my->AutoObjects, node) {
         Object *iobj = node->sn_Object;
         struct IBox ibox;
+        BOOL placed = FALSE;
 
         wbGABox(wb, iobj, &ibox);
 
-        if ((CurrRight + ibox.Width) < my->MaxWidth) {
+        while (!placed) {
+            WORD nextLeft = CurrRight;
+            WORD nextTop = CurrBottom;
+
+            if (CurrRight && CurrRight + ibox.Width > my->MaxWidth) {
+                CurrRight = 0;
+                CurrBottom += RowHeight;
+                RowHeight = 0;
+                continue;
+            }
+
             ibox.Left = CurrRight;
-        } else {
-            wbGABox(wb, obj, &sbox);
-            ibox.Left = 0;
-            CurrRight = 0;
-            CurrBottom = sbox.Height;
+            ibox.Top = CurrBottom;
+
+            if (wbFixedCollision(wb, my, &sbox, &ibox,
+                                 &nextLeft, &nextTop)) {
+                if (nextLeft + ibox.Width <= my->MaxWidth) {
+                    CurrRight = nextLeft;
+                } else {
+                    CurrRight = 0;
+                    CurrBottom = nextTop;
+                    RowHeight = 0;
+                }
+                continue;
+            }
+
+            placed = TRUE;
         }
-        ibox.Top  = CurrBottom;
+
         CurrRight += ibox.Width;
+        if (ibox.Height > RowHeight)
+            RowHeight = ibox.Height;
 
         D(bug("New icon position: @%d,%d\n", ibox.Left, ibox.Top));
 

--- a/workbench/system/Workbook/wbwindow.c
+++ b/workbench/system/Workbook/wbwindow.c
@@ -309,6 +309,9 @@ static void wbwiAppend(Class *cl, Object *obj, Object *iobj)
     } else {
         struct opMember opmmsg;
         struct wbWindow_Icon *tmp, *pred = NULL;
+        struct Rectangle oldAutoBounds;
+        BOOL haveOldAutoBounds = FALSE;
+        IPTR positioned = FALSE;
         wbwi->wbwiObject = iobj;
 
         /* Insert in Alpha order */
@@ -325,15 +328,73 @@ static void wbwiAppend(Class *cl, Object *obj, Object *iobj)
 
         Insert((struct List *)&my->IconList, (struct Node *)wbwi, (struct Node *)pred);
 
+        /* Adding a positioned icon can enlarge the fixed part of WBSet and
+         * move auto-positioned icons which have already been rendered by the
+         * progressive loader. Remember their old on-screen bounds so those
+         * images do not remain behind as non-interactive ghosts. */
+        GetAttr(WBIA_Positioned, iobj, &positioned);
+        if (positioned) {
+            ForeachNode(&my->IconList, tmp) {
+                IPTR oldPositioned = FALSE;
+                struct Gadget *gadget;
+                struct Rectangle bounds;
+
+                if (tmp->wbwiObject == iobj)
+                    continue;
+
+                GetAttr(WBIA_Positioned, tmp->wbwiObject, &oldPositioned);
+                if (oldPositioned)
+                    continue;
+
+                gadget = (struct Gadget *)tmp->wbwiObject;
+                bounds.MinX = gadget->LeftEdge;
+                bounds.MinY = gadget->TopEdge;
+                bounds.MaxX = gadget->LeftEdge + gadget->Width - 1;
+                bounds.MaxY = gadget->TopEdge + gadget->Height - 1;
+
+                if (!haveOldAutoBounds) {
+                    oldAutoBounds = bounds;
+                    haveOldAutoBounds = TRUE;
+                } else {
+                    if (bounds.MinX < oldAutoBounds.MinX)
+                        oldAutoBounds.MinX = bounds.MinX;
+                    if (bounds.MinY < oldAutoBounds.MinY)
+                        oldAutoBounds.MinY = bounds.MinY;
+                    if (bounds.MaxX > oldAutoBounds.MaxX)
+                        oldAutoBounds.MaxX = bounds.MaxX;
+                    if (bounds.MaxY > oldAutoBounds.MaxY)
+                        oldAutoBounds.MaxY = bounds.MaxY;
+                }
+            }
+        }
+
         /* Make each completed icon visible immediately instead of waiting
          * for the entire directory scan and all following disk reads. */
         opmmsg.MethodID = OM_ADDMEMBER;
         opmmsg.opam_Object = iobj;
         DoMethodA(my->Set, (Msg)&opmmsg);
         wbProgressiveRedimension(cl, obj);
-        AddGadget(my->Window, (struct Gadget *)iobj, 0);
-        RefreshGList((struct Gadget *)iobj, my->Window, NULL, 1);
-        RemoveGadget(my->Window, (struct Gadget *)iobj);
+
+        if (haveOldAutoBounds) {
+            /* Erase the old images, then redraw the loaded set at its final
+             * positions. This path is only needed when existing gadgets were
+             * potentially moved; ordinary progressive additions still draw
+             * just the newly loaded icon. */
+            EraseRect(my->Window->RPort,
+                      oldAutoBounds.MinX, oldAutoBounds.MinY,
+                      oldAutoBounds.MaxX, oldAutoBounds.MaxY);
+
+            ForeachNode(&my->IconList, tmp) {
+                AddGadget(my->Window, (struct Gadget *)tmp->wbwiObject, 0);
+                RefreshGList((struct Gadget *)tmp->wbwiObject,
+                             my->Window, NULL, 1);
+                RemoveGadget(my->Window, (struct Gadget *)tmp->wbwiObject);
+            }
+        } else {
+            AddGadget(my->Window, (struct Gadget *)iobj, 0);
+            RefreshGList((struct Gadget *)iobj, my->Window, NULL, 1);
+            RemoveGadget(my->Window, (struct Gadget *)iobj);
+        }
     }
 }
 


### PR DESCRIPTION
- **workbook:** erase stale progressive icon images so partially-loaded icons don't leave artifacts
- **workbook:** pack automatically-placed icons around already-positioned objects to avoid overlap
- **intuition:** optimize proportional (scroller) gadget updates
- **intuition:** add a distinct built-in busy pointer
- **console:** reuse a scratch raster when rendering single characters
- **console:** reduce line-buffer allocation churn
- **amiga:** use the blitter for chip RAM clears
- **graphics:** speed up fixed-width text rendering