### PR TITLE
m68k: Fix system time initialization and accelerate Clock rendering

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
@@ -712,9 +712,10 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
     UBYTE i;
     UWORD shifta, shiftb;
     UWORD afwm, alwm;
-    ULONG dstoffset;
-    WORD dstwidth;
+    ULONG maskoffset = 0, dstoffset;
+    WORD width, maskwidth = 0, dstwidth;
     WORD patcnt;
+    BOOL reverse = FALSE;
 
     WORD height = pat->height;
     WORD dstx = pat->x;
@@ -726,8 +727,6 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
     if (!canblit(bm))
         return FALSE;
 
-    if (pat->mask)
-        return FALSE;
     if (pat->patterndepth != 1)
         return FALSE;
 
@@ -753,16 +752,43 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
 
     shifta = 0;
     shiftb = 0;
+    width = dstwidth;
     afwm = leftmask[dstx];
     alwm = rightmask[dstx2];
+
+    if (pat->mask) {
+        WORD maskx = pat->masksrcx;
+        WORD maskx2 = maskx + pat->width - 1;
+        BYTE shift;
+
+        maskoffset = (maskx / 16) * 2;
+        maskwidth = maskx2 / 16 - maskx / 16 + 1;
+        maskx &= 15;
+        maskx2 &= 15;
+        shift = dstx - maskx;
+
+        if (shift < 0) {
+            reverse = TRUE;
+            shift = -shift;
+            width = dstwidth >= maskwidth ? dstwidth : maskwidth;
+            shifta = shift << 12;
+            afwm = rightmask[dstx2];
+            alwm = leftmask[dstx];
+        } else {
+            width = dstwidth >= maskwidth ? dstwidth : maskwidth;
+            shifta = shift << 12;
+        }
+    }
 
     OwnBlitter();
     WaitBlit();
 
     custom->bltafwm = afwm;
     custom->bltalwm = alwm;
