### PR TITLE
hidds/input: buffer input events until the first consumer registers

### DIFF
--- a/rom/hidds/input/include/input.h
+++ b/rom/hidds/input/include/input.h
@@ -48,11 +48,13 @@ enum {
 
 enum {
    aoHW_Input_ConsumerList,
-   
+   aoHW_Input_EventSize,
+
    num_HW_Input_Attrs
 };
 
 #define aHW_Input_ConsumerList		(aoHW_Input_ConsumerList        + HWInputAB)
+#define aHW_Input_EventSize		(aoHW_Input_EventSize           + HWInputAB)
 
 #define IS_HWINPUT_ATTR(attr, idx) IS_IF_ATTR(attr, idx, HWInputAB, num_HW_Input_Attrs)
 

--- a/rom/hidds/input/input.h
+++ b/rom/hidds/input/input.h
@@ -11,10 +11,35 @@ struct InputHWInstData
     APTR                        ihid_private;
 };
 
+/*
+ * Input events which arrive before any consumer has registered are copied
+ * into a small pending buffer and replayed to the first consumer that
+ * attaches. Without this, everything a hardware driver delivers between
+ * its installation and the first consumer registration is lost - e.g. the
+ * Amiga keyboard's power-up key stream (keys held during boot) arrives as
+ * soon as the driver starts handshaking, before keyboard.device has
+ * opened, which broke the "hold SPACE for the boot menu" check.
+ *
+ * ihd_evsize is the per-event byte size the owning subsystem declared
+ * with aHW_Input_EventSize (0 = buffering disabled).
+ *
+ * NOTE: ihd_consumers must remain the first member: the default input
+ * processing hook and InputHW_FlushPendingEvents() recover the
+ * InputHWData from the consumer-list pointer used as callback data.
+ */
+#define IHD_PENDING_MAX     16  /* events held before the first consumer */
+#define IHD_PENDING_EVSIZE  8   /* maximum per-event copy, in bytes */
+
 struct InputHWData
 {
     struct MinList              ihd_consumers;
+    UWORD                       ihd_evsize;
+    UWORD                       ihd_pendingcnt;
+    UBYTE                       ihd_pending[IHD_PENDING_MAX][IHD_PENDING_EVSIZE];
 };
+
+void InputHW_FlushPendingEvents(struct MinList *cbList, InputIrqCallBack_t callback,
+    APTR callbackdata);
 
 struct InputClassStaticData
 {

--- a/rom/hidds/input/inputclass.c
+++ b/rom/hidds/input/inputclass.c
@@ -197,6 +197,10 @@ OOP_Object *Input__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg
                 if (cbList) {
                     Disable();
                     ADDTAIL(cbList, &data->ihid_node);
+                    /* Replay events which arrived before the first consumer
+                       registered (e.g. keys typed or held during boot) */
+                    InputHW_FlushPendingEvents((struct MinList *)cbList,
+                        data->ihid_callback, data->ihid_private);
                     Enable();
                 }
             }

--- a/rom/hidds/input/inputsubsystem.c
+++ b/rom/hidds/input/inputsubsystem.c
@@ -68,17 +68,61 @@
 
 *****************************************************************************************/
 
