### PR TITLE
usb2otg: fix low/full-speed INT split scheduling and IN DMA bounce

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
@@ -63,7 +63,7 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
             {
                 volatile int i;
                 for (i = 0; i < 100000; i++)
-                    asm volatile("mov r0, r0\n");
+                    asm volatile("yield\n");
             }
 
             /*
@@ -86,7 +86,7 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
             {
                 volatile int i;
                 for (i = 0; i < 30000000; i++)
-                    asm volatile("mov r0, r0\n");
+                    asm volatile("yield\n");
             }
 
             /* Step 4: Configure HOSTCFG (FSLSPCLKSEL) after core reset. */
@@ -206,7 +206,7 @@ struct Unit * FNAME_DEV(OpenUnit)(struct IOUsbHWReq *ioreq,
                     {
                         int timeout = 100000;
                         while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
-                            asm volatile("mov r0, r0\n");
+                            asm volatile("yield\n");
                         if (timeout == 0)
                             bug("[USB2OTG] Init: Channel #%d halt timed out!\n", chan);
                     }

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
@@ -242,7 +242,7 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     wr32le(USB2OTG_USB, otg_RegVal);
                                     D(bug("[USB2OTG] %s: Reseting Controller ..\n", __PRETTY_FUNCTION__));
                                     wr32le(USB2OTG_RESET, USB2OTG_RESET_CORESOFT);
-                                    for (ns = 0; ns < 10000; ns++) { asm volatile("mov r0, r0\n"); } // Wait 10ms
+                                    for (ns = 0; ns < 10000; ns++) { asm volatile("yield\n"); } // Wait 10ms
                                     if ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_CORESOFT) != 0)
                                         bug("[USB2OTG] %s: Reset Timed-Out!\n", __PRETTY_FUNCTION__);
 

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
@@ -114,7 +114,7 @@ static inline void wr8be(IPTR iobase, UBYTE value) {
 static inline BOOL usb2otg_wait_ahb_idle(int timeout, const char *where)
 {
     while (!(rd32le(USB2OTG_RESET) & USB2OTG_RESET_AHBIDLE) && --timeout > 0)
-        asm volatile("mov r0, r0\n");
+        asm volatile("yield\n");
     if (timeout <= 0)
     {
         bug("[USB2OTG] AHB IDLE wait timed out (%s)\n", where);
@@ -128,7 +128,7 @@ static inline BOOL usb2otg_wait_reset_bit_clear(ULONG bit, int timeout,
     const char *what)
 {
     while ((rd32le(USB2OTG_RESET) & bit) && --timeout > 0)
-        asm volatile("mov r0, r0\n");
+        asm volatile("yield\n");
     if (timeout <= 0)
     {
         bug("[USB2OTG] %s timed out\n", what);

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
@@ -55,9 +55,8 @@ static void DumpChannelRegs(int channel)
 
 /*
  * 0 = drop PING-protocol, recover from NYET via DATA-retry with NAK
- * gate. BCM2835 DWC2 in Buffer-DMA mode does not reliably issue PING
- * tokens — channel wedges with bare-CHHLTD after every NYET. Linux
- * dwc2 and FreeBSD dwc_otg shipped without PING for years. USB 2.0
+ * gate. The DWC2 core in Buffer-DMA mode does not reliably issue PING
+ * tokens — channel wedges with bare-CHHLTD after every NYET. USB 2.0
  * §8.5.1 says SHOULD PING after NYET; in practice all MSC tested
  * tolerates plain NAK retry. Set to 1 if a strict-PING device appears.
  */
@@ -105,7 +104,7 @@ static void usb2otg_halt_channel_preserve_char(int chan)
         int timeout = 200000;
         while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE)
                && --timeout > 0)
-            asm volatile("mov r0, r0\n");
+            asm volatile("yield\n");
         if (timeout <= 0)
         {
             HALT_SNAP(chan, "timeout-pre-flush");
@@ -128,7 +127,7 @@ static void usb2otg_halt_channel_preserve_char(int chan)
                 int t = 10000;
                 while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH)
                        && --t > 0)
-                    asm volatile("mov r0, r0\n");
+                    asm volatile("yield\n");
                 if (t <= 0)
                     HALT_SNAP(chan, "flush-self-timeout");
             }
@@ -138,7 +137,7 @@ static void usb2otg_halt_channel_preserve_char(int chan)
             timeout = 200000;
             while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE)
                    && --timeout > 0)
