### PR TITLE
battmem: add battmem.resource for m68k-amiga

### DIFF
--- a/arch/m68k-amiga/battclock/battclock_intern.c
+++ b/arch/m68k-amiga/battclock/battclock_intern.c
@@ -65,7 +65,12 @@ void resetbattclock(struct BattClockBase *Battclock)
     } else if (Battclock->clocktype == RF5C01A) {
         putreg(p, 0xd, 0); // stop
         putreg(p, 0xe, 0);
-        for (j = 0; j < 4; j++) {
+        /*
+           Only blocks 0 and 1 are the clock. Blocks 2 and 3 are battery
+           backed up memory, holding settings that belong to the user -
+           clearing them here would throw those away on every clock reset.
+        */
+        for (j = 0; j < 2; j++) {
             putreg(p, 0xd, j);
             for (i = 0; i < 12; i++)
                 putreg(p, i, 0);

--- a/arch/m68k-amiga/battclock/battclock_intern.c
+++ b/arch/m68k-amiga/battclock/battclock_intern.c
@@ -46,6 +46,92 @@ void startclock(struct BattClockBase *Battclock)
     }
 }
 
+/*
+   Checksum over the battery memory, a nibble wide CRC seeded with 0xff.
+   It has to match the one the Amiga ROM uses byte for byte, or settings
+   written under Kickstart would be discarded here and the other way round.
+*/
+static UBYTE battmemsum(const UBYTE *buf)
+{
+    static const UBYTE tab[16] =
+    {
+        0x00, 0x57, 0xae, 0xf9, 0x0b, 0x5c, 0xa5, 0xf2,
+        0x16, 0x41, 0xb8, 0x7f, 0x1d, 0x4a, 0xb3, 0xe4
+    };
+    UBYTE sum = 0xff;
+    UBYTE i, t;
+
+    for (i = 0; i < BATTMEM_BYTES * 2; i++)
+    {
+        /* High nibble of each byte first, then the low one. */
+        t = ((i & 1) ? (buf[i / 2] << 4) : (buf[i / 2] & 0xf0)) ^ sum;
+        t = (t >> 4) | (t << 4);
+        sum = (t & 0xf0) ^ tab[t & 0x0f];
+    }
+
+    return sum;
+}
+
+static void battmemread(struct BattClockBase *Battclock, UBYTE *buf)
+{
+    volatile UBYTE *p = Battclock->clockptr;
+    UBYTE i;
+
+    putreg(p, 0xd, 8 | 2); // timer en, block 2
+    for (i = 0; i < BATTMEM_REGS; i++)
+        buf[i] = getreg(p, i) << 4;
+    putreg(p, 0xd, 8 | 3); // timer en, block 3
+    for (i = 0; i < BATTMEM_REGS; i++)
+        buf[i] |= getreg(p, i);
+    putreg(p, 0xd, 8); // timer en, block 0
+}
+
+static void battmemwrite(struct BattClockBase *Battclock, const UBYTE *buf)
+{
+    volatile UBYTE *p = Battclock->clockptr;
+    UBYTE i;
+
+    putreg(p, 0xd, 8 | 2); // timer en, block 2
+    for (i = 0; i < BATTMEM_REGS; i++)
+        putreg(p, i, buf[i] >> 4);
+    putreg(p, 0xd, 8 | 3); // timer en, block 3
+    for (i = 0; i < BATTMEM_REGS; i++)
+        putreg(p, i, buf[i] & 0x0f);
+    putreg(p, 0xd, 8); // timer en, block 0
+}
+
+/*
+   Fetch the battery memory into buf, which holds BATTMEM_REGS bytes. If the
+   checksum does not match, the battery lost its contents: clear it out, so
+   that the AMNESIA bits read back as zero and callers can tell.
+   Returns FALSE if this clock has no battery memory at all.
+*/
+BOOL battmemload(struct BattClockBase *Battclock, UBYTE *buf)
+{
+    UBYTE i;
+
+    if (!Battclock->clockptr || Battclock->clocktype != RF5C01A)
+        return FALSE;
+
+    battmemread(Battclock, buf);
+
+    if (buf[BATTMEM_BYTES] != battmemsum(buf))
+    {
+        for (i = 0; i < BATTMEM_REGS; i++)
+            buf[i] = 0;
+        buf[BATTMEM_BYTES] = battmemsum(buf);
+        battmemwrite(Battclock, buf);
+    }
+
+    return TRUE;
+}
+
+void battmemstore(struct BattClockBase *Battclock, UBYTE *buf)
+{
+    buf[BATTMEM_BYTES] = battmemsum(buf);
+    battmemwrite(Battclock, buf);
+}
+
 void resetbattclock(struct BattClockBase *Battclock)
 {
     volatile UBYTE *p = Battclock->clockptr;
@@ -67,7 +153,7 @@ void resetbattclock(struct BattClockBase *Battclock)
         putreg(p, 0xe, 0);
         /*
            Only blocks 0 and 1 are the clock. Blocks 2 and 3 are battery
-           backed up memory, holding settings that belong to the user -
+           backed up memory holding settings that belong to the user -
            clearing them here would throw those away on every clock reset.
         */
         for (j = 0; j < 2; j++) {

--- a/arch/m68k-amiga/battclock/battclock_intern.h
+++ b/arch/m68k-amiga/battclock/battclock_intern.h
@@ -20,6 +20,16 @@
 #define MSM6242B 1
 #define RF5C01A 2
 
+/*
+   Battery backed up memory of the RF5C01A/RP5C01. Blocks 2 and 3 are plain
+   battery RAM, 13 registers of 4 bits each: block 2 holds the high nibble of
+   a byte, block 3 the low one. Registers 0 to 11 are the storage proper,
+   register 12 holds a checksum over them.
+*/
+#define BATTMEM_REGS    13
+#define BATTMEM_BYTES   12
+#define BATTMEM_BITS    (BATTMEM_BYTES * 8)
+
 struct BattClockBase
 {
     struct Library bb_LibNode;
@@ -35,5 +45,7 @@ UBYTE getbcd(volatile UBYTE *p, UBYTE regnum);
 void putbcd(volatile UBYTE *p, UBYTE regnum, UBYTE v);
 void stopclock(struct BattClockBase *Battclock);
 void startclock(struct BattClockBase *Battclock);
+BOOL battmemload(struct BattClockBase *Battclock, UBYTE *buf);
+void battmemstore(struct BattClockBase *Battclock, UBYTE *buf);
 
 #endif //BATTCLOCK_INTERN_H

--- a/arch/m68k-amiga/battclock/mmakefile.src
+++ b/arch/m68k-amiga/battclock/mmakefile.src
@@ -3,6 +3,7 @@ include $(SRCDIR)/config/aros.cfg
 %build_archspecific \
   mainmmake=kernel-battclock modname=battclock maindir=rom/battclock \
   arch=amiga-m68k \
-  files="battclock_init readbattclock writebattclock battclock_intern"
+  files="battclock_init readbattclock writebattclock battclock_intern \
+         readbattclockmem writebattclockmem"
 
 %common

--- a/arch/m68k-amiga/battclock/readbattclockmem.c
+++ b/arch/m68k-amiga/battclock/readbattclockmem.c
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: ReadBattClockMem() function.
+*/
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <aros/libcall.h>
+
+#include <proto/exec.h>
+
+#include "battclock_intern.h"
+
+#include <proto/battclock.h>
+
+/* See rom/battclock/readbattclockmem.c for documentation */
+
+AROS_LH2(ULONG, ReadBattClockMem,
+    AROS_LHA(ULONG, offset, D1),
+    AROS_LHA(ULONG, length, D2),
+    struct BattClockBase *, BattClockBase, 4, Battclock)
+{
+    AROS_LIBFUNC_INIT
+
+    UBYTE buf[BATTMEM_REGS];
+    ULONG value = 0;
+    ULONG i, bit;
+
+    D(bug("ReadBattClockMem(%d, %d)\n", offset, length));
+
+    if (length > 32)
+        length = 32;
+    if (length == 0 || offset >= BATTMEM_BITS)
+        return 0;
+
+    Disable();
+    if (!battmemload(BattClockBase, buf))
+    {
+        Enable();
+        return 0;
+    }
+    Enable();
+
+    /* Bit 0 is the most significant bit of the first byte. */
+    for (i = 0; i < length; i++)
+    {
+        bit = offset + i;
+        value <<= 1;
+        if (bit < BATTMEM_BITS && (buf[bit >> 3] & (0x80 >> (bit & 7))))
+            value |= 1;
+    }
+
+    D(bug("ReadBattClockMem = %08x\n", value));
+    return value;
+
+    AROS_LIBFUNC_EXIT
+
+} /* ReadBattClockMem */

--- a/arch/m68k-amiga/battclock/writebattclockmem.c
+++ b/arch/m68k-amiga/battclock/writebattclockmem.c
@@ -1,0 +1,63 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: WriteBattClockMem() function.
+*/
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <aros/libcall.h>
+
+#include <proto/exec.h>
+
+#include "battclock_intern.h"
+
+#include <proto/battclock.h>
+
+/* See rom/battclock/writebattclockmem.c for documentation */
+
+AROS_LH3(void, WriteBattClockMem,
+    AROS_LHA(ULONG, data,   D0),
+    AROS_LHA(ULONG, offset, D1),
+    AROS_LHA(ULONG, length, D2),
+    struct BattClockBase *, BattClockBase, 5, Battclock)
+{
+    AROS_LIBFUNC_INIT
+
+    UBYTE buf[BATTMEM_REGS];
+    UBYTE mask;
+    ULONG i, bit;
+
+    D(bug("WriteBattClockMem(%08x, %d, %d)\n", data, offset, length));
+
+    if (length > 32)
+        length = 32;
+    if (length == 0 || offset >= BATTMEM_BITS)
+        return;
+    if (offset + length > BATTMEM_BITS)
+    {
+        /* Drop the bits that would not fit rather than wrapping around. */
+        data >>= offset + length - BATTMEM_BITS;
+        length = BATTMEM_BITS - offset;
+    }
+
+    Disable();
+    if (battmemload(BattClockBase, buf))
+    {
+        /* Bit 0 is the most significant bit of the first byte. */
+        for (i = 0; i < length; i++)
+        {
+            bit = offset + i;
+            mask = 0x80 >> (bit & 7);
+            if (data & (1UL << (length - 1 - i)))
+                buf[bit >> 3] |= mask;
+            else
+                buf[bit >> 3] &= ~mask;
+        }
+        battmemstore(BattClockBase, buf);
+    }
+    Enable();
+
+    AROS_LIBFUNC_EXIT
+
+} /* WriteBattClockMem */

--- a/arch/m68k-amiga/boot/mmakefile.src
+++ b/arch/m68k-amiga/boot/mmakefile.src
@@ -23,6 +23,7 @@ include $(SRCDIR)/config/aros.cfg
 #MM     kernel-ata-kobj \
 #MM     kernel-audio-kobj \
 #MM     kernel-battclock-kobj \
+#MM     kernel-battmem-kobj \
 #MM     kernel-bootloader-amiga-m68k-kobj \
 #MM     kernel-bootloader-kobj \
 #MM     kernel-cardres-kobj \
@@ -140,7 +141,7 @@ KLIBS   := exec aros dos utility oop expansion partition debug \
 KDEVS   := timer input keyboard console trackdisk gameport audio
 KHNDLRS := con afs ram
 KHIDDS  := amigakbd amigamouse amigavideo ata_gayle gfx hiddclass inputclass keyboard mouse
-KRSRCS  := battclock kernel processor task lddemon dosboot cia potgo disk FileSystem misc shell card bootloader
+KRSRCS  := battclock battmem kernel processor task lddemon dosboot cia potgo disk FileSystem misc shell card bootloader
 KHOOKS  := diag romboot
 
 KOBJS_rom := $(addprefix $(KOBJSDIR)/,$(addsuffix _library.ko ,$(KLIBS))) \
@@ -343,7 +344,7 @@ KLIBS   := aros utility dos oop mathffp mathieeesingbas partition \
 KDEVS   := timer input keyboard console trackdisk gameport audio ata cd
 KHNDLRS := cdrom con afs ram
 KHIDDS  := amigakbd amigamouse amigavideo ata_gayle bus gfx hiddclass keyboard mouse storage system p96gfx
-KRSRCS  := battclock processor task lddemon dosboot cia potgo disk \
+KRSRCS  := battclock battmem processor task lddemon dosboot cia potgo disk \
            misc shell shellcommands workbook wbtag card FileSystem
 KHOOKS  := alert romboot
 

--- a/compiler/include/resources/battmem.h
+++ b/compiler/include/resources/battmem.h
@@ -1,0 +1,10 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+*/
+
+#ifndef RESOURCES_BATTMEM_H
+#define RESOURCES_BATTMEM_H 1
+
+#define BATTMEMNAME     "battmem.resource"
+
+#endif /* RESOURCES_BATTMEM_H */

--- a/rom/battclock/battclock.conf
+++ b/rom/battclock/battclock.conf
@@ -13,6 +13,6 @@ options resautoinit
 void ResetBattClock() ()
 ULONG ReadBattClock() ()
 void WriteBattClock(ULONG time) (D0)
-.skip 1 # ULONG ReadBattClockMem(ULONG offset, ULONG length) (D1, D2)
-.skip 1 # void WriteBattClockMem(ULONG data, ULONG offset, ULONG length) (D0,D1,D2)
+ULONG ReadBattClockMem(ULONG offset, ULONG length) (D1, D2)
+void WriteBattClockMem(ULONG data, ULONG offset, ULONG length) (D0, D1, D2)
 ##end functionlist

--- a/rom/battclock/mmakefile.src
+++ b/rom/battclock/mmakefile.src
@@ -20,7 +20,8 @@ endif
 #MM kernel-battclock : includes kernel-battclock-$(ARCH)-$(CPU)
 #MM kernel-battclock-linklib : includes kernel-battclock-$(ARCH)-$(CPU)
 
-FUNCTIONS := readbattclock resetbattclock writebattclock
+FUNCTIONS := readbattclock resetbattclock writebattclock \
+	     readbattclockmem writebattclockmem
 
 %build_module mmake=kernel-battclock \
     modname=battclock modtype=resource version=$(AROS_TARGET_PLATFORM) \

--- a/rom/battclock/readbattclockmem.c
+++ b/rom/battclock/readbattclockmem.c
@@ -1,0 +1,61 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: ReadBattClockMem() function.
+*/
+#include "battclock_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battclock.h>
+
+        AROS_LH2(ULONG, ReadBattClockMem,
+
+/*  SYNOPSIS */
+        AROS_LHA(ULONG, offset, D1),
+        AROS_LHA(ULONG, length, D2),
+
+/*  LOCATION */
+        APTR, BattClockBase, 4, Battclock)
+
+/*  FUNCTION
+        Read a field of up to 32 bits out of the battery backed up memory
+        of the real time clock. This is the storage battmem.resource is
+        built on; normal applications should use that resource instead.
+
+    INPUTS
+        offset - bit offset of the field, counted from the first bit of
+                 the battery memory.
+        length - size of the field in bits. Values above 32 are clamped
+                 to 32.
+
+    RESULT
+        The field, right aligned. Zero if the clock has no battery memory,
+        or if offset lies beyond the end of it.
+
+    NOTES
+        Not all clock chips have battery backed up memory. The MSM6242B
+        fitted to some machines has none, and this function returns 0
+        there.
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        WriteBattClockMem()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+#warning battclock.resource functionality not added
+    return 0;
+
+    AROS_LIBFUNC_EXIT
+} /* ReadBattClockMem */

--- a/rom/battclock/writebattclockmem.c
+++ b/rom/battclock/writebattclockmem.c
@@ -1,0 +1,61 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: WriteBattClockMem() function.
+*/
+#include "battclock_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battclock.h>
+
+        AROS_LH3(void, WriteBattClockMem,
+
+/*  SYNOPSIS */
+        AROS_LHA(ULONG, data,   D0),
+        AROS_LHA(ULONG, offset, D1),
+        AROS_LHA(ULONG, length, D2),
+
+/*  LOCATION */
+        APTR, BattClockBase, 5, Battclock)
+
+/*  FUNCTION
+        Write a field of up to 32 bits into the battery backed up memory
+        of the real time clock. This is the storage battmem.resource is
+        built on; normal applications should use that resource instead.
+
+    INPUTS
+        data   - the field value, right aligned.
+        offset - bit offset of the field, counted from the first bit of
+                 the battery memory.
+        length - size of the field in bits. Values above 32 are clamped
+                 to 32.
+
+    RESULT
+
+    NOTES
+        Not all clock chips have battery backed up memory. The MSM6242B
+        fitted to some machines has none, and this function does nothing
+        there. Writes that start beyond the end of the battery memory are
+        ignored; writes that run past the end are truncated.
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        ReadBattClockMem()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+#warning battclock.resource functionality not added
+
+    AROS_LIBFUNC_EXIT
+} /* WriteBattClockMem */

--- a/rom/battmem/battmem.conf
+++ b/rom/battmem/battmem.conf
@@ -1,0 +1,24 @@
+##begin config
+version 41.1
+residentpri 69
+libbase BattMemBase
+libbasetype struct BattMemBase
+libbasetypeextern struct Library
+options resautoinit, noautolib
+##end config
+
+##begin cdef
+#include <resources/battmem.h>
+##end cdef
+
+##begin cdefprivate
+#include <resources/battmem.h>
+#include <battmem_intern.h>
+##end cdefprivate
+
+##begin functionlist
+void ObtainBattSemaphore() ()
+void ReleaseBattSemaphore() ()
+ULONG ReadBattMem(APTR buffer, ULONG offset, ULONG length) (A0, D0, D1)
+ULONG WriteBattMem(CONST_APTR buffer, ULONG offset, ULONG length) (A0, D0, D1)
+##end functionlist

--- a/rom/battmem/battmem_init.c
+++ b/rom/battmem/battmem_init.c
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+*/
+
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <aros/symbolsets.h>
+
+#include <proto/exec.h>
+#include <resources/battclock.h>
+
+#include "battmem_intern.h"
+
+static int BattMem_Init(struct BattMemBase *BattMemBase)
+{
+    /*
+       All the storage lives in battclock.resource, which owns the real
+       time clock chip. Without it there is nowhere to put anything, so
+       do not install the resource at all.
+    */
+    BattMemBase->bm_BattClockBase = OpenResource(BATTCLOCKNAME);
+    if (!BattMemBase->bm_BattClockBase)
+    {
+        D(bug("BattMem: no %s\n", BATTCLOCKNAME));
+        return FALSE;
+    }
+
+    InitSemaphore(&BattMemBase->bm_Semaphore);
+
+    return TRUE;
+}
+
+ADD2INITLIB(BattMem_Init, 0)

--- a/rom/battmem/battmem_intern.h
+++ b/rom/battmem/battmem_intern.h
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Internal data structures for battmem.resource
+*/
+
+#ifndef BATTMEM_INTERN_H
+#define BATTMEM_INTERN_H
+
+#ifndef EXEC_TYPES_H
+#include <exec/types.h>
+#endif
+#ifndef EXEC_LIBRARIES_H
+#include <exec/libraries.h>
+#endif
+#ifndef EXEC_SEMAPHORES_H
+#include <exec/semaphores.h>
+#endif
+
+struct BattMemBase
+{
+    struct Library          bm_LibNode;
+    struct SignalSemaphore  bm_Semaphore;
+    /* battclock.resource holds the battery backed up memory itself */
+    struct Library         *bm_BattClockBase;
+};
+
+#endif /* BATTMEM_INTERN_H */

--- a/rom/battmem/mmakefile.src
+++ b/rom/battmem/mmakefile.src
@@ -1,0 +1,12 @@
+include $(SRCDIR)/config/aros.cfg
+
+USER_INCLUDES := -I$(SRCDIR)/rom/battmem
+
+FUNCTIONS := obtainbattsemaphore releasebattsemaphore \
+	     readbattmem writebattmem
+
+%build_module mmake=kernel-battmem \
+    modname=battmem modtype=resource version=$(AROS_TARGET_PLATFORM) \
+    files="$(FUNCTIONS) battmem_init"
+
+%common

--- a/rom/battmem/obtainbattsemaphore.c
+++ b/rom/battmem/obtainbattsemaphore.c
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: ObtainBattSemaphore() function.
+*/
+#include <proto/exec.h>
+
+#include "battmem_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battmem.h>
+
+        AROS_LH0(void, ObtainBattSemaphore,
+
+/*  SYNOPSIS */
+        /* void */
+
+/*  LOCATION */
+        struct BattMemBase *, BattMemBase, 1, Battmem)
+
+/*  FUNCTION
+        Gain exclusive access to the battery backed up memory. Reads and
+        writes of related fields have to be bracketed by this and
+        ReleaseBattSemaphore(), so that they are not interleaved with
+        those of another task.
+
+    INPUTS
+
+    RESULT
+
+    NOTES
+        ReadBattMem() and WriteBattMem() are safe to call on their own;
+        the semaphore is only needed to keep a group of them together.
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        ReleaseBattSemaphore()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&BattMemBase->bm_Semaphore);
+
+    AROS_LIBFUNC_EXIT
+} /* ObtainBattSemaphore */

--- a/rom/battmem/readbattmem.c
+++ b/rom/battmem/readbattmem.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: ReadBattMem() function.
+*/
+#include <proto/battclock.h>
+
+#include "battmem_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battmem.h>
+
+        AROS_LH3(ULONG, ReadBattMem,
+
+/*  SYNOPSIS */
+        AROS_LHA(APTR,  buffer, A0),
+        AROS_LHA(ULONG, offset, D0),
+        AROS_LHA(ULONG, length, D1),
+
+/*  LOCATION */
+        struct BattMemBase *, BattMemBase, 3, Battmem)
+
+/*  FUNCTION
+        Copy a field out of the battery backed up memory into a buffer.
+
+    INPUTS
+        buffer - where to put the field. It has to be large enough to hold
+                 (length + 7) / 8 bytes.
+        offset - bit offset of the field within the battery memory.
+        length - size of the field in BITS, not bytes.
+
+    RESULT
+        Always zero.
+
+    NOTES
+        Bit offsets and lengths beyond the end of the battery memory read
+        back as zero rather than failing. See <resources/battmembitsamiga.h>
+        and <resources/battmembitsshared.h> for the assigned fields.
+
+        A trailing partial byte is right aligned in the last byte written.
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        WriteBattMem(), ObtainBattSemaphore()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    struct Library *BattClockBase = BattMemBase->bm_BattClockBase;
+    UBYTE *buf = (UBYTE *)buffer;
+    ULONG bytes = length >> 3;
+    ULONG bits = length & 7;
+
+    while (bytes-- > 0)
+    {
+        *buf++ = (UBYTE)ReadBattClockMem(offset, 8);
+        offset += 8;
+    }
+
+    if (bits)
+        *buf = (UBYTE)ReadBattClockMem(offset, bits);
+
+    return 0;
+
+    AROS_LIBFUNC_EXIT
+} /* ReadBattMem */

--- a/rom/battmem/releasebattsemaphore.c
+++ b/rom/battmem/releasebattsemaphore.c
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: ReleaseBattSemaphore() function.
+*/
+#include <proto/exec.h>
+
+#include "battmem_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battmem.h>
+
+        AROS_LH0(void, ReleaseBattSemaphore,
+
+/*  SYNOPSIS */
+        /* void */
+
+/*  LOCATION */
+        struct BattMemBase *, BattMemBase, 2, Battmem)
+
+/*  FUNCTION
+        Give up the exclusive access to the battery backed up memory
+        gained with ObtainBattSemaphore().
+
+    INPUTS
+
+    RESULT
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        ObtainBattSemaphore()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    ReleaseSemaphore(&BattMemBase->bm_Semaphore);
+
+    AROS_LIBFUNC_EXIT
+} /* ReleaseBattSemaphore */

--- a/rom/battmem/writebattmem.c
+++ b/rom/battmem/writebattmem.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: WriteBattMem() function.
+*/
+#include <proto/battclock.h>
+
+#include "battmem_intern.h"
+
+/*****************************************************************************
+
+    NAME */
+#include <proto/battmem.h>
+
+        AROS_LH3(ULONG, WriteBattMem,
+
+/*  SYNOPSIS */
+        AROS_LHA(CONST_APTR, buffer, A0),
+        AROS_LHA(ULONG,      offset, D0),
+        AROS_LHA(ULONG,      length, D1),
+
+/*  LOCATION */
+        struct BattMemBase *, BattMemBase, 4, Battmem)
+
+/*  FUNCTION
+        Copy a field from a buffer into the battery backed up memory.
+
+    INPUTS
+        buffer - the field to store, (length + 7) / 8 bytes.
+        offset - bit offset of the field within the battery memory.
+        length - size of the field in BITS, not bytes.
+
+    RESULT
+        Always zero.
+
+    NOTES
+        Writes that run past the end of the battery memory are truncated
+        rather than failing. See <resources/battmembitsamiga.h> and
+        <resources/battmembitsshared.h> for the assigned fields.
+
+        A trailing partial byte is taken right aligned from the last byte
+        of the buffer.
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        ReadBattMem(), ObtainBattSemaphore()
+
+    INTERNALS
+
+    HISTORY
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    struct Library *BattClockBase = BattMemBase->bm_BattClockBase;
+    const UBYTE *buf = (const UBYTE *)buffer;
+    ULONG bytes = length >> 3;
+    ULONG bits = length & 7;
+
+    while (bytes-- > 0)
+    {
+        WriteBattClockMem(*buf++, offset, 8);
+        offset += 8;
+    }
+
+    if (bits)
+        WriteBattClockMem(*buf, offset, bits);
+
+    return 0;
+
+    AROS_LIBFUNC_EXIT
+} /* WriteBattMem */


### PR DESCRIPTION
Adds `battmem.resource` for m68k-amiga, and fills in the
`ReadBattClockMem`/`WriteBattClockMem` vectors already reserved in
`battclock.conf` that back it.

On the RF5C01A, register blocks 2 and 3 are 96 bits of battery backed up
memory addressed as a big endian bit string, with a checksum in the last
register that flags a lost battery. Clocks without battery memory keep the
existing stub behaviour. `battmem.resource` itself is a thin layer over those
two functions plus the semaphore, with offsets and lengths in bits.

Also fixes a separate bug that stands on its own: `resetbattclock()` cleared
all four RF5C01A blocks, but only 0 and 1 are the clock, so every clock reset
wiped the battery memory.

Confirmed working on Copperline 0.13, with the A4091 open source firmware
reading and updating its own settings in battmem: settings written from the
board's boot menu survive a reset and read back correctly.

The layout and checksum were checked against battery memory written by a
Kickstart ROM, so existing settings are not invalidated. A full round trip of
writing under Kickstart and reading back here has not been run yet.