+/*
+ * Copy an event into the subsystem's pending buffer. Called (possibly in
+ * interrupt context) when an event arrives while no consumer is
+ * registered; the buffered events are replayed to the first consumer by
+ * InputHW_FlushPendingEvents(). Events beyond the buffer capacity, and
+ * events of subsystems that declared no aHW_Input_EventSize, are dropped
+ * as before.
+ */
+static void InputHW__BufferPendingEvent(struct InputHWData *hd, InputIrqData_t cbData)
+{
+    const UBYTE *src = cbData;
+    UBYTE *dst;
+    UWORD i;
+
+    if (!hd->ihd_evsize || hd->ihd_pendingcnt >= IHD_PENDING_MAX)
+        return;
+
+    dst = hd->ihd_pending[hd->ihd_pendingcnt];
+    for (i = 0; i < hd->ihd_evsize; i++)
+        dst[i] = src[i];
+    hd->ihd_pendingcnt++;
+}
+
 static void InputHW__CallBackFunc(struct MinList *cbList, InputIrqData_t cbData)
 {
+    /* cbList is &InputHWData::ihd_consumers, its first member */
+    struct InputHWData *hd = (struct InputHWData *)cbList;
     struct InputHWInstData *data;
 
     D(bug("[Input:HW] %s(0x%p)\n", __func__, cbList));
 
-    for (data = (struct InputHWInstData *)cbList->mlh_Head; data->ihid_node.mln_Succ;
+    data = (struct InputHWInstData *)cbList->mlh_Head;
+    if (!data->ihid_node.mln_Succ) {
+        /* No consumer registered yet: hold the event for replay */
+        InputHW__BufferPendingEvent(hd, cbData);
+        return;
+    }
+
+    for (; data->ihid_node.mln_Succ;
          data = (struct InputHWInstData *)data->ihid_node.mln_Succ)
     {
         data->ihid_callback(data->ihid_private, cbData);
     }
+}
+
+void InputHW_FlushPendingEvents(struct MinList *cbList, InputIrqCallBack_t callback,
+    APTR callbackdata)
+{
+    /* cbList is &InputHWData::ihd_consumers, its first member */
+    struct InputHWData *hd = (struct InputHWData *)cbList;
+    UWORD i;
+
+    for (i = 0; i < hd->ihd_pendingcnt; i++)
+        callback(callbackdata, (InputIrqData_t)hd->ihd_pending[i]);
+    hd->ihd_pendingcnt = 0;
 }
 
 OOP_Object *InputHW__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
@@ -88,6 +132,7 @@ OOP_Object *InputHW__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *m
     struct TagItem              *tag, *tstate;
     char                        *inputSSName = NULL;
     OOP_Object                  *inputSSObj = NULL;
+    UWORD                       inputSSEvSize = 0;
 
     D(bug("[Input:HW] %s(0x%p, 0x%p, 0x%p)\n", __func__, cl, o, msg));
 
@@ -102,6 +147,13 @@ OOP_Object *InputHW__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *m
                     break;
             }
         }
+        else if (IS_HWINPUT_ATTR(tag->ti_Tag, idx)) {
+            switch (idx) {
+                case aoHW_Input_EventSize:
+                    inputSSEvSize = (UWORD)tag->ti_Data;
+                    break;
+            }
+        }
     }
 
     if (inputSSName) {
@@ -111,6 +163,8 @@ OOP_Object *InputHW__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *m
             struct InputHWData *hd = OOP_INST_DATA(cl, inputSSObj);
             D(bug("[Input:HW] %s: Consumer List @ 0x%p\n", __func__, &hd->ihd_consumers));
             NEWLIST(&hd->ihd_consumers);
+            hd->ihd_evsize = (inputSSEvSize <= IHD_PENDING_EVSIZE) ? inputSSEvSize : 0;
+            hd->ihd_pendingcnt = 0;
         }
     }
     D(bug("[Input:HW] %s: Returning 0x%p\n", __func__, inputSSObj));
