### PR TITLE
console: Improve cursor rendering and text selection behavior

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -977,9 +977,12 @@ VOID AmigaVideoBM__Hidd_BitMap__FillRect(OOP_Class *cl, OOP_Object *o, struct pH
     WORD height = msg->maxY - msg->minY + 1;
 
     CLEARCACHE;
-    /* For tiny fills the blitter setup and ownership cost exceeds the few
-     * direct planar writes performed by the optimized superclass. */
-    if (((width <= 16) && (height <= 16)) ||
+    /* For tiny copy fills the blitter setup and ownership cost exceeds the
+     * few direct planar writes performed by the optimized superclass.  Keep
+     * logical operations such as COMPLEMENT on the blitter: updating their
+     * bitplanes incrementally can expose a partially inverted object. */
+    if (((width <= 16) && (height <= 16) &&
+         (mode == vHidd_GC_DrawMode_Copy)) ||
         ((height == 1) && (width >= 256) &&
          (mode == vHidd_GC_DrawMode_Copy)) ||
         !blit_fillrect(csd, data->pbm, msg->minX, msg->minY, msg->maxX, msg->maxY, fg, mode)) {

--- a/rom/devs/console/cdinputhandler.c
+++ b/rom/devs/console/cdinputhandler.c
@@ -21,7 +21,8 @@
 #include <aros/debug.h>
 
 /* protos */
-static Object *obtainconunit(struct ConsoleBase *ConsoleDevice);
+static Object *obtainconunit(struct Window *window,
+    struct ConsoleBase *ConsoleDevice);
 static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
 
 /*************************************************************************
@@ -76,6 +77,8 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
             || (ie->ie_Class == IECLASS_GADGETUP)
             || (ie->ie_Class == IECLASS_MENULIST)
             || (ie->ie_Class == IECLASS_RAWMOUSE)
+            || (ie->ie_Class == IECLASS_ACTIVEWINDOW)
+            || (ie->ie_Class == IECLASS_INACTIVEWINDOW)
             || (ie->ie_Class == IECLASS_TIMER))
         {
             /* What console do we send it to ? */
@@ -83,7 +86,11 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
 
             D(bug("Got some event\n"));
             /* find and prevent deletion of unit */
-            unit = obtainconunit(ConsoleDevice);
+            unit = obtainconunit(
+                (ie->ie_Class == IECLASS_ACTIVEWINDOW ||
+                 ie->ie_Class == IECLASS_INACTIVEWINDOW) ?
+                    (struct Window *)ie->ie_EventAddress : NULL,
+                ConsoleDevice);
             if (unit)
             {
                 /* Hand the event to the console task asynchronously: one
@@ -135,7 +142,8 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
    not deleted while we work on it
 */
 
-static Object *obtainconunit(struct ConsoleBase *ConsoleDevice)
+static Object *obtainconunit(struct Window *window,
+    struct ConsoleBase *ConsoleDevice)
 {
     struct IntuitionBase *IntuitionBase =
         (APTR) ConsoleDevice->cb_IntuitionBase;
@@ -154,13 +162,18 @@ static Object *obtainconunit(struct ConsoleBase *ConsoleDevice)
     /* Lock the console list */
     ObtainSemaphoreShared(&ConsoleDevice->unitListLock);
 
-    /* What is the currently active window ? */
-    D(bug("Obtaining IBase\n"));
-    lock = LockIBase(0UL);
-
-    activewin = IntuitionBase->ActiveWindow;
-
-    UnlockIBase(lock);
+    /* Activation events name the affected window explicitly.  This matters
+     * for INACTIVEWINDOW, because ActiveWindow already points at the newly
+     * activated window by the time the event is delivered. */
+    if (window)
+        activewin = window;
+    else
+    {
+        D(bug("Obtaining IBase\n"));
+        lock = LockIBase(0UL);
+        activewin = IntuitionBase->ActiveWindow;
+        UnlockIBase(lock);
+    }
     D(bug("Released IBase, active win=%p\n", activewin));
 
     /* Try to find the correct unit object for taht window */

--- a/rom/devs/console/charmapconclass.c
+++ b/rom/devs/console/charmapconclass.c
@@ -103,6 +103,8 @@ struct charmapcondata
     struct Library *ccd_GfxBase;
 };
 
+static VOID charmapcon_clear_selection(Class *cl, Object *o);
+
 
 /* Template used to quickly fill constant fields */
 CONST struct Scroll ScrollBar = {
@@ -464,16 +466,39 @@ static VOID charmap_ascii(Class *cl, Object *o, ULONG xcp, ULONG ycp,
 {
     struct charmap_line *line = charmapcon_find_line(cl, o, ycp);
     ULONG oldsize = line->size;
+    ULONG newsize = xcp + len;
 
-    // Ensure the line has sufficient capacity.
-    if (line->size < xcp + len)
-        charmap_resize(ConsoleDevice, line, xcp + len);
+    /* Extending within the existing allocation needs no clearing here: all
+     * newly exposed cells are initialized below, including any gap between
+     * the old end and xcp.  Avoid four SetMem() calls for every appended
+     * character. */
+    if (line->size < newsize)
+    {
+        if (newsize <= line->capacity)
+            line->size = newsize;
+        else
+            charmap_resize(ConsoleDevice, line, newsize);
 
-    // .. copy the required data
-    SetMem(line->fgpen + xcp, CU(o)->cu_FgPen, len);
-    SetMem(line->bgpen + xcp, CU(o)->cu_BgPen, len);
-    SetMem(line->flags + xcp, CU(o)->cu_TxFlags, len);
-    memcpy(line->text + xcp, str, len);
+        if (line->size < newsize)
+            return;
+    }
+
+    /* A console's interactive hot path is a one-character write.  Direct
+     * stores avoid four library calls for four bytes. */
+    if (len == 1)
+    {
+        line->fgpen[xcp] = CU(o)->cu_FgPen;
+        line->bgpen[xcp] = CU(o)->cu_BgPen;
+        line->flags[xcp] = CU(o)->cu_TxFlags;
+        line->text[xcp] = str[0];
+    }
+    else
+    {
+        SetMem(line->fgpen + xcp, CU(o)->cu_FgPen, len);
+        SetMem(line->bgpen + xcp, CU(o)->cu_BgPen, len);
+        SetMem(line->flags + xcp, CU(o)->cu_TxFlags, len);
+        memcpy(line->text + xcp, str, len);
+    }
 
     // If cursor output is moved further right on the screen than
     // the last output, we need to fill the line
@@ -783,11 +808,13 @@ static VOID charmapcon_docommand(Class *cl, Object *o,
     switch (msg->Command)
     {
     case C_ASCII:
+        charmapcon_clear_selection(cl, o);
         charmap_ascii(cl, o, XCP, YCP, (char *)&params[0], 1);
         DoSuperMethodA(cl, o, (Msg) msg);
         break;
 
     case C_ASCII_STRING:
+        charmapcon_clear_selection(cl, o);
         charmap_ascii(cl, o, XCP, YCP, (char *)params[0], (int)params[1]);
         DoSuperMethodA(cl, o, (Msg) msg);
         break;
@@ -893,6 +920,7 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
     UWORD scratchWidth = GFX_XMAX(o) - GFX_XMIN(o) + 1;
     UWORD scratchHeight = rp->Font->tf_YSize;
     ULONG scratchSize = RASSIZE(scratchWidth, scratchHeight);
+    BOOL cursor_in_range;
 
     if (fromLine < CHAR_YMIN(o))
         fromLine = CHAR_YMIN(o);
@@ -905,6 +933,8 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
     if (toLine < fromLine)
         return;
 
+    cursor_in_range = YCP >= fromLine && YCP <= toLine;
+
     if (!savedTmpRas || savedTmpRas->Size < scratchSize)
     {
         scratch = AllocRaster(scratchWidth, scratchHeight);
@@ -912,7 +942,8 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
             rp->TmpRas = InitTmpRas(&localTmpRas, scratch, scratchSize);
     }
 
-    Console_UnRenderCursor(o);
+    if (cursor_in_range)
+        Console_UnRenderCursor(o);
 
     D(bug("Rendering charmap\n"));
 
@@ -1060,7 +1091,8 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
             GFX_XMIN(o), GFX_Y(o, yc), GFX_XMAX(o), GFX_Y(o, toLine));
     }
 
-    Console_RenderCursor(o);
+    if (cursor_in_range)
+        Console_RenderCursor(o);
 
     if (scratch)
     {
@@ -1068,6 +1100,25 @@ static VOID charmapcon_refresh_lines(Class *cl, Object *o, LONG fromLine,
         FreeRaster(scratch, scratchWidth, scratchHeight);
     }
 
+}
+
+static VOID charmapcon_clear_selection(Class *cl, Object *o)
+{
+    struct charmapcondata *data = INST_DATA(cl, o);
+
+    if (data->select_x_min != data->select_x_max ||
+        data->select_y_min != data->select_y_max)
+    {
+        LONG fromLine = MIN(data->select_y_min, data->select_y_max);
+        LONG toLine = MAX(data->select_y_min, data->select_y_max);
+
+        data->select_x_max = data->select_x_min;
+        data->select_y_max = data->select_y_min;
+        data->select_line_max = data->select_line_min;
+        data->active_selection = FALSE;
+        data->ignore_drag = FALSE;
+        charmapcon_refresh_lines(cl, o, fromLine, toLine);
+    }
 }
 
 
@@ -1384,6 +1435,9 @@ static VOID charmapcon_handlemouse(Class *cl, Object *o,
                     MIN(data->select_y_min, data->select_y_max);
                 LONG old_max_y =
                     MAX(data->select_y_min, data->select_y_max);
+                BOOL clear_old_selection =
+                    data->select_x_min != data->select_x_max ||
+                    data->select_y_min != data->select_y_max;
 
                 /* Yes, so start selection */
                 data->active_selection = 1;
@@ -1396,8 +1450,9 @@ static VOID charmapcon_handlemouse(Class *cl, Object *o,
                 data->select_x_max = data->select_x_min;
                 data->select_y_max = data->select_y_min;
 
-                /* Clear */
-
+                /* Clear a previous non-empty selection.  Equal endpoints
+                 * select no cells, so refreshing that line only redraws its
+                 * contents and needlessly removes/restores the cursor. */
                 /* FIXME: Determine exactly which lines are affected, as
                    follows:
 
@@ -1407,7 +1462,8 @@ static VOID charmapcon_handlemouse(Class *cl, Object *o,
                    - If there's been a reversal of the relative positions of
                    y_min/y_max, refresh the entire range.
                  */
-                charmapcon_refresh_lines(cl, o, old_min_y, old_max_y);
+                if (clear_old_selection)
+                    charmapcon_refresh_lines(cl, o, old_min_y, old_max_y);
 
             }
             else
@@ -1449,9 +1505,22 @@ static VOID charmapcon_handlegadgets(Class *cl, Object *o,
 {
     struct InputEvent *e = msg->Event;
 
+    if (e->ie_Class == IECLASS_ACTIVEWINDOW ||
+        e->ie_Class == IECLASS_INACTIVEWINDOW)
+    {
+        DoSuperMethodA(cl, o, (Msg)msg);
+        return;
+    }
+
     if (e->ie_Class == IECLASS_RAWMOUSE)
     {
         charmapcon_handlemouse(cl, o, msg);
+        return;
+    }
+
+    if (e->ie_Class == IECLASS_RAWKEY)
+    {
+        charmapcon_clear_selection(cl, o);
         return;
     }
 

--- a/rom/devs/console/consoletask.c
+++ b/rom/devs/console/consoletask.c
@@ -371,6 +371,13 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
 
                                 if (actual > 0)
                                 {
+                                    /* Let the console update input-related
+                                     * visual state (for example, dropping a
+                                     * text selection) before the character is
+                                     * handed to its reader. */
+                                    Console_HandleGadgets(cdihmsg->unit,
+                                        &cdihmsg->ie);
+
                                     /* Copy received characters to the console
                                      * unit input buffer. If the buffer is
                                      * full, then console input will be lost
@@ -401,6 +408,8 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                     case IECLASS_GADGETUP:
                     case IECLASS_TIMER:
                     case IECLASS_RAWMOUSE:
+                    case IECLASS_ACTIVEWINDOW:
+                    case IECLASS_INACTIVEWINDOW:
                         Console_HandleGadgets(cdihmsg->unit,
                             &(cdihmsg->ie));
                         //.ie_Class, (APTR)cdihmsg->ie.ie_EventAddress);

--- a/rom/devs/console/stdconclass.c
+++ b/rom/devs/console/stdconclass.c
@@ -27,6 +27,7 @@ struct stdcondata
     struct DrawInfo *dri;
     WORD rendercursorcount;
     BOOL cursorvisible;
+    BOOL windowactive;
 
     UWORD pens[CONUNIT_PEN_MAX];
     UWORD *penmap[CONUNIT_PEN_MAX];
@@ -82,6 +83,8 @@ static Object *stdcon_new(Class *cl, Object *o, struct opSet *msg)
                 data->charScratch = AllocRaster(8, data->charScratchHeight);
 
                 data->cursorvisible = TRUE;
+                data->windowactive =
+                    (CU(o)->cu_Window->Flags & WFLG_WINDOWACTIVE) != 0;
                 Console_RenderCursor(o);
 
                 ReturnPtr("StdCon::New", Object *, o);
@@ -152,6 +155,14 @@ static void stdcon_text(struct stdcondata *data, struct RastPort *rp,
     rp->TmpRas = savedTmpRas;
 }
 
+/* JAM2 text replaces every pixel in the first character cell, including a
+ * rendered full-cell cursor.  Update cursor nesting without first drawing
+ * the redundant COMPLEMENT erase. */
+static void stdcon_overwritecursor(struct stdcondata *data)
+{
+    data->rendercursorcount--;
+}
+
 /*********  StdCon::DoCommand()  ****************************/
 
 static VOID stdcon_docommand(Class *cl, Object *o,
@@ -177,7 +188,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
         D(bug("Writing char %c at (%d, %d)\n",
                 params[0], CP_X(o), CP_Y(o) + rp->Font->tf_Baseline));
 
-        Console_UnRenderCursor(o);
+        stdcon_overwritecursor(data);
 
         setstyle(GfxBase, rp, o);
         Move(rp, CP_X(o), CP_Y(o) + rp->Font->tf_Baseline);
@@ -198,7 +209,7 @@ static VOID stdcon_docommand(Class *cl, Object *o,
                 (int)params[1], (char *)params[0], CP_X(o),
                 CP_Y(o) + rp->Font->tf_Baseline));
 
-        Console_UnRenderCursor(o);
+        stdcon_overwritecursor(data);
 
         setstyle(GfxBase, rp, o);
 
@@ -667,12 +678,34 @@ static VOID stdcon_docommand(Class *cl, Object *o,
 }
 
 /*********  StdCon::RenderCursor()  ****************************/
+static VOID stdcon_drawcursor(Object *o, struct stdcondata *data)
+{
+    static const UWORD inactive_pattern[] = { 0xAAAA, 0x5555 };
+    struct RastPort *rp = RASTPORT(o);
+    const UWORD *oldpattern = rp->AreaPtrn;
+    BYTE oldpatternsize = rp->AreaPtSz;
+    struct Library *GfxBase = data->scd_GfxBase;
+
+    SetDrMd(rp, COMPLEMENT);
+    if (!data->windowactive)
+    {
+        rp->AreaPtrn = inactive_pattern;
+        rp->AreaPtSz = 1;
+    }
+    RectFill(rp, CP_X(o), CP_Y(o), CP_X(o) + XRSIZE - 1,
+        CP_Y(o) + YRSIZE - 1);
+    if (!data->windowactive)
+    {
+        rp->AreaPtrn = oldpattern;
+        rp->AreaPtSz = oldpatternsize;
+    }
+    SetDrMd(rp, JAM2);
+}
+
 static VOID stdcon_rendercursor(Class *cl, Object *o,
     struct P_Console_RenderCursor *msg)
 {
-    struct RastPort *rp = RASTPORT(o);
     struct stdcondata *data = INST_DATA(cl, o);
-    struct Library *GfxBase = data->scd_GfxBase;
 
     /* SetAPen(rp, data->dri->dri_Pens[FILLPEN]); */
 
@@ -680,10 +713,7 @@ static VOID stdcon_rendercursor(Class *cl, Object *o,
 
     if (data->cursorvisible && (data->rendercursorcount == 1))
     {
-        SetDrMd(rp, COMPLEMENT);
-        RectFill(rp, CP_X(o), CP_Y(o), CP_X(o) + XRSIZE - 1,
-            CP_Y(o) + YRSIZE - 1);
-        SetDrMd(rp, JAM2);
+        stdcon_drawcursor(o, data);
     }
 }
 
@@ -691,9 +721,7 @@ static VOID stdcon_rendercursor(Class *cl, Object *o,
 static VOID stdcon_unrendercursor(Class *cl, Object *o,
     struct P_Console_UnRenderCursor *msg)
 {
-    struct RastPort *rp = RASTPORT(o);
     struct stdcondata *data = INST_DATA(cl, o);
-    struct Library *GfxBase = data->scd_GfxBase;
 
     data->rendercursorcount--;
 
@@ -701,11 +729,24 @@ static VOID stdcon_unrendercursor(Class *cl, Object *o,
 
     if (data->cursorvisible && (data->rendercursorcount == 0))
     {
-        SetDrMd(rp, COMPLEMENT);
-        RectFill(rp, CP_X(o), CP_Y(o), CP_X(o) + XRSIZE - 1,
-            CP_Y(o) + YRSIZE - 1);
-        SetDrMd(rp, JAM2);
+        stdcon_drawcursor(o, data);
     }
+}
+
+static VOID stdcon_setactive(Class *cl, Object *o,
+    struct P_Console_HandleGadgets *msg)
+{
+    struct stdcondata *data = INST_DATA(cl, o);
+    BOOL active = msg->Event->ie_Class == IECLASS_ACTIVEWINDOW;
+
+    if (active == data->windowactive)
+        return;
+
+    if (data->cursorvisible && data->rendercursorcount == 1)
+        stdcon_drawcursor(o, data);
+    data->windowactive = active;
+    if (data->cursorvisible && data->rendercursorcount == 1)
+        stdcon_drawcursor(o, data);
 }
 
 /**************************
@@ -829,6 +870,11 @@ AROS_UFH3S(IPTR, dispatch_stdconclass,
 
     case M_Console_NewWindowSize:
         stdcon_newwindowsize(cl, o, (struct P_Console_NewWindowSize *)msg);
+        break;
+
+    case M_Console_HandleGadgets:
+        stdcon_setactive(cl, o,
+            (struct P_Console_HandleGadgets *)msg);
         break;
 
     default:

--- a/rom/devs/console/support.c
+++ b/rom/devs/console/support.c
@@ -109,6 +109,7 @@ ULONG writeToConsole(struct ConUnit *unit, STRPTR buf, ULONG towrite,
     LONG orig_towrite;
     UBYTE *allocbuf = NULL;
     ULONG accepted = towrite;
+    BOOL plainText = TRUE;
 
     EnterFunc(bug("WriteToConsole(ioreq=%p)\n"));
 
@@ -129,6 +130,20 @@ ULONG writeToConsole(struct ConUnit *unit, STRPTR buf, ULONG towrite,
     write_str = orig_write_str = (UBYTE *) buf;
     orig_towrite = towrite;
 
+    {
+        ULONG i;
+
+        for (i = 0; i < towrite; i++)
+        {
+            if ((UBYTE)buf[i] < 0x20 ||
+                ((UBYTE)buf[i] >= 0x7f && (UBYTE)buf[i] < 0xa0))
+            {
+                plainText = FALSE;
+                break;
+            }
+        }
+    }
+
     D(bug("Number of chars to write %d\n", towrite));
 
 #if DEBUG
@@ -141,6 +156,9 @@ ULONG writeToConsole(struct ConUnit *unit, STRPTR buf, ULONG towrite,
 
     }
 #endif
+    if (towrite > 0 && !plainText)
+        Console_UnRenderCursor((Object *) unit);
+
     while (towrite > 0)
     {
         if (csi_incomplete(write_str, towrite)
@@ -158,12 +176,13 @@ ULONG writeToConsole(struct ConUnit *unit, STRPTR buf, ULONG towrite,
                 param_tab, (Object *) unit, ConsoleDevice))
             break;
 
-        Console_UnRenderCursor((Object *) unit);
         Console_DoCommand((Object *) unit, command, numparams, param_tab);
-        Console_RenderCursor((Object *) unit);
 
         towrite = orig_towrite - (write_str - orig_write_str);
     } /* while (characters left to interpret) */
+
+    if (orig_towrite > 0 && !plainText)
+        Console_RenderCursor((Object *) unit);
 
     if (allocbuf)
         FreeMem(allocbuf, orig_towrite);

--- a/rom/filesys/console_handler/support.c
+++ b/rom/filesys/console_handler/support.c
@@ -852,11 +852,14 @@ BOOL process_input(struct filehandle *fh)
         case INP_BACKSPACE:
             if (fh->inputpos > fh->inputstart)
             {
-                do_movecursor(fh, CUR_LEFT, 1);
-
                 if (fh->inputpos == fh->inputsize)
                 {
-                    do_deletechar(fh);
+                    /* Match the classic CON: handler: submit the cursor
+                     * movement and deletion as one console.device write so
+                     * no intermediate cursor position becomes visible. */
+                    UBYTE seq[] = { 8, 0x9B, 'P' };
+
+                    do_write(fh, seq, sizeof(seq));
 
                     fh->inputsize--;
                     fh->inputpos--;
@@ -864,6 +867,8 @@ BOOL process_input(struct filehandle *fh)
                 else
                 {
                     WORD chars_right = fh->inputsize - fh->inputpos;
+
+                    do_movecursor(fh, CUR_LEFT, 1);
 
                     fh->inputsize--;
                     fh->inputpos--;


### PR DESCRIPTION
 Improves console cursor and selection handling by reducing unnecessary redraws and visual artifacts. It also fixes selection clearing when applications output text, improves inactive-window cursor rendering, and makes mouse-based text selection behave more like the original Amiga console.

Before:

https://github.com/user-attachments/assets/08236ecd-2374-4fb2-8e1f-07b92e5dbb7a

After:

https://github.com/user-attachments/assets/e5a3a397-0eba-45ff-8d77-a4cd262acca4



