### PR TITLE
Build: only apply the lld AROS patch for the v11 toolchain.

### DIFF
--- a/tools/crosstools/llvm/mmakefile.src
+++ b/tools/crosstools/llvm/mmakefile.src
@@ -458,10 +458,17 @@ endif
     archive=$(LIBUNWIND_ARCHBASE) suffixes="tar.xz"                                                                                     \
     destination=$(HOSTDIR)/Ports/host/libunwind
 
+# The AROS lld patch only exists for the v11 toolchain; v20+ builds stock lld.
+ifeq ($(shell test $(LLVM_VERSION_MAJOR) -lt 20; echo $$?),0)
+LLVMLLD_PATCHES_SPECS   := $(LLVMLLD_ARCHBASE)-aros.diff:$(LLVMLLD_ARCHBASE):-p1
+else
+LLVMLLD_PATCHES_SPECS   :=
+endif
+
 %fetch mmake=crosstools-llvm-lld-fetch archive=$(LLVMLLD_ARCHBASE)                                                                      \
     archive_origins=$(LLVM_REPOSITORY) suffixes="tar.xz"                                                                                \
     location=$(PORTSSOURCEDIR) destination=$(HOSTDIR)/Ports/host/llvm-lld                                                              \
-    patches_specs=$(LLVMLLD_ARCHBASE)-aros.diff:$(LLVMLLD_ARCHBASE):-p1
+    patches_specs=$(LLVMLLD_PATCHES_SPECS)
 
 %create_patch mmake=crosstools-llvm-lld-create-patch                                                                                    \
     archive=$(LLVMLLD_ARCHBASE) suffixes="tar.xz"                                                                                       \


### PR DESCRIPTION
The lld patchspec pointed to a version-specific diff that only exists for v11, breaking LLVM 20 builds. Guard it behind LLVM_VERSION_MAJOR so LLVM 20+ builds use the stock lld.

If or when we create an lld patch for v20, this should be reverted.