### PR TITLE
p96gfx: pass the plane mask and prepare struct Line for DrawLine()

### DIFF
--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
@@ -834,15 +834,60 @@ VOID P96GFXBitmap__Hidd_BitMap__DrawLine(OOP_Class *cl, OOP_Object *o,
     if (data->invram) {
         struct RenderInfo ri;
         struct Line renderLine;
+        /*
+         * P96 wants dX/dY as the end-minus-start difference, not as the end
+         * coordinate, and it wants the Bresenham terms prepared: lDelta and
+         * sDelta are the major and minor extents keeping their sign, and
+         * twoSDminusLD is the error accumulator the card starts from.
+         *
+         * Every field matters. A card is entitled to read all of them, and the
+         * Z3660 reads Length, DrawMode, PatternShift and pad among others, so
+         * the structure is cleared rather than partly filled.
+         */
+        WORD dx = msg->x2 - msg->x1;
+        WORD dy = msg->y2 - msg->y1;
+        WORD adx = dx < 0 ? -dx : dx;
+        WORD ady = dy < 0 ? -dy : dy;
+        BOOL horizontal = adx > ady;
+
         P96GFXRTG__MakeRenderInfo(csd, cid, &ri, data);
-        renderLine.FgPen = GC_FG(msg->gc);
-        renderLine.BgPen = GC_BG(msg->gc);
-        renderLine.LinePtrn = GC_LINEPAT(msg->gc);
+
+        memset(&renderLine, 0, sizeof(renderLine));
         renderLine.X = msg->x1;
         renderLine.Y = msg->y1;
-        renderLine.dX = msg->x2;
-        renderLine.dY = msg->y2;
-        v = DrawLine(cid, &ri, &renderLine, data->rgbformat);
+        /* The major extent, not the pixel count: P96 draws the endpoint itself. */
+        renderLine.Length = horizontal ? adx : ady;
+        renderLine.dX = dx;
+        renderLine.dY = dy;
+        renderLine.lDelta = horizontal ? dx : dy;
+        renderLine.sDelta = horizontal ? dy : dx;
+        renderLine.twoSDminusLD = 2 * (horizontal ? ady : adx)
+                                    - (horizontal ? adx : ady);
+        renderLine.LinePtrn = GC_LINEPAT(msg->gc);
+        /*
+         * The Amiga pattern counter selects a bit from the top down and P96
+         * counts from the bottom, so the two run in opposite directions.
+         */
+        renderLine.PatternShift = 15 - (GC_LINEPATCNT(msg->gc) & 15);
+        renderLine.FgPen = GC_FG(msg->gc);
+        renderLine.BgPen = GC_BG(msg->gc);
+        renderLine.Horizontal = horizontal;
+        /*
+         * The GC has already folded the RastPort's draw mode into a ROP and a
+         * color-expansion flag, so it is reconstructed rather than copied.
+         * INVERSVID is deliberately not set: Draw() applies it by inverting
+         * LinePtrn before we get here, and setting it again would undo that.
+         */
+        if (GC_DRMD(msg->gc) == vHidd_GC_DrawMode_Invert)
+            renderLine.DrawMode = COMPLEMENT;
+        else if (GC_COLEXP(msg->gc) == vHidd_GC_ColExp_Opaque)
+            renderLine.DrawMode = JAM2;
+        else
+            renderLine.DrawMode = JAM1;
+        renderLine.Xorigin = msg->x1;
+        renderLine.Yorigin = msg->y1;
+
+        v = DrawLine(cid, &ri, &renderLine, 0xff, data->rgbformat);
     }
 
     UNLOCK_HW

--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_card.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_card.c
@@ -202,23 +202,25 @@ void SetPanning(struct p96gfx_carddata *cid, UBYTE *video, UWORD width, WORD x, 
 }
 
 BOOL DrawLine(struct p96gfx_carddata *cid, struct RenderInfo *ri,
-    struct Line * line, ULONG rgbformat)
+    struct Line * line, UBYTE mask, ULONG rgbformat)
 {
     if (cid->CardBase) {
-        AROS_CALL4(BOOL, __cardFunc(cid, PSSO_BoardInfo_DrawLine),
+        AROS_CALL5(BOOL, __cardFunc(cid, PSSO_BoardInfo_DrawLine),
             AROS_LCA(APTR, cid->boardinfo, A0),
             AROS_LCA(APTR, ri, A1),
             AROS_LCA(struct Line *, line, A2),
+            AROS_LCA(UBYTE, mask, D0),
             AROS_LCA(ULONG, rgbformat, D7),
             struct Library*, cid->CardBase);
         return gw (cid->boardinfo + PSSO_BoardInfo_AROSFlag);
     }
 #if (0)
     else
-        return P96_LC4(BOOL, cid->p96romvector, 28,
+        return P96_LC5(BOOL, cid->p96romvector, 28,
             AROS_LCA(APTR, cid->boardinfo, A0),
             AROS_LCA(APTR, ri, A1),
             AROS_LCA(struct Line *, line, A2),
+            AROS_LCA(UBYTE, mask, D0),
             AROS_LCA(ULONG, rgbformat, D7));
 #else
     return FALSE;

--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_rtg.h
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_rtg.h
@@ -441,7 +441,7 @@ SetFeatureAttrs
 
 /* Card Render Operation Stubs .. */
 BOOL DrawLine(struct p96gfx_carddata *cid, struct RenderInfo *ri,
-    struct Line *line, ULONG rgbformat);
+    struct Line *line, UBYTE mask, ULONG rgbformat);
 BOOL BlitRect(struct p96gfx_carddata *cid, struct RenderInfo *ri,
     WORD sx, WORD sy, WORD dx, WORD dy, WORD w, WORD h, UBYTE mask, ULONG rgbformat);
 BOOL FillRect(struct p96gfx_carddata *cid, struct RenderInfo *ri, WORD x, WORD y, WORD w, WORD h, ULONG pen, UBYTE mask, ULONG rgbformat);


### PR DESCRIPTION
Line drawing on a Picasso96 card driver produced nothing on m68k. `Draw()` on an RTG screen left the scene untouched, with no fallback to the software rasterizer, because the card hook reported success.

Two problems, both in how `p96gfx` calls the card:

- The `DrawLine` hook takes a plane mask in D0 (`__REGD0(UBYTE)`), which the dispatch never set. The card ANDed pixels against whatever happened to be in that register; a zero mask writes nothing. `FillRect` alongside it already passes its mask explicitly, which is why filling worked and line drawing did not.
- `struct Line` was a stack variable with seven of its seventeen fields assigned and the rest left as garbage, including `Length`, `DrawMode`, `PatternShift` and `pad`, all of which a card may read. `dX`/`dY` also held the end coordinates, where P96 defines them as the end-minus-start difference.

The structure is now cleared and fully populated: the Bresenham terms (`lDelta`, `sDelta`, `twoSDminusLD`, `Horizontal`), `Length` as the major extent, and `DrawMode` reconstructed from the GC, which by then has folded the RastPort mode into a ROP plus a colour-expansion flag. INVERSVID is deliberately not re-applied, since `Draw()` has already inverted `LinePtrn`.

Tested on a Z3660 under emulation with [p96cts](https://github.com/codewiz/p96cts), at 640x480 in 8-bit and 24-bit. Before, all five DrawLine scenes rendered empty. After, `solid`, `pattern`, `jam2` and `inversvid` pass at both depths, and `complement` differs by the same four pixels it does under AmigaOS 3.x with the same card, which is a known bug in the card driver rather than in this path.

The plane mask is passed as `0xff` here, matching what `FillRect` and the other render stubs already do; plumbing `rp->Mask` through to the card is a separate problem and is not addressed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)