### PR TITLE
m68k-amiga: include inputclass in bootstrap ELF

### DIFF
--- a/arch/m68k-amiga/boot/mmakefile.src
+++ b/arch/m68k-amiga/boot/mmakefile.src
@@ -345,7 +345,7 @@ KLIBS   := aros utility dos oop mathffp mathieeesingbas partition \
            keymap graphics layers intuition gadtools icon workbench setpatch
 KDEVS   := timer input keyboard console trackdisk gameport audio ata cd
 KHNDLRS := cdrom con afs ram
-KHIDDS  := amigakbd amigamouse amigavideo ata_gayle bus gfx hiddclass keyboard mouse storage system p96gfx
+KHIDDS  := amigakbd amigamouse amigavideo ata_gayle bus gfx hiddclass inputclass keyboard mouse storage system p96gfx
 KRSRCS  := battclock battmem processor task lddemon dosboot cia potgo disk \
            misc shell shellcommands workbook wbtag card FileSystem
 KHOOKS  := alert romboot


### PR DESCRIPTION
When input.device was refactored to use the new inputclass.hidd module (a18361f3), that module was added to the normal fixed-ROM configuration—but accidentally omitted from the bootstrap ELF’s module list. This broke the floppy+ISO bootstrap for fresh installs in UAE.

This patch adds it back in.