### PR TITLE
m68k-amiga: don't store the AGA palette through NULL copper pointers

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -144,9 +144,24 @@ VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm,
     if (!c2d->copper2_palette)
         return;
 
+    /*
+        The short frame list is built lazily, and its pointers are only
+        refreshed from the long frame ones when it is (re)built - so an
+        interlaced bitmap can reach us with some of them still NULL.
+    */
+    const BOOL doilace = bm->interlace && c2di->copper2_palette;
+
     UWORD i;
 
-    if (csd->aga && csd->aga_enabled) {
+    /*
+        Pick the branch that matches how this copper list was actually built,
+        not the current chipset state: aga_enabled can be switched on long
+        after the list exists (see the AGA-only mode hack in setmode()), and
+        the lo half of the palette is only emitted for lists built with AGA
+        already enabled. Trusting aga_enabled here would store through a NULL
+        copper2_palette_aga_lo, which lands in the first page of memory.
+    */
+    if (csd->aga && csd->aga_enabled && c2d->copper2_palette_aga_lo) {
         UWORD off = 1;
         D(bug("[AmigaVideo] %s: AGA\n", __func__));
         for (i = 0; i < bm->use_colors; i++) {
@@ -160,7 +175,7 @@ VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm,
             vallo = ((r & 0x0f) << 8) | ((g & 0x0f) << 4) | ((b & 0x0f));
             c2d->copper2_palette[i * 2 + off] = valhi;
             c2d->copper2_palette_aga_lo[i * 2 + off] = vallo;
-            if (bm->interlace) {
+            if (doilace && c2di->copper2_palette_aga_lo) {
                 c2di->copper2_palette[i * 2 + off] = valhi;
                 c2di->copper2_palette_aga_lo[i * 2 + off] = vallo;
             }
@@ -176,7 +191,7 @@ VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm,
             UWORD val2 = ((palette[c2 * 3 + 0] >> 4) << 8) | ((palette[c2 * 3 + 1] >> 4) << 4) | ((palette[c2 * 3 + 2] >> 4) << 0);
             UWORD val = (val1 & 0xccc) | ((val2 & 0xccc) >> 2);
             c2d->copper2_palette[i * 2 + 1] = val;
-            if (bm->interlace)
+            if (doilace)
                 c2di->copper2_palette[i * 2 + 1] = val;
         }
         
@@ -184,7 +199,7 @@ VOID setcoppercolors(struct amigavideo_staticdata *csd, struct amigabm_data *bm,
         for (i = 0; i < bm->use_colors; i++) {
             UWORD val = ((palette[i * 3 + 0] >> 4) << 8) | ((palette[i * 3 + 1] >> 4) << 4) | ((palette[i * 3 + 2] >> 4) << 0);
             c2d->copper2_palette[i * 2 + 1] = val;
-            if (bm->interlace)
+            if (doilace)
                 c2di->copper2_palette[i * 2 + 1] = val;
         }
     }


### PR DESCRIPTION
Boot dies in SetPatch with a CPU double fault on an A4000/040 with a Z3660 RTG
board (tested under Copperline). Registering the P96 display driver puts deeper
modes in the display database, which is enough to trigger this.

`setcoppercolors()` picks its palette layout from the live chipset state, but
`csd->aga_enabled` is promoted FALSE -> TRUE at runtime by `setmode()` when a
mode needs more bitplanes than the current fmode allows. A copper list built
before that promotion has `copper2_palette_aga_lo` still NULL - it is only
assigned in the AGA branch of the list builder, while `copper2_palette` is
assigned unconditionally, and the existing guard checked only the latter. We
then write the palette through the NULL pointer, landing in the first page of
memory and corrupting SysBase.

Fix by picking the branch that matches how the list was actually built rather
than the current chipset state. The interlace short-frame pointers get the same
treatment: `copsd.copper2_palette_aga_lo` is refreshed only when the long-frame
one is already non-NULL, unlike every other `copsd` pointer, so a stale NULL
survives a mode rebuild.

After the fix the same run reaches Wanderer; a plain boot is unchanged.