### PR TITLE
amigavideo: revert unsafe OCS screen rollover handling

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -240,15 +240,17 @@ VOID AmigaVideoBM__Root__Set(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg
         newyoffset = data->height - 1;
 
     /*
-     * OCS cannot switch a display fragment cleanly on the vertical-counter
-     * rollover itself.  Round that single position to the following line;
-     * Root::Get then reports the actual hardware position to graphics and
-     * Intuition, as for other chipset positioning constraints.
+     * An OCS display fragment cannot cross the 8-bit vertical-counter
+     * rollover without changing a live Copper list.  Keep its first line on
+     * the safe side of the rollover; ECS Denise uses DIWHIGH and is exempt.
      */
-    if (data->disp && !csd->ecs_denise &&
-        newyoffset == ((256 - csd->starty) << data->interlace))
+    if (data->disp && !csd->ecs_denise)
     {
-        newyoffset += 1 << data->interlace;
+        LONG maxyoffset = ((REZ_Y_MIN + REZ_PAL_LINES - 1 - csd->starty)
+                           << data->interlace);
+
+        if (newyoffset > maxyoffset)
+            newyoffset = maxyoffset;
     }
 
     if ((newxoffset != data->leftedge) || (newyoffset != data->topedge))

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -324,11 +324,6 @@ static VOID setcopperscroll2(struct amigavideo_staticdata *csd, struct amigabm_d
         copptr[0] = 0x01fe;  // NOP
     copptr[2] = (ystart << 8) | 0x05;
 
-    /* Do not enable DMA before the screen's exact first scanline. */
-    copptr = c2d->copper2_bplstart;
-    copptr[0] = 0x01fe;
-    copptr[2] = (y << 8) | 0x05;
-
     copptr = c2d->copper2_tail;
     if (copptr[0] != 0x0084)
     {
@@ -499,10 +494,6 @@ UWORD *populatebmcopperlist(struct amigavideo_staticdata *csd, struct amigabm_da
     c2d->copper2_scroll = c;
 
     COPPEROUT(c, 0x008e, 0)                     // Push (DIWSTRT) Display window start
-
-    c2d->copper2_bplstart = c;
-    COPPEROUT(c, 0x01fe, 0xfffe)                // Rollover marker or NOP
-    COPPEROUT(c, 0xffff, 0xfffe)                // Exact screen start WAIT
 
     COPPEROUT(c, 0x0100, bplcon0)               // Push the screens bplcon0
     COPPEROUT(c, 0x0104, csd->bplcon2 | ((csd->aga && !(bm->modeid & EXTRAHALFBRITE_KEY)) ? 0x0200 : 0))  // Push the screens bplcon2

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_intern.h
@@ -22,7 +22,6 @@ struct copper2data
     UWORD                       *copper2_palette_aga_lo;
     UWORD                       *copper2_scroll;
     UWORD                       *copper2_diwstop;
-    UWORD                       *copper2_bplstart;
     UWORD                       *copper2_bpl;
     UWORD                       *copper2_fmode;
     UWORD                       *copper2_tail;

--- a/arch/m68k-amiga/hidd/amigavideo/chipset.h
+++ b/arch/m68k-amiga/hidd/amigavideo/chipset.h
@@ -59,7 +59,6 @@ static inline VOID initvpicopper(struct ViewPort  *vp, struct amigabm_data *bm, 
     bm->copsd.copper2_palette = vp->DspIns->CopSStart + (bm->copld.copper2_palette - vp->DspIns->CopLStart);
     bm->copsd.copper2_scroll = vp->DspIns->CopSStart + (bm->copld.copper2_scroll - vp->DspIns->CopLStart);
     bm->copsd.copper2_diwstop = vp->DspIns->CopSStart + (bm->copld.copper2_diwstop - vp->DspIns->CopLStart);
-    bm->copsd.copper2_bplstart = vp->DspIns->CopSStart + (bm->copld.copper2_bplstart - vp->DspIns->CopLStart);
     bm->copsd.copper2_bpl = vp->DspIns->CopSStart + (bm->copld.copper2_bpl - vp->DspIns->CopLStart);
     bm->copsd.copper2_tail = vp->DspIns->CopSStart + (bm->copld.copper2_tail - vp->DspIns->CopLStart);
     bm->copsd.extralines = bm->copld.extralines;


### PR DESCRIPTION
This fixes a regression where the no-media boot animation appeared blurry and color-fringed on OCS systems.

The OCS screen-drag rollover handling delayed bitplane DMA through an additional Copper wait. This affected normal screens and corrupted the otherwise crisp planar boot animation. Updating the live Copper list near the vertical-counter rollover could also cause transient corruption during screen dragging.

Before:
<img width="565" height="282" alt="Screenshot 2026-07-22 at 14 47 46" src="https://github.com/user-attachments/assets/7f46544a-302f-4942-9af2-360fdff430af" />

After:
<img width="577" height="321" alt="Screenshot 2026-07-22 at 14 50 14" src="https://github.com/user-attachments/assets/9bd5a43d-27f0-421e-9b03-e04b64130f7f" />
