### PR TITLE
AROS_SH commands: fix DEBUG builds crashing in kprintf(), and AROSMonDrvs return codes

### DIFF
--- a/workbench/c/AROSMonDrvs.c
+++ b/workbench/c/AROSMonDrvs.c
@@ -189,7 +189,7 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
     APTR pool;
     struct Library *IconBase;
     BPTR dir, olddir;
-    BOOL res = TRUE;
+    UBYTE res = RETURN_OK;
 
     D(bug("[LoadMonDrvs] Start: NOCOMPOSITION=%d ONLYCOMPOSITION=%d\n",
           SHArg(NOCOMPOSITION), SHArg(ONLYCOMPOSITION)));
@@ -226,7 +226,8 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
                 if (IconBase)
                 {
                     D(bug("[LoadMonDrvs] findMonitors ...\n"));
-                    findMonitors(&MonitorsList, DOSBase, IconBase, SysBase, pool);
+                    if (!findMonitors(&MonitorsList, DOSBase, IconBase, SysBase, pool))
+                        res = RETURN_ERROR;
                     D(bug("[LoadMonDrvs] findMonitors done, list %s\n",
                           IsListEmpty(&MonitorsList) ? "empty" : "non-empty"));
                     loadMonitors(&MonitorsList, DOSBase, SysBase);
@@ -236,12 +237,14 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
                 DeletePool(pool);
             }
             else
-                res = FALSE;
+                res = RETURN_FAIL;
         }
 
         CurrentDir(olddir);
         UnLock(dir);
     }
+    else
+        res = RETURN_WARN;
 
     D(bug("[LoadMonDrvs] Exit, res %d\n", res));
 

--- a/workbench/c/AROSMonDrvs.c
+++ b/workbench/c/AROSMonDrvs.c
@@ -48,6 +48,9 @@
 ******************************************************************************/
 
 #define DEBUG 0
+#if DEBUG
+#define SH_GLOBAL_SYSBASE 1     /* for kprintf() */
+#endif
 
 #include <aros/debug.h>
 #include <dos/dosextens.h>
