### PR TITLE
PFS3 i386 support / endianness fixes

### DIFF
--- a/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
+++ b/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
@@ -7,6 +7,8 @@
 #include "blocks.h"
 #include "endian.h"
 
+void TestListTypeLayout(void);
+
 #define BLOCK_BYTES_1K 1024
 #define BLOCK_BYTES_2K 2048
 #define BLOCK_BYTES_4K 4096
@@ -259,6 +261,68 @@ static void TestMalformedDirectoryEntry(void)
 	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
 }
 
+static void TestDirectoryEntryWithoutTerminator(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	UBYTE original[BLOCK_BYTES_1K];
+	struct dirblock *block = (struct dirblock *)data;
+	UBYTE lengths[] = { 254, 250, 250, 250 };
+	ULONG offset = sizeof(*block);
+	ULONG i;
+
+	memset(data, 0, sizeof(data));
+	block->id = DBLKID;
+	for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++)
+	{
+		struct direntry *entry = (struct direntry *)(data + offset);
+		entry->next = lengths[i];
+		entry->nlength = 0;
+		*(UBYTE *)&entry->startofname = 0;
+		offset += lengths[i];
+	}
+	CU_ASSERT_EQUAL(offset, sizeof(data));
+	memcpy(original, data, sizeof(data));
+
+	CU_ASSERT_FALSE(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+	CU_ASSERT_FALSE(PFS3MetadataToDiskForRecovery(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+}
+
+static void TestMalformedExtraFields(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	UBYTE original[BLOCK_BYTES_1K];
+	struct dirblock *block = (struct dirblock *)data;
+	struct direntry *entry;
+	struct extrafields extra;
+
+	memset(data, 0, sizeof(data));
+	block->id = DBLKID;
+	entry = (struct direntry *)block->entries;
+	entry->next = sizeof(*entry) + sizeof(UWORD);
+	entry->nlength = 0;
+	*(UBYTE *)&entry->startofname = 0;
+	data[sizeof(*block) + entry->next - 2] = 0xff;
+	data[sizeof(*block) + entry->next - 1] = 0xff;
+	memcpy(original, data, sizeof(data));
+
+	CU_ASSERT_FALSE(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+	memset(&extra, 0xa5, sizeof(extra));
+	CU_ASSERT_EQUAL(PFS3GetExtraFields(entry, &extra), 0xffff);
+	CU_ASSERT_EQUAL(extra.link, 0);
+	CU_ASSERT_EQUAL(extra.uid, 0);
+	CU_ASSERT_EQUAL(extra.gid, 0);
+	CU_ASSERT_EQUAL(extra.prot, 0);
+	CU_ASSERT_EQUAL(extra.virtualsize, 0);
+	CU_ASSERT_EQUAL(extra.rollpointer, 0);
+	CU_ASSERT_EQUAL(extra.fsizex, 0);
+}
+
 static void TestRecoveryDirectoryEntry(void)
 {
 	UBYTE data[BLOCK_BYTES_1K];
@@ -342,12 +406,18 @@ int main(void)
 			TestDirectoryEntriesAndExtras) == NULL ||
 		CU_add_test(suite, "malformed directory entry",
 			TestMalformedDirectoryEntry) == NULL ||
+		CU_add_test(suite, "directory entry without terminator",
+			TestDirectoryEntryWithoutTerminator) == NULL ||
+		CU_add_test(suite, "malformed extra fields",
+			TestMalformedExtraFields) == NULL ||
 		CU_add_test(suite, "recovery directory entry",
 			TestRecoveryDirectoryEntry) == NULL ||
 		CU_add_test(suite, "unsafe recovery directory entry",
 			TestUnsafeRecoveryDirectoryEntry) == NULL ||
 		CU_add_test(suite, "unknown reserved block",
-			TestUnknownReservedBlock) == NULL)
+			TestUnknownReservedBlock) == NULL ||
+		CU_add_test(suite, "list type layout",
+			TestListTypeLayout) == NULL)
 	{
 		CU_cleanup_registry();
 		return CU_get_error();

--- a/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
+++ b/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
@@ -1,0 +1,306 @@
+#include <exec/types.h>
+#include <string.h>
+
+#include <CUnit/Automated.h>
+#include <CUnit/Basic.h>
+
+#include "blocks.h"
+#include "endian.h"
+
+#define BLOCK_BYTES_1K 1024
+#define BLOCK_BYTES_2K 2048
+#define BLOCK_BYTES_4K 4096
+
+static void AssertRoundTrip(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type)
+{
+	UBYTE original[BLOCK_BYTES_4K];
+
+	CU_ASSERT_TRUE_FATAL(bytes <= sizeof(original));
+	memcpy(original, data, bytes);
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDisk(data, bytes, type));
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHost(data, bytes, type));
+	CU_ASSERT_EQUAL(memcmp(data, original, bytes), 0);
+}
+
+static void TestBootBlock(void)
+{
+	UBYTE data[512];
+	struct bootblock *block = (struct bootblock *)data;
+
+	memset(data, 0xa5, sizeof(data));
+	block->disktype = ID_PFS_DISK;
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_BOOT));
+	CU_ASSERT_EQUAL(data[0], 'P');
+	CU_ASSERT_EQUAL(data[1], 'F');
+	CU_ASSERT_EQUAL(data[2], 'S');
+	CU_ASSERT_EQUAL(data[3], 1);
+	CU_ASSERT_EQUAL(data[4], 0xa5);
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_BOOT));
+	CU_ASSERT_EQUAL(block->disktype, ID_PFS_DISK);
+}
+
+static void TestRootBlock(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	struct rootblock *root = (struct rootblock *)data;
+	struct bitmapblock *bitmap;
+
+	memset(data, 0, sizeof(data));
+	root->disktype = ID_PFS2_DISK;
+	root->options = 0x12345678;
+	root->datestamp = 0x11223344;
+	root->creationday = 0x1357;
+	root->creationminute = 0x2468;
+	root->creationtick = 0x369c;
+	root->lastreserved = 0x01020304;
+	root->reserved_blksize = BLOCK_BYTES_1K;
+	root->rblkcluster = 2;
+	root->idx.large.bitmapindex[0] = 0x89abcdef;
+
+	bitmap = (struct bitmapblock *)(root + 1);
+	bitmap->id = BMBLKID;
+	bitmap->datestamp = 0x55667788;
+	bitmap->seqnr = 0x10203040;
+	bitmap->bitmap[0] = 0x12345678;
+
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_ROOT));
+	CU_ASSERT_EQUAL(data[0], 'P');
+	CU_ASSERT_EQUAL(data[1], 'F');
+	CU_ASSERT_EQUAL(data[2], 'S');
+	CU_ASSERT_EQUAL(data[3], 2);
+	CU_ASSERT_EQUAL(data[4], 0x12);
+	CU_ASSERT_EQUAL(data[5], 0x34);
+	CU_ASSERT_EQUAL(data[sizeof(*root)], 'B');
+	CU_ASSERT_EQUAL(data[sizeof(*root) + 1], 'M');
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_ROOT));
+	CU_ASSERT_EQUAL(root->options, 0x12345678);
+	CU_ASSERT_EQUAL(root->idx.large.bitmapindex[0], 0x89abcdef);
+	CU_ASSERT_EQUAL(bitmap->bitmap[0], 0x12345678);
+}
+
+static void TestBitmapSizes(void)
+{
+	ULONG sizes[] = { BLOCK_BYTES_1K, BLOCK_BYTES_2K, BLOCK_BYTES_4K };
+	UBYTE data[BLOCK_BYTES_4K];
+	ULONG i;
+
+	for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
+	{
+		struct bitmapblock *block = (struct bitmapblock *)data;
+		ULONG count = (sizes[i] - sizeof(*block)) / sizeof(ULONG);
+
+		memset(data, 0, sizes[i]);
+		block->id = BMBLKID;
+		block->datestamp = 0x10203040;
+		block->seqnr = 0x50607080;
+		block->bitmap[0] = 0x12345678;
+		block->bitmap[count - 1] = 0x89abcdef;
+		AssertRoundTrip(data, sizes[i], PFS3_METADATA_RESERVED);
+	}
+}
+
+static void TestIndexAndAnodeBlocks(void)
+{
+	UBYTE index_data[BLOCK_BYTES_2K];
+	UBYTE anode_data[BLOCK_BYTES_4K];
+	struct indexblock *index = (struct indexblock *)index_data;
+	struct anodeblock *anodes = (struct anodeblock *)anode_data;
+	ULONG count;
+
+	memset(index_data, 0, sizeof(index_data));
+	index->id = IBLKID;
+	index->datestamp = 0x10203040;
+	index->seqnr = 0x11223344;
+	count = (sizeof(index_data) - sizeof(*index)) / sizeof(ULONG);
+	index->index[0] = 0x12345678;
+	index->index[count - 1] = 0x89abcdef;
+	AssertRoundTrip(index_data, sizeof(index_data), PFS3_METADATA_RESERVED);
+
+	memset(anode_data, 0, sizeof(anode_data));
+	anodes->id = ABLKID;
+	anodes->datestamp = 0x50607080;
+	anodes->seqnr = 0x11223344;
+	anodes->nodes[0].clustersize = 0x01020304;
+	anodes->nodes[0].blocknr = 0x12345678;
+	anodes->nodes[0].next = 0x89abcdef;
+	AssertRoundTrip(anode_data, sizeof(anode_data),
+		PFS3_METADATA_RESERVED);
+}
+
+static void TestFixedReservedBlocks(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	struct deldirblock *deldir = (struct deldirblock *)data;
+	struct rootblockextension *extension =
+		(struct rootblockextension *)data;
+
+	memset(data, 0, sizeof(data));
+	deldir->id = DELDIRID;
+	deldir->datestamp = 0x10203040;
+	deldir->seqnr = 0x11223344;
+	deldir->uid = 0x1357;
+	deldir->gid = 0x2468;
+	deldir->protection = 0x55667788;
+	deldir->entries[0].anodenr = 0x12345678;
+	deldir->entries[0].fsize = 0x89abcdef;
+	deldir->entries[0].fsizex = 0x369c;
+	AssertRoundTrip(data, sizeof(data), PFS3_METADATA_RESERVED);
+
+	memset(data, 0, sizeof(data));
+	extension->id = EXTENSIONID;
+	extension->ext_options = 0x10203040;
+	extension->datestamp = 0x11223344;
+	extension->pfs2version = 0x55667788;
+	extension->root_date[0] = 0x1357;
+	extension->tobedone.operation_id = 0x12345678;
+	extension->tobedone.argument3 = 0x89abcdef;
+	extension->reserved_roving = 0x50607080;
+	extension->superindex[0] = 0x01020304;
+	extension->superindex[MAXSUPER] = 0x90abcdef;
+	extension->dd_protection = 0xa1b2c3d4;
+	extension->deldir[31] = 0x18273645;
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(data[0], 'E');
+	CU_ASSERT_EQUAL(data[1], 'X');
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(extension->ext_options, 0x10203040);
+	CU_ASSERT_EQUAL(extension->superindex[MAXSUPER], 0x90abcdef);
+	CU_ASSERT_EQUAL(extension->deldir[31], 0x18273645);
+}
+
+static void TestDirectoryEntriesAndExtras(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	UBYTE original[BLOCK_BYTES_1K];
+	struct dirblock *block = (struct dirblock *)data;
+	struct direntry *entry;
+	struct extrafields input, output;
+	UBYTE *packed;
+
+	memset(data, 0, sizeof(data));
+	block->id = DBLKID;
+	block->datestamp = 0x10203040;
+	block->anodenr = 0x11223344;
+	block->parent = 0x55667788;
+	entry = (struct direntry *)block->entries;
+	entry->type = 2;
+	entry->anode = 0x12345678;
+	entry->fsize = 0x89abcdef;
+	entry->creationday = 0x1357;
+	entry->creationminute = 0x2468;
+	entry->creationtick = 0x369c;
+	entry->protection = 0x5a;
+	entry->nlength = 1;
+	*(UBYTE *)&entry->startofname = 'x';
+	*((UBYTE *)&entry->startofname + 1) = 0;
+
+	memset(&input, 0, sizeof(input));
+	input.link = 0x10203040;
+	input.uid = 0x1357;
+	input.gid = 0x2468;
+	input.prot = 0xabcdef5a;
+	input.virtualsize = 0x11223344;
+	input.rollpointer = 0x55667788;
+	input.fsizex = 0x369c;
+	PFS3AddExtraFields(entry, &input);
+	memset(&output, 0, sizeof(output));
+	PFS3GetExtraFields(entry, &output);
+	CU_ASSERT_EQUAL(output.link, 0x10203040);
+	CU_ASSERT_EQUAL(output.uid, 0x1357);
+	CU_ASSERT_EQUAL(output.gid, 0x2468);
+	CU_ASSERT_EQUAL(output.prot, 0xabcdef5a);
+	CU_ASSERT_EQUAL(output.virtualsize, 0x11223344);
+	CU_ASSERT_EQUAL(output.rollpointer, 0x55667788);
+	CU_ASSERT_EQUAL(output.fsizex, 0x369c);
+
+	packed = (UBYTE *)entry + sizeof(*entry);
+	CU_ASSERT_EQUAL(packed[0], 0x36);
+	CU_ASSERT_EQUAL(packed[1], 0x9c);
+	CU_ASSERT_EQUAL(packed[18], 0x30);
+	CU_ASSERT_EQUAL(packed[19], 0x40);
+	CU_ASSERT_EQUAL(packed[20], 0x10);
+	CU_ASSERT_EQUAL(packed[21], 0x20);
+	CU_ASSERT_EQUAL(packed[22], 0x07);
+	CU_ASSERT_EQUAL(packed[23], 0xff);
+
+	memcpy(original, data, sizeof(data));
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(data[0], 'D');
+	CU_ASSERT_EQUAL(data[1], 'B');
+	CU_ASSERT_EQUAL(data[sizeof(*block) + 2], 0x12);
+	CU_ASSERT_EQUAL(data[sizeof(*block) + 3], 0x34);
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+}
+
+static void TestMalformedDirectoryEntry(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	struct dirblock *block = (struct dirblock *)data;
+	struct direntry *entry;
+
+	memset(data, 0, sizeof(data));
+	block->id = DBLKID;
+	entry = (struct direntry *)block->entries;
+	entry->next = 3;
+	CU_ASSERT_FALSE(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+}
+
+static void TestUnknownReservedBlock(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+
+	memset(data, 0, sizeof(data));
+	CU_ASSERT_FALSE(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_FALSE(PFS3MetadataToDisk(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+}
+
+int main(void)
+{
+	CU_pSuite suite;
+
+	if (CU_initialize_registry() != CUE_SUCCESS)
+		return CU_get_error();
+
+	suite = CU_add_suite("PFS3 endian conversion", NULL, NULL);
+	if (suite == NULL ||
+		CU_add_test(suite, "boot block", TestBootBlock) == NULL ||
+		CU_add_test(suite, "root block", TestRootBlock) == NULL ||
+		CU_add_test(suite, "bitmap block sizes", TestBitmapSizes) == NULL ||
+		CU_add_test(suite, "index and anode blocks",
+			TestIndexAndAnodeBlocks) == NULL ||
+		CU_add_test(suite, "fixed reserved blocks",
+			TestFixedReservedBlocks) == NULL ||
+		CU_add_test(suite, "directory entries and extras",
+			TestDirectoryEntriesAndExtras) == NULL ||
+		CU_add_test(suite, "malformed directory entry",
+			TestMalformedDirectoryEntry) == NULL ||
+		CU_add_test(suite, "unknown reserved block",
+			TestUnknownReservedBlock) == NULL)
+	{
+		CU_cleanup_registry();
+		return CU_get_error();
+	}
+
+	CU_basic_set_mode(CU_BRM_VERBOSE);
+	CU_basic_run_tests();
+	CU_basic_set_mode(CU_BRM_SILENT);
+	CU_automated_package_name_set("PFS3EndianUnitTests");
+	CU_set_output_filename("PFS3Endian");
+	CU_automated_enable_junit_xml(CU_TRUE);
+	CU_automated_run_tests();
+	CU_cleanup_registry();
+	return CU_get_error();
+}

--- a/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
+++ b/developer/debug/test/filesys/pfs3/cunit-pfs3-endian.c
@@ -211,7 +211,7 @@ static void TestDirectoryEntriesAndExtras(void)
 	input.fsizex = 0x369c;
 	PFS3AddExtraFields(entry, &input);
 	memset(&output, 0, sizeof(output));
-	PFS3GetExtraFields(entry, &output);
+	CU_ASSERT_EQUAL(PFS3GetExtraFields(entry, &output), 0);
 	CU_ASSERT_EQUAL(output.link, 0x10203040);
 	CU_ASSERT_EQUAL(output.uid, 0x1357);
 	CU_ASSERT_EQUAL(output.gid, 0x2468);
@@ -245,6 +245,7 @@ static void TestDirectoryEntriesAndExtras(void)
 static void TestMalformedDirectoryEntry(void)
 {
 	UBYTE data[BLOCK_BYTES_1K];
+	UBYTE original[BLOCK_BYTES_1K];
 	struct dirblock *block = (struct dirblock *)data;
 	struct direntry *entry;
 
@@ -252,8 +253,62 @@ static void TestMalformedDirectoryEntry(void)
 	block->id = DBLKID;
 	entry = (struct direntry *)block->entries;
 	entry->next = 3;
+	memcpy(original, data, sizeof(data));
 	CU_ASSERT_FALSE(PFS3MetadataToDisk(data, sizeof(data),
 		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+}
+
+static void TestRecoveryDirectoryEntry(void)
+{
+	UBYTE data[BLOCK_BYTES_1K];
+	UBYTE original[BLOCK_BYTES_1K];
+	struct dirblock *block = (struct dirblock *)data;
+	struct direntry *entry;
+	ULONG entry_offset = offsetof(struct dirblock, entries);
+
+	memset(data, 0, sizeof(data));
+	data[0] = 'D';
+	data[1] = 'B';
+	data[offsetof(struct dirblock, anodenr)] = 0x11;
+	data[offsetof(struct dirblock, anodenr) + 1] = 0x22;
+	data[offsetof(struct dirblock, anodenr) + 2] = 0x33;
+	data[offsetof(struct dirblock, anodenr) + 3] = 0x44;
+	data[entry_offset] = sizeof(*entry) + 1;
+	data[entry_offset + offsetof(struct direntry, anode)] = 0x12;
+	data[entry_offset + offsetof(struct direntry, anode) + 1] = 0x34;
+	data[entry_offset + offsetof(struct direntry, anode) + 2] = 0x56;
+	data[entry_offset + offsetof(struct direntry, anode) + 3] = 0x78;
+	data[entry_offset + offsetof(struct direntry, nlength)] = 0xff;
+	memcpy(original, data, sizeof(data));
+
+	CU_ASSERT_FALSE(PFS3MetadataToHost(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToHostForRecovery(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(block->anodenr, 0x11223344);
+	entry = (struct direntry *)block->entries;
+	CU_ASSERT_EQUAL(entry->anode, 0x12345678);
+	CU_ASSERT_TRUE_FATAL(PFS3MetadataToDiskForRecovery(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
+}
+
+static void TestUnsafeRecoveryDirectoryEntry(void)
+{
+	UBYTE data[64];
+	UBYTE original[64];
+	ULONG entry_offset = offsetof(struct dirblock, entries);
+
+	memset(data, 0, sizeof(data));
+	data[0] = 'D';
+	data[1] = 'B';
+	data[entry_offset] = sizeof(data);
+	memcpy(original, data, sizeof(data));
+
+	CU_ASSERT_FALSE(PFS3MetadataToHostForRecovery(data, sizeof(data),
+		PFS3_METADATA_RESERVED));
+	CU_ASSERT_EQUAL(memcmp(data, original, sizeof(data)), 0);
 }
 
 static void TestUnknownReservedBlock(void)
@@ -287,6 +342,10 @@ int main(void)
 			TestDirectoryEntriesAndExtras) == NULL ||
 		CU_add_test(suite, "malformed directory entry",
 			TestMalformedDirectoryEntry) == NULL ||
+		CU_add_test(suite, "recovery directory entry",
+			TestRecoveryDirectoryEntry) == NULL ||
+		CU_add_test(suite, "unsafe recovery directory entry",
+			TestUnsafeRecoveryDirectoryEntry) == NULL ||
 		CU_add_test(suite, "unknown reserved block",
 			TestUnknownReservedBlock) == NULL)
 	{

--- a/developer/debug/test/filesys/pfs3/cunit-pfs3-listtype.c
+++ b/developer/debug/test/filesys/pfs3/cunit-pfs3-listtype.c
@@ -1,0 +1,22 @@
+#include <exec/types.h>
+
+#include <CUnit/CUnit.h>
+
+#include "blocks.h"
+#include "struct.h"
+
+void TestListTypeLayout(void)
+{
+	listtype type;
+
+	type.value = ET_FILEENTRY | ET_EXCLWRITE;
+	CU_ASSERT_EQUAL(type.flags.type, ETF_FILEENTRY);
+	CU_ASSERT_EQUAL(type.flags.access, ET_EXCLWRITE);
+	CU_ASSERT_EQUAL(type.flags.dir, 0);
+
+	type.value = 0;
+	type.flags.type = ETF_LOCK;
+	type.flags.access = ET_EXCLREAD;
+	type.flags.dir = 1;
+	CU_ASSERT_EQUAL(type.value, ET_LOCK | ET_EXCLREAD | 0x10);
+}

--- a/developer/debug/test/filesys/pfs3/mmakefile.src
+++ b/developer/debug/test/filesys/pfs3/mmakefile.src
@@ -24,6 +24,6 @@ USER_INCLUDES := \
 USER_LDFLAGS := -L$(AROS_CONTRIB_LIB)
 
 %build_prog mmake=test-pfs3-yes-cunit \
-	files="cunit-pfs3-endian $(PFS3DIR)/endian" \
+	files="cunit-pfs3-endian cunit-pfs3-listtype $(PFS3DIR)/endian" \
 	progname=cunit-pfs3-endian targetdir=$(CUNITEXEDIR) \
 	uselibs="cunit posixc"

--- a/developer/debug/test/filesys/pfs3/mmakefile.src
+++ b/developer/debug/test/filesys/pfs3/mmakefile.src
@@ -1,0 +1,29 @@
+include $(SRCDIR)/config/aros.cfg
+
+CUNITEXEDIR := $(AROS_TESTS)/cunit/filesys/pfs3
+PFS3DIR := $(SRCDIR)/rom/filesys/pfs3/fs
+
+#MM- test : test-pfs3-cunit
+#MM- test-quick : test-pfs3-cunit-quick
+
+#MM- test-cunit : test-pfs3-cunit
+#MM- test-cunit-quick : test-pfs3-cunit-quick
+
+#MM- test-pfs3-cunit : test-pfs3-$(TARGET_UNITTESTS)-cunit
+#MM- test-pfs3-cunit-quick : test-pfs3-$(TARGET_UNITTESTS)-cunit-quick
+
+#MM test-pfs3-yes-cunit : includes includes-copy linklibs linklibs-cunit
+
+USER_CPPFLAGS := \
+	-DDELDIR=1 \
+	-DVERSION23=1 \
+	-DLARGE_FILE_SIZE=1
+USER_INCLUDES := \
+	-I$(AROS_CONTRIB_INCLUDES) \
+	-I$(PFS3DIR)
+USER_LDFLAGS := -L$(AROS_CONTRIB_LIB)
+
+%build_prog mmake=test-pfs3-yes-cunit \
+	files="cunit-pfs3-endian $(PFS3DIR)/endian" \
+	progname=cunit-pfs3-endian targetdir=$(CUNITEXEDIR) \
+	uselibs="cunit posixc"

--- a/rom/filesys/pfs3/fs/allocation.c
+++ b/rom/filesys/pfs3/fs/allocation.c
@@ -819,7 +819,7 @@ struct cbitmapblock *GetBitmapBlock(ULONG seqnr, globaldata *g)
 	DB(Trace(10,"GetBitmapBlock", "seqnr = %ld blocknr = %lx\n", seqnr, blocknr));
 
 	/* read it */
-	if (RawRead((UBYTE*)&bmb->blk, RESCLUSTER, blocknr, g) != 0)
+	if (ReadReservedBlocks((UBYTE*)&bmb->blk, RESCLUSTER, blocknr, g) != 0)
 	{
 		FreeLRU((struct cachedblock *)bmb);
 		return NULL;
@@ -870,7 +870,7 @@ cindexblock_t *GetBitmapIndex (UWORD nr, globaldata *g)
 
 	DB(Trace(10,"GetBitmapIndex", "seqnr = %ld blocknr = %lx\n", nr, blocknr));
 
-	if (RawRead((UBYTE*)&indexblk->blk, RESCLUSTER, blocknr, g) != 0) {
+	if (ReadReservedBlocks((UBYTE*)&indexblk->blk, RESCLUSTER, blocknr, g) != 0) {
 		FreeLRU((struct cachedblock *)indexblk);
 		return NULL;
 	}

--- a/rom/filesys/pfs3/fs/anodes.c
+++ b/rom/filesys/pfs3/fs/anodes.c
@@ -299,7 +299,8 @@ void GetAnode (struct canode *anode, ULONG anodenr, globaldata *g)
 		anodeoffset  = temp >> 16;
 	}
 	
-	ablock = GetAnodeBlock(seqnr, g);
+	ablock = anodeoffset < andata.anodesperblock ?
+		GetAnodeBlock(seqnr, g) : NULL;
 	if(ablock)
 	{
 		anode->clustersize = ablock->blk.nodes[anodeoffset].clustersize;
@@ -340,6 +341,9 @@ void SaveAnode (struct canode *anode, ULONG anodenr, globaldata *g)
 	anode->nr   = anodenr;
 
 	/* Save Anode */
+	if (anodeoffset >= andata.anodesperblock)
+		return;
+
 	ablock = GetAnodeBlock (seqnr, g);
 	if (ablock)
 	{

--- a/rom/filesys/pfs3/fs/anodes.c
+++ b/rom/filesys/pfs3/fs/anodes.c
@@ -535,7 +535,7 @@ static struct canodeblock *big_GetAnodeBlock (UWORD seqnr, globaldata *g)
 	DBERR(ErrorTrace(10,"GetAnodeBlock", "seqnr = %lu blocknr = %lu\n", seqnr, blocknr));
 
 	/* read it */
-	if (RawRead ((UBYTE*)&ablock->blk, RESCLUSTER, blocknr, g) != 0)
+	if (ReadReservedBlocks ((UBYTE*)&ablock->blk, RESCLUSTER, blocknr, g) != 0)
 	{
 		DB(Trace(5,"GetAnodeBlock","Read ERR: seqnr = %lu blocknr = %lx\n", seqnr, blocknr));
 		FreeLRU ((struct cachedblock *)ablock);
@@ -671,7 +671,7 @@ struct cindexblock *GetIndexBlock (UWORD nr, globaldata *g)
 
 	DBERR(ErrorTrace(10,"GetIndexBlock","seqnr = %lu blocknr = %lu\n", nr, blocknr));
 
-	if (RawRead ((UBYTE*)&indexblk->blk, RESCLUSTER, blocknr, g) != 0) {
+	if (ReadReservedBlocks ((UBYTE*)&indexblk->blk, RESCLUSTER, blocknr, g) != 0) {
 		FreeLRU ((struct cachedblock *)indexblk);
 		return NULL;
 	}
@@ -798,7 +798,7 @@ struct cindexblock *GetSuperBlock (UWORD nr, globaldata *g)
 
 	DBERR(ErrorTrace(10,"GetSuperBlock","seqnr = %lu blocknr = %lu\n", nr, blocknr));
 
-	if (RawRead ((UBYTE*)&superblk->blk, RESCLUSTER, blocknr, g) != 0) {
+	if (ReadReservedBlocks ((UBYTE*)&superblk->blk, RESCLUSTER, blocknr, g) != 0) {
 		DBERR(ErrorTrace(1, "GetSuperBlock", "ERR: read error. %lu %lu\n", nr, blocknr));
 		FreeLRU ((struct cachedblock *)superblk);
 		return NULL;

--- a/rom/filesys/pfs3/fs/anodes.c
+++ b/rom/filesys/pfs3/fs/anodes.c
@@ -289,9 +289,8 @@ void GetAnode (struct canode *anode, ULONG anodenr, globaldata *g)
 
 	if(g->anodesplitmode)
 	{
-		anodenr_t *split = (anodenr_t *)&anodenr;
-		seqnr = split->seqnr;
-		anodeoffset = split->offset;
+		seqnr = anodenr >> 16;
+		anodeoffset = anodenr;
 	}
 	else
 	{
@@ -328,9 +327,8 @@ void SaveAnode (struct canode *anode, ULONG anodenr, globaldata *g)
 
 	if (g->anodesplitmode)
 	{
-		anodenr_t *split = (anodenr_t *)&anodenr;
-		seqnr = split->seqnr;
-		anodeoffset = split->offset;
+		seqnr = anodenr >> 16;
+		anodeoffset = anodenr;
 	}
 	else
 	{

--- a/rom/filesys/pfs3/fs/blocks.h
+++ b/rom/filesys/pfs3/fs/blocks.h
@@ -235,12 +235,6 @@ typedef struct anode
     ULONG next;
 } anode_t;
 
-typedef struct
-{
-	UWORD seqnr;
-	UWORD offset;
-} anodenr_t;
-
 typedef struct anodeblock
 {
     UWORD id;               /* AB                               */

--- a/rom/filesys/pfs3/fs/boot.c
+++ b/rom/filesys/pfs3/fs/boot.c
@@ -509,6 +509,7 @@ terminate:
 	CloseLibrary((struct Library *) IntuitionBase);
 
 	FreeMem(g, sizeof(struct globaldata));
+	AfsDie ();
 }
 
 void ReturnPacket (struct DosPacket *packet, struct MsgPort *sender, globaldata *g)
@@ -697,18 +698,7 @@ static void Quit (globaldata *g)
 	LibDeletePool (g->bufferPool);
 	LibDeletePool (g->mainPool);
 
-#if MULTIUSER
-	if (muBase)
-		CloseLibrary((struct Library *) muBase);
-#endif
-	CloseLibrary(UtilityBase);
-	CloseLibrary((struct Library *) DOSBase);
-	CloseLibrary((struct Library *) IntuitionBase);
-
 	EXIT("dd_Quit");
-
-	FreeMem (g, sizeof(struct globaldata));
-	AfsDie ();
 }
 
 #undef SysBase
@@ -724,5 +714,4 @@ LONG __saveds __startup Main(void)
     return EntryPoint(*(struct ExecBase **)4L);
 }
 #endif
-
 

--- a/rom/filesys/pfs3/fs/dd_funcs.c
+++ b/rom/filesys/pfs3/fs/dd_funcs.c
@@ -1135,7 +1135,7 @@ static SIPTR dd_SerializeDisk(struct DosPacket *pkt, globaldata * g)
 		return DOSFALSE;
 	}
 
-	pkt->dp_Res2 = RawRead((UBYTE *)rbl, 1, ROOTBLOCK, g);
+	pkt->dp_Res2 = ReadRootBlocks((UBYTE *)rbl, 1, ROOTBLOCK, g);
 	if (pkt->dp_Res2)
 		goto inh_error;
 
@@ -1143,7 +1143,7 @@ static SIPTR dd_SerializeDisk(struct DosPacket *pkt, globaldata * g)
 	rbl->creationday = (UWORD)time.ds_Days;
 	rbl->creationminute = (UWORD)time.ds_Minute;
 	rbl->creationtick = (UWORD)time.ds_Tick + 3;
-	pkt->dp_Res2 = RawWrite((UBYTE *)rbl, 1, ROOTBLOCK, g);
+	pkt->dp_Res2 = WriteRootBlocks((UBYTE *)rbl, 1, ROOTBLOCK, g);
 	if (pkt->dp_Res2)
 		goto inh_error;
 

--- a/rom/filesys/pfs3/fs/dd_support.c
+++ b/rom/filesys/pfs3/fs/dd_support.c
@@ -149,7 +149,7 @@ static BOOL RenameDisk (UBYTE *newname, globaldata *g)  //%4.5
 		diskname = volume->rootblk->diskname;
 		*diskname = strlen(newname);
 		CopyMem (newname, diskname+1, strlen(newname));
-		RawWrite ((UBYTE *)volume->rootblk, 1, ROOTBLOCK, g);   /* %7.2 */
+		WriteRootBlocks ((UBYTE *)volume->rootblk, 1, ROOTBLOCK, g);   /* %7.2 */
 		UpdateAndMotorOff(g);
 		volume->rootblockchangeflag = FALSE;
 		return DOSTRUE;
@@ -388,11 +388,11 @@ static void Awake (globaldata *g)
 	{
 		/* reload current rootblock  */
 		rootblock = volume->rootblk;
-		RawRead((UBYTE *)rootblock, rootblock->rblkcluster, ROOTBLOCK, g);
+		ReadRootBlocks((UBYTE *)rootblock, rootblock->rblkcluster, ROOTBLOCK, g);
 
 		/* reload rootblock extension */
 		if (rootblock->extension && (rootblock->options & MODE_EXTENSION))
-			RawRead((UBYTE *)&volume->rblkextension->blk, volume->rescluster,
+			ReadReservedBlocks((UBYTE *)&volume->rblkextension->blk, volume->rescluster,
 				rootblock->extension, g);
 
 		/* reload deldir */

--- a/rom/filesys/pfs3/fs/directory.c
+++ b/rom/filesys/pfs3/fs/directory.c
@@ -243,6 +243,7 @@
 #include "debug.h"
 #include "blocks.h"
 #include "struct.h"
+#include "endian.h"
 #include "directory_protos.h"
 #include "allocation_protos.h"
 #include "volume_protos.h"
@@ -3493,7 +3494,7 @@ struct cdirblock *LoadDirBlock(ULONG blocknr, globaldata * g)
 		dirblk = (struct cdirblock *)AllocLRU(g);
 
 		DB(Trace(10, "LoadDirBlock", "loading block %lx from disk\n", blocknr));
-		if (RawRead((UBYTE *)&dirblk->blk, RESCLUSTER, blocknr, g) == 0)
+		if (ReadReservedBlocks((UBYTE *)&dirblk->blk, RESCLUSTER, blocknr, g) == 0)
 		{
 			if (dirblk->blk.id == DBLKID)
 			{
@@ -3624,16 +3625,7 @@ void SetDDFileSize(struct deldirentry *dde, FSIZE size, globaldata *g)
  */
 void GetExtraFields(struct direntry *direntry, struct extrafields *extrafields)
 {
-	UWORD *extra = (UWORD *)extrafields;
-	UWORD *fields = (UWORD *)(((UBYTE *)direntry) + direntry->next);
-	UWORD flags, i;
-
-	flags = *(--fields);
-	for (i = 0; i < sizeof(struct extrafields) / 2; i++, flags >>= 1)
-		*(extra++) = (flags & 1) ? *(--fields) : 0;
-
-	/* patch protection lower 8 bits */
-	extrafields->prot |= direntry->protection;
+	PFS3GetExtraFields(direntry, extrafields);
 }
 
 #if DELDIR
@@ -3669,40 +3661,7 @@ static void GetExtraFieldsRoot(struct extrafields *extrafields, globaldata * g)
 
 void AddExtraFields(struct direntry *direntry, struct extrafields *extra)
 {
-	UWORD offset, *dirext;
-	UWORD array[16], i = 0, j = 0;
-	UWORD flags = 0, orvalue;
-	UWORD *fields = (UWORD *)extra;
-
-	/* patch protection lower 8 bits */
-	extra->prot &= 0xffffff00;
-	offset = (sizeof(struct direntry) + (direntry->nlength) + *COMMENT(direntry)) & 0xfffe;
-	dirext = (UWORD *)((UBYTE *)(direntry) + (UBYTE)offset);
-
-	orvalue = 1;
-	/* fill packed field array */
-	for (i = 0; i < sizeof(struct extrafields) / 2; i++)
-	{
-		if (*fields)
-		{
-			array[j++] = *fields++;
-			flags |= orvalue;
-		}
-		else
-		{
-			fields++;
-		}
-
-		orvalue <<= 1;
-	}
-
-	/* add fields to direntry */
-	i = j;
-	while (i)
-		*dirext++ = array[--i];
-	*dirext++ = flags;
-
-	direntry->next = offset + 2 * j + 2;
+	PFS3AddExtraFields(direntry, extra);
 }
 
 
@@ -4285,7 +4244,7 @@ static struct cdeldirblock *GetDeldirBlock(UWORD seqnr, globaldata *g)
 	}
 
 	/* read block */
-	if (RawRead ((UBYTE*)&ddblk->blk, RESCLUSTER, blocknr, g) != 0)
+	if (ReadReservedBlocks ((UBYTE*)&ddblk->blk, RESCLUSTER, blocknr, g) != 0)
 	{
 		DB(Trace(5,"GetDeldirBlock","Read ERR: seqnr = %d blocknr = %lx\n", seqnr, blocknr));
 		FreeLRU ((struct cachedblock *)ddblk);

--- a/rom/filesys/pfs3/fs/disk.c
+++ b/rom/filesys/pfs3/fs/disk.c
@@ -171,6 +171,7 @@
 // own includes
 #include "blocks.h"
 #include "struct.h"
+#include "endian.h"
 #include "disk_protos.h"
 #include "allocation_protos.h"
 #include "volume_protos.h"
@@ -1698,6 +1699,59 @@ ULONG RawWrite(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
 #else
 	return RawReadWrite_TD(TRUE, buffer, blocks, blocknr, g);
 #endif
+}
+
+static ULONG ReadMetadata(UBYTE *buffer, ULONG blocks, ULONG blocknr,
+	enum pfs3_metadata_type type, globaldata *g)
+{
+	ULONG error;
+
+	error = RawRead(buffer, blocks, blocknr, g);
+	if (!error && !PFS3MetadataToHost(buffer, blocks << BLOCKSHIFT, type))
+		error = ERROR_NOT_A_DOS_DISK;
+	return error;
+}
+
+static ULONG WriteMetadata(UBYTE *buffer, ULONG blocks, ULONG blocknr,
+	enum pfs3_metadata_type type, globaldata *g)
+{
+	ULONG error;
+
+	if (!PFS3MetadataToDisk(buffer, blocks << BLOCKSHIFT, type))
+		return ERROR_NOT_A_DOS_DISK;
+	error = RawWrite(buffer, blocks, blocknr, g);
+	PFS3MetadataToHost(buffer, blocks << BLOCKSHIFT, type);
+	return error;
+}
+
+ULONG ReadBootBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return ReadMetadata(buffer, blocks, blocknr, PFS3_METADATA_BOOT, g);
+}
+
+ULONG WriteBootBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return WriteMetadata(buffer, blocks, blocknr, PFS3_METADATA_BOOT, g);
+}
+
+ULONG ReadRootBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return ReadMetadata(buffer, blocks, blocknr, PFS3_METADATA_ROOT, g);
+}
+
+ULONG WriteRootBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return WriteMetadata(buffer, blocks, blocknr, PFS3_METADATA_ROOT, g);
+}
+
+ULONG ReadReservedBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return ReadMetadata(buffer, blocks, blocknr, PFS3_METADATA_RESERVED, g);
+}
+
+ULONG WriteReservedBlocks(UBYTE *buffer, ULONG blocks, ULONG blocknr, globaldata *g)
+{
+	return WriteMetadata(buffer, blocks, blocknr, PFS3_METADATA_RESERVED, g);
 }
 
 #if ACCESS_DETECT

--- a/rom/filesys/pfs3/fs/disk_protos.h
+++ b/rom/filesys/pfs3/fs/disk_protos.h
@@ -19,6 +19,18 @@ ULONG RawRead(UBYTE * , ULONG , ULONG , globaldata * );
 
 ULONG RawWrite(UBYTE * , ULONG , ULONG , globaldata * );
 
+ULONG ReadBootBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
+ULONG WriteBootBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
+ULONG ReadRootBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
+ULONG WriteRootBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
+ULONG ReadReservedBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
+ULONG WriteReservedBlocks(UBYTE *, ULONG, ULONG, globaldata *);
+
 void UpdateAndMotorOff(globaldata * );
 
 void UpdateCache (globaldata *g);

--- a/rom/filesys/pfs3/fs/endian.c
+++ b/rom/filesys/pfs3/fs/endian.c
@@ -1,5 +1,6 @@
 #include <exec/types.h>
 #include <stddef.h>
+#include <string.h>
 
 #ifdef __AROS__
 #include <aros/macros.h>
@@ -62,6 +63,17 @@ static void ConvertUnalignedLong(UBYTE *data)
 	data[1] = unaligned.bytes[1];
 	data[2] = unaligned.bytes[2];
 	data[3] = unaligned.bytes[3];
+}
+
+UWORD PFS3DiskBlockId(const UBYTE *data)
+{
+	return ((UWORD)data[0] << 8) | data[1];
+}
+
+static void WriteDiskWord(UBYTE *data, UWORD value)
+{
+	data[0] = value >> 8;
+	data[1] = value;
 }
 
 static BOOL ConvertBootBlock(UBYTE *data, ULONG bytes)
@@ -163,29 +175,64 @@ static BOOL ConvertAnodeBlock(struct anodeblock *block, ULONG bytes)
 	return TRUE;
 }
 
+static BOOL ValidateDirEntryLayout(const UBYTE *data, ULONG bytes,
+	UWORD *extra_flags)
+{
+	ULONG field_bytes = 0;
+	ULONG name_end;
+	ULONG packed_offset;
+	UWORD flags;
+	UWORD remaining;
+
+	if (bytes < sizeof(struct direntry))
+		return FALSE;
+
+	name_end = offsetof(struct direntry, startofname) +
+		data[offsetof(struct direntry, nlength)];
+	if (name_end >= bytes)
+		return FALSE;
+
+	packed_offset = (sizeof(struct direntry) +
+		data[offsetof(struct direntry, nlength)] + data[name_end]) & 0xfffe;
+	if (bytes < sizeof(UWORD) || packed_offset > bytes - sizeof(UWORD))
+		return FALSE;
+
+	flags = PFS3DiskBlockId(data + bytes - sizeof(UWORD));
+	remaining = flags;
+	while (remaining)
+	{
+		field_bytes += (remaining & 1) ? sizeof(UWORD) : 0;
+		remaining >>= 1;
+	}
+	if (field_bytes > bytes - sizeof(UWORD) - packed_offset)
+		return FALSE;
+
+	if (extra_flags)
+		*extra_flags = flags;
+	return TRUE;
+}
+
 static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes,
 	BOOL recovery)
 {
-	struct direntry *entry;
-	ULONG offset;
+	const UBYTE *data = (const UBYTE *)block;
+	ULONG offset = sizeof(*block);
+	UBYTE next;
 
-	offset = sizeof(*block);
 	while (offset < bytes)
 	{
-		entry = (struct direntry *)((UBYTE *)block + offset);
-		if (entry->next == 0)
+		next = data[offset + offsetof(struct direntry, next)];
+		if (next == 0)
 			return TRUE;
-		if (entry->next < sizeof(*entry) || entry->next > bytes - offset)
+		if (next < sizeof(struct direntry) || next > bytes - offset)
 			return FALSE;
-		if (!recovery &&
-			((entry->next & 1) ||
-			 offsetof(struct direntry, startofname) + entry->nlength >=
-				entry->next))
+		if (!recovery && ((next & 1) ||
+			!ValidateDirEntryLayout(data + offset, next, NULL)))
 			return FALSE;
 
-		offset += entry->next;
+		offset += next;
 	}
-	return TRUE;
+	return FALSE;
 }
 
 static void ConvertDirEntry(struct direntry *entry)
@@ -201,8 +248,9 @@ static void ConvertDirEntry(struct direntry *entry)
 
 static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes, BOOL recovery)
 {
-	struct direntry *entry;
+	UBYTE *data = (UBYTE *)block;
 	ULONG offset;
+	UBYTE next;
 
 	if (bytes < sizeof(*block) ||
 		!ValidateDirEntries(block, bytes, recovery))
@@ -218,13 +266,13 @@ static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes, BOOL recovery)
 	offset = sizeof(*block);
 	while (offset < bytes)
 	{
-		entry = (struct direntry *)((UBYTE *)block + offset);
-		if (entry->next == 0)
+		next = data[offset + offsetof(struct direntry, next)];
+		if (next == 0)
 			return TRUE;
-		ConvertDirEntry(entry);
-		offset += entry->next;
+		ConvertDirEntry((struct direntry *)(data + offset));
+		offset += next;
 	}
-	return TRUE;
+	return FALSE;
 }
 
 #if DELDIR
@@ -306,11 +354,6 @@ static BOOL ConvertRootBlockExtension(struct rootblockextension *block,
 }
 #endif
 
-static UWORD DiskBlockId(const UBYTE *data)
-{
-	return ((UWORD)data[0] << 8) | data[1];
-}
-
 static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk,
 	BOOL recovery)
 {
@@ -319,7 +362,7 @@ static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk,
 	if (bytes < sizeof(UWORD))
 		return FALSE;
 
-	id = from_disk ? DiskBlockId(data) : *(UWORD *)data;
+	id = from_disk ? PFS3DiskBlockId(data) : *(UWORD *)data;
 	switch (id)
 	{
 	case BMBLKID:
@@ -387,18 +430,30 @@ UWORD PFS3GetExtraFields(struct direntry *direntry,
 	struct extrafields *extrafields)
 {
 	UWORD values[11] = { 0 };
-	UWORD *source = (UWORD *)((UBYTE *)direntry + direntry->next);
+	UBYTE *data = (UBYTE *)direntry;
+	UBYTE next = data[offsetof(struct direntry, next)];
+	ULONG source;
 	UWORD flags, i;
 
-	flags = AROS_BE2WORD(*(--source));
+	memset(extrafields, 0, sizeof(*extrafields));
+	if (!ValidateDirEntryLayout(data, next, &flags))
+		return ~0;
+
+	source = next - sizeof(UWORD);
 	for (i = 0; i < sizeof(values) / sizeof(values[0]); i++, flags >>= 1)
-		values[i] = (flags & 1) ? AROS_BE2WORD(*(--source)) : 0;
+	{
+		if (flags & 1)
+		{
+			source -= sizeof(UWORD);
+			values[i] = PFS3DiskBlockId(data + source);
+		}
+	}
 
 	extrafields->link = ((ULONG)values[0] << 16) | values[1];
 	extrafields->uid = values[2];
 	extrafields->gid = values[3];
 	extrafields->prot = ((ULONG)values[4] << 16) | values[5] |
-		direntry->protection;
+		data[offsetof(struct direntry, protection)];
 	extrafields->virtualsize = ((ULONG)values[6] << 16) | values[7];
 	extrafields->rollpointer = ((ULONG)values[8] << 16) | values[9];
 	extrafields->fsizex = values[10];
@@ -408,7 +463,8 @@ UWORD PFS3GetExtraFields(struct direntry *direntry,
 void PFS3AddExtraFields(struct direntry *direntry,
 	struct extrafields *extrafields)
 {
-	UWORD offset, *destination;
+	UBYTE *data = (UBYTE *)direntry;
+	UWORD offset;
 	UWORD fields[11];
 	UWORD values[11];
 	UWORD i, count = 0;
@@ -427,9 +483,10 @@ void PFS3AddExtraFields(struct direntry *direntry,
 	fields[9] = extrafields->rollpointer;
 	fields[10] = extrafields->fsizex;
 
-	offset = (sizeof(*direntry) + direntry->nlength +
-		*((UBYTE *)&direntry->startofname + direntry->nlength)) & 0xfffe;
-	destination = (UWORD *)((UBYTE *)direntry + offset);
+	offset = (sizeof(*direntry) +
+		data[offsetof(struct direntry, nlength)] +
+		data[offsetof(struct direntry, startofname) +
+			data[offsetof(struct direntry, nlength)]]) & 0xfffe;
 
 	for (i = 0; i < sizeof(fields) / sizeof(fields[0]); i++)
 	{
@@ -443,7 +500,11 @@ void PFS3AddExtraFields(struct direntry *direntry,
 
 	i = count;
 	while (i)
-		*destination++ = AROS_WORD2BE(values[--i]);
-	*destination = AROS_WORD2BE(flags);
-	direntry->next = offset + 2 * count + 2;
+	{
+		WriteDiskWord(data + offset, values[--i]);
+		offset += sizeof(UWORD);
+	}
+	WriteDiskWord(data + offset, flags);
+	offset += sizeof(UWORD);
+	data[offsetof(struct direntry, next)] = offset;
 }

--- a/rom/filesys/pfs3/fs/endian.c
+++ b/rom/filesys/pfs3/fs/endian.c
@@ -1,0 +1,393 @@
+#include <exec/types.h>
+#include <stddef.h>
+
+#ifdef __AROS__
+#include <aros/macros.h>
+#else
+#define AROS_BE2WORD(value) (value)
+#define AROS_WORD2BE(value) (value)
+#define AROS_BE2LONG(value) (value)
+#endif
+
+#include "blocks.h"
+#include "endian.h"
+
+static void ConvertWords(UWORD *values, ULONG count)
+{
+	while (count--)
+	{
+		*values = AROS_BE2WORD(*values);
+		values++;
+	}
+}
+
+static void ConvertLongs(ULONG *values, ULONG count)
+{
+	while (count--)
+	{
+		*values = AROS_BE2LONG(*values);
+		values++;
+	}
+}
+
+static BOOL ConvertBootBlock(UBYTE *data, ULONG bytes)
+{
+	struct bootblock *block = (struct bootblock *)data;
+
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->disktype = AROS_BE2LONG(block->disktype);
+	return TRUE;
+}
+
+static BOOL ConvertBitmapBlock(struct bitmapblock *block, ULONG bytes)
+{
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used = AROS_BE2WORD(block->not_used);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->seqnr = AROS_BE2LONG(block->seqnr);
+	ConvertLongs(block->bitmap, (bytes - sizeof(*block)) / sizeof(ULONG));
+	return TRUE;
+}
+
+static BOOL ConvertRootBlock(UBYTE *data, ULONG bytes)
+{
+	struct rootblock *block = (struct rootblock *)data;
+
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->disktype = AROS_BE2LONG(block->disktype);
+	block->options = AROS_BE2LONG(block->options);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->creationday = AROS_BE2WORD(block->creationday);
+	block->creationminute = AROS_BE2WORD(block->creationminute);
+	block->creationtick = AROS_BE2WORD(block->creationtick);
+	block->protection = AROS_BE2WORD(block->protection);
+	block->lastreserved = AROS_BE2LONG(block->lastreserved);
+	block->firstreserved = AROS_BE2LONG(block->firstreserved);
+	block->reserved_free = AROS_BE2LONG(block->reserved_free);
+	block->reserved_blksize = AROS_BE2WORD(block->reserved_blksize);
+	block->rblkcluster = AROS_BE2WORD(block->rblkcluster);
+	block->blocksfree = AROS_BE2LONG(block->blocksfree);
+	block->alwaysfree = AROS_BE2LONG(block->alwaysfree);
+	block->roving_ptr = AROS_BE2LONG(block->roving_ptr);
+	block->deldir = AROS_BE2LONG(block->deldir);
+	block->disksize = AROS_BE2LONG(block->disksize);
+	block->extension = AROS_BE2LONG(block->extension);
+	block->not_used = AROS_BE2LONG(block->not_used);
+	ConvertLongs(block->idx.large.bitmapindex,
+		sizeof(block->idx) / sizeof(ULONG));
+
+	if (bytes > sizeof(*block))
+		return ConvertBitmapBlock((struct bitmapblock *)(block + 1),
+			bytes - sizeof(*block));
+	return TRUE;
+}
+
+static BOOL ConvertIndexBlock(struct indexblock *block, ULONG bytes)
+{
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used = AROS_BE2WORD(block->not_used);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->seqnr = AROS_BE2LONG(block->seqnr);
+	ConvertLongs((ULONG *)block->index,
+		(bytes - sizeof(*block)) / sizeof(ULONG));
+	return TRUE;
+}
+
+static BOOL ConvertAnodeBlock(struct anodeblock *block, ULONG bytes)
+{
+	struct anode *node;
+	ULONG count;
+
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used = AROS_BE2WORD(block->not_used);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->seqnr = AROS_BE2LONG(block->seqnr);
+	block->not_used_2 = AROS_BE2LONG(block->not_used_2);
+
+	node = block->nodes;
+	count = (bytes - sizeof(*block)) / sizeof(*node);
+	while (count--)
+	{
+		node->clustersize = AROS_BE2LONG(node->clustersize);
+		node->blocknr = AROS_BE2LONG(node->blocknr);
+		node->next = AROS_BE2LONG(node->next);
+		node++;
+	}
+	return TRUE;
+}
+
+static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes)
+{
+	struct direntry *entry;
+	ULONG offset;
+
+	offset = sizeof(*block);
+	while (offset < bytes)
+	{
+		entry = (struct direntry *)((UBYTE *)block + offset);
+		if (entry->next == 0)
+			return TRUE;
+		if (entry->next < sizeof(*entry) || (entry->next & 1) ||
+			entry->next > bytes - offset ||
+			offsetof(struct direntry, startofname) + entry->nlength >=
+				entry->next)
+			return FALSE;
+
+		offset += entry->next;
+	}
+	return TRUE;
+}
+
+static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes)
+{
+	struct direntry *entry;
+	ULONG offset;
+
+	if (bytes < sizeof(*block) || !ValidateDirEntries(block, bytes))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used = AROS_BE2WORD(block->not_used);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	ConvertWords(block->not_used_2, 2);
+	block->anodenr = AROS_BE2LONG(block->anodenr);
+	block->parent = AROS_BE2LONG(block->parent);
+
+	offset = sizeof(*block);
+	while (offset < bytes)
+	{
+		entry = (struct direntry *)((UBYTE *)block + offset);
+		if (entry->next == 0)
+			return TRUE;
+		entry->anode = AROS_BE2LONG(entry->anode);
+		entry->fsize = AROS_BE2LONG(entry->fsize);
+		entry->creationday = AROS_BE2WORD(entry->creationday);
+		entry->creationminute = AROS_BE2WORD(entry->creationminute);
+		entry->creationtick = AROS_BE2WORD(entry->creationtick);
+		offset += entry->next;
+	}
+	return TRUE;
+}
+
+#if DELDIR
+static BOOL ConvertDeldirBlock(struct deldirblock *block, ULONG bytes)
+{
+	struct deldirentry *entry;
+	ULONG count;
+
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used = AROS_BE2WORD(block->not_used);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->seqnr = AROS_BE2LONG(block->seqnr);
+	ConvertWords(block->not_used_2, 2);
+	block->not_used_3 = AROS_BE2WORD(block->not_used_3);
+	block->uid = AROS_BE2WORD(block->uid);
+	block->gid = AROS_BE2WORD(block->gid);
+	block->protection = AROS_BE2LONG(block->protection);
+	block->creationday = AROS_BE2WORD(block->creationday);
+	block->creationminute = AROS_BE2WORD(block->creationminute);
+	block->creationtick = AROS_BE2WORD(block->creationtick);
+
+	entry = block->entries;
+	count = (bytes - sizeof(*block)) / sizeof(*entry);
+	while (count--)
+	{
+		entry->anodenr = AROS_BE2LONG(entry->anodenr);
+		entry->fsize = AROS_BE2LONG(entry->fsize);
+		entry->creationday = AROS_BE2WORD(entry->creationday);
+		entry->creationminute = AROS_BE2WORD(entry->creationminute);
+		entry->creationtick = AROS_BE2WORD(entry->creationtick);
+		entry->fsizex = AROS_BE2WORD(entry->fsizex);
+		entry++;
+	}
+	return TRUE;
+}
+#endif
+
+#if VERSION23
+static BOOL ConvertRootBlockExtension(struct rootblockextension *block,
+	ULONG bytes)
+{
+	struct postponed_op *op;
+
+	if (bytes < sizeof(*block))
+		return FALSE;
+
+	block->id = AROS_BE2WORD(block->id);
+	block->not_used_1 = AROS_BE2WORD(block->not_used_1);
+	block->ext_options = AROS_BE2LONG(block->ext_options);
+	block->datestamp = AROS_BE2LONG(block->datestamp);
+	block->pfs2version = AROS_BE2LONG(block->pfs2version);
+	ConvertWords(block->root_date, 3);
+	ConvertWords(block->volume_date, 3);
+	op = &block->tobedone;
+	op->operation_id = AROS_BE2LONG(op->operation_id);
+	op->argument1 = AROS_BE2LONG(op->argument1);
+	op->argument2 = AROS_BE2LONG(op->argument2);
+	op->argument3 = AROS_BE2LONG(op->argument3);
+	block->reserved_roving = AROS_BE2LONG(block->reserved_roving);
+	block->rovingbit = AROS_BE2WORD(block->rovingbit);
+	block->curranseqnr = AROS_BE2WORD(block->curranseqnr);
+	block->deldirroving = AROS_BE2WORD(block->deldirroving);
+	block->deldirsize = AROS_BE2WORD(block->deldirsize);
+	block->fnsize = AROS_BE2WORD(block->fnsize);
+	ConvertWords(block->not_used_2, 3);
+	ConvertLongs(block->superindex, MAXSUPER + 1);
+	block->dd_uid = AROS_BE2WORD(block->dd_uid);
+	block->dd_gid = AROS_BE2WORD(block->dd_gid);
+	block->dd_protection = AROS_BE2LONG(block->dd_protection);
+	block->dd_creationday = AROS_BE2WORD(block->dd_creationday);
+	block->dd_creationminute = AROS_BE2WORD(block->dd_creationminute);
+	block->dd_creationtick = AROS_BE2WORD(block->dd_creationtick);
+	block->not_used_3 = AROS_BE2WORD(block->not_used_3);
+	ConvertLongs(block->deldir, 32);
+	return TRUE;
+}
+#endif
+
+static UWORD DiskBlockId(const UBYTE *data)
+{
+	return ((UWORD)data[0] << 8) | data[1];
+}
+
+static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk)
+{
+	UWORD id;
+
+	if (bytes < sizeof(UWORD))
+		return FALSE;
+
+	id = from_disk ? DiskBlockId(data) : *(UWORD *)data;
+	switch (id)
+	{
+	case BMBLKID:
+		return ConvertBitmapBlock((struct bitmapblock *)data, bytes);
+	case BMIBLKID:
+	case IBLKID:
+	case SBLKID:
+		return ConvertIndexBlock((struct indexblock *)data, bytes);
+	case ABLKID:
+		return ConvertAnodeBlock((struct anodeblock *)data, bytes);
+	case DBLKID:
+		return ConvertDirBlock((struct dirblock *)data, bytes);
+#if DELDIR
+	case DELDIRID:
+		return ConvertDeldirBlock((struct deldirblock *)data, bytes);
+#endif
+#if VERSION23
+	case EXTENSIONID:
+		return ConvertRootBlockExtension(
+			(struct rootblockextension *)data, bytes);
+#endif
+	default:
+		return FALSE;
+	}
+}
+
+BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
+{
+	switch (type)
+	{
+	case PFS3_METADATA_BOOT:
+		return ConvertBootBlock(data, bytes);
+	case PFS3_METADATA_ROOT:
+		return ConvertRootBlock(data, bytes);
+	case PFS3_METADATA_RESERVED:
+		return ConvertReservedBlock(data, bytes, TRUE);
+	}
+	return FALSE;
+}
+
+BOOL PFS3MetadataToDisk(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
+{
+	switch (type)
+	{
+	case PFS3_METADATA_BOOT:
+		return ConvertBootBlock(data, bytes);
+	case PFS3_METADATA_ROOT:
+		return ConvertRootBlock(data, bytes);
+	case PFS3_METADATA_RESERVED:
+		return ConvertReservedBlock(data, bytes, FALSE);
+	}
+	return FALSE;
+}
+
+void PFS3GetExtraFields(struct direntry *direntry,
+	struct extrafields *extrafields)
+{
+	UWORD values[11] = { 0 };
+	UWORD *source = (UWORD *)((UBYTE *)direntry + direntry->next);
+	UWORD flags, i;
+
+	flags = AROS_BE2WORD(*(--source));
+	for (i = 0; i < sizeof(values) / sizeof(values[0]); i++, flags >>= 1)
+		values[i] = (flags & 1) ? AROS_BE2WORD(*(--source)) : 0;
+
+	extrafields->link = ((ULONG)values[0] << 16) | values[1];
+	extrafields->uid = values[2];
+	extrafields->gid = values[3];
+	extrafields->prot = ((ULONG)values[4] << 16) | values[5] |
+		direntry->protection;
+	extrafields->virtualsize = ((ULONG)values[6] << 16) | values[7];
+	extrafields->rollpointer = ((ULONG)values[8] << 16) | values[9];
+	extrafields->fsizex = values[10];
+}
+
+void PFS3AddExtraFields(struct direntry *direntry,
+	struct extrafields *extrafields)
+{
+	UWORD offset, *destination;
+	UWORD fields[11];
+	UWORD values[11];
+	UWORD i, count = 0;
+	UWORD flags = 0, flag = 1;
+
+	extrafields->prot &= 0xffffff00;
+	fields[0] = extrafields->link >> 16;
+	fields[1] = extrafields->link;
+	fields[2] = extrafields->uid;
+	fields[3] = extrafields->gid;
+	fields[4] = extrafields->prot >> 16;
+	fields[5] = extrafields->prot;
+	fields[6] = extrafields->virtualsize >> 16;
+	fields[7] = extrafields->virtualsize;
+	fields[8] = extrafields->rollpointer >> 16;
+	fields[9] = extrafields->rollpointer;
+	fields[10] = extrafields->fsizex;
+
+	offset = (sizeof(*direntry) + direntry->nlength +
+		*((UBYTE *)&direntry->startofname + direntry->nlength)) & 0xfffe;
+	destination = (UWORD *)((UBYTE *)direntry + offset);
+
+	for (i = 0; i < sizeof(fields) / sizeof(fields[0]); i++)
+	{
+		if (fields[i])
+		{
+			values[count++] = fields[i];
+			flags |= flag;
+		}
+		flag <<= 1;
+	}
+
+	i = count;
+	while (i)
+		*destination++ = AROS_WORD2BE(values[--i]);
+	*destination = AROS_WORD2BE(flags);
+	direntry->next = offset + 2 * count + 2;
+}

--- a/rom/filesys/pfs3/fs/endian.c
+++ b/rom/filesys/pfs3/fs/endian.c
@@ -30,6 +30,40 @@ static void ConvertLongs(ULONG *values, ULONG count)
 	}
 }
 
+static void ConvertUnalignedWord(UBYTE *data)
+{
+	union
+	{
+		UWORD value;
+		UBYTE bytes[sizeof(UWORD)];
+	} unaligned;
+
+	unaligned.bytes[0] = data[0];
+	unaligned.bytes[1] = data[1];
+	unaligned.value = AROS_BE2WORD(unaligned.value);
+	data[0] = unaligned.bytes[0];
+	data[1] = unaligned.bytes[1];
+}
+
+static void ConvertUnalignedLong(UBYTE *data)
+{
+	union
+	{
+		ULONG value;
+		UBYTE bytes[sizeof(ULONG)];
+	} unaligned;
+
+	unaligned.bytes[0] = data[0];
+	unaligned.bytes[1] = data[1];
+	unaligned.bytes[2] = data[2];
+	unaligned.bytes[3] = data[3];
+	unaligned.value = AROS_BE2LONG(unaligned.value);
+	data[0] = unaligned.bytes[0];
+	data[1] = unaligned.bytes[1];
+	data[2] = unaligned.bytes[2];
+	data[3] = unaligned.bytes[3];
+}
+
 static BOOL ConvertBootBlock(UBYTE *data, ULONG bytes)
 {
 	struct bootblock *block = (struct bootblock *)data;
@@ -129,7 +163,8 @@ static BOOL ConvertAnodeBlock(struct anodeblock *block, ULONG bytes)
 	return TRUE;
 }
 
-static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes)
+static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes,
+	BOOL recovery)
 {
 	struct direntry *entry;
 	ULONG offset;
@@ -140,10 +175,12 @@ static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes)
 		entry = (struct direntry *)((UBYTE *)block + offset);
 		if (entry->next == 0)
 			return TRUE;
-		if (entry->next < sizeof(*entry) || (entry->next & 1) ||
-			entry->next > bytes - offset ||
-			offsetof(struct direntry, startofname) + entry->nlength >=
-				entry->next)
+		if (entry->next < sizeof(*entry) || entry->next > bytes - offset)
+			return FALSE;
+		if (!recovery &&
+			((entry->next & 1) ||
+			 offsetof(struct direntry, startofname) + entry->nlength >=
+				entry->next))
 			return FALSE;
 
 		offset += entry->next;
@@ -151,12 +188,24 @@ static BOOL ValidateDirEntries(struct dirblock *block, ULONG bytes)
 	return TRUE;
 }
 
-static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes)
+static void ConvertDirEntry(struct direntry *entry)
+{
+	UBYTE *data = (UBYTE *)entry;
+
+	ConvertUnalignedLong(data + offsetof(struct direntry, anode));
+	ConvertUnalignedLong(data + offsetof(struct direntry, fsize));
+	ConvertUnalignedWord(data + offsetof(struct direntry, creationday));
+	ConvertUnalignedWord(data + offsetof(struct direntry, creationminute));
+	ConvertUnalignedWord(data + offsetof(struct direntry, creationtick));
+}
+
+static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes, BOOL recovery)
 {
 	struct direntry *entry;
 	ULONG offset;
 
-	if (bytes < sizeof(*block) || !ValidateDirEntries(block, bytes))
+	if (bytes < sizeof(*block) ||
+		!ValidateDirEntries(block, bytes, recovery))
 		return FALSE;
 
 	block->id = AROS_BE2WORD(block->id);
@@ -172,11 +221,7 @@ static BOOL ConvertDirBlock(struct dirblock *block, ULONG bytes)
 		entry = (struct direntry *)((UBYTE *)block + offset);
 		if (entry->next == 0)
 			return TRUE;
-		entry->anode = AROS_BE2LONG(entry->anode);
-		entry->fsize = AROS_BE2LONG(entry->fsize);
-		entry->creationday = AROS_BE2WORD(entry->creationday);
-		entry->creationminute = AROS_BE2WORD(entry->creationminute);
-		entry->creationtick = AROS_BE2WORD(entry->creationtick);
+		ConvertDirEntry(entry);
 		offset += entry->next;
 	}
 	return TRUE;
@@ -266,7 +311,8 @@ static UWORD DiskBlockId(const UBYTE *data)
 	return ((UWORD)data[0] << 8) | data[1];
 }
 
-static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk)
+static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk,
+	BOOL recovery)
 {
 	UWORD id;
 
@@ -285,7 +331,7 @@ static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk)
 	case ABLKID:
 		return ConvertAnodeBlock((struct anodeblock *)data, bytes);
 	case DBLKID:
-		return ConvertDirBlock((struct dirblock *)data, bytes);
+		return ConvertDirBlock((struct dirblock *)data, bytes, recovery);
 #if DELDIR
 	case DELDIRID:
 		return ConvertDeldirBlock((struct deldirblock *)data, bytes);
@@ -300,7 +346,8 @@ static BOOL ConvertReservedBlock(UBYTE *data, ULONG bytes, BOOL from_disk)
 	}
 }
 
-BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
+static BOOL ConvertMetadata(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type, BOOL from_disk, BOOL recovery)
 {
 	switch (type)
 	{
@@ -309,26 +356,34 @@ BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
 	case PFS3_METADATA_ROOT:
 		return ConvertRootBlock(data, bytes);
 	case PFS3_METADATA_RESERVED:
-		return ConvertReservedBlock(data, bytes, TRUE);
+		return ConvertReservedBlock(data, bytes, from_disk, recovery);
 	}
 	return FALSE;
+}
+
+BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
+{
+	return ConvertMetadata(data, bytes, type, TRUE, FALSE);
+}
+
+BOOL PFS3MetadataToHostForRecovery(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type)
+{
+	return ConvertMetadata(data, bytes, type, TRUE, TRUE);
 }
 
 BOOL PFS3MetadataToDisk(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type)
 {
-	switch (type)
-	{
-	case PFS3_METADATA_BOOT:
-		return ConvertBootBlock(data, bytes);
-	case PFS3_METADATA_ROOT:
-		return ConvertRootBlock(data, bytes);
-	case PFS3_METADATA_RESERVED:
-		return ConvertReservedBlock(data, bytes, FALSE);
-	}
-	return FALSE;
+	return ConvertMetadata(data, bytes, type, FALSE, FALSE);
 }
 
-void PFS3GetExtraFields(struct direntry *direntry,
+BOOL PFS3MetadataToDiskForRecovery(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type)
+{
+	return ConvertMetadata(data, bytes, type, FALSE, TRUE);
+}
+
+UWORD PFS3GetExtraFields(struct direntry *direntry,
 	struct extrafields *extrafields)
 {
 	UWORD values[11] = { 0 };
@@ -347,6 +402,7 @@ void PFS3GetExtraFields(struct direntry *direntry,
 	extrafields->virtualsize = ((ULONG)values[6] << 16) | values[7];
 	extrafields->rollpointer = ((ULONG)values[8] << 16) | values[9];
 	extrafields->fsizex = values[10];
+	return flags;
 }
 
 void PFS3AddExtraFields(struct direntry *direntry,

--- a/rom/filesys/pfs3/fs/endian.h
+++ b/rom/filesys/pfs3/fs/endian.h
@@ -1,0 +1,27 @@
+#ifndef PFS3_ENDIAN_H
+#define PFS3_ENDIAN_H
+
+#include <exec/types.h>
+
+struct direntry;
+struct extrafields;
+
+enum pfs3_metadata_type
+{
+	PFS3_METADATA_BOOT,
+	PFS3_METADATA_ROOT,
+	PFS3_METADATA_RESERVED
+};
+
+/*
+ * Convert metadata between its native in-memory representation and the
+ * big-endian representation used on disk. Both operations are in-place.
+ */
+BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type);
+BOOL PFS3MetadataToDisk(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type);
+void PFS3GetExtraFields(struct direntry *direntry,
+	struct extrafields *extrafields);
+void PFS3AddExtraFields(struct direntry *direntry,
+	struct extrafields *extrafields);
+
+#endif

--- a/rom/filesys/pfs3/fs/endian.h
+++ b/rom/filesys/pfs3/fs/endian.h
@@ -13,6 +13,8 @@ enum pfs3_metadata_type
 	PFS3_METADATA_RESERVED
 };
 
+UWORD PFS3DiskBlockId(const UBYTE *data);
+
 /*
  * Convert metadata between its native in-memory representation and the
  * big-endian representation used on disk. Both operations are in-place.

--- a/rom/filesys/pfs3/fs/endian.h
+++ b/rom/filesys/pfs3/fs/endian.h
@@ -18,8 +18,17 @@ enum pfs3_metadata_type
  * big-endian representation used on disk. Both operations are in-place.
  */
 BOOL PFS3MetadataToHost(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type);
+/*
+ * Convert metadata for a recovery tool. Directory entries are required to be
+ * safely traversable, but semantic errors which PFSDoctor can repair are
+ * accepted.
+ */
+BOOL PFS3MetadataToHostForRecovery(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type);
 BOOL PFS3MetadataToDisk(UBYTE *data, ULONG bytes, enum pfs3_metadata_type type);
-void PFS3GetExtraFields(struct direntry *direntry,
+BOOL PFS3MetadataToDiskForRecovery(UBYTE *data, ULONG bytes,
+	enum pfs3_metadata_type type);
+UWORD PFS3GetExtraFields(struct direntry *direntry,
 	struct extrafields *extrafields);
 void PFS3AddExtraFields(struct direntry *direntry,
 	struct extrafields *extrafields);

--- a/rom/filesys/pfs3/fs/format.c
+++ b/rom/filesys/pfs3/fs/format.c
@@ -306,7 +306,7 @@ static ULONG MakeBootBlock (globaldata *g)
 
 	memset (bbl, 0, 2*BLOCKSIZE);
 	bbl->disktype = ID_PFS_DISK;
-	error = RawWrite ((UBYTE *)bbl, 2, BOOTBLOCK1, g);
+	error = WriteBootBlocks ((UBYTE *)bbl, 2, BOOTBLOCK1, g);
 	FreeBufmem (bbl, g);
 	return error;
 }

--- a/rom/filesys/pfs3/fs/format.c
+++ b/rom/filesys/pfs3/fs/format.c
@@ -320,6 +320,8 @@ static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g)
 {
   struct rootblock *rbl;
   struct DateStamp time;
+  UBYTE c_diskname[DNSIZE];
+  ULONG diskname_length;
   ULONG numreserved;
   ULONG rescluster;
   ULONG resblocksize;
@@ -385,7 +387,10 @@ static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g)
 	rbl->alwaysfree = rbl->blocksfree/20;
 	// rbl->roving_ptr = 0;
 
-	memcpy(rbl->diskname, diskname, min(*diskname+1, DNSIZE));
+	BCPLtoCString(c_diskname, diskname);
+	diskname_length = min(strlen(c_diskname), DNSIZE - 1);
+	rbl->diskname[0] = diskname_length;
+	memcpy(rbl->diskname + 1, c_diskname, diskname_length);
 	MakeReservedBitmap(&rbl, numreserved, g);	// sets reserved_free & rblkcluster too
 	return rbl;
 }

