### PR TITLE
binutils 2.32-2.40 arm-aros: emit REL relocations on ARM

### DIFF
--- a/tools/crosstools/gnu/binutils-2.32-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.32-aros.diff
@@ -336,13 +336,13 @@ diff -ruN binutils-2.32/bfd/elf32-arm.c binutils-2.32-aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
-+#define elf_backend_rela_normal		1
++#define elf_backend_rela_normal		0
 +#undef  elf_backend_want_plt_sym
 +#define elf_backend_want_plt_sym	0
 +

--- a/tools/crosstools/gnu/binutils-2.35-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.35-aros.diff
@@ -336,13 +336,13 @@ diff -ruN binutils-2.35/bfd/elf32-arm.c binutils-2.35.aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
-+#define elf_backend_rela_normal		1
++#define elf_backend_rela_normal		0
 +#undef  elf_backend_want_plt_sym
 +#define elf_backend_want_plt_sym	0
 +

--- a/tools/crosstools/gnu/binutils-2.38-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.38-aros.diff
@@ -296,13 +296,13 @@ diff -ruN binutils-2.38/bfd/elf32-arm.c binutils-2.38.aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
-+#define elf_backend_rela_normal		1
++#define elf_backend_rela_normal		0
 +#undef  elf_backend_want_plt_sym
 +#define elf_backend_want_plt_sym	0
 +

--- a/tools/crosstools/gnu/binutils-2.40-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.40-aros.diff
@@ -298,13 +298,13 @@ diff -ruN binutils-2.40/bfd/elf32-arm.c binutils-2.40.aros/bfd/elf32-arm.c
 +#define ELF_COMMONPAGESIZE		0x1000
 +
 +#undef  elf_backend_may_use_rel_p
-+#define elf_backend_may_use_rel_p	0
++#define elf_backend_may_use_rel_p	1
 +#undef  elf_backend_may_use_rela_p
-+#define elf_backend_may_use_rela_p	1
++#define elf_backend_may_use_rela_p	0
 +#undef  elf_backend_default_use_rela_p
-+#define elf_backend_default_use_rela_p	1
++#define elf_backend_default_use_rela_p	0
 +#undef  elf_backend_rela_normal
-+#define elf_backend_rela_normal		1
++#define elf_backend_rela_normal		0
 +#undef  elf_backend_want_plt_sym
 +#define elf_backend_want_plt_sym	0
 +


### PR DESCRIPTION
32-bit ARM ELF keeps the addend in the instruction field, and for bl that addend is the -8 PC pipeline bias. Declaring the AROS target RELA made the linker drop it, so every relocated bl landed 8 bytes past the callee. Brings these patches in line with binutils-2.45-aros.diff.