-                asm volatile("mov r0, r0\n");
+                asm volatile("yield\n");
             if (timeout <= 0)
             {
                 HALT_SNAP(chan, "stuck-after-flush");
@@ -187,12 +186,12 @@ static inline void usb2otg_post_halt_bulk_out_settle(void)
         int t = 10000;
         while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH)
                && --t > 0)
-            asm volatile("mov r0, r0\n");
+            asm volatile("yield\n");
     }
     {
         int t = 1200000;
         while (--t > 0)
-            asm volatile("mov r0, r0\n");
+            asm volatile("yield\n");
     }
 }
 
@@ -225,7 +224,7 @@ static void usb2otg_escalate_hw_reset(struct USB2OTGUnit *USBUnit, int wedged_ch
     /* Wait for AHB master to idle before asserting reset, per DWC2 spec. */
     t = 100000;
     while (!(rd32le(USB2OTG_RESET) & (1UL << 31)) && --t > 0)
-        asm volatile("mov r0, r0\n");
+        asm volatile("yield\n");
     if (t <= 0)
         bug("[USB2OTG] WEDGE-RECOVERY: AHB never idled before HCLKSOFT RESET=%08x\n",
             rd32le(USB2OTG_RESET));
@@ -235,7 +234,7 @@ static void usb2otg_escalate_hw_reset(struct USB2OTGUnit *USBUnit, int wedged_ch
 
     t = 200000;
     while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_HCLKSOFT) && --t > 0)
-        asm volatile("mov r0, r0\n");
+        asm volatile("yield\n");
 
     char_after = rd32le(USB2OTG_CHANNEL_REG(wedged_chan, CHARBASE));
     if (char_after & USB2OTG_HOSTCHAR_ENABLE)
@@ -1530,7 +1529,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                                 while ((rd32le(USB2OTG_RESET)
                                                         & USB2OTG_RESET_TXFIFOFLUSH)
                                                        && --timeout > 0)
-                                                    asm volatile("mov r0, r0\n");
+                                                    asm volatile("yield\n");
                                             }
                                             bug("[USB2OTG:MSS] BARE-CHHLTD NP-TX-FIFO-FLUSH after giveup chan=%d dev=%d ep=%d\n",
                                                 chan,
@@ -2243,7 +2242,7 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
                         /* Belt-and-braces second halt wait (~200 µs). */
                         int timeout = 200000;
                         while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
-                            asm volatile("mov r0, r0\n");
+                            asm volatile("yield\n");
                     }
 
                     /* If CHENA still stuck after full flush → escalate to HCLKSOFT. */

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
@@ -424,7 +424,7 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         {
             int timeout = 100000;
             while ((rd32le(USB2OTG_RESET) & USB2OTG_RESET_TXFIFOFLUSH) && --timeout > 0)
-                asm volatile("mov r0, r0\n");
+                asm volatile("yield\n");
         }
     }
 