--- a/rom/filesys/pfs3/fs/lru.c
+++ b/rom/filesys/pfs3/fs/lru.c
@@ -197,7 +197,7 @@ retry:
 				DB(Trace(1,"AllocLRU","ResToBeFreed %lx\n",&lrunode->cblk));
 				ResToBeFreed(lrunode->cblk.oldblocknr, g);
 				UpdateDatestamp(&lrunode->cblk, g);
-				error = RawWrite ((UBYTE *)&lrunode->cblk.data, RESCLUSTER, lrunode->cblk.blocknr, g);
+				error = WriteReservedBlocks ((UBYTE *)&lrunode->cblk.data, RESCLUSTER, lrunode->cblk.blocknr, g);
 				if (error) {
 					ULONG args[2];
 					args[0] = lrunode->cblk.blocknr;

--- a/rom/filesys/pfs3/fs/mmakefile.src
+++ b/rom/filesys/pfs3/fs/mmakefile.src
@@ -5,6 +5,7 @@ FILES := \
 	directory \
 	dostohandlerinterface \
 	disk \
+	endian \
 	init \
 	diskchange \
 	volume \

--- a/rom/filesys/pfs3/fs/struct.h
+++ b/rom/filesys/pfs3/fs/struct.h
@@ -925,10 +925,17 @@ union listtype
 {
 	struct
 	{
+#if defined(AROS_BIG_ENDIAN) && !AROS_BIG_ENDIAN
+		unsigned access:2;
+		unsigned type:2;
+		unsigned dir:1;
+		unsigned pad:11;
+#else
 		unsigned pad:11;
 		unsigned dir:1;     // 0 = file; 1 = dir or volume
 		unsigned type:2;    // 0 = unknown; 3 = lock; 1 = volume; 2 = fileentry
 		unsigned access:2;  // 0 = read shared; 2 = read excl; 1,3 = write shared, excl
+#endif
 	} flags;
 
 	UWORD value;

--- a/rom/filesys/pfs3/fs/update.c
+++ b/rom/filesys/pfs3/fs/update.c
@@ -260,7 +260,7 @@ BOOL UpdateDisk (globaldata *g)
 		/* update root (MUST be done last) */
 		if (updateok)
 		{
-			RawWrite((UBYTE *)volume->rootblk, volume->rootblk->rblkcluster, ROOTBLOCK, g);
+			WriteRootBlocks((UBYTE *)volume->rootblk, volume->rootblk->rblkcluster, ROOTBLOCK, g);
 			volume->rootblk->datestamp++;
 			volume->rootblockchangeflag = FALSE;
 
@@ -460,7 +460,7 @@ static BOOL UpdateList (struct cachedblock *blk, globaldata *g)
 			blk2 = (struct cbitmapblock *)blk;
 			blk2->blk.datestamp = blk2->volume->rootblk->datestamp;
 			blk->oldblocknr = 0;
-			error = RawWrite ((UBYTE *)&blk->data, RESCLUSTER, blk->blocknr, g);
+			error = WriteReservedBlocks ((UBYTE *)&blk->data, RESCLUSTER, blk->blocknr, g);
 			if (error)
 				goto update_error;
 
@@ -488,7 +488,7 @@ static BOOL UpdateDirtyBlock (struct cachedblock *blk, globaldata *g)
 	{
 		FreeReservedBlock (blk->oldblocknr, g);
 		blk->oldblocknr = 0;
-		error = RawWrite ((UBYTE *)&blk->data, RESCLUSTER, blk->blocknr, g);
+		error = WriteReservedBlocks ((UBYTE *)&blk->data, RESCLUSTER, blk->blocknr, g);
 		if (error)
 		{
 			ErrorMsg (AFS_ERROR_UPDATE_FAIL, NULL, g);

--- a/rom/filesys/pfs3/fs/volume.c
+++ b/rom/filesys/pfs3/fs/volume.c
@@ -166,6 +166,18 @@
 static VOID CreateInputEvent(BOOL inserted, globaldata *g);
 static BOOL GetCurrentRoot(struct rootblock **rootblock, globaldata *g);
 
+static UBYTE *DiskStringToCString(UBYTE *dest, const UBYTE *src)
+{
+	ULONG length = min(src[0], DNSIZE - 1);
+	UBYTE *result = dest;
+
+	src++;
+	while (length--)
+		*dest++ = *src++;
+	*dest = 0;
+	return result;
+}
+
 /**********************************************************************/
 /*                               DEBUG                                */
 /**********************************************************************/
@@ -393,7 +405,7 @@ static void DiskInsertSequence(struct rootblock *rootblock, globaldata *g)
 
 	/* -I- Search new disk in volumelist */
 
-	BCPLtoCString(diskname, rootblock->diskname);
+	DiskStringToCString(diskname, rootblock->diskname);
 	di = BADDR(((struct RootNode *)DOSBase->dl_Root)->rn_Info);
 	doslist = BADDR(di->di_DevInfo);
 	
@@ -1217,7 +1229,7 @@ void RequestCurrentVolumeBack(globaldata *g)
 
 	ENTER("GetCurrentVolumeBack");
 
-	BCPLtoCString(volumename, volume->rootblk->diskname);
+	DiskStringToCString(volumename, volume->rootblk->diskname);
 
 	while(!ready)
 	{

--- a/rom/filesys/pfs3/fs/volume.c
+++ b/rom/filesys/pfs3/fs/volume.c
@@ -517,7 +517,7 @@ static void DiskInsertSequence(struct rootblock *rootblock, globaldata *g)
 		ddblk = (struct cdeldirblock *)AllocLRU(g);
 		if (ddblk)
 		{
-			if (RawRead ((UBYTE*)&ddblk->blk, RESCLUSTER, rootblock->deldir, g) == 0)
+			if (ReadReservedBlocks ((UBYTE*)&ddblk->blk, RESCLUSTER, rootblock->deldir, g) == 0)
 			{
 				if (ddblk->blk.id == DELDIRID)
 				{
@@ -630,7 +630,7 @@ struct volumedata *MakeVolumeData (struct rootblock *rootblock, globaldata *g)
 
 		rext = AllocBufmemR (sizeof(struct cachedblock) + rootblock->reserved_blksize, g);
 		memset (rext, 0, sizeof(struct cachedblock) + rootblock->reserved_blksize);
-		if (RawRead ((UBYTE *)&rext->blk, volume->rescluster, rootblock->extension, g) != 0)
+		if (ReadReservedBlocks ((UBYTE *)&rext->blk, volume->rescluster, rootblock->extension, g) != 0)
 		{
 			ErrorMsg (AFS_ERROR_READ_EXTENSION, NULL, g);
 			FreeBufmem (rext, g);
@@ -1034,7 +1034,7 @@ static BOOL GetCurrentRoot(struct rootblock **rootblock, globaldata *g)
 		goto nrd_error;
 #endif
 
-	error = RawRead((UBYTE *)*rootblock, 1, BOOTBLOCK1, g);
+	error = ReadBootBlocks((UBYTE *)*rootblock, 1, BOOTBLOCK1, g);
 	g->ErrorMsg = _NormalErrorMsg;
 
 	if (!error)
@@ -1042,7 +1042,7 @@ static BOOL GetCurrentRoot(struct rootblock **rootblock, globaldata *g)
 		if ((*rootblock)->disktype == ID_PFS_DISK || (*rootblock)->disktype == ID_PFS2_DISK)
 		{
 			g->disktype = ID_PFS_DISK;
-			error = RawRead((UBYTE *)*rootblock, 1, ROOTBLOCK, g);
+			error = ReadRootBlocks((UBYTE *)*rootblock, 1, ROOTBLOCK, g);
 			if (!error)
 			{
 				/* check size and read all rootblock blocks */
@@ -1060,7 +1060,7 @@ static BOOL GetCurrentRoot(struct rootblock **rootblock, globaldata *g)
 
 				FreeBufmem(*rootblock, g);
 				*rootblock = AllocBufmemR (rblsize << BLOCKSHIFT, g);
-				error = RawRead((UBYTE *)*rootblock, rblsize, ROOTBLOCK, g);
+				error = ReadRootBlocks((UBYTE *)*rootblock, rblsize, ROOTBLOCK, g);
 			}
 
 			/* size check */

--- a/rom/filesys/pfs3/pfsdoctor/access.c
+++ b/rom/filesys/pfs3/pfsdoctor/access.c
@@ -244,7 +244,7 @@ bool GetAnode(canode_t *anode, uint32 anodenr, bool fix)
 		}
 	}
 
-	if (offset > ANODES_PER_BLOCK)
+	if (offset >= ANODES_PER_BLOCK)
 		return false;
 
 	anode->nr = anodenr;
@@ -266,7 +266,7 @@ bool SaveAnode(canode_t *anode, uint32 nr)
 	if (GetResBlock((cachedblock_t *)&ablk, ABLKID, seqnr, false))
 		return false;
 
-	if (offset > ANODES_PER_BLOCK)
+	if (offset >= ANODES_PER_BLOCK)
 		return false;
 
 	ablk.data->nodes[offset].clustersize = anode->clustersize;

--- a/rom/filesys/pfs3/pfsdoctor/access.c
+++ b/rom/filesys/pfs3/pfsdoctor/access.c
@@ -112,7 +112,9 @@ error_t GetResBlock(cachedblock_t *blok, uint16 bloktype, uint32 seqnr, bool fix
 					if (error)
 						*bp = 0;
 					else
-						c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+						WritePFS3Metadata((uint8 *)rbl,
+							ROOTBLOCK + volume.firstblock,
+							volume.blocksize, PFS3_METADATA_ROOT);
 				}
 			}
 			break;
@@ -151,7 +153,10 @@ error_t GetResBlock(cachedblock_t *blok, uint16 bloktype, uint32 seqnr, bool fix
 						if (rbl->options & MODE_SUPERINDEX)
 							volume.writeblock((cachedblock_t *)&blk);
 						else
-							c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+							WritePFS3Metadata((uint8 *)rbl,
+								ROOTBLOCK + volume.firstblock,
+								volume.blocksize,
+								PFS3_METADATA_ROOT);
 					}
 				}
 			}
@@ -226,45 +231,47 @@ static anodeblock_t *tanodeblk = (anodeblock_t*)tanodedata;
 
 bool GetAnode(canode_t *anode, uint32 anodenr, bool fix)
 {
-	anodenr_t *split = (anodenr_t *)&anodenr;
+	uint16 seqnr = anodenr >> 16;
+	uint16 offset = anodenr;
 
-	if (!(tablk.data && tanodeblk->seqnr == split->seqnr))
+	if (!(tablk.data && tanodeblk->seqnr == seqnr))
 	{
 		tablk.data = tanodeblk;
-		if (GetResBlock((cachedblock_t *)&tablk, ABLKID, split->seqnr, fix))
+		if (GetResBlock((cachedblock_t *)&tablk, ABLKID, seqnr, fix))
 		{
 			tablk.data = NULL;
 			return false;
 		}
 	}
 
-	if (split->offset > ANODES_PER_BLOCK)
+	if (offset > ANODES_PER_BLOCK)
 		return false;
 
 	anode->nr = anodenr;
-	anode->clustersize = tablk.data->nodes[split->offset].clustersize;
-	anode->blocknr     = tablk.data->nodes[split->offset].blocknr;
-	anode->next        = tablk.data->nodes[split->offset].next;
+	anode->clustersize = tablk.data->nodes[offset].clustersize;
+	anode->blocknr     = tablk.data->nodes[offset].blocknr;
+	anode->next        = tablk.data->nodes[offset].next;
 	return true;
 }
 
 bool SaveAnode(canode_t *anode, uint32 nr)
 {
-	anodenr_t *split = (anodenr_t *)&nr;
+	uint16 seqnr = nr >> 16;
+	uint16 offset = nr;
 	c_anodeblock_t ablk;
 	uint32 buffer[MAXRESBLOCKSIZE/4];
 
 	tablk.data = NULL;			/* kill anode read cache */
 	ablk.data = (anodeblock_t *)buffer;
-	if (GetResBlock((cachedblock_t *)&ablk, ABLKID, split->seqnr, false))
+	if (GetResBlock((cachedblock_t *)&ablk, ABLKID, seqnr, false))
 		return false;
 
-	if (split->offset > ANODES_PER_BLOCK)
+	if (offset > ANODES_PER_BLOCK)
 		return false;
 
-	ablk.data->nodes[split->offset].clustersize = anode->clustersize;
-	ablk.data->nodes[split->offset].blocknr     = anode->blocknr;
-	ablk.data->nodes[split->offset].next        = anode->next;
+	ablk.data->nodes[offset].clustersize = anode->clustersize;
+	ablk.data->nodes[offset].blocknr     = anode->blocknr;
+	ablk.data->nodes[offset].next        = anode->next;
 	volume.writeblock((cachedblock_t *)&ablk);
 	return true;
 }

--- a/rom/filesys/pfs3/pfsdoctor/device.c
+++ b/rom/filesys/pfs3/pfsdoctor/device.c
@@ -137,6 +137,30 @@ error_t c_WriteBlock(uint8 *data, uint32 bloknr, uint32 bytes)
 	return error;
 }
 
+error_t ReadPFS3Metadata(uint8 *data, uint32 bloknr, uint32 bytes,
+	enum pfs3_metadata_type type)
+{
+	error_t error;
+
+	error = c_GetBlock(data, bloknr, bytes);
+	if (!error && !PFS3MetadataToHostForRecovery(data, bytes, type))
+		error = e_syntax_error;
+	return error;
+}
+
+error_t WritePFS3Metadata(uint8 *data, uint32 bloknr, uint32 bytes,
+	enum pfs3_metadata_type type)
+{
+	error_t error, convert_error = e_none;
+
+	if (!PFS3MetadataToDiskForRecovery(data, bytes, type))
+		return e_syntax_error;
+	error = c_WriteBlock(data, bloknr, bytes);
+	if (!PFS3MetadataToHostForRecovery(data, bytes, type))
+		convert_error = e_syntax_error;
+	return error ? error : convert_error;
+}
+
 /* (private) locale function to search a cacheline 
  */
 static struct cacheline *c_GetCacheLine(uint32 bloknr)
@@ -669,4 +693,3 @@ BOOL DetectAccessmode(UBYTE *buffer, BOOL scsidirectfirst)
 	volume.accessmode = ACCESS_STD;
 	return FALSE;
 }
-

--- a/rom/filesys/pfs3/pfsdoctor/doctor.h
+++ b/rom/filesys/pfs3/pfsdoctor/doctor.h
@@ -38,6 +38,8 @@
 
 #define __USE_SYSBASE
 
+#include "endian.h"
+
 
 
 #ifndef min
@@ -459,6 +461,10 @@ void exitblock(void);
 error_t InitCache(uint32 linesize, uint32 nolines);
 error_t c_GetBlock(uint8 *data, uint32 bloknr, uint32 bytes);
 error_t c_WriteBlock(uint8 *data, uint32 bloknr, uint32 bytes);
+error_t ReadPFS3Metadata(uint8 *data, uint32 bloknr, uint32 bytes,
+	enum pfs3_metadata_type type);
+error_t WritePFS3Metadata(uint8 *data, uint32 bloknr, uint32 bytes,
+	enum pfs3_metadata_type type);
 void UpdateCache(void);
 void FreeCache(void);
 
@@ -496,4 +502,3 @@ static __inline void __chkabort(void) { };
 #if defined(__SASC)
 void __regargs __chkabort(void);
 #endif
-

--- a/rom/filesys/pfs3/pfsdoctor/doctor.h
+++ b/rom/filesys/pfs3/pfsdoctor/doctor.h
@@ -479,6 +479,7 @@ bool SaveAnode(canode_t *anode, uint32 nr);
 error_t StandardScan(uint32 opties);
 bool GetPFS2Revision(char *vstring);
 error_t vol_GetBlock(cachedblock_t *blok, ULONG bloknr);
+error_t vol_GetRawBlock(cachedblock_t *blok, ULONG bloknr);
 error_t vol_WriteBlock(cachedblock_t *blok);
 bool IsRootBlock(rootblock_t *r);
 error_t ResBlockUsed(uint32 bloknr);

--- a/rom/filesys/pfs3/pfsdoctor/fullscan.c
+++ b/rom/filesys/pfs3/pfsdoctor/fullscan.c
@@ -226,7 +226,7 @@ error_t BuildBootBlock(void)
 	memset (bbl, 0, 2*volume.blocksize);
 	bbl->disktype = ID_PFS_DISK;
 	error = WritePFS3Metadata((UBYTE *)bbl,
-		BOOTBLOCK + volume.firstblock, volume.blocksize,
+		BOOTBLOCK + volume.firstblock, 2 * volume.blocksize,
 		PFS3_METADATA_BOOT);
 	FreeBufMem (bbl);
 	return error;
@@ -480,10 +480,10 @@ uint32 SearchLastReserved(volume_t *vol)
 			break;
 		}
 
-		if (volume.getblock(&blk, i))
+		if (vol_GetRawBlock(&blk, i))
 			goto s_ret;
 
-		switch (blk.data->id)
+		switch (PFS3DiskBlockId((uint8 *)blk.data))
 		{
 			case DBLKID:
 			case ABLKID:

--- a/rom/filesys/pfs3/pfsdoctor/fullscan.c
+++ b/rom/filesys/pfs3/pfsdoctor/fullscan.c
@@ -78,7 +78,9 @@ error_t AllocBuildBlocks(void)
 			{
 				case EXTENSIONID:
 					rbl->extension = blocknr;
-					c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+					WritePFS3Metadata((uint8 *)rbl,
+						ROOTBLOCK + volume.firstblock,
+						volume.blocksize, PFS3_METADATA_ROOT);
 					rext.mode = check;
 					rext.data = calloc(1, SIZEOF_RESBLOCK);
 					rext.blocknr = blocknr;
@@ -92,14 +94,19 @@ error_t AllocBuildBlocks(void)
 
 				case BMIBLKID:
 					rbl->idx.large.bitmapindex[bbl->b.data->indexblock.seqnr] = blocknr;
-					c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+					WritePFS3Metadata((uint8 *)rbl,
+						ROOTBLOCK + volume.firstblock,
+						volume.blocksize, PFS3_METADATA_ROOT);
 					break;
 
 				case IBLKID:
 					if (!(rbl->options & MODE_SUPERDELDIR))
 					{
 						rbl->idx.small.indexblocks[bbl->b.data->indexblock.seqnr] = blocknr;
-						c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+						WritePFS3Metadata((uint8 *)rbl,
+							ROOTBLOCK + volume.firstblock,
+							volume.blocksize,
+							PFS3_METADATA_ROOT);
 						break;
 					}
 					type = SBLKID;
@@ -183,7 +190,9 @@ error_t Repartition(uint32 bloknr)
 		return e_out_of_memory;
 
 	// read rootblock 
-	error = c_GetBlock ((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+	error = ReadPFS3Metadata((uint8 *)rbl,
+		ROOTBLOCK + volume.firstblock, volume.blocksize,
+		PFS3_METADATA_ROOT);
 	if (error)
 		goto ret_error;
 
@@ -216,7 +225,9 @@ error_t BuildBootBlock(void)
 	
 	memset (bbl, 0, 2*volume.blocksize);
 	bbl->disktype = ID_PFS_DISK;
-	error = c_WriteBlock ((UBYTE *)bbl, 1, BOOTBLOCK + volume.firstblock);
+	error = WritePFS3Metadata((UBYTE *)bbl,
+		BOOTBLOCK + volume.firstblock, volume.blocksize,
+		PFS3_METADATA_BOOT);
 	FreeBufMem (bbl);
 	return error;
 }
@@ -528,7 +539,8 @@ uint32 SearchFileSystem(int32 startblok, int32 endblok)
 		}
 
 		// read block and check if it is a rootblock */
-		if (c_GetBlock ((uint8 *)rbl, b, volume.blocksize))
+		if (ReadPFS3Metadata((uint8 *)rbl, b, volume.blocksize,
+			PFS3_METADATA_ROOT))
 			break;
 
 		if (IsRootBlock(rbl))
@@ -692,4 +704,3 @@ error_t BuildBitmapBlock(c_bitmapblock_t *blk, uint32 seqnr)
 	volume.status(1, " ", 100);
 	return e_none;
 }
-

--- a/rom/filesys/pfs3/pfsdoctor/mmakefile.src
+++ b/rom/filesys/pfs3/pfsdoctor/mmakefile.src
@@ -1,20 +1,27 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+PFS3DIR := $(SRCDIR)/rom/filesys/pfs3/fs
+
 FILES := \
 	access \
 	device \
 	fullscan \
 	standardscan \
 	stats \
-	console
+	console \
+	$(PFS3DIR)/endian
 
 USER_CPPFLAGS := \
 	-DLARGE_FILE_SIZE=1 \
+	-DDELDIR=1 \
+	-DVERSION23=1 \
 	-DNO_GUI=1 \
 	-DREVISION=19 \
 	-DREVDATE="\"$(shell date '+%d.%m.%Y')\"" \
 	-DADATE="\"$(shell date '+%d.%m.%Y')\""
+
+USER_INCLUDES := -I$(PFS3DIR)
 
 EXEDIR = $(AROSDIR)/C
 

--- a/rom/filesys/pfs3/pfsdoctor/pfs3.h
+++ b/rom/filesys/pfs3/pfsdoctor/pfs3.h
@@ -131,12 +131,6 @@ typedef struct indexblock
     LONG index[253];        /* the indices */
 } indexblock_t;
 
-typedef struct
-{
-	UWORD seqnr;
-	UWORD offset;
-} anodenr_t;
-
 typedef struct anode
 {
     ULONG clustersize;

--- a/rom/filesys/pfs3/pfsdoctor/standardscan.c
+++ b/rom/filesys/pfs3/pfsdoctor/standardscan.c
@@ -95,6 +95,7 @@ static error_t GetRootBlock(void);
 static error_t CheckRootBlock(void);
 static error_t GetRext(void);
 static error_t RepairBootBlock(void);
+static error_t GetRepairBlock(cachedblock_t *block, ULONG blocknr);
 static error_t RepairDeldir(void);
 static bool dd_CheckBlock(uint32 bloknr, int seqnr);
 static error_t RepairDirTree(void);
@@ -517,6 +518,36 @@ error_t vol_GetBlock(cachedblock_t *blok, ULONG bloknr)
 	}
 }
 
+error_t vol_GetRawBlock(cachedblock_t *blok, ULONG bloknr)
+{
+	error_t error;
+	ULONG realbloknr = bloknr;
+
+	if ((error = vol_CheckBlockNr(&realbloknr)))
+		return error;
+	if ((error = c_GetBlock((uint8 *)blok->data, realbloknr,
+		SIZEOF_RESBLOCK)))
+		return error;
+
+	blok->mode = check;
+	blok->blocknr = bloknr;
+	return e_none;
+}
+
+/*
+ * Repair routines need the contents of an overwritten metadata block so they
+ * can take their wrong-ID recovery path.  A syntactically invalid metadata
+ * block is therefore readable here; actual I/O and bounds errors still fail.
+ */
+static error_t GetRepairBlock(cachedblock_t *block, ULONG blocknr)
+{
+	error_t error = volume.getblock(block, blocknr);
+
+	if (error == e_syntax_error)
+		return vol_GetRawBlock(block, blocknr);
+	return error;
+}
+
 error_t vol_WriteBlock(cachedblock_t *blok)
 {
 	int status;
@@ -917,7 +948,7 @@ static error_t GetRext(void)
 
 	if (bloknr)
 	{
-		if ((error = volume.getblock((cachedblock_t *)&rext, bloknr)))
+		if ((error = GetRepairBlock((cachedblock_t *)&rext, bloknr)))
 			return error;
 	}
 
@@ -1065,9 +1096,9 @@ static error_t RepairBootBlock(void)
 	enterblock(BOOTBLOCK);
 
 	// read bootblock 
-	bootbl.data = calloc(1, MAXRESBLOCKSIZE);
+	bootbl.data = calloc(1, 2 * volume.blocksize);
 	if ((error = ReadPFS3Metadata((uint8 *)bootbl.data,
-		BOOTBLOCK + volume.firstblock, volume.blocksize,
+		BOOTBLOCK + volume.firstblock, 2 * volume.blocksize,
 		PFS3_METADATA_BOOT)))
 	{
 		adderror("bootblock could not be loaded");
@@ -1085,7 +1116,7 @@ static error_t RepairBootBlock(void)
 			bootbl.data->bootblock.disktype = ID_PFS_DISK;
 			fixederror("bootblock had wrong ID");
 			if ((error = WritePFS3Metadata((uint8 *)bootbl.data,
-				BOOTBLOCK + volume.firstblock, volume.blocksize,
+				BOOTBLOCK + volume.firstblock, 2 * volume.blocksize,
 				PFS3_METADATA_BOOT)))
 			{
 				adderror("bootblock could not be written");
@@ -2160,7 +2191,7 @@ error_t RepairAnodeBlock(uint32 *bloknr, uint32 seqnr)
 	ablk.data = calloc(1, SIZEOF_RESBLOCK);
 	if (*bloknr)
 	{
-		if ((error = volume.getblock((cachedblock_t *)&ablk, *bloknr)))
+		if ((error = GetRepairBlock((cachedblock_t *)&ablk, *bloknr)))
 		{
 			free (ablk.data);
 			return error;
@@ -2269,7 +2300,7 @@ error_t RepairBitmapBlock(uint32 *bloknr, uint32 seqnr)
 
 	if (*bloknr)
 	{
-		if ((error = volume.getblock((cachedblock_t *)&bmblk, *bloknr)))
+		if ((error = GetRepairBlock((cachedblock_t *)&bmblk, *bloknr)))
 		{
 			free (bmblk.data);
 			return error;
@@ -2344,7 +2375,7 @@ error_t RepairIndexBlock(uint16 bloktype, error_t (*repairchild)(uint32 *, uint3
 
 		/* read or build indexblock
 		 */
-		if ((error = volume.getblock((cachedblock_t *)&iblk, *bloknr)))
+		if ((error = GetRepairBlock((cachedblock_t *)&iblk, *bloknr)))
 		{
 			free (iblk.data);
 			return error;

--- a/rom/filesys/pfs3/pfsdoctor/standardscan.c
+++ b/rom/filesys/pfs3/pfsdoctor/standardscan.c
@@ -504,7 +504,8 @@ error_t vol_GetBlock(cachedblock_t *blok, ULONG bloknr)
 	if ((error = vol_CheckBlockNr(&realbloknr)))
 		return error;
 
-	if ((error = c_GetBlock((uint8 *)blok->data, realbloknr, SIZEOF_RESBLOCK)))
+	if ((error = ReadPFS3Metadata((uint8 *)blok->data, realbloknr,
+		SIZEOF_RESBLOCK, PFS3_METADATA_RESERVED)))
 	{
 		return error;
 	}
@@ -527,7 +528,8 @@ error_t vol_WriteBlock(cachedblock_t *blok)
 		if ((status = vol_CheckBlockNr(&bloknr)))
 			return status;
 
-		return c_WriteBlock((uint8 *)blok->data, bloknr, SIZEOF_RESBLOCK);
+		return WritePFS3Metadata((uint8 *)blok->data, bloknr,
+			SIZEOF_RESBLOCK, PFS3_METADATA_RESERVED);
 	}
 
 	return e_none;
@@ -552,7 +554,9 @@ static error_t BuildRootBlock_hub(void)
 		if (!(error = BuildRootBlock(rbl)))
 		{
 			fixederror("new rootblock build");
-			c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+			WritePFS3Metadata((uint8 *)rbl,
+				ROOTBLOCK + volume.firstblock, volume.blocksize,
+				PFS3_METADATA_ROOT);
 		}
 	}
 	else
@@ -585,7 +589,9 @@ static error_t GetRootBlock(void)
 	}
 
 	// read rootblock 
-	if ((error = c_GetBlock ((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize)))
+	if ((error = ReadPFS3Metadata((uint8 *)rbl,
+		ROOTBLOCK + volume.firstblock, volume.blocksize,
+		PFS3_METADATA_ROOT)))
 	{
 		adderror("rootblock could not be loaded");
 		return error;
@@ -885,7 +891,9 @@ static error_t CheckRootBlock(void)
 	}
 
 	if (dirty)
-		return c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+		return WritePFS3Metadata((uint8 *)rbl,
+			ROOTBLOCK + volume.firstblock, volume.blocksize,
+			PFS3_METADATA_ROOT);
 
 	return error;
 }
@@ -1058,7 +1066,9 @@ static error_t RepairBootBlock(void)
 
 	// read bootblock 
 	bootbl.data = calloc(1, MAXRESBLOCKSIZE);
-	if ((error = volume.getblock ((cachedblock_t *)&bootbl, BOOTBLOCK)))
+	if ((error = ReadPFS3Metadata((uint8 *)bootbl.data,
+		BOOTBLOCK + volume.firstblock, volume.blocksize,
+		PFS3_METADATA_BOOT)))
 	{
 		adderror("bootblock could not be loaded");
 		free (bootbl.data);
@@ -1074,7 +1084,9 @@ static error_t RepairBootBlock(void)
 		{
 			bootbl.data->bootblock.disktype = ID_PFS_DISK;
 			fixederror("bootblock had wrong ID");
-			if ((error = volume.writeblock((cachedblock_t *)&bootbl)))
+			if ((error = WritePFS3Metadata((uint8 *)bootbl.data,
+				BOOTBLOCK + volume.firstblock, volume.blocksize,
+				PFS3_METADATA_BOOT)))
 			{
 				adderror("bootblock could not be written");
 				free (bootbl.data);
@@ -1247,7 +1259,8 @@ static error_t RepairDeldir(void)
 	}
 
 	if (rootdirty)
-		c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+		WritePFS3Metadata((uint8 *)rbl, ROOTBLOCK + volume.firstblock,
+			volume.blocksize, PFS3_METADATA_ROOT);
 	if (rextdirty)
 		volume.writeblock((cachedblock_t *)&rext);
 
@@ -1924,21 +1937,8 @@ static error_t DeleteAnode(uint32 anodechain, uint32 node)
  */
 static error_t GetExtraFields(struct extrafields *extrafields, struct direntry *de)
 {
-	uint16 *extra = (uint16 *)extrafields;
-	uint16 *fields = (uint16 *)(((uint8 *)de)+de->next);
-	uint16 flags, i;
-
-	// extract extrafields from directoryentry
-	flags = *(--fields);
-	for (i=0; i < sizeof(struct extrafields)/2; i++, flags>>=1)
-		*(extra++) = (flags&1) ? *(--fields) : 0;
-
-	// check flags field
-	if (flags)
+	if (PFS3GetExtraFields(de, extrafields))
 		addfileerror("unknown extrafield flags found (ignored)");
-
-	// patch protection lower 8 bits
-	extrafields->prot |= de->protection;
 	return e_none;
 }
 
@@ -1974,40 +1974,7 @@ static error_t SetExtraFields(struct extrafields *extrafields, struct direntry *
 
 static void AddExtraFields(struct direntry *direntry, struct extrafields *extra)
 {
-	UWORD offset, *dirext;
-	UWORD array[16], i = 0, j = 0;
-	UWORD flags = 0, orvalue;
-	UWORD *fields = (UWORD *)extra;
-
-	/* patch protection lower 8 bits */
-	extra->prot &= 0xffffff00;
-	offset = (sizeof(struct direntry) + (direntry->nlength) + *FILENOTE(direntry)) & 0xfffe;
-	dirext = (UWORD *)((UBYTE *)(direntry) + (UBYTE)offset);
-
-	orvalue = 1;
-	/* fill packed field array */
-	for (i = 0; i < sizeof(struct extrafields) / 2; i++)
-	{
-		if (*fields)
-		{
-			array[j++] = *fields++;
-			flags |= orvalue;
-		}
-		else
-		{
-			fields++;
-		}
-
-		orvalue <<= 1;
-	}
-
-	/* add fields to direntry */
-	i = j;
-	while (i)
-		*dirext++ = array[--i];
-	*dirext++ = flags;
-
-	direntry->next = offset + 2 * j + 2;
+	PFS3AddExtraFields(direntry, extra);
 }
 
 
@@ -2050,7 +2017,7 @@ static error_t RepairLinkChain(struct direntry *de, c_dirblock_t *dirblk)
 				 && (linknode.nr == extra.link))
 			{
 				extra.link = 0;
-			 = { NULL} SetExtraFields(&extra, de, 0lk);
+				SetExtraFields(&extra, de, dirblk);
 			}
 		}
 
@@ -2159,7 +2126,9 @@ static error_t RepairAnodeTree(void)
 					return error;
 
 				if (rbl->idx.small.indexblocks[i] != child_blk_nr)
-					c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+					WritePFS3Metadata((uint8 *)rbl,
+						ROOTBLOCK + volume.firstblock,
+						volume.blocksize, PFS3_METADATA_ROOT);
 			}
 		}
 	}
@@ -2269,7 +2238,9 @@ static error_t RepairBitmapTree(void)
 				return error;
 			
 			if (rbl->idx.large.bitmapindex[i] != blknr)
-				c_WriteBlock((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+				WritePFS3Metadata((uint8 *)rbl,
+					ROOTBLOCK + volume.firstblock,
+					volume.blocksize, PFS3_METADATA_ROOT);
 		}
 	}
 
@@ -2614,28 +2585,26 @@ static error_t RepairReservedBitmap(void)
 	bool dirty = false;
 	error_t error;
 	uint32 nuba=0, ubna=0;
-	uint8 *t;
 
 	volume.status(0, "validating reserved", volume.resbitmap->lwsize/0xff);
 
 	/* first save current rootblock */
-	if ((error = c_WriteBlock ((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize)))
+	if ((error = WritePFS3Metadata((uint8 *)rbl,
+		ROOTBLOCK + volume.firstblock, volume.blocksize,
+		PFS3_METADATA_ROOT)))
 		return error;		
 	
 	/* now get reserved bitmap with rootblock in memory */
 	if (!(lrb = (rootblock_t *)AllocBufMem(volume.blocksize * rbl->rblkcluster)))
 		return e_out_of_memory;
 
-	t = (uint8 *)lrb;
-	for (i=0; i<rbl->rblkcluster; i++)
+	if ((error = ReadPFS3Metadata((uint8 *)lrb,
+		ROOTBLOCK + volume.firstblock,
+		volume.blocksize * rbl->rblkcluster, PFS3_METADATA_ROOT)))
 	{
-		if ((error = c_GetBlock (t, ROOTBLOCK + volume.firstblock + i, volume.blocksize)))
-		{
-			adderror("reserved bitmap could not be loaded");
-			FreeBufMem(lrb);
-			return error;
-		}
-		t += volume.blocksize;
+		adderror("reserved bitmap could not be loaded");
+		FreeBufMem(lrb);
+		return error;
 	}
 
 	bitmap = (bitmapblock_t *)(lrb + 1);
@@ -2724,12 +2693,10 @@ static error_t RepairReservedBitmap(void)
 	error = e_none;
 	if (dirty && !aborting)
 	{
-		t = (uint8 *)lrb;
-		for (i=0; i<lrb->rblkcluster; i++)
-		{
-			error = c_WriteBlock (t, ROOTBLOCK + volume.firstblock + i, volume.blocksize);
-			t += volume.blocksize;
-		}
+		error = WritePFS3Metadata((uint8 *)lrb,
+			ROOTBLOCK + volume.firstblock,
+			volume.blocksize * lrb->rblkcluster,
+			PFS3_METADATA_ROOT);
 		memcpy(rbl, lrb, SIZEOF_RESBLOCK);
 	}
 	
@@ -2840,7 +2807,9 @@ static error_t RepairMainBitmap(void)
 	}
 
 	if (dirty)
-		error = c_WriteBlock ((uint8 *)rbl, ROOTBLOCK + volume.firstblock, volume.blocksize);
+		error = WritePFS3Metadata((uint8 *)rbl,
+			ROOTBLOCK + volume.firstblock, volume.blocksize,
+			PFS3_METADATA_ROOT);
 	
 	if (!build)
 		free (bmb.data);
@@ -3073,4 +3042,3 @@ static BOOL bg_IsItemUsed(bitmap_t *bm, uint32 nr)
 	else
 		return TRUE;
 }
-

--- a/scripts/nightly/autotest/User-Startup.cunit
+++ b/scripts/nightly/autotest/User-Startup.cunit
@@ -8,6 +8,9 @@ If NOT WARN
     ; Perform entropy.resource stress/behaviour unit tests...
     Execute S/Test cunit/entropy/cunit-entropy
 
+    ; Perform PFS3 on-disk endian conversion unit tests...
+    Execute S/Test cunit/filesys/pfs3/cunit-pfs3-endian
+
     ; Peform basic 'C' type unit tests..
     Execute S/Test cunit/crt/stdc/cunit-crt-types
 


### PR DESCRIPTION
PFS3 and PFSDoctor little-endian support

* add shared routines for PFS3 metadata and uses them in handler and PFSDoctor. 
* fix endian assumptions in anode numbers, dir entries, extra fields, volume names, boot blocks and list entry flags.
* PFSDoctor still gets the unconverted blocks when metadata has been overwritten or damaged, so invalid block IDs won't stop it
* CUnit tests cover block conversion, malformed metadata, recovery-mode directory entries and list entry layout. Failed conversions leave the original buffer unchanged.

~~**Tested on i386-pc only at the moment, hence draft PR.**~~

^ works now

~~I'm currently building a minimal i386-pc and m68k image and testing those. I'll attach them and mark this ready when I'm done proving them out :)~~