@@ -189,6 +243,13 @@ void InputHW__HW_Input__PushEvent(OOP_Class *cl, OOP_Object *o, struct pHW_Input
     struct InputHWInstData *data;
 
     D(bug("[Input:HW] %s()\n", __func__));
+
+    data = (struct InputHWInstData *)hd->ihd_consumers.mlh_Head;
+    if (!data->ihid_node.mln_Succ) {
+        /* No consumer registered yet: hold the event for replay */
+        InputHW__BufferPendingEvent(hd, Msg->iedata);
+        return;
+    }
 
     ForeachNode(&hd->ihd_consumers, data) {
         data->ihid_callback(data->ihid_private, Msg->iedata);

--- a/rom/hidds/kbd/kbd.h
+++ b/rom/hidds/kbd/kbd.h
@@ -15,6 +15,7 @@ struct kbd_data
 struct kbd_staticdata
 {
     OOP_AttrBase        hiddInputAB;
+    OOP_AttrBase        hwInputAB;
     OOP_AttrBase        hwAB;
     OOP_MethodID        hwMB;
     OOP_Class           *kbdClass;
@@ -34,8 +35,10 @@ struct kbdbase
 #define CSD(cl) (&((struct kbdbase *)cl->UserData)->csd)
 
 #undef HiddInputAB
+#undef HWInputAB
 #undef HWAttrBase
 #undef HWBase
 #define HiddInputAB  (CSD(cl)->hiddInputAB)
+#define HWInputAB    (CSD(cl)->hwInputAB)
 #define HWAttrBase (CSD(cl)->hwAB)
 #define HWBase     (CSD(cl)->hwMB)

--- a/rom/hidds/kbd/kbd_init.c
+++ b/rom/hidds/kbd/kbd_init.c
@@ -20,6 +20,7 @@ static int KbdHidd_InitClass(struct kbdbase *LIBBASE)
     struct OOP_ABDescr attrbases[] =
     {
         {IID_HW,            &LIBBASE->csd.hwAB          },
+        {IID_HW_Input,      &LIBBASE->csd.hwInputAB     },
         {IID_Hidd_Input,    &LIBBASE->csd.hiddInputAB   },
         {NULL,              NULL                        }
     };
@@ -54,6 +55,7 @@ static int KbdHidd_ExpungeClass(struct kbdbase *LIBBASE)
     struct OOP_ABDescr attrbases[] =
     {
         {IID_HW,            &LIBBASE->csd.hwAB          },
+        {IID_HW_Input,      &LIBBASE->csd.hwInputAB     },
         {IID_Hidd_Input,    &LIBBASE->csd.hiddInputAB   },
         {NULL,              NULL                        }
     };

--- a/rom/hidds/kbd/kbdsubsystem.c
+++ b/rom/hidds/kbd/kbdsubsystem.c
@@ -69,8 +69,9 @@ OOP_Object *KBDHW__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg
     {
         struct TagItem new_tags[] =
         {
-            {aHW_ClassName, (IPTR)"Keyboards"},
-            {TAG_DONE     , 0                }
+            {aHW_ClassName,       (IPTR)"Keyboards"                 },
+            {aHW_Input_EventSize, sizeof(struct pHidd_Kbd_Event)    },
+            {TAG_DONE           , 0                                 }
         };
         struct pRoot_New new_msg =
         {


### PR DESCRIPTION
## The bug

Keys held during boot never reach `KBD_READMATRIX`, so dosboot's "hold SPACE or HELP for the boot menu" check (`buttonsPressed()` in `rom/dosboot/menu.c`) does not fire. Reported against the Copperline emulator in CopperlineHQ/Copperline#317, but the loss is in AROS and reproduces with a hardware-faithful keyboard on any speed of machine.

## Root cause

Input HW subsystems dispatch driver events only to registered consumers; with no consumer attached the event is silently dropped (`InputHW__CallBackFunc`). On amiga-m68k there is a substantial window where that is exactly the state:

1. The `amigakbd` driver installs its CIA-A serial interrupt handler at driver creation, inside `initHidds`, and starts handshaking the keyboard immediately. A real (or faithfully emulated) Amiga keyboard has been waiting for exactly that: it holds its power-up key stream ($FD, the codes of keys held during power-up, $FE) under the KDAT handshake flow control, and the first handshake releases it. The whole stream drains at wire speed, roughly 1 ms per byte.
2. `keyboard.device` only registers its `keyCallback` with the hidd at first `OpenDevice`, which happens a few hundred ms later on a 68000 (input.device / dosboot init). Every key event decoded in between - including the held keys of the power-up stream - evaporated.
3. `buttonsPressed()` then opens keyboard.device and reads an all-zero matrix.

Measured on an emulated A500 (bundled Copperline AROS ROM): the driver starts handshaking and drains the stream at ~3.10 s after power-on, keyboard.device registers its callback between 3.2 s and 3.6 s, and dosboot samples the matrix once between 5.0 s and 5.6 s. A SPACE press only registered if it landed in the ~3.3-5.3 s window; on an A4000/040 the window shrinks to well under a second. Keys held from power-on can never work, because the power-up stream is always consumed the instant the driver starts handshaking, before any consumer exists. (Emulators that pace keyboard bytes artificially, e.g. WinUAE-derived ones, can hide the race on fast configurations, which is why this seemed to work on Amiberry.)

## The fix

Give each input HW subsystem a small pending-event buffer: events which arrive while no consumer is registered are copied there (in the driver's interrupt context) and replayed to the first consumer at registration, before it can miss anything - the replay happens inside the consumer's `OOP_NewObject`, so even a consumer that immediately reads the matrix observes them.

Subsystems opt in by declaring their per-event size with a new `aHW_Input_EventSize` init attribute; the keyboard subsystem declares `sizeof(struct pHidd_Kbd_Event)`. Subsystems that do not declare a size keep today's drop-on-arrival behaviour. The default processing hook still receives the consumer-list pointer as its callback data (the subsystem data is recovered from it, as the list is the struct's first member), so the mouse and controller driver-data proxies, which capture that pointer from `aHW_Input_ConsumerList`, are unaffected.

## Testing

Built the amiga-m68k ROM with this change and ran it under Copperline (its keyboard model is verified against a disassembly of the real 6570-036 keyboard MCU ROM, including the handshake-gated power-up stream):

- A500, SPACE held from 1 s after power-on: Early Startup menu appears (previously: never).
- A500, HELP held from 1 s: menu appears.
- A4000/040, SPACE held from 0.5 s: menu appears (previously: sub-second timing window).
- No keys held: boots normally to the insert-media screen.
- SPACE pressed later during boot (4 s): still opens the menu, so live key delivery is unchanged.