### PR TITLE
i386-pc: fix boot ISO kernel dependency

### DIFF
--- a/arch/i386-pc/boot/iso/mmakefile.src
+++ b/arch/i386-pc/boot/iso/mmakefile.src
@@ -7,7 +7,7 @@ TARGET_ISO := $(DISTDIR)/aros$(AROS_TARGET_SUFFIX)-pc-i386.iso
 
 #MM bootiso-pc-i386 : \
 #MM                              bootiso-native \
-#MM                              kernel-package-pc-i386 \
+#MM                              kernel-link-pc-i386 \
 #MM                              AROS-pc-drivers
 
 #MM


### PR DESCRIPTION
`bootiso-pc-i386` depends on `kernel-package-pc-i386`, which isn't defined anymore. Changed it to `kernel-link-pc-i386` so building `bootiso-pc-i386` just works.