-    custom->bltcmod = (bm->BytesPerRow - dstwidth * 2) + bm->BytesPerRow * (pat->patternheight - 1);
-    custom->bltdmod = (bm->BytesPerRow - dstwidth * 2) + bm->BytesPerRow * (pat->patternheight - 1);
+    if (pat->mask)
+        custom->bltamod = pat->maskmodulo * pat->patternheight - width * 2;
+    custom->bltcmod = bm->BytesPerRow * pat->patternheight - width * 2;
+    custom->bltdmod = bm->BytesPerRow * pat->patternheight - width * 2;
     custom->bltadat = 0xffff;
     
     for (i = 0; i < bm->Depth; i++, fgpen >>= 1, bgpen >>= 1) {
@@ -777,23 +803,39 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
         fg = fgpen & 1;
         bg = bgpen & 1;
         
-        chmask = 0x0300;
+        chmask = pat->mask ? 0x0f00 : 0x0300;
  
         minterm = getminterm(type, fg, bg);
  
         WaitBlit();
         custom->bltcon0 = shifta | chmask | minterm;
-        custom->bltcon1 = shiftb;
+        custom->bltcon1 = (reverse ? 0x0002 : 0x0000) | shiftb;
 
         for(patcnt = 0, dstoffset2 = 0; patcnt < pat->patternheight; patcnt++, dstoffset2 += bm->BytesPerRow) {
             UWORD blitheight = (height - patcnt + 1) / pat->patternheight;
             UWORD pattern = ((UWORD*)pat->pattern)[(pat->patternsrcy + patcnt) & patternymask];
-            if (blitheight && pattern) {
+            UWORD patternshift = (dstx - pat->patternsrcx) & 15;
+
+            if (patternshift)
+                pattern = (pattern >> patternshift) |
+                          (pattern << (16 - patternshift));
+            if (blitheight) {
+                ULONG planeoffset = dstoffset + dstoffset2;
+                ULONG sourceoffset = maskoffset + patcnt * pat->maskmodulo;
+
+                if (reverse) {
+                    planeoffset += (blitheight - 1) * bm->BytesPerRow * pat->patternheight +
+                                   (width - 1) * 2;
+                    sourceoffset += (blitheight - 1) * pat->maskmodulo * pat->patternheight +
+                                    (width - 1) * 2;
+                }
                 WaitBlit();
                 custom->bltbdat = pattern;
-                custom->bltcpt = (APTR)(bm->Planes[i] + dstoffset + dstoffset2);
-                custom->bltdpt = (APTR)(bm->Planes[i] + dstoffset + dstoffset2);
-                startblitter(csd, dstwidth, blitheight);
+                if (pat->mask)
+                    custom->bltapt = (APTR)(pat->mask + sourceoffset);
+                custom->bltcpt = (APTR)(bm->Planes[i] + planeoffset);
+                custom->bltdpt = (APTR)(bm->Planes[i] + planeoffset);
+                startblitter(csd, width, blitheight);
             }
         }
     }

--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -11,6 +11,8 @@
 #include <libraries/expansion.h>
 #include <libraries/expansionbase.h>
 #include <resources/filesysres.h>
+#include <devices/timer.h>
+#include <proto/timer.h>
 
 #include <ctype.h>
 #include <string.h>
@@ -46,6 +48,66 @@ static void PRINT_DOSTYPE(ULONG dt)
 #endif
 
 static LONG internalBootCliHandler(void);
+
+#define SECONDS_PER_DAY    (24UL * 60 * 60)
+#define SECONDS_PER_MINUTE 60UL
+#define MINUTES_PER_DAY    (24UL * 60)
+#define TICKS_PER_MINUTE   (60UL * TICKS_PER_SECOND)
+#define MAX_TIMER_DAYS     (0xffffffffUL / SECONDS_PER_DAY)
+/*
+ * Machines without a battery-backed clock start timer.device at the epoch.
+ * AmigaOS derives a useful initial time from the boot disk in that case.  Do
+ * this only for the volume selected as SYS:, before any other media is
+ * mounted.  A newer hardware clock is never moved backwards.
+ */
+static void internalSetTimeFromBootVolume(BPTR lock, struct DosLibrary *DOSBase)
+{
+    struct FileLock *filelock = (struct FileLock *)BADDR(lock);
+    struct DeviceList *volume;
+    struct DateStamp *date;
+    struct timeval now;
+    ULONG seconds;
+
+    if ((filelock == NULL) || (filelock->fl_Volume == BNULL))
+        return;
+
+    volume = (struct DeviceList *)BADDR(filelock->fl_Volume);
+    date = &volume->dl_VolumeDate;
+    if ((date->ds_Days < 0) || ((ULONG)date->ds_Days > MAX_TIMER_DAYS)
+        || (date->ds_Minute < 0)
+        || ((ULONG)date->ds_Minute >= MINUTES_PER_DAY)
+        || (date->ds_Tick < 0)
+        || ((ULONG)date->ds_Tick >= TICKS_PER_MINUTE))
+        return;
+
+    seconds = (ULONG)date->ds_Days * SECONDS_PER_DAY
+            + (ULONG)date->ds_Minute * SECONDS_PER_MINUTE
+            + (ULONG)date->ds_Tick / TICKS_PER_SECOND;
+    GetSysTime(&now);
+
+    if (seconds > now.tv_secs)
+    {
+        struct timerequest timerio;
+        struct MsgPort timermp;
+
+        SetMem(&timermp, 0, sizeof(timermp));
+        timermp.mp_Node.ln_Type = NT_MSGPORT;
+        timermp.mp_Flags = PA_SIGNAL;
+        timermp.mp_SigBit = SIGB_SINGLE;
+        timermp.mp_SigTask = FindTask(NULL);
+        NEWLIST(&timermp.mp_MsgList);
+
+        CopyMem(DOSBase->dl_TimeReq, &timerio, sizeof(timerio));
+        timerio.tr_node.io_Message.mn_Node.ln_Type = NT_REPLYMSG;
+        timerio.tr_node.io_Message.mn_ReplyPort = &timermp;
+        timerio.tr_node.io_Command = TR_SETSYSTIME;
+        timerio.tr_time.tv_secs = seconds;
+        timerio.tr_time.tv_micro =
+            ((ULONG)date->ds_Tick % TICKS_PER_SECOND)
+            * (1000000UL / TICKS_PER_SECOND);
+        DoIO(&timerio.tr_node);
+    }
+}
 
 /*****************************************************************************
 
@@ -550,6 +612,8 @@ static LONG internalBootCliHandler(void)
     /* We're now at the point of no return. */
     DOSBase->dl_Root->rn_BootProc = ((struct FileLock*)BADDR(lock))->fl_Task;
     SetFileSysTask(DOSBase->dl_Root->rn_BootProc);
+
+    internalSetTimeFromBootVolume(lock, DOSBase);
 
     AssignLock("SYS", lock);
     lock = Lock("SYS:", SHARED_LOCK);

--- a/rom/filesys/afs/os_aros_support.c
+++ b/rom/filesys/afs/os_aros_support.c
@@ -84,11 +84,11 @@ UBYTE i;
         volume->devicelist.dl_Type = DLT_VOLUME;
         volume->devicelist.dl_Lock = 0;
         volume->devicelist.dl_VolumeDate.ds_Days =
-                AROS_BE2LONG(rootblock->buffer[BLK_ROOT_DAYS(volume)]);
+                AROS_BE2LONG(rootblock->buffer[BLK_CREATION_DAYS(volume)]);
         volume->devicelist.dl_VolumeDate.ds_Minute =
-                AROS_BE2LONG(rootblock->buffer[BLK_ROOT_MINS(volume)]);
+                AROS_BE2LONG(rootblock->buffer[BLK_CREATION_MINS(volume)]);
         volume->devicelist.dl_VolumeDate.ds_Tick =
-                AROS_BE2LONG(rootblock->buffer[BLK_ROOT_TICKS(volume)]);
+                AROS_BE2LONG(rootblock->buffer[BLK_CREATION_TICKS(volume)]);
         volume->devicelist.dl_LockList = 0;
         volume->devicelist.dl_DiskType = volume->dostype;
         if (volume->devicelist.dl_Name != BNULL)

--- a/rom/graphics/areaend.c
+++ b/rom/graphics/areaend.c
@@ -118,19 +118,6 @@
                  * Must draw from lower y's to higher ones otherwise
                  * the fill algo does not work nicely.
                  */
-#if 1
-                if(rp->cp_y <= CurVctr[1]) {
-                    Draw(rp, CurVctr[0], CurVctr[1]);
-                } else {
-                    int _x = rp->cp_x;
-                    int _y = rp->cp_y;
-                    rp->cp_x = CurVctr[0];
-                    rp->cp_y = CurVctr[1];
-                    Draw(rp, _x, _y);
-                    rp->cp_x = CurVctr[0];
-                    rp->cp_y = CurVctr[1];
-                }
-#endif
                 CurVctr = &CurVctr[2];
                 CurFlag = &CurFlag[1];
                 /*
@@ -197,23 +184,6 @@
 
             case AREAINFOFLAG_DRAW:
                 /* Draw a line to new position */
-#if 1
-                /*
-                 * Must draw from lower y's to higher ones otherwise
-                 * the fill algo does not work nicely.
-                 */
-                if(rp->cp_y <= CurVctr[1]) {
-                    Draw(rp, CurVctr[0], CurVctr[1]);
-                } else {
-                    int _x = rp->cp_x;
-                    int _y = rp->cp_y;
-                    rp->cp_x = CurVctr[0];
-                    rp->cp_y = CurVctr[1];
-                    Draw(rp, _x, _y);
-                    rp->cp_x = CurVctr[0];
-                    rp->cp_y = CurVctr[1];
-                }
-#endif
                 if(bounds.MinX > CurVctr[0])
                     bounds.MinX = CurVctr[0];
                 if(bounds.MaxX < CurVctr[0])
@@ -241,17 +211,9 @@
                 if((ULONG)rp->TmpRas->Size < BytesPerRow * (bounds.MaxY - bounds.MinY + 1))
                     return -1;
 
-                /* Draw an Ellipse and fill it */
-                /* see how the data are stored by the second entry */
-                /* I get cx,cy,cx+a,cy+b*/
-
-                DrawEllipse(rp, CurVctr[0],
-                            CurVctr[1],
-                            CurVctr[2],
-                            CurVctr[3]);
-
-                /* area-fill the ellipse with the pattern given
-                   in rp->AreaPtrn , AreaPtSz */
+                /* Build the complete filled ellipse, including its boundary,
+                   in TmpRas.  Drawing the boundary first would expose a
+                   partially rendered ellipse before the fill is blitted. */
 
                 areafillellipse(rp,
                                 &bounds,

--- a/rom/graphics/areafill.c
+++ b/rom/graphics/areafill.c
@@ -15,8 +15,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <aros/debug.h>
-
 #include "graphics_intern.h"
 
 /*
@@ -43,486 +41,195 @@ void LineInTmpRas(struct RastPort   *rp,
                   struct GfxBase    *GfxBase);
 
 
-struct BoundLine {
-    UWORD StartIndex;
-    UWORD EndIndex;
-    UWORD LeftX;
-    UWORD RightX;
-    WORD DeltaX;
-    WORD DeltaY;
-    WORD Count;
-    BOOL Valid;
-    WORD incrE;
-    WORD incrNE;
-    WORD s1;
-    WORD t;
-    WORD horiz;
-    WORD NLeftX;
-    WORD NRightX;
-};
 
-UWORD Include(UWORD lastused,
-              UWORD lastindex,
-              struct BoundLine *AreaBound,
-              UWORD scan,
-              UWORD *VctTbl)
+/* Build an even-odd polygon mask one scanline at a time.  The previous edge
+ * state machine allocated a large edge table and repeatedly sorted it while
+ * walking the polygon.  Recomputing the few active intersections is smaller
+ * and considerably faster for the small polygons used by classic software. */
+BOOL areafillpolygon(struct RastPort *rp, struct Rectangle *bounds,
+                     UWORD first_idx, UWORD last_idx, ULONG BytesPerRow,
+                     struct GfxBase *GfxBase)
 {
-    while(lastused < lastindex &&
-            VctTbl[AreaBound[lastused + 1].StartIndex + 1] == scan) {
-        /*
-            kprintf("including new one! ");
-            kprintf("(%d,%d)-(%d,%d)\n",VctTbl[AreaBound[lastused+1].StartIndex],
-                                        VctTbl[AreaBound[lastused+1].StartIndex+1],
-                                        VctTbl[AreaBound[lastused+1].EndIndex],
-                                        VctTbl[AreaBound[lastused+1].EndIndex]);
-        */
-        lastused++;
-    }
-    return lastused;
-}
+    struct AreaInfo *ai = rp->AreaInfo;
+    UWORD edges = last_idx - first_idx;
+    WORD *crossings;
+    WORD y;
 
-void FillScan(UWORD StartIndex,
-              UWORD EndIndex,
-              struct BoundLine *AreaBound,
-              UWORD scanline,
-              struct RastPort *rp,
-              struct Rectangle *bounds,
-              UWORD BytesPerRow,
-              struct GfxBase *GfxBase)
-{
-    int i = StartIndex;
-    int x1;
-    while(i < EndIndex) {
-        /* simply draw a line */
-        while(!AreaBound[i].Valid) {
-            i++;
-            if(i > EndIndex) return;
-        }
-        x1 = AreaBound[i].RightX + 1;
+    /* Filled hands, arrows, diamonds and many other classic UI shapes are
+     * convex quadrilaterals.  Drawing their four edges into TmpRas first
+     * avoids doing a signed division for every edge on every scanline. */
+    if (edges == 4) {
+        UWORD *v = &ai->VctrTbl[first_idx * 2];
+        LONG winding = 0;
+        UWORD vertex;
 
-        while(!AreaBound[i + 1].Valid) {
-            i++;
-            if(i > EndIndex) return;
-        }
+        for (vertex = 0; vertex < 4; vertex++) {
+            UWORD next = (vertex + 1) & 3;
+            UWORD after = (vertex + 2) & 3;
+            LONG ax = (WORD)v[next * 2] - (WORD)v[vertex * 2];
+            LONG ay = (WORD)v[next * 2 + 1] - (WORD)v[vertex * 2 + 1];
+            LONG bx = (WORD)v[after * 2] - (WORD)v[next * 2];
+            LONG by = (WORD)v[after * 2 + 1] - (WORD)v[next * 2 + 1];
+            LONG cross = ax * by - ay * bx;
 
-        if(x1 <= AreaBound[i + 1].LeftX - 1) {
-            LineInTmpRas(rp,
-                         bounds,
-                         BytesPerRow,
-                         x1,
-                         AreaBound[i + 1].LeftX - 1,
-                         scanline,
-                         GfxBase);
-        }
-
-        i += 2;
-    }
-}
-
-
-void XSort(UWORD StartIndex,
-           UWORD EndIndex,
-           struct BoundLine *AreaBound)
-{
-    /* a simple bubble sort */
-    struct BoundLine tmpAreaBound;
-    int i = StartIndex + 1;
-
-    //kprintf("%d,%d\n",StartIndex,EndIndex);
-
-//kprintf("%d  ",AreaBound[StartIndex].LeftX);
-
-    while(i <= EndIndex) {
-        if(AreaBound[i].LeftX < AreaBound[i - 1].LeftX) {
-            /* The one at index i needs to go more to smaller indices */
-            int i2 = i;
-            //kprintf("sorting!!\n");
-            tmpAreaBound = AreaBound[i];
-            while(TRUE) {
-                AreaBound[i2] = AreaBound[i2 - 1];
-                i2--;
-                if(i2 == StartIndex ||
-                        AreaBound[i2 - 1].LeftX <= tmpAreaBound.LeftX) {
-                    AreaBound[i2] = tmpAreaBound;
+            if (cross) {
+                if (winding && ((cross < 0) != (winding < 0)))
                     break;
-                }
+                winding = cross;
             }
         }
-        i++;
-        //kprintf("%d  ",AreaBound[i].LeftX);
 
-    }
-    //kprintf("\n");
-}
+        if (vertex == 4 && winding) {
+            LONG edge_x[4];
+            LONG edge_step[4];
+            WORD edge_min_y[4];
+            WORD edge_max_y[4];
 
+            memset(rp->TmpRas->RasPtr, 0,
+                   BytesPerRow * (bounds->MaxY - bounds->MinY + 1));
 
-UWORD UpdateXValues(UWORD StartIndex,
-                    UWORD EndIndex,
-                    UWORD scan,
-                    struct BoundLine *AreaBound,
-                    UWORD *VctTbl)
-{
-    int i = StartIndex;
-    BOOL foundvalid = FALSE;
+            for (vertex = 0; vertex < 4; vertex++) {
+                UWORD next = (vertex + 1) & 3;
+                WORD x1 = v[vertex * 2];
+                WORD y1 = v[vertex * 2 + 1];
+                WORD x2 = v[next * 2];
+                WORD y2 = v[next * 2 + 1];
 
-    while(i <= EndIndex) {
-        /* Test whether this one is still to be considered */
-        // CHANGED <= to <
-        if(VctTbl[AreaBound[i].EndIndex + 1] <=  scan ||
-                !AreaBound[i].Valid) {
-            /*
-            if (!AreaBound[i].Valid)
-              kprintf ("already marked as invalid! ");
-            else
-              kprintf("marking %d as anvalid! ",i);
-            kprintf("(%d,%d)-(%d,%d)\n",VctTbl[AreaBound[i].StartIndex],
-                                        VctTbl[AreaBound[i].StartIndex+1],
-                                        VctTbl[AreaBound[i].EndIndex],
-                                        VctTbl[AreaBound[i].EndIndex+1]);
-            */
-            AreaBound[i].Valid = FALSE;
-            if(!foundvalid)
-                StartIndex += 1;
-        } else {
-            /* It is still to be considered!! */
-            foundvalid = TRUE;
-            /* calculate the new x-coordinates for the new line */
-            if(0 == AreaBound[i].DeltaX) {
-                /* a vertical line !!! easy!! */
-                i++;
-                continue;
-            }
-
-            AreaBound[i].RightX += AreaBound[i].NRightX;
-            AreaBound[i].LeftX  += AreaBound[i].NLeftX;
-            AreaBound[i].NRightX = 0;
-            AreaBound[i].NLeftX  = 0;
-            /*
-             * If we're moving more in the horizontal
-             * than in the vertical, then the line
-             * has a pure horizontal component which I
-             * must take care of by not painting over it.
-             * This means that on a y coordinate the line
-             * can go from the LeftX to the RightX.
-             */
-            if(1 == AreaBound[i].horiz) {
-                /*
-                 * More towards the horizontal than down
-                 */
-                if(AreaBound[i].s1 > 0) {
-                    AreaBound[i].LeftX  = AreaBound[i].RightX;
+                if (y1 < y2) {
+                    edge_min_y[vertex] = y1;
+                    edge_max_y[vertex] = y2;
+                    edge_x[vertex] = (LONG)x1 * 65536;
+                    edge_step[vertex] =
+                        ((LONG)(x2 - x1) * 65536) / (y2 - y1);
+                } else if (y2 < y1) {
+                    edge_min_y[vertex] = y2;
+                    edge_max_y[vertex] = y1;
+                    edge_x[vertex] = (LONG)x2 * 65536;
+                    edge_step[vertex] =
+                        ((LONG)(x1 - x2) * 65536) / (y1 - y2);
                 } else {
-                    AreaBound[i].RightX = AreaBound[i].LeftX;
+                    edge_min_y[vertex] = y1;
+                    edge_max_y[vertex] = y1;
+                    edge_x[vertex] = (LONG)x1 * 65536;
+                    edge_step[vertex] = 0;
                 }
             }
 
+            for (y = bounds->MinY; y <= bounds->MaxY; y++) {
+                LONG left = 0x7fffffff;
+                LONG right = -0x7fffffff;
 
-            while(1) {
-                if(AreaBound[i].Count <= 0) {
-                    AreaBound[i].Count += AreaBound[i].incrE;
-                    if(1 == AreaBound[i].t) {
-                        if(AreaBound[i].s1 > 0) {
-                            /*
-                             * Towards right
-                             */
-                            AreaBound[i].RightX++;
-                        } else {
-                            /*
-                             * Towards left
-                             */
-                            AreaBound[i].LeftX--;
-                        }
-                    } else {
-                        /*
-                         * Going to next Y coordinate
-                         */
-                        break;
+                for (vertex = 0; vertex < 4; vertex++) {
+                    if (y >= edge_min_y[vertex] &&
+                        y < edge_max_y[vertex]) {
+                        if (edge_x[vertex] < left)
+                            left = edge_x[vertex];
+                        if (edge_x[vertex] > right)
+                            right = edge_x[vertex];
+                        edge_x[vertex] += edge_step[vertex];
                     }
-                } else {
-                    AreaBound[i].Count += AreaBound[i].incrNE;
-                    /*
-                     * Going to next Y coordinate
-                     */
-                    if(AreaBound[i].s1 > 0) {
-                        /*
-                         * Towards right
-                         */
-                        AreaBound[i].NRightX = 1;
-                    } else {
-                        /*
-                         * Towards left
-                         */
-                        AreaBound[i].NLeftX = -1;
-                    }
-                    break;
                 }
-            } /* while (1) */
 
-            /*
-             * If we're going more vertical than horizontal
-             * then the left and right are always the same.
-             */
-            if(0 == AreaBound[i].horiz) {
-                if(AreaBound[i].s1 > 0) {
-                    /*
-                      AreaBound[i].RightX += AreaBound[i].NRightX;
-                      AreaBound[i].NRightX = 0;
-                     */
-                    AreaBound[i].LeftX  = AreaBound[i].RightX;
-                } else {
-                    /*
-                      AreaBound[i].LeftX += AreaBound[i].NLeftX;
-                      AreaBound[i].NLeftX = 0;
-                     */
-                    AreaBound[i].RightX = AreaBound[i].LeftX;
-                }
+                if (left <= right)
+                    LineInTmpRas(rp, bounds, BytesPerRow,
+                                 left >> 16, right >> 16, y, GfxBase);
             }
+
+            areaoutlinepolygonmask(rp, bounds, first_idx, last_idx,
+                                   BytesPerRow);
+            return TRUE;
         }
-        i++;
     }
 
-    return StartIndex;
-}
-
-/* functions for filling of the RastPort */
-BOOL areafillpolygon(struct RastPort   *rp,
-                     struct Rectangle *bounds,
-                     UWORD              first_idx,
-                     UWORD              last_idx,
-                     ULONG              BytesPerRow,
-                     struct GfxBase    *GfxBase)
-{
-    int i, c;
-    UWORD StartEdge = 1;
-    UWORD EndEdge = 1;
-    WORD LastIndex;
-    UWORD ymin;
-    UWORD LastEdge = last_idx - first_idx + 1; // needed later on. Don't change!!
-    struct AreaInfo *areainfo = rp->AreaInfo;
-    UWORD *StartVctTbl = &areainfo->VctrTbl[first_idx * 2];
-    UWORD scan;
-    struct BoundLine tmpAreaBound;
-    struct BoundLine *AreaBound =
-        (struct BoundLine *) AllocMem(sizeof(struct BoundLine) * LastEdge,
-                                      MEMF_CLEAR);
-
-    if(NULL == AreaBound)
+    crossings = AllocMem(sizeof(*crossings) * edges, MEMF_ANY);
+    if (!crossings)
         return FALSE;
 
-    /* first clear the buffer of the temporary rastport as far as necessary  */
-
-    memset(rp->TmpRas->RasPtr,
-           0,
+    memset(rp->TmpRas->RasPtr, 0,
            BytesPerRow * (bounds->MaxY - bounds->MinY + 1));
 
-    /*
-      kprintf("first: %d, last: %d\n",first_idx,last_idx);
-      kprintf("(%d,%d)-(%d,%d)\n",bounds->MinX,bounds->MinY,
-                                  bounds->MaxX,bounds->MaxY);
-      kprintf("width: %d, bytesperrow: %d\n",bounds->MaxX - bounds->MinX + 1,
-                                             BytesPerRow);
-    */
-    /* I need a list of sorted indices that represent the lines of the
-    ** polygon. Horizontal lines don't go into that list!!!
-    ** The lines are sorted by their start-y coordinates.
-    */
+    for (y = bounds->MinY; y <= bounds->MaxY; y++) {
+        UWORD count = 0;
+        UWORD edge;
 
-    i = -1;
-    c = 0;
+        for (edge = first_idx; edge < last_idx; edge++) {
+            WORD x1 = ai->VctrTbl[edge * 2];
+            WORD y1 = ai->VctrTbl[edge * 2 + 1];
+            WORD x2 = ai->VctrTbl[(edge + 1) * 2];
+            WORD y2 = ai->VctrTbl[(edge + 1) * 2 + 1];
 
-    /* process all points of the polygon */
-    while(c < (LastEdge - 1) * 2) {
-        int i2;
-        /* is the next one starting point of a horizontal line??? If yes,
-           then skip it */
-        /*
-            kprintf("current idx for y: %d, next idx for y: %d\n",c+1,c+3);
-        */
-        if(StartVctTbl[c + 1] == StartVctTbl[c + 3]) {
-//      kprintf("Found horizontal Line!!\n");
-            c += 2;
-            continue;
+            if (y1 == y2 || y < (y1 < y2 ? y1 : y2) ||
+                y >= (y1 > y2 ? y1 : y2))
+                continue;
+
+            crossings[count++] = x1 +
+                ((LONG)(y - y1) * (x2 - x1)) / (y2 - y1);
         }
 
-        /* which coordinate of this line has the lower y value */
-        if(StartVctTbl[c + 1] < StartVctTbl[c + 3]) {
-            tmpAreaBound.StartIndex = c;
-            tmpAreaBound.EndIndex   = c + 2;
-            ymin = StartVctTbl[c + 1];
-        } else {
-            tmpAreaBound.StartIndex = c + 2;
-            tmpAreaBound.EndIndex   = c;
-            ymin = StartVctTbl[c + 3];
-        }
-
-        /*
-            kprintf("line: (%d,%d)-(%d,%d)  ",StartVctTbl[c],
-                                              StartVctTbl[c+1],
-                                              StartVctTbl[c+2],
-                                              StartVctTbl[c+3]);
-            kprintf("miny: %d\n",ymin);
-        */
-        i2 = 0;
-        /*
-        ** search for the place where to put this entry into the sorted
-        ** (increasing start y-coordinates) list
-        */
-        if(i > -1) {
-            while(TRUE) {
-                /*
-                kprintf("ymin: %d< %d?\n",ymin,StartVctTbl[AreaBound[i2].StartIndex+1]);
-                */
-                if(ymin < StartVctTbl[AreaBound[i2].StartIndex + 1]) {
-                    int i3 = i + 1;
-                    /* found the place! */
-                    while(i3 > i2) {
-                        /*
-                        kprintf("moving!\n");
-                        */
-                        AreaBound[i3].StartIndex = AreaBound[i3 - 1].StartIndex;
-                        AreaBound[i3].EndIndex   = AreaBound[i3 - 1].EndIndex;
-                        i3--;
-                    }
-                    AreaBound[i2].StartIndex = tmpAreaBound.StartIndex;
-                    AreaBound[i2].EndIndex   = tmpAreaBound.EndIndex;
-                    break;
-                }
-                i2++;
-                if(i2 > i) {
-                    /*
-                    kprintf("at end!\n");
-                    */
-                    AreaBound[i + 1].StartIndex = tmpAreaBound.StartIndex;
-                    AreaBound[i + 1].EndIndex   = tmpAreaBound.EndIndex;
-                    break;
-                }
+        for (edge = 1; edge < count; edge++) {
+            WORD value = crossings[edge];
+            WORD pos = edge;
+            while (pos && crossings[pos - 1] > value) {
+                crossings[pos] = crossings[pos - 1];
+                pos--;
             }
-        } else { /* first one to insert into list */
-            AreaBound[0].StartIndex = tmpAreaBound.StartIndex;
-            AreaBound[0].EndIndex   = tmpAreaBound.EndIndex;
+            crossings[pos] = value;
         }
-        c += 2;
-        i++;
+
+        for (edge = 0; edge + 1 < count; edge += 2)
+            LineInTmpRas(rp, bounds, BytesPerRow,
+                         crossings[edge], crossings[edge + 1], y, GfxBase);
     }
 
-    LastIndex = i;
-    i = 0;
-
-    /*
-      {
-        int i2 = 0;
-        while (i2 <= LastIndex)
-        {
-          kprintf("%d.: index %d (%d,%d)-(%d,%d)\n",i2,AreaBound[i2].StartIndex,
-                                   StartVctTbl[AreaBound[i2].StartIndex],
-                                   StartVctTbl[AreaBound[i2].StartIndex+1],
-                                   StartVctTbl[AreaBound[i2].EndIndex],
-                                   StartVctTbl[AreaBound[i2].EndIndex+1]);
-          i2++;
-        }
-      }
-    */
-
-    while(i <= LastIndex) {
-        int StartIndex = AreaBound[i].StartIndex;
-        int EndIndex   = AreaBound[i].EndIndex;
-
-        if((StartVctTbl[EndIndex] - StartVctTbl[StartIndex]) > 0) {
-            AreaBound[i].s1 = 1;
-        } else {
-            AreaBound[i].s1 = -1;
-        }
-
-        AreaBound[i].DeltaX = abs(StartVctTbl[EndIndex] -
-                                  StartVctTbl[StartIndex]);
-
-        AreaBound[i].DeltaY = abs(StartVctTbl[EndIndex + 1] -
-                                  StartVctTbl[StartIndex + 1]);
-
-        if(AreaBound[i].DeltaX > AreaBound[i].DeltaY) {
-            AreaBound[i].horiz = 1;
-        }
-
-
-        if(AreaBound[i].DeltaX < AreaBound[i].DeltaY) {
-            WORD d = AreaBound[i].DeltaX;
-            AreaBound[i].DeltaX = AreaBound[i].DeltaY;
-            AreaBound[i].DeltaY = d;
-            AreaBound[i].t = 0;
-        } else {
-            AreaBound[i].t = 1;
-        }
-
-        AreaBound[i].Count = (AreaBound[i].DeltaY * 2) - AreaBound[i].DeltaX;
-        AreaBound[i].incrE  =  AreaBound[i].DeltaY * 2;
-        AreaBound[i].incrNE = (AreaBound[i].DeltaY - AreaBound[i].DeltaX) * 2;
-
-        AreaBound[i].LeftX = AreaBound[i].RightX = StartVctTbl[StartIndex];
-        AreaBound[i].Valid = TRUE;
-        i++;
-    }
-
-    /* indexlist now contains i+1 indices into the vector table.
-       Either the coordinate at the index as declared in the indexlist
-       contains the lower y value or the following coordinate */
-
-    scan = bounds->MinY;
-
-    LastIndex = i;
-
-    StartEdge = 0;
-    EndEdge = Include(1, LastIndex, AreaBound, scan, StartVctTbl);
-    StartEdge = UpdateXValues(StartEdge, EndEdge, scan, AreaBound, StartVctTbl);
-
-    while(scan < bounds->MaxY) {
-        XSort(StartEdge, EndEdge, AreaBound);
-
-        if(scan > bounds->MinY)
-            FillScan(StartEdge,
-                     EndEdge,
-                     AreaBound,
-                     scan,
-                     rp,
-                     bounds,
-                     BytesPerRow,
-                     GfxBase);
-
-        /*
-            kprintf("scanline: %d   StartEdge: %d, EndEdge: %d\n",scan,StartEdge,EndEdge);
-
-            {
-              int x = StartEdge;
-              while (x <= EndEdge)
-              {
-                if (AreaBound[x].Valid)
-                {
-                  kprintf("(%d,%d)-(%d,%d) currently at: Left: %d Right: %d\n",
-                              StartVctTbl[AreaBound[x].StartIndex],
-                              StartVctTbl[AreaBound[x].StartIndex+1],
-                              StartVctTbl[AreaBound[x].EndIndex],
-                              StartVctTbl[AreaBound[x].EndIndex+1],
-                              AreaBound[x].LeftX,
-                              AreaBound[x].RightX);
-                }
-                else
-                  kprintf("invalid\n");
-                x++;
-              }
-            }
-        */
-        scan++;
-        EndEdge = Include(EndEdge, LastIndex, AreaBound, scan, StartVctTbl);
-        StartEdge = UpdateXValues(StartEdge, EndEdge, scan, AreaBound, StartVctTbl);
-        /*
-            kprintf("StartEdge: %d, EndEdge: %d\n",StartEdge,EndEdge);
-        */
-    }
-
-    FreeMem(AreaBound, sizeof(struct BoundLine) * LastEdge);
-
+    FreeMem(crossings, sizeof(*crossings) * edges);
+    areaoutlinepolygonmask(rp, bounds, first_idx, last_idx, BytesPerRow);
     return TRUE;
 }
 
+/* Add the polygon boundary to the mask built by areafillpolygon().  Keeping
+ * both the interior and its edge in TmpRas lets AreaEnd apply a normal filled
+ * polygon with one BltPattern instead of rendering every edge separately. */
+void areaoutlinepolygonmask(struct RastPort *rp, struct Rectangle *bounds,
+                            UWORD first_idx, UWORD last_idx,
+                            ULONG BytesPerRow)
+{
+    UWORD *v = rp->AreaInfo->VctrTbl;
+    UWORD idx;
+
+    for (idx = first_idx; idx < last_idx; idx++) {
+        WORD x = v[idx * 2];
+        WORD y = v[idx * 2 + 1];
+        WORD x2 = v[(idx + 1) * 2];
+        WORD y2 = v[(idx + 1) * 2 + 1];
+        WORD dx = x2 >= x ? x2 - x : x - x2;
+        WORD dy = y2 >= y ? y2 - y : y - y2;
+        WORD sx = x < x2 ? 1 : -1;
+        WORD sy = y < y2 ? 1 : -1;
+        WORD error = dx - dy;
+
+        for (;;) {
+            ULONG rx = (UWORD)(x - bounds->MinX);
+            ULONG ry = (UWORD)(y - bounds->MinY);
+            UBYTE *byte = (UBYTE *)rp->TmpRas->RasPtr +
+                          ry * BytesPerRow + (rx >> 3);
+            *byte |= 0x80 >> (rx & 7);
+
+            if (x == x2 && y == y2)
+                break;
+            {
+                WORD twice = error << 1;
+                if (twice > -dy) {
+                    error -= dy;
+                    x += sx;
+                }
+                if (twice < dx) {
+                    error += dx;
+                    y += sy;
+                }
+            }
+        }
+    }
+}
 
 void areafillellipse(struct RastPort   *rp,
                      struct Rectangle *bounds,
@@ -543,28 +250,22 @@ void areafillellipse(struct RastPort   *rp,
     memset(rp->TmpRas->RasPtr,
            0x00,
            BytesPerRow * (bounds->MaxY - bounds->MinY + 1));
-    /*
-    kprintf("filled bytes: %d\n",BytesPerRow * (bounds->MaxY - bounds->MinY + 1));
-
-    kprintf("Filling ellipse with center at (%d,%d) and radius in x: %d and in y: %d\n",
-                                CurVctr[0],CurVctr[1],CurVctr[2],CurVctr[3]);
-    */
     while(d2 < 0 && y < CurVctr[3]) {
         /* draw 2 lines using symmetry */
-        if(x > 1) {
+        if(x >= 0) {
             LineInTmpRas(rp,
                          bounds,
                          BytesPerRow,
-                         CurVctr[0] - x + 1,
-                         CurVctr[0] + x - 1,
+                         CurVctr[0] - x,
+                         CurVctr[0] + x,
                          CurVctr[1] - y,
                          GfxBase);
 
             LineInTmpRas(rp,
                          bounds,
                          BytesPerRow,
-                         CurVctr[0] - x + 1,
-                         CurVctr[0] + x - 1,
+                         CurVctr[0] - x,
+                         CurVctr[0] + x,
                          CurVctr[1] + y,
                          GfxBase);
         }
@@ -588,20 +289,20 @@ void areafillellipse(struct RastPort   *rp,
         x--;         /* always move left here */
         t8 = t8 - t6;
         if(d2 < 0) { /* move up and left */
-            if(x > 1) {
+            if(x >= 0) {
                 LineInTmpRas(rp,
                              bounds,
                              BytesPerRow,
-                             CurVctr[0] - x + 1,
-                             CurVctr[0] + x - 1,
+                             CurVctr[0] - x,
+                             CurVctr[0] + x,
                              CurVctr[1] - y,
                              GfxBase);
 
                 LineInTmpRas(rp,
                              bounds,
                              BytesPerRow,
-                             CurVctr[0] - x + 1,
-                             CurVctr[0] + x - 1,
+                             CurVctr[0] - x,
+                             CurVctr[0] + x,
                              CurVctr[1] + y,
                              GfxBase);
             } else
@@ -635,14 +336,10 @@ void LineInTmpRas(struct RastPort   *rp,
     UWORD *RasPtr = (WORD *)rp->TmpRas->RasPtr;
     ULONG  shift;
 
-//kprintf("(%d/%d) to (%d/%d)\n",xleft,y,xright,y);
-
     /* adjust the coordinates */
     xleft  -= bounds->MinX;
     xright -= bounds->MinX;
     y      -= bounds->MinY;
-
-    //kprintf("line from %d to %d y = %d\n",xleft,xright,y);
 
     if(xleft > xright) return;
     /*
@@ -673,7 +370,6 @@ void LineInTmpRas(struct RastPort   *rp,
     PixelMask2 = PixelMask2 << 8 | PixelMask2 >> 8;
 #endif
     RasPtr[index] |= PixelMask2;
-//    kprintf("%x (left)\n",PixelMask2);
 
     index++;
 
@@ -705,7 +401,6 @@ fillright:
 #endif
 
         RasPtr[index] |= PixelMask2;
-//        kprintf("%x (right)\n",PixelMask2);
     }
 
 }
@@ -733,4 +428,3 @@ void areaclosepolygon(struct AreaInfo *areainfo)
         }
     }
 }
-

--- a/rom/graphics/bltpattern.c
+++ b/rom/graphics/bltpattern.c
@@ -99,29 +99,59 @@ static ULONG bltpattern_render(APTR bpr_data, WORD srcx, WORD srcy,
     AROS_LIBFUNC_INIT
 
     if(rp->AreaPtrn) {
-        struct bp_render_data   bprd;
-        struct Rectangle        rr;
+        BOOL solidpattern = FALSE;
 
-        FIX_GFXCOORD(xMin);
-        FIX_GFXCOORD(yMin);
+        /* A solid, non-inverted area pattern plus a mask is a template blit.
+         * The native Amiga bitmap class accelerates masked templates with the
+         * blitter, while its pattern method cannot accelerate masked input. */
+        if(mask && rp->AreaPtSz >= 0 && !(rp->DrawMode & INVERSVID)) {
+            UWORD rows = 1U << rp->AreaPtSz;
+            UWORD row;
 
-        bprd.pattern        = (UBYTE *)rp->AreaPtrn;
-        bprd.mask           = mask;
-        bprd.maskmodulo     = byteCnt;
-        bprd.patterndepth   = (rp->AreaPtSz >= 0) ? 1 : rp->BitMap->Depth;
-        bprd.patternheight  = 1L << ((rp->AreaPtSz >= 0) ? rp->AreaPtSz : -rp->AreaPtSz);
-        bprd.renderx1       = xMin;
-        bprd.rendery1       = yMin;
-        bprd.invertpattern  = (rp->DrawMode & INVERSVID) ? TRUE : FALSE;
-        bprd.pixlut.entries = bprd.patterndepth;
-        bprd.pixlut.pixels  = IS_HIDD_BM(rp->BitMap) ? HIDD_BM_PIXTAB(rp->BitMap) : NULL;
+            solidpattern = TRUE;
+            for(row = 0; row < rows; row++) {
+                if(((UWORD *)rp->AreaPtrn)[row] != 0xffff) {
+                    solidpattern = FALSE;
+                    break;
+                }
+            }
+        }
 
-        rr.MinX = xMin;
-        rr.MinY = yMin;
-        rr.MaxX = xMax;
-        rr.MaxY = yMax;
+        if(solidpattern) {
+            ULONG old_drawmode = GetDrMd(rp);
 
-        do_render_func(rp, NULL, &rr, bltpattern_render, &bprd, TRUE, FALSE, GfxBase);
+            if((old_drawmode & ~INVERSVID) == JAM2)
+                SetDrMd(rp, JAM1);
+
+            BltTemplate(mask, 0, byteCnt, rp, xMin, yMin,
+                        xMax - xMin + 1, yMax - yMin + 1);
+            SetDrMd(rp, old_drawmode);
+        } else {
+            struct bp_render_data   bprd;
+            struct Rectangle        rr;
+
+            FIX_GFXCOORD(xMin);
+            FIX_GFXCOORD(yMin);
+
+            bprd.pattern        = (UBYTE *)rp->AreaPtrn;
+            bprd.mask           = mask;
+            bprd.maskmodulo     = byteCnt;
+            bprd.patterndepth   = (rp->AreaPtSz >= 0) ? 1 : rp->BitMap->Depth;
+            bprd.patternheight  = 1L << ((rp->AreaPtSz >= 0) ? rp->AreaPtSz : -rp->AreaPtSz);
+            bprd.renderx1       = xMin;
+            bprd.rendery1       = yMin;
+            bprd.invertpattern  = (rp->DrawMode & INVERSVID) ? TRUE : FALSE;
+            bprd.pixlut.entries = bprd.patterndepth;
+            bprd.pixlut.pixels  = IS_HIDD_BM(rp->BitMap) ? HIDD_BM_PIXTAB(rp->BitMap) : NULL;
+
+            rr.MinX = xMin;
+            rr.MinY = yMin;
+            rr.MaxX = xMax;
+            rr.MaxY = yMax;
+
+            do_render_func(rp, NULL, &rr, bltpattern_render, &bprd,
+                           TRUE, FALSE, GfxBase);
+        }
     } else {
         if(mask) {
             ULONG old_drawmode = GetDrMd(rp);

--- a/rom/graphics/graphics_intern.h
+++ b/rom/graphics/graphics_intern.h
@@ -329,6 +329,12 @@ BOOL areafillpolygon(struct RastPort   *rp,
                      ULONG              bytesperrow,
                      struct GfxBase    *GfxBase);
 
+void areaoutlinepolygonmask(struct RastPort   *rp,
+                            struct Rectangle *bounds,
+                            UWORD              first_idx,
+                            UWORD              last_idx,
+                            ULONG              bytesperrow);
+
 void areafillellipse(struct RastPort    *rp,
                      struct Rectangle   *bounds,
                      UWORD              *CurVctr,


### PR DESCRIPTION
- Initialize system time from the boot volume when no battery-backed clock is available, fixing Clock continuously redrawing with an invalid time.
- Rework area filling to compose shapes before rendering and substantially reduce the visible incremental drawing of Clock circles and hands.
- Add an accelerated m68k Amiga path for masked area patterns.
- Improve console cursor and text-selection rendering behavior.

This fixes the Clock app from Workbench 3.1

Before:

https://github.com/user-attachments/assets/ae197b83-5f78-4c23-be26-4c079eaf6eee


After:

https://github.com/user-attachments/assets/3518b7a4-3b6b-4bc4-9baa-7f30019431e0






