### PR TITLE
bcm2708: make the SoC drivers build for arm and aarch64

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
@@ -255,7 +255,7 @@ AROS_LH2(int, DMAWaitChannel,
         (dsig = AllocSignal(-1)) >= 0)
     {
         DMABase->dma_Wait[channel].sig = dsig;
-        __asm__ __volatile__("dmb" ::: "memory");
+        __asm__ __volatile__("dmb sy" ::: "memory");
         DMABase->dma_Wait[channel].waiter = FindTask(NULL);
 
         /* One reusable timer signal for the whole wait — the safety
@@ -321,7 +321,7 @@ AROS_LH2(int, DMAWaitChannel,
         /* Stop the IRQ handler from signalling a bit we're about to free */
         Disable();
         DMABase->dma_Wait[channel].waiter = NULL;
-        __asm__ __volatile__("dmb" ::: "memory");
+        __asm__ __volatile__("dmb sy" ::: "memory");
         if (tsig >= 0)
             FreeSignal(tsig);
         FreeSignal(dsig);

--- a/arch/arm-native/soc/broadcom/2708/hidd/i2c/i2c-bcm2708.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/i2c/i2c-bcm2708.c
@@ -22,7 +22,7 @@ void METHOD(I2CBCM2708, Hidd_I2C, PutByte)
 {
     while (!(rd32le(BSC0_STATUS) & BSC_STATUS_DONE))
     {
-        asm volatile ("mov r2,r2\n");
+        asm volatile ("yield\n");
     }
 
     wr32le(BSC0_DATALEN, 1);
@@ -36,7 +36,7 @@ void METHOD(I2CBCM2708, Hidd_I2C, GetByte)
 {
     while (!(rd32le(BSC0_STATUS) & BSC_STATUS_DONE))
     {
-        asm volatile ("mov r2,r2\n");
+        asm volatile ("yield\n");
     }
 
     wr32le(BSC0_DATALEN, 1);

--- a/arch/arm-native/soc/broadcom/2708/hidd/i2c/i2c-bcm2708.conf
+++ b/arch/arm-native/soc/broadcom/2708/hidd/i2c/i2c-bcm2708.conf
@@ -5,7 +5,7 @@ version			1.0
 superclass     	CLID_Hidd_I2C
 classid			CLID_I2C_BCM2708
 classptr_field  i2c_DrvClass
-residentpri     89
+residentpri     88
 ##end config
 
 ##begin cdefprivate

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
@@ -29,7 +29,7 @@
 extern APTR KernelBase;
 APTR DMABase = NULL;
 
-static inline void vc4_dsb(void) { asm volatile("dsb" ::: "memory"); }
+static inline void vc4_dsb(void) { asm volatile("dsb sy" ::: "memory"); }
 
 /* BCM system timer ticks at 1 MHz. */
 static inline ULONG vc4_now_us(void)

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
@@ -20,6 +20,7 @@
 static inline void neon_copyline(UBYTE *dst, const UBYTE *src, ULONG bytes)
 {
     /* 64-byte bulk copy using NEON: vldm/vstm with 4 q-regs (d0-d7) */
+#if defined(__arm__)
     while (bytes >= 64)
     {
         asm volatile(
@@ -32,7 +33,8 @@ static inline void neon_copyline(UBYTE *dst, const UBYTE *src, ULONG bytes)
         );
         bytes -= 64;
     }
-    /* Tail: word-at-a-time */
+#endif
+    /* Tail (and full copy on non-ARM): word-at-a-time */
     while (bytes >= 4)
     {
         *(ULONG *)dst = *(const ULONG *)src;
@@ -51,6 +53,7 @@ static inline void neon_copyline_rev(UBYTE *dst, const UBYTE *src, ULONG bytes)
 {
     dst += bytes;
     src += bytes;
+#if defined(__arm__)
     while (bytes >= 64)
     {
         src -= 64;
@@ -64,6 +67,7 @@ static inline void neon_copyline_rev(UBYTE *dst, const UBYTE *src, ULONG bytes)
             : "d0","d1","d2","d3","d4","d5","d6","d7","memory"
         );
     }
+#endif
     while (bytes >= 4)
     {
         src -= 4;
@@ -85,6 +89,7 @@ static inline void neon_copyline_rev(UBYTE *dst, const UBYTE *src, ULONG bytes)
 static inline void neon_blit_mask32_row_opaque(UBYTE *dst,
     const ULONG *mask, ULONG width, ULONG fg, ULONG bg)
 {
+#if defined(__arm__)
     ULONG quads = width >> 2;
     if (quads)
     {
@@ -105,6 +110,8 @@ static inline void neon_blit_mask32_row_opaque(UBYTE *dst,
         );
     }
     width &= 3;
+#endif
+    /* Tail (and full row on non-ARM): one pixel at a time */
     while (width--)
     {
         *(ULONG *)dst = (*mask++ != 0) ? fg : bg;
@@ -114,6 +121,7 @@ static inline void neon_blit_mask32_row_opaque(UBYTE *dst,
 
 static inline void neon_fillline(UBYTE *dst, ULONG fill_val, ULONG bytes)
 {
+#if defined(__arm__)
     asm volatile(
         NEON_PREFIX
         "vdup.32 d0, %[val]\n\t"
@@ -137,6 +145,8 @@ static inline void neon_fillline(UBYTE *dst, ULONG fill_val, ULONG bytes)
         );
         bytes -= 64;
     }
+#endif
+    /* Tail (and full fill on non-ARM): word-at-a-time */
     while (bytes >= 4)
     {
         *(ULONG *)dst = fill_val;

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -158,6 +158,7 @@
 #define ARMIRQ_PEND                                     (IRQ_BASE + 0x00)
 #define GPUIRQ_PEND0                                    (IRQ_BASE + 0x04)               // Pending IRQs
 #define GPUIRQ_PEND1                                    (IRQ_BASE + 0x08)
+#define ARMFIQ_CTRL                                     (IRQ_BASE + 0x0C)               // FIQ source select/enable
 #define GPUIRQ_ENBL0                                    (IRQ_BASE + 0x10)               // IRQ enable bits
 #define GPUIRQ_ENBL1                                    (IRQ_BASE + 0x14)
 #define ARMIRQ_ENBL                                     (IRQ_BASE + 0x18)

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
@@ -51,7 +51,7 @@ volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
         unsigned int wtry = 0x2000000;
         while ((MBoxStatus(mb) & VCMB_STATUS_WRITEREADY) != 0)
         {
-            __asm__ __volatile__("dsb" ::: "memory");
+            __asm__ __volatile__("dsb sy" ::: "memory");
             if (--wtry == 0)
             {
                 ReleaseSemaphore(&MBoxBase->mbox_Sem);
@@ -60,7 +60,7 @@ volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
         }
     }
 
-    __asm__ __volatile__("dmb" ::: "memory");
+    __asm__ __volatile__("dmb sy" ::: "memory");
     *((volatile unsigned int *)(mb + VCMB_WRITE)) =
         AROS_LONG2LE(((unsigned int)phys_addr | chan));
 
@@ -72,14 +72,14 @@ volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
     {
         if ((MBoxStatus(mb) & VCMB_STATUS_READREADY) != 0)
         {
-            __asm__ __volatile__("dsb" ::: "memory");
+            __asm__ __volatile__("dsb sy" ::: "memory");
             try--;
             continue;
         }
 
-        __asm__ __volatile__("dmb" ::: "memory");
+        __asm__ __volatile__("dmb sy" ::: "memory");
         reply = AROS_LE2LONG(*((volatile unsigned int *)(mb + VCMB_READ)));
-        __asm__ __volatile__("dmb" ::: "memory");
+        __asm__ __volatile__("dmb sy" ::: "memory");
 
         if ((reply & VCMB_CHAN_MASK) == chan)
         {
@@ -138,14 +138,14 @@ AROS_LH2(volatile unsigned int *, MBoxRead,
     {
         if ((MBoxStatus(mb) & VCMB_STATUS_READREADY) != 0)
         {
-            asm volatile ("mcr p15, 0, %[r], c7, c10, 4" : : [r] "r" (0) );
+            asm volatile ("dsb sy" ::: "memory");
             try--;
             continue;
         }
 
-        asm volatile ("mcr p15, 0, %[r], c7, c10, 5" : : [r] "r" (0) );
+        asm volatile ("dmb sy" ::: "memory");
         msg = AROS_LE2LONG(*((volatile unsigned int *)(mb + VCMB_READ)));
-        asm volatile ("mcr p15, 0, %[r], c7, c10, 5" : : [r] "r" (0) );
+        asm volatile ("dmb sy" ::: "memory");
 
         if ((msg & VCMB_CHAN_MASK) == chan)
         {
@@ -188,10 +188,10 @@ AROS_LH3(void, MBoxWrite,
         while ((MBoxStatus(mb) & VCMB_STATUS_WRITEREADY) != 0)
         {
             /* Data synchronization barrier */
-            asm volatile ("mcr p15, 0, %[r], c7, c10, 4" : : [r] "r" (0) );
+            asm volatile ("dsb sy" ::: "memory");
         }
 
-        asm volatile ("mcr p15, 0, %[r], c7, c10, 5" : : [r] "r" (0) );
+        asm volatile ("dmb sy" ::: "memory");
 
         *((volatile unsigned int *)(mb + VCMB_WRITE)) = AROS_LONG2LE(((unsigned int)phys_addr | chan));
 

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708time.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708time.c
@@ -4,6 +4,12 @@
 
 #include "sdcard_intern.h"
 
+#if defined(__aarch64__)
+#define NOP() asm volatile("yield\n")
+#else
+#define NOP() asm volatile("mov r0, r0\n")
+#endif
+
 ULONG sdcard_CurrentTime()
 {
     return AROS_LE2LONG(*((volatile ULONG *)(SYSTIMER_CLO)));
@@ -14,7 +20,7 @@ void sdcard_Udelay(ULONG usec)
     ULONG now = sdcard_CurrentTime();
     do
     {
-        asm volatile("mov r0, r0\n");
+        NOP();
     } while (sdcard_CurrentTime() < (now + usec));
 }
 
@@ -22,7 +28,7 @@ void sdcard_WaitNano(register ULONG ns, struct SDCardBase *SDCardBase)
 {
     while (ns > 0)
     {
-        asm volatile("mov r0, r0\n");
+        NOP();
         --ns;
     }
 }

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_bus.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_bus.c
@@ -57,7 +57,7 @@ ULONG FNAME_SDCBUS(GetClockDiv)(ULONG speed, struct sdcard_Bus *bus)
     return 0;
 }
 
-static inline void sdhost_dsb(void) { asm volatile("dsb" ::: "memory"); }
+static inline void sdhost_dsb(void) { asm volatile("dsb sy" ::: "memory"); }
 
 /* Translate a virtual address to its bus-addressable form for the DMA
  * engine.  On Pi 3 the kernel identity-maps low memory and adds an
@@ -75,6 +75,7 @@ static inline ULONG sdhost_bus_addr(struct sdcard_Bus *bus, APTR virt)
  * alignment vldm/vstm strictly require. */
 static inline void sdhost_neon_copy(void *dst, const void *src, ULONG bytes)
 {
+#if defined(__arm__)
     ULONG chunks = bytes >> 6;          /* 64-byte chunks */
     ULONG tail   = (bytes & 0x3f) >> 2; /* trailing whole words */
     ULONG *wsrc, *wdst;
@@ -96,6 +97,14 @@ static inline void sdhost_neon_copy(void *dst, const void *src, ULONG bytes)
     wdst = (ULONG *)dst;
     while (tail--)
         *wdst++ = *wsrc++;
+#else
+    /* Non-ARM: plain word copy (clang auto-vectorises). Covers bytes
+     * rounded down to a whole word, matching the ARM path. */
+    ULONG *wsrc = (ULONG *)src, *wdst = (ULONG *)dst;
+    ULONG words = bytes >> 2;
+    while (words--)
+        *wdst++ = *wsrc++;
+#endif
 }
 
 /* ---------------------------------------------------------------------- */

--- a/workbench/hidds/i2c/i2c_init.c
+++ b/workbench/hidds/i2c/i2c_init.c
@@ -16,7 +16,7 @@
 
 #include <utility/utility.h>
 
-#define DEBUG 1
+#define DEBUG 0
 
 #include <proto/exec.h>
 #include <proto/oop.h>
@@ -28,7 +28,7 @@
 static int I2C_Init(LIBBASETYPEPTR LIBBASE)
 {
     D(bug("[I2C] Init\n"));
-    
+
     return TRUE;
 }
 


### PR DESCRIPTION
Use architecture-neutral dsb/dmb sy and yield barriers and guard the NEON asm paths behind __arm__ with plain C fallbacks. Add the ARMFIQ_CTRL register define. The arm NEON fast paths are unchanged.