### PR TITLE
z, png: enable the ARMv8 SIMD paths on aarch64

### DIFF
--- a/workbench/libs/png/mmakefile.src
+++ b/workbench/libs/png/mmakefile.src
@@ -45,14 +45,12 @@ FILES += \
 	intel/filter_sse2_intrinsics
 endif
 
-## Add for ARM at a later date ...
-#USER_CPPFLAGS += -DPNG_ARM_NEON
-#FILES += \
-#	arm/arm_init \
-#	arm/filter_neon_intrinsics \
-#	arm/palette_neon_intrinsics
-#AFILES += \
-#	arm/filter_neon
+ifeq ($(AROS_TARGET_CPU),aarch64)
+FILES += \
+	arm/arm_init \
+	arm/filter_neon_intrinsics \
+	arm/palette_neon_intrinsics
+endif
 
 # Clang auto-defines __ARM_NEON for armv7-a+fp even with -mfpu=vfpv3-d16,
 # which makes pngpriv.h enable PNG_ARM_NEON_OPT=2 and reference the

--- a/workbench/libs/z/mmakefile.src
+++ b/workbench/libs/z/mmakefile.src
@@ -85,6 +85,18 @@ LIBZ_CPPFLAGS +=-DINFLATE_CHUNK_READ_64LE
 LIBZ_CPPFLAGS +=-DDEFLATE_CHUNK_WRITE_64LE
 LIBZ_CPPFLAGS +=-DCRC32_ARMV8_CRC32
 LIBZ_CPPFLAGS +=-DDEFLATE_SLIDE_HASH_NEON
+# Force-enable the ARMv8 CRC path: AROS has no getauxval for runtime
+# detection. ARMV8_OS_MACOS hardcodes arm_cpu_enable_crc32=1 and avoids the
+# getauxval/pthread machinery. Note: it also sets arm_cpu_enable_pmull=1, but
+# Pi3/Pi4 (Cortex-A53/A72) implement CRC32 without the ARMv8 crypto extension,
+# so PMULL is an undefined instruction there; zlib-aros.diff forces
+# arm_cpu_enable_pmull=0 under __AROS__ so the PMULL crc path is never taken.
+LIBZ_CPPFLAGS +=-DARMV8_OS_MACOS
+# clang 11's AArch64 backend ignores crc32_simd.c's per-function
+# __attribute__((target("arch=armv8-a+aes+crc"))), so the crc32 intrinsics
+# can't be selected. Give the whole TU the features via -march instead. The
+# PMULL code in crc32_512_simd.c still compiles (harmless; never executed).
+LIBZ_CPPFLAGS +=-march=armv8-a+crc+crypto
 FILES += \
         adler32_simd \
         contrib/optimizations/inffast_chunk \

--- a/workbench/libs/z/zlib-aros.diff
+++ b/workbench/libs/z/zlib-aros.diff
@@ -23,6 +23,19 @@ diff -ruN zlib/adler32_simd.c zlib.aros/adler32_simd.c
 diff -ruN zlib/cpu_features.c zlib.aros/cpu_features.c
 --- zlib/cpu_features.c	2025-07-31 17:05:57.714000000 +0000
 +++ zlib.aros/cpu_features.c	2025-09-18 12:12:01.548914796 +0000
+@@ -23,7 +23,11 @@
+  * runtime detection.
+  */
+ int ZLIB_INTERNAL arm_cpu_enable_crc32 = 1;
+-int ZLIB_INTERNAL arm_cpu_enable_pmull = 1;
++#if defined(__AROS__)
++int ZLIB_INTERNAL arm_cpu_enable_pmull = 0; /* Pi3/Pi4 (Cortex-A53/A72) lack the ARMv8 crypto ext (PMULL) */
++#else
++int ZLIB_INTERNAL arm_cpu_enable_pmull = 1;
++#endif
+ #else
+ int ZLIB_INTERNAL arm_cpu_enable_crc32 = 0;
+ int ZLIB_INTERNAL arm_cpu_enable_pmull = 0;
 @@ -80,7 +80,11 @@
  void ZLIB_INTERNAL cpu_check_features(void)
  {


### PR DESCRIPTION
Build the NEON and ARMv8 CRC32 sources for aarch64 and force the crc feature via -march, since AROS has no getauxval. Disable PMULL under AROS because the Pi3/Pi4 cores lack the crypto extension. Enable the libpng NEON filters for aarch64.