### PR TITLE
AROSTCP: support the AArch64 va_list layout

### DIFF
--- a/workbench/network/stacks/AROSTCP/bsdsocket/api/amiga_generic2.c
+++ b/workbench/network/stacks/AROSTCP/bsdsocket/api/amiga_generic2.c
@@ -69,6 +69,15 @@
   ap.__ap = args;
 #endif
 
+#ifdef __aarch64__
+#define va_set(ap, args)	\
+  ap.__stack = args;		\
+  ap.__gr_top = args;		\
+  ap.__vr_top = args;		\
+  ap.__gr_offs = 0;		\
+  ap.__vr_offs = 0;
+#endif
+
 #ifndef va_set
 #define va_set(ap, args)	\
   ap = (va_list)args;

--- a/workbench/network/stacks/AROSTCP/bsdsocket/kern/subr_prf.c
+++ b/workbench/network/stacks/AROSTCP/bsdsocket/kern/subr_prf.c
@@ -477,7 +477,7 @@ reswitch:
             break;
             case 'r':
                 p = va_arg(ap, char *);
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
                 vcsprintf(cs, p, va_arg(ap, va_list));
 #else
                 vcsprintf(cs, p, va_arg(ap, void *));


### PR DESCRIPTION
Add the aarch64 va_set that initialises the AAPCS64 va_list fields and route the %r conversion through the aarch64 va_list path.