### PR TITLE
i386-pc: use @arch.dir@ rather than pc

### DIFF
--- a/arch/i386-pc/boot/modules.default
+++ b/arch/i386-pc/boot/modules.default
@@ -1,5 +1,5 @@
-/boot/pc/kernel.@pkg.fmt@
-/boot/pc/aros-bsp.pkg.@pkg.fmt@
+/boot/@arch.dir@/kernel.@pkg.fmt@
+/boot/@arch.dir@/aros-bsp.pkg.@pkg.fmt@
 /boot/aros-base.pkg.@pkg.fmt@
 /boot/aros-fs.pkg.@pkg.fmt@
 /boot/poseidon.pkg.@pkg.fmt@


### PR DESCRIPTION
The module list hard-coded /boot/pc rather than @arch.dir@. Had to change it to get `--target=pc-i386 --enable-target-variant=tiny --with-bootloader=grub2` building and booting under QEMU.