@@ -477,9 +477,9 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
     {
         /*
          * HCCHAR.EC/MC = transactions per microframe; only high-bandwidth
-         * HS endpoints use >1. A low-/full-speed INT split must be EC=1
-         * (matches Linux dwc2 multi_count=1) — EC=3 makes the core expect
-         * 3 transactions and deschedule the periodic split (bare CHHLTD).
+         * HS endpoints use >1. A low-/full-speed INT split must be EC=1;
+         * EC=3 makes the core expect 3 transactions and deschedule the
+         * periodic split (bare CHHLTD).
          */
         if (req->iouh_Req.io_Command == UHCMD_ISOXFER)
             reg |= USB2OTG_HOSTCHAR_EC(3);
@@ -603,11 +603,22 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
      * full cache lines — a misaligned buffer would drag adjacent
      * unrelated bytes across the flush, which is harmless for OUT
      * but a real cache-pollution risk for IN.
+     *
+     * For IN this applies to the END as well as the START: an
+     * aligned buffer whose length is not a cache-line multiple shares
+     * its tail line with the following allocation, and the post-DMA
+     * dc-ivac (invalidate-only) then DISCARDS that neighbour's dirty
+     * data -- observed corrupting an unrelated task's stacked x29 on
+     * real Pi during lan78xx (ethernet, ~1514 B) enumeration. Bouncing
+     * moves the rounded invalidate onto the 16 KB bounce buffer's own
+     * slack, so no foreign line is touched.
      */
     otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
     {
         APTR dma_buf = buffer;
-        if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size <= DMA_BOUNCE_SIZE)
+        if (buffer != NULL
+            && (((ULONG)buffer & 0x3F) || (direction && ((ULONG)xfer_size & 0x3F)))
+            && xfer_size <= DMA_BOUNCE_SIZE)
         {
             otg_Unit->hu_Channel[chan].hc_OrigBuffer = buffer;
             otg_Unit->hu_Channel[chan].hc_BounceLen = xfer_size;
@@ -903,7 +914,7 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
                 /* ~200 µs budget — matches halt_channel_preserve_char. */
                 int timeout = 200000;
                 while ((rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE) && --timeout > 0)
-                    asm volatile("mov r0, r0\n");
+                    asm volatile("yield\n");
                 if (timeout <= 0)
                     bug("[USB2OTG] AdvanceChannel halt timeout chan=%d CHAR=%08x INTR=%08x\n",
                         chan,
@@ -963,8 +974,12 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         /* If split transaction requested limit transfer size to max packet size or 188 bytes, whichever is less */
         if (req->iouh_Flags & UHFF_SPLITTRANS)
         {
-            if (req->iouh_Req.io_Command == UHCMD_INTXFER ||
-                req->iouh_Req.io_Command == UHCMD_ISOXFER)
+            /*
+             * Must match SetupChannel: a low-/full-speed INT split needs
+             * EC=1 (EC=3 makes the core deschedule the periodic split,
+             * bare CHHLTD -> watchdog). Only ISO uses EC=3 here.
+             */
+            if (req->iouh_Req.io_Command == UHCMD_ISOXFER)
                 reg |= USB2OTG_HOSTCHAR_EC(3);
             else
                 reg |= USB2OTG_HOSTCHAR_EC(1);
@@ -1053,11 +1068,18 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
          * Misaligned buffer → bounce. Aligned direct DMA needs per-arm
          * cache flush — speculative prefetch refills stale lines
          * between continuation arms, controller sends garbage.
+         *
+         * IN also bounces when the length is not a cache-line multiple:
+         * the tail line is shared with the next allocation and the
+         * post-DMA invalidate would discard its dirty data (see the
+         * Setup path for the full rationale).
          */
         otg_Unit->hu_Channel[chan].hc_OrigBuffer = NULL;
         {
             APTR dma_buf = buffer;
-            if (buffer != NULL && ((ULONG)buffer & 0x3F) && xfer_size <= DMA_BOUNCE_SIZE)
+            if (buffer != NULL
+                && (((ULONG)buffer & 0x3F) || (direction && ((ULONG)xfer_size & 0x3F)))
+                && xfer_size <= DMA_BOUNCE_SIZE)
             {
                 otg_Unit->hu_Channel[chan].hc_OrigBuffer = buffer;
                 otg_Unit->hu_Channel[chan].hc_BounceLen = xfer_size;
@@ -1261,7 +1283,7 @@ void FNAME_DEV(StartChannel)(struct USB2OTGUnit *otg_Unit, int chan, int quick)
             {
                 int t = USB2OTG_BULK_OUT_THROTTLE_COUNT;
                 while (--t > 0)
-                    asm volatile("mov r0, r0\n");
+                    asm volatile("yield\n");
             }
 #endif
         }


### PR DESCRIPTION
A periodic INT split must program EC=1, not EC=3, or the core deschedules the split and wedges with bare CHHLTD. Also bounce IN transfers whose length is not a cache-line multiple so the post-DMA invalidate cannot discard the neighbouring allocation's data.