### PR TITLE
Add AArch64 definitions to architecture-generic headers

### DIFF
--- a/compiler/include/aros/printertag.h
+++ b/compiler/include/aros/printertag.h
@@ -25,6 +25,8 @@
 #define AROS_PRINTER_MAGIC   0x4e800020      /* blr */
 #elif defined(__riscv)
 #define AROS_PRINTER_MAGIC   0x8082          /* ret */
+#elif defined(__aarch64__)
+#define AROS_PRINTER_MAGIC   0xd65f03c0      /* ret */
 #else
 #error AROS_PRINTER_MAGIC is not defined for your architecture
 #endif

--- a/compiler/include/asm/cpu.h
+++ b/compiler/include/asm/cpu.h
@@ -21,6 +21,9 @@
 #ifdef __powerpc__
 #   include <asm/ppc/cpu.h>
 #endif
+#ifdef __aarch64__
+#   include <asm/aarch64/cpu.h>
+#endif
 #ifdef __arm__
 #   if defined __thumb2__
 #       if defined __ARMEB__

--- a/rom/kernel/kernel_syscall.h
+++ b/rom/kernel/kernel_syscall.h
@@ -25,6 +25,7 @@
 #define SC_SUPERVISOR	0x00A
 #define SC_CACHECLEARE  0x00B
 #define SC_GETCPUNUMBER 0x00C
+#define SC_USERSTATE    0x00D
 #define SC_REBOOT	    0x100
 
 #endif

--- a/tools/flexcat/src/version.h
+++ b/tools/flexcat/src/version.h
@@ -65,7 +65,9 @@
 #endif
 
 // identify the CPU model
-#if defined(__arm__)
+#if defined(__aarch64__)
+  #define CPU "ARM64"
+#elif defined(__arm__)
   #define CPU "ARM"
 #elif defined(__PPC__) || defined(__powerpc__)
   #define CPU "PPC"


### PR DESCRIPTION
Add the aarch64 printer magic, the asm/aarch64/cpu.h include, the SC_USERSTATE syscall number and the flexcat ARM64 CPU string.