@@ -119,7 +122,7 @@ static BOOL findMonitors(struct List *monitorsList, struct DosLibrary *DOSBase, 
         {
             struct MonitorNode *newnode;
 
-            DB2(bug("[LoadMonDrvs] Found monitor name %s\n", ap->ap_Info.fib_FileName));
+            D(bug("[LoadMonDrvs] Found monitor name %s\n", ap->ap_Info.fib_FileName));
 
             /* Software composition driver was loaded before */
             if (strcmp(ap->ap_Info.fib_FileName, COMPOSITING_NAME))
@@ -161,6 +164,7 @@ static void loadMonitors(struct List *monitorsList, struct DosLibrary *DOSBase,
     struct ExecBase *SysBase)
 {
     struct MonitorNode *node;
+    D(BOOL res;)
 
     D(bug("[LoadMonDrvs] Loading monitor drivers...\n"));
     D(bug(" Pri Name\n"));
@@ -168,7 +172,9 @@ static void loadMonitors(struct List *monitorsList, struct DosLibrary *DOSBase,
     ForeachNode(monitorsList, node)
     {
         D(bug("%4d %s\n", node->n.ln_Pri, node->Name));
-        Execute(node->Name, BNULL, BNULL);
+        D(bug("[LoadMonDrvs] Execute('%s') ...\n", node->Name));
+        D(res = ) Execute(node->Name, BNULL, BNULL);
+        D(bug("[LoadMonDrvs] Execute('%s') returned %d, IoErr %ld\n", node->Name, res, (long)IoErr()));
     }
 
     D(bug("--------------------------\n"));
@@ -185,19 +191,28 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
     BPTR dir, olddir;
     BOOL res = TRUE;
 
+    D(bug("[LoadMonDrvs] Start: NOCOMPOSITION=%d ONLYCOMPOSITION=%d\n",
+          SHArg(NOCOMPOSITION), SHArg(ONLYCOMPOSITION)));
+
     dir = Lock(MONITORS_DIR, SHARED_LOCK);
     D(bug("[LoadMonDrvs] Monitors directory 0x%p\n", dir));
     if (dir)
     {
         olddir = CurrentDir(dir);
+        D(bug("[LoadMonDrvs] CurrentDir 0x%p -> 0x%p\n", olddir, dir));
 
         if (!SHArg(NOCOMPOSITION))
         {
             /* Software composition driver is run first */
+            D(BOOL cres;)
+
             D(bug("[LoadMonDrvs] Loading composition driver...\n"));
-            Execute(COMPOSITING_NAME, BNULL, BNULL);
+            D(bug("[LoadMonDrvs] Execute('%s') ...\n", COMPOSITING_NAME));
+            D(cres = ) Execute(COMPOSITING_NAME, BNULL, BNULL);
+            D(bug("[LoadMonDrvs] Execute('%s') returned %d, IoErr %ld\n",
+                  COMPOSITING_NAME, cres, (long)IoErr()));
         }
-        
+
         if (!SHArg(ONLYCOMPOSITION))
         {
             pool = CreatePool(MEMF_ANY, sizeof(struct MonitorNode) * 10, sizeof(struct MonitorNode) * 5);
@@ -210,8 +225,12 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
                 IconBase = OpenLibrary("icon.library", 0);
                 if (IconBase)
                 {
+                    D(bug("[LoadMonDrvs] findMonitors ...\n"));
                     findMonitors(&MonitorsList, DOSBase, IconBase, SysBase, pool);
+                    D(bug("[LoadMonDrvs] findMonitors done, list %s\n",
+                          IsListEmpty(&MonitorsList) ? "empty" : "non-empty"));
                     loadMonitors(&MonitorsList, DOSBase, SysBase);
+                    D(bug("[LoadMonDrvs] loadMonitors done\n"));
                     CloseLibrary(IconBase);
                 }
                 DeletePool(pool);
@@ -223,7 +242,9 @@ AROS_SH2H(AROSMonDrvs, 1.0, "Load AROS Monitor and Compositor drivers",
         CurrentDir(olddir);
         UnLock(dir);
     }
-    
+
+    D(bug("[LoadMonDrvs] Exit, res %d\n", res));
+
     return res;
 
     AROS_SHCOMMAND_EXIT

--- a/workbench/c/WBRun/main.c
+++ b/workbench/c/WBRun/main.c
@@ -13,6 +13,9 @@
 #include <proto/utility.h>
 
 #define DEBUG 0
+#if DEBUG
+#define SH_GLOBAL_SYSBASE 1     /* for kprintf() */
+#endif
 #include <aros/debug.h>
 
 #define SH_GLOBAL_DOSBASE TRUE


### PR DESCRIPTION
Two independent fixes, one crash and one wrong result code.

## Any AROS_SH*() command crashes when built with DEBUG

`AROSMonDrvs` guru'd on the first `D(bug())` as soon as `DEBUG` was set to 1:

```
Hardware bus fault/address error
PC 0xFFFFFE0E
```

`0xFFFFFE0E` is `-498`, i.e. `_LVOOpenResource` called through a NULL library
base. That is `kprintf()`:

```c
struct Library *KernelBase = OpenResource("kernel.resource");
```

`bug()` is `kprintf` (arossupport), and it resolves `OpenResource()` through the
program's *global* `SysBase`. Commands built from the `AROS_SH*()` macros are
linked with `usestartup=no`, and with `SH_GLOBAL_SYSBASE` unset
`DEFINE_SysBase_global` is empty, so `SysBase` only ever exists as a local in
the entry function - which is exactly why the helpers in `AROSMonDrvs.c` pass
`struct ExecBase *SysBase` around explicitly. Nothing ever initializes the
global the linklib reads.

`BindDrivers.c` already has the guard this needs:

```c
#if DEBUG
#define SH_GLOBAL_SYSBASE 1     /* for kprintf() */
#endif
```

Added to `AROSMonDrvs` (which crashes today) and to `WBRun` (which will the
moment anyone debugs it). I checked the rest of the `AROS_SH*` commands that
call `bug()`: `Shell` and `shellcommands` build with `-DUSE_EMBEDDED_COMMANDS`
and route `bug` through `SysBase->DebugAROSBase` themselves, so they are fine.

The `Execute()` calls are now traced too, since finding this took adding that
by hand.

## AROSMonDrvs returned a BOOL as its result code

That value goes straight out as the process return code
(`shcommands_notembedded.h`), so a successful run returned 1 rather than
`RETURN_OK`, and the `CreatePool()` failure path returned `FALSE`, i.e. 0 -
the one hard out-of-memory case reported success. `findMonitors()`'s `BOOL`
was discarded entirely, so a partial scan also looked clean.

Now `RETURN_OK`, with `RETURN_ERROR` if `findMonitors()` fails and
`RETURN_FAIL` if the pool cannot be created. A missing `DEVS:Monitors` gets
`RETURN_WARN` rather than a hard failure, deliberately: it is below the default
`FailAt 10`, so an install that legitimately has no Monitors drawer still gets
through `Startup-Sequence` as it does today, while the condition stops being
invisible.

Tested on amiga-m68k: builds clean, and `C:AROSMonDrvs` with `DEBUG 1` now runs
to completion and traces the monitor loading instead of taking the machine
down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
