### PR TITLE
serial.hidd: fix transmitter status test

### DIFF
--- a/arch/i386-pc/drivers/serial.hidd/SerialUnitClass.c
+++ b/arch/i386-pc/drivers/serial.hidd/SerialUnitClass.c
@@ -320,7 +320,7 @@ ULONG PCSerUnit__Hidd_SerialUnit__Write(OOP_Class *cl, OOP_Object *o, struct pHi
     {
       serial_outp(data, UART_TX, msg->Outbuffer[count++]);
       len--;
-    } while (len > 0 && serial_inp(data, UART_LSR & UART_LSR_TEMT));
+    } while (len > 0 && (serial_inp(data, UART_LSR) & UART_LSR_TEMT));
   }
 
   ReturnInt("SerialUnit::Write()",ULONG, count);

--- a/arch/ppc-sam440/serial.hidd/SerialUnitClass.c
+++ b/arch/ppc-sam440/serial.hidd/SerialUnitClass.c
@@ -238,7 +238,7 @@ ULONG PPC4xxSerUnit__Hidd_SerialUnit__Write(OOP_Class *cl, OOP_Object *o, struct
     {
       serial_outp(data, UART_TX, msg->Outbuffer[count++]);
       len--;
-    } while (len > 0 && serial_inp(data, UART_LSR & UART_LSR_TEMT));
+    } while (len > 0 && (serial_inp(data, UART_LSR) & UART_LSR_TEMT));
   }
 
   ReturnInt("SerialUnit::Write()",ULONG, count);


### PR DESCRIPTION
Read `UART_LSR` first, then mask the returned status with `UART_LSR_TEMT`.

Otherwise the expression evaluates to register offset zero, causing the loop to read and potentially consume received data instead of checking whether the transmitter is empty.

Fixed in i386-pc and ppc-sam440, but only tested in i386-pc.