### PR TITLE
64-bits fixes to poseidon and shell command segs

### DIFF
--- a/rom/usb/poseidon/popo.gui.c
+++ b/rom/usb/poseidon/popo.gui.c
@@ -1113,9 +1113,9 @@ STRPTR pBindingsString(LIBBASETYPEPTR ps, struct PsdDevice *pd)
 /* /// "pCheckConfigurable()" */
 ULONG pCheckConfigurable(LIBBASETYPEPTR ps, struct PsdDevice *pd)
 {
-    ULONG  hasclassgui;
-    ULONG  hasbindinggui;
-    ULONG  noconfig;
+    IPTR   hasclassgui;
+    IPTR   hasbindinggui;
+    IPTR   noconfig;
     struct PsdConfig *pc;
     struct PsdInterface *pif;
     struct Library *UsbClsBase;
@@ -1217,7 +1217,7 @@ void pOpenBindingsConfigGUI(LIBBASETYPEPTR ps, struct PsdDevice *pd)
     struct PsdConfig *pc;
     struct PsdInterface *pif;
     struct Library *UsbClsBase;
-    ULONG hascfggui;
+    IPTR hascfggui;
     psdLockReadPBase();
     if(!pIsDeviceStillValid(ps, pd))
     {
@@ -1276,7 +1276,7 @@ void pOpenClassesConfigGUI(LIBBASETYPEPTR ps, struct PsdDevice *pd)
     struct PsdConfig *pc;
     struct PsdInterface *pif;
     struct Library *UsbClsBase;
-    ULONG hascfggui;
+    IPTR hascfggui;
 
     psdLockReadPBase();
     if(!pIsDeviceStillValid(ps, pd))

--- a/workbench/c/shellcommands/shellcommands_intern.h
+++ b/workbench/c/shellcommands/shellcommands_intern.h
@@ -23,8 +23,8 @@ struct ShellCommandsBase {
      * &sc_Command[i].scs_Next as the 'seglist' to add.
      */
     struct ShellCommandSeg {
-    	ULONG              scs_Size;      /* Length of segment in # of ULONGs */
-    	ULONG              scs_Next;      /* Next segment (always 0 for this) */
+    	IPTR               scs_Size;      /* Length of segment in # of ULONGs */
+    	BPTR               scs_Next;      /* Next segment (always 0 for this) */
     	struct FullJumpVec scs_Code;      /* Code to jump to shell command */
     	CONST_STRPTR __attribute__((aligned(4)))  scs_Name;      /* Name of the segment */
     } *sc_Command;


### PR DESCRIPTION
usbGetAttrs writes IPTR-sized values, so the popo config locals must be IPTR or the store overruns the adjacent stack slot. The shell command seglist likewise needs IPTR/BPTR fields instead of ULONG.