### PR TITLE
Fix crash and scroll issues after deleting selected text in Edit

### DIFF
--- a/workbench/tools/Edit/Edit.c
+++ b/workbench/tools/Edit/Edit.c
@@ -1,7 +1,7 @@
 /******************************************************
 **  Edit.c : Implementation of 'Edit' menu commands  **
 **  (mark/cut/[un]indent/[lower|upper|toggle] case)  **
-**  © T.Pierron, C.Guillaume.                        **
+**  Â© T.Pierron, C.Guillaume.                        **
 ******************************************************/
 
 #include <exec/types.h>
@@ -330,14 +330,15 @@ void del_block(Project p)
 	p->max_lines -= nbrem;
 	p->ccp.select = 0;
 	p->ccp.xp     = (ULONG)-1;
-	if(nbrem>=1) prop_adj(p);
 
 	/* Adjust cursor's position */
 	p->edited = p->the_line;
 	nbrem     = p->nbl;
 	p->nbl    = 0;
+	if(p->top_line >= p->max_lines) p->top_line = p->max_lines > 0 ? p->max_lines-1 : 0;
 	set_cursor_line(p, nbrem, p->top_line);
 	if(p->top_line == p->nbl) p->show=p->edited;
+	if(nbdel>=1) prop_adj(p);
 
 	/* What should be redrawn? */
 	if(nbdel>1)

--- a/workbench/tools/Edit/Jed.c
+++ b/workbench/tools/Edit/Jed.c
@@ -486,11 +486,11 @@ void scroll_ydelta(Project p, LONG y)
 	/* Clamp values to the boundary */
 
 	if(pos<0) pos=0;
-#if 0
-	if(pos>(LONG)p->max_lines-(LONG)gui.nbline) pos=p->max_lines-gui.nbline;
-#else
-	if(pos>p->max_lines-1) pos=p->max_lines-1;
-#endif
+	if(p->max_lines > gui.nbline)
+    {
+        if(pos>(LONG)p->max_lines-(LONG)gui.nbline) pos=p->max_lines-gui.nbline;
+    }
+    else pos=0;
 
 	if(pos!=p->top_line)
 	{

--- a/workbench/tools/Edit/Jed.c
+++ b/workbench/tools/Edit/Jed.c
@@ -494,10 +494,13 @@ void scroll_ydelta(Project p, LONG y)
 
 	if(pos!=p->top_line)
 	{
-		if(!p->ccp.select) inv_curs(p,FALSE);
-		scroll_xy(p, curs_visible(p,pos), pos, TRUE);
-		if(p->ccp.select) move_selection(p, p->nbrwc, p->nbl);
-		inv_curs(p,TRUE);
+        if(p->ccp.select)
+            p->ycurs-=(pos-p->top_line)*YSIZE,
+            scroll_xy(p, p->left_pos, pos, TRUE);
+        else
+            inv_curs(p,FALSE),
+            scroll_xy(p, curs_visible(p,pos), pos, TRUE),
+            inv_curs(p,TRUE);
 	}
 }
 


### PR DESCRIPTION
## Problems fixed

### 1. Crash after Select All + Backspace + click/scroll
After selecting all text with Select All (or mouse) and deleting with
Backspace, the editor crashed on the next mouse click or mouse wheel
scroll. Root cause: `p->top_line` was not clamped after deletion,
leaving `p->show` pointing to freed memory.

### 2. Cursor invisible after Select All + Backspace
The cursor was rendered off-screen (negative y position) because
`set_cursor_line` calculated `p->ycurs` using the stale `p->top_line`
value. Moving the clamp before `set_cursor_line` fixes this.

### 3. Scroll bar not updated after deletion
`prop_adj` was called before `p->top_line` was clamped (receiving
stale values) and used `nbrem` which was already overwritten by the
cursor position, not the deleted-lines count.

### 4. Mouse wheel allowed scrolling past content
`scroll_ydelta` used `p->max_lines-1` as the upper bound, while
`autoscroll` and the scroll bar correctly used `p->max_lines-gui.nbline`.
This allowed empty space to appear below the last line.

### 5. Mouse wheel lost text selection during scroll
Scrolling with the mouse wheel while text was selected caused lines
that scrolled into view to lose their selection state. `scroll_ydelta`
called `curs_visible` and `move_selection` which recalculated the
selection from the clamped cursor position. The scroll bar handler
(`scroll_disp`) already skipped these calls when selection was active.

## Changes

### Edit.c (`del_block`)
- Clamp `p->top_line` to `p->max_lines-1` before `set_cursor_line`
  so cursor position and `p->show` are calculated correctly
- Move `prop_adj` after the clamp and cursor adjustment
- Use `nbdel` (deleted-lines count) instead of `nbrem` (overwritten
  by cursor position) for `prop_adj` condition

### Jed.c (`scroll_ydelta`)
- Change upper boundary from `p->max_lines-1` to
  `p->max_lines-gui.nbline` (matching `autoscroll` and scroll bar)
- When selection is active, skip `curs_visible` and `move_selection`,
  only adjust `p->ycurs` and call `scroll_xy` (matching `scroll_disp`)