### PR TITLE
Fix default serial I/O through port-handler

### DIFF
--- a/workbench/devs/serial/serial_init.c
+++ b/workbench/devs/serial/serial_init.c
@@ -491,6 +491,7 @@ AROS_LH1(void, beginio,
           else
             SU->su_WriteLength = ioreq->IOSer.io_Length-writtenbytes;
         }
+        ioreq->IOSer.io_Actual = writtenbytes;
         /*
         ** A consistency check between the STATUS_WRITES_PENDING flag
         ** and the pointer SU->su_ActiveWrite which both have to be

--- a/workbench/devs/serial/serial_interrupthandlers.c
+++ b/workbench/devs/serial/serial_interrupthandlers.c
@@ -151,6 +151,7 @@ ULONG WBE_InterruptHandler( ULONG unitnum, APTR userdata)
                                 writtenbytes = HIDD_SerialUnit_Write(SU->su_Unit,
                                                                      &((char *)ioserreq->IOSer.io_Data)[SU->su_NextToWrite],
                                                                      SU->su_WriteLength);
+                                ioserreq->IOSer.io_Actual += writtenbytes;
                                 /*
                                  * Check whether this was written completely.
                                  */

--- a/workbench/fs/port/port-handler.c
+++ b/workbench/fs/port/port-handler.c
@@ -184,6 +184,7 @@ static void portSerialDefaults(struct portArgs *pa)
     pa->pa_Serial.ps_Baud = 115200;
 #endif
     /* 8N1 */
+    pa->pa_Serial.ps_LenBits = 8;
     pa->pa_Serial.ps_StopBits = 1;
     pa->pa_Serial.ps_SerFlags = 0;
     pa->pa_Serial.ps_ExtFlags = 0;


### PR DESCRIPTION
two fixes:

## port-handler: initialize serial data length for 8N1

portSerialDefaults() describes its default as 8N1, but did not initialize ps_LenBits. This left the data length as zero unless it was explicitly provided in the control arguments, causing SDCMD_SETPARAMS to fail.

Change initializes ps_LenBits to 8 so the default matches the 8N1 config

## serial.device: report transmitted bytes

serial.device didn't update io_Actual as bytes were transmitted. So write completed with a reported length of zero, causing callers like `Echo` to retry the same data indefinitely.
