### PR TITLE
Fix guru 84000009 boot loop on NTSC machines

### DIFF
--- a/rom/dosboot/bootscreen.c
+++ b/rom/dosboot/bootscreen.c
@@ -31,6 +31,13 @@ static struct Screen *OpenBootScreenType(struct DOSBootBase *DOSBootBase, BYTE M
     mode = BestModeID(BIDTAG_DesiredWidth, 640, BIDTAG_DesiredHeight, height,
         BIDTAG_Depth, MinDepth, TAG_DONE);
     if (mode == INVALID_ID)
+        /* An NTSC-only display database (Amiga chipset without a PAL
+           monitor) has no 480-line mode, so probe again with the smallest
+           standard height. The result is only used to detect the monitor
+           type; the real height is picked below. */
+        mode = BestModeID(BIDTAG_DesiredWidth, 640, BIDTAG_DesiredHeight, 200,
+            BIDTAG_Depth, MinDepth, TAG_DONE);
+    if (mode == INVALID_ID)
         Alert(AN_SysScrnType);
 
     /* Set PAL or NTSC default height if we are running on Amiga(tm) hardware.

--- a/rom/intuition/shutdownscreen.c
+++ b/rom/intuition/shutdownscreen.c
@@ -64,6 +64,13 @@ static struct Screen *OpenFinalScreen(BYTE MinDepth, BOOL squarePixels,
     mode = BestModeID(BIDTAG_DesiredWidth, 640, BIDTAG_DesiredHeight, height,
         BIDTAG_Depth, MinDepth, TAG_DONE);
     if (mode == INVALID_ID)
+        /* An NTSC-only display database (Amiga chipset without a PAL
+           monitor) has no 480-line mode, so probe again with the smallest
+           standard height. The result is only used to detect the monitor
+           type; the real height is picked below. */
+        mode = BestModeID(BIDTAG_DesiredWidth, 640, BIDTAG_DesiredHeight, 200,
+            BIDTAG_Depth, MinDepth, TAG_DONE);
+    if (mode == INVALID_ID)
         Alert(AN_SysScrnType);
 
     /* Set PAL or NTSC default height if we are running on Amiga(tm) hardware.


### PR DESCRIPTION
## The bug

An amiga-m68k system running as NTSC never boots: it alerts with
84000009 "unknown type of system screen" (`AN_SysScrnType`) and
reboot-loops with a black screen before dosboot can open the boot
screen.

## Cause

`OpenBootScreenType()` in `rom/dosboot/bootscreen.c` (and the identical
code in `rom/intuition/shutdownscreen.c`) first probes
`BestModeID(640x480, MinDepth)` to find out what monitor it is on, and
calls `Alert(AN_SysScrnType)` if the probe fails. On an NTSC Amiga
chipset:

- the amigavideo hidd registers only same-standard modes, so the display
  database holds nothing taller than 400 lines, and
- `BestModeIDA()` never returns a mode smaller than the desired size,
  and its relaxation retries require `BIDTAG_MonitorID`, which is not
  passed here,

so the 480-line probe always returns `INVALID_ID` and the Alert is a
dead end. PAL only survives because "PAL:High Res Laced" (640x512)
satisfies the >= 480 check.

## Fix

Retry the probe with a 200-line desired height before raising the
alert. The probe result is only used to distinguish NTSC from PAL; the
real screen height (200/400 or 256/512) is chosen immediately
afterwards, so PAL and RTG paths are unchanged.

## Testing

Built the amiga-m68k ROM from this branch and booted it in the
Copperline emulator (cycle-driven, 262/263-line NTSC beam, so
`InitCustom()` detects NTSC exactly as on hardware):

- Before: NTSC gurus 84000009 and reboot-loops every ~5.6 s. A PC
  breakpoint on the first `BestModeID` return shows D0 = 0xFFFFFFFF
  (`INVALID_ID`); the failure also reproduces in vAmiga.
- After: NTSC boots to the boot animation / insert-disk screen on a
  640x400 NTSC mode; PAL boot is unchanged (640x512 laced picked, same
  as before).
