### PR TITLE
dosboot: enter the boot menu on HELP

### DIFF
--- a/rom/dosboot/menu.c
+++ b/rom/dosboot/menu.c
@@ -930,6 +930,11 @@ static BOOL buttonsPressed(LIBBASETYPEPTR LIBBASE)
                             D(bug("[DOSBoot:bootmenu] %s: SPACEBAR press detected\n", __func__));
                             success = TRUE;
                     }
+                    else if (matrix[RAWKEY_HELP/8] & (1<<(RAWKEY_HELP%8)))
+                    {
+                            D(bug("[DOSBoot:bootmenu] %s: HELP press detected\n", __func__));
+                            success = TRUE;
+                    }
                 }
                 CloseDevice(io);
             }


### PR DESCRIPTION
Hold HELP at boot to enter the boot menu, in addition to the existing LMB+RMB combo. HELP is the standard OS 3.x boot menu key, and it is much easier to hit under emulation.