### PR TITLE
crosstools: enable the clang AArch64 AROS target

### DIFF
--- a/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
+++ b/tools/crosstools/llvm/clang-11.0.0.src-aros.diff
@@ -116,31 +116,25 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets/OSTargets.h clang-11.0.0.src.aros/l
 diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic/Targets.cpp
 --- clang-11.0.0.src/lib/Basic/Targets.cpp	2020-10-07 10:10:48.000000000 +0000
 +++ clang-11.0.0.src.aros/lib/Basic/Targets.cpp	2025-06-26 12:47:36.147031156 +0000
-@@ -136,6 +136,11 @@
+@@ -136,6 +136,8 @@
        return new DarwinAArch64TargetInfo(Triple, Opts);
- 
+
      switch (os) {
-+    //  FIXME:
-+    //  Needs to be tested before inclusion!!!
-+    //  New Target AROS AArch64
-+    //  case llvm::Triple::AROS:
-+    //    return new AROSTargetInfo<AArch64leTargetInfo>(Triple, Opts);
++    case llvm::Triple::AROS:
++      return new AROSTargetInfo<AArch64leTargetInfo>(Triple, Opts);
      case llvm::Triple::CloudABI:
        return new CloudABITargetInfo<AArch64leTargetInfo>(Triple, Opts);
      case llvm::Triple::FreeBSD:
-@@ -180,6 +185,11 @@
+@@ -180,6 +182,8 @@
        return new DarwinARMTargetInfo(Triple, Opts);
-
+ 
      switch (os) {
-+    //  FIXME:
-+    //  Needs to be tested!!!
-+    //  New Target AROS ARMle
 +    case llvm::Triple::AROS:
 +      return new AROSTargetInfo<ARMleTargetInfo>(Triple, Opts);
      case llvm::Triple::CloudABI:
        return new CloudABITargetInfo<ARMleTargetInfo>(Triple, Opts);
      case llvm::Triple::Linux:
-@@ -216,6 +226,11 @@
+@@ -216,6 +220,11 @@
        return new DarwinARMTargetInfo(Triple, Opts);
  
      switch (os) {
@@ -152,7 +146,7 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic
      case llvm::Triple::Linux:
        return new LinuxTargetInfo<ARMbeTargetInfo>(Triple, Opts);
      case llvm::Triple::FreeBSD:
-@@ -318,6 +333,11 @@
+@@ -318,6 +327,11 @@
      if (Triple.isOSDarwin())
        return new DarwinPPC32TargetInfo(Triple, Opts);
      switch (os) {
@@ -164,7 +158,7 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic
      case llvm::Triple::Linux:
        return new LinuxTargetInfo<PPC32TargetInfo>(Triple, Opts);
      case llvm::Triple::FreeBSD:
-@@ -338,6 +358,11 @@
+@@ -338,6 +352,11 @@
      if (Triple.isOSDarwin())
        return new DarwinPPC64TargetInfo(Triple, Opts);
      switch (os) {
@@ -176,7 +170,7 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic
      case llvm::Triple::Linux:
        return new LinuxTargetInfo<PPC64TargetInfo>(Triple, Opts);
      case llvm::Triple::Lv2:
-@@ -465,6 +490,11 @@
+@@ -465,6 +484,11 @@
      switch (os) {
      case llvm::Triple::Ananas:
        return new AnanasTargetInfo<X86_32TargetInfo>(Triple, Opts);
@@ -188,7 +182,7 @@ diff -ruN clang-11.0.0.src/lib/Basic/Targets.cpp clang-11.0.0.src.aros/lib/Basic
      case llvm::Triple::CloudABI:
        return new CloudABITargetInfo<X86_32TargetInfo>(Triple, Opts);
      case llvm::Triple::Linux: {
-@@ -524,6 +554,11 @@
+@@ -524,6 +548,11 @@
      switch (os) {
      case llvm::Triple::Ananas:
        return new AnanasTargetInfo<X86_64TargetInfo>(Triple, Opts);
@@ -312,9 +306,9 @@ diff -ruN clang-11.0.0.src/lib/Driver/ToolChains/AROS.cpp clang-11.0.0.src.aros/
 +    switch (T.getArch()) {
 +    case llvm::Triple::x86:
 +        return "elf_i386";
-+#if (0)
 +    case llvm::Triple::aarch64:
-+        return "aarch64";
++        return "aarch64elf";
++#if (0)
 +    case llvm::Triple::aarch64_be:
 +        return "aarch64b";
 +    case llvm::Triple::arm:

--- a/tools/crosstools/llvm/mmakefile.src
+++ b/tools/crosstools/llvm/mmakefile.src
@@ -65,6 +65,7 @@ $(eval -include $(SRCDIR)/tools/crosstools/$(AROS_TOOLCHAIN).cfg)
 #MM- toolchain-linklibs-llvm-arm    : linklibs-arm
 #MM- toolchain-linklibs-llvm-armeb  : linklibs-armeb
 #MM- tools-crosstools-llvm-riscv    : tools-crosstools-llvm-toolchain
+#MM- tools-crosstools-llvm-aarch64  : tools-crosstools-llvm-toolchain
 #MM- tools-crosstools-llvm-m68k    : tools-crosstools-llvm-toolchain
 
 # Flags used for stages of the build


### PR DESCRIPTION
Turn on the AROSTargetInfo<AArch64leTargetInfo> case, set the aarch64elf emulation, and add the aarch64 toolchain metatarget.