### PR TITLE
graphics: fix RectFill drawmodes, plane masks and the stencil minterm

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -559,7 +559,7 @@ VOID AmigaVideoBM__Hidd_BitMap__DrawLine(OOP_Class *cl, OOP_Object *o,
             }
         }
 
-        if (blit_fillrect(csd, data->pbm, x1, y1, x2, y2, fg, mode))
+        if (blit_fillrect(csd, data->pbm, x1, y1, x2, y2, fg, mode, GC_COLMASK(gc)))
             doSuper = FALSE;
     }
     if (doSuper)
@@ -989,7 +989,7 @@ VOID AmigaVideoBM__Hidd_BitMap__FillRect(OOP_Class *cl, OOP_Object *o, struct pH
          (mode == vHidd_GC_DrawMode_Copy)) ||
         ((height == 1) && (width >= 256) &&
          (mode == vHidd_GC_DrawMode_Copy)) ||
-        !blit_fillrect(csd, data->pbm, msg->minX, msg->minY, msg->maxX, msg->maxY, fg, mode)) {
+        !blit_fillrect(csd, data->pbm, msg->minX, msg->minY, msg->maxX, msg->maxY, fg, mode, GC_COLMASK(msg->gc))) {
         CMDDEBUGUNIMP(bug("[AmigaVideo:Bitmap] %s()\n", __func__);)
         OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
     }

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
@@ -117,7 +117,7 @@ BOOL blit_copybox(struct amigavideo_staticdata *data, struct BitMap *srcbm, stru
     srcx2 = srcx + w - 1;
     dstx2 = dstx + w - 1;
     if (copy_minterm[mode] == 0xff)
-        return blit_fillrect(data, dstbm, dstx, dsty, dstx2, dsty + h - 1, 0, mode);
+        return blit_fillrect(data, dstbm, dstx, dsty, dstx2, dsty + h - 1, 0, mode, 0xff);
 
     if (copy_minterm[mode] == 0)
         return FALSE;
@@ -422,7 +422,7 @@ static const UBYTE fill_minterm[] = { 0xca, 0x00, 0x00, 0xca, 0x00, 0x00, 0x5a, 
 // C     = source
 // D     = destination
 
-BOOL blit_fillrect(struct amigavideo_staticdata *data, struct BitMap *bm, WORD x1,WORD y1,WORD x2,WORD y2, HIDDT_Pixel pixel, HIDDT_DrawMode mode)
+BOOL blit_fillrect(struct amigavideo_staticdata *data, struct BitMap *bm, WORD x1,WORD y1,WORD x2,WORD y2, HIDDT_Pixel pixel, HIDDT_DrawMode mode, UBYTE mask)
 {
     volatile struct Custom *custom = (struct Custom*)0xdff000;
     struct GfxBase *GfxBase = (APTR)data->cs_GfxBase;
@@ -462,7 +462,10 @@ BOOL blit_fillrect(struct amigavideo_staticdata *data, struct BitMap *bm, WORD x
         pixel = 0xff;
 
     for (i = 0; i < bm->Depth; i++) {
-        if (bm->Planes[i] != (UBYTE*)0x00000000 && bm->Planes[i] != (UBYTE*)0xffffffff) {
+        /* The write mask protects the planes it clears. It is a UBYTE, so it
+           says nothing about a ninth plane and beyond: leave those writable. */
+        if ((i >= 8 || (mask & (1 << i))) &&
+            bm->Planes[i] != (UBYTE*)0x00000000 && bm->Planes[i] != (UBYTE*)0xffffffff) {
             WaitBlit();
             custom->bltbdat = (pixel & 1) ? 0xffff : 0x0000;
             custom->bltcpt = (APTR)(bm->Planes[i] + offset);

--- a/arch/m68k-amiga/hidd/amigavideo/blitter.h
+++ b/arch/m68k-amiga/hidd/amigavideo/blitter.h
@@ -4,7 +4,7 @@
 
 #define USE_BLITTER 1
 
-BOOL blit_fillrect(struct amigavideo_staticdata*, struct BitMap* ,WORD,WORD,WORD,WORD,HIDDT_Pixel,HIDDT_DrawMode);
+BOOL blit_fillrect(struct amigavideo_staticdata*, struct BitMap* ,WORD,WORD,WORD,WORD,HIDDT_Pixel,HIDDT_DrawMode,UBYTE);
 BOOL blit_copybox(struct amigavideo_staticdata*, struct BitMap*, struct BitMap*, WORD, WORD, WORD, WORD, WORD, WORD, HIDDT_DrawMode);
 BOOL blit_copybox_mask(struct amigavideo_staticdata*, struct BitMap*, struct BitMap*, WORD, WORD, WORD, WORD, WORD, WORD, HIDDT_DrawMode, APTR);
 BOOL blit_puttemplate(struct amigavideo_staticdata*, struct BitMap*, struct pHidd_BitMap_PutTemplate*);

--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
@@ -1326,6 +1326,8 @@ VOID P96GFXBitmap__Hidd_BitMap__FillRect(OOP_Class *cl, OOP_Object *o, struct pH
     HIDDT_DrawMode mode = GC_DRMD(msg->gc);
     HIDDT_Pixel fg = GC_FG(msg->gc);
     struct p96gfx_staticdata *csd = CSD(cl);
+    ULONG colmask = GC_COLMASK(msg->gc);
+    UBYTE mask = (UBYTE)colmask;
     BOOL v = FALSE;
 
     D(bug("[P96Gfx:Bitmap] %s()\n", __func__));
@@ -1348,14 +1350,23 @@ VOID P96GFXBitmap__Hidd_BitMap__FillRect(OOP_Class *cl, OOP_Object *o, struct pH
 
         if (mode == vHidd_GC_DrawMode_Clear || mode == vHidd_GC_DrawMode_Set) {
             ULONG pen = mode == vHidd_GC_DrawMode_Clear ? 0x00000000 : 0xffffffff;
-            v = FillRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, pen, 0xff, data->rgbformat);
+            v = FillRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, pen, mask, data->rgbformat);
         } else if (mode == vHidd_GC_DrawMode_Copy) {
-            v = FillRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, fg, 0xff, data->rgbformat);
+            v = FillRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, fg, mask, data->rgbformat);
         } else if (mode == vHidd_GC_DrawMode_Invert) {
-            v = InvertRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, 0xff, data->rgbformat);
+            v = InvertRect(cid, &ri, msg->minX, msg->minY, msg->maxX - msg->minX + 1, msg->maxY - msg->minY + 1, mask, data->rgbformat);
         }
 
         UNLOCK_HW
+    }
+
+    /* The memory fallbacks below write whole pixels, so a partial mask has to
+       go to the superclass instead. */
+    if (!v && colmask != ~0)
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        UNLOCK_BITMAP(data)
+        return;
     }
 
     if (!v) switch(mode)

--- a/rom/graphics/bltbitmap.c
+++ b/rom/graphics/bltbitmap.c
@@ -209,7 +209,7 @@ static void copyonepixel(PLANEPTR src, ULONG xsrc, PLANEPTR dest,
                                   , destBitMap, dstbm_obj
                                   , xDest, yDest
                                   , xSize, ySize
-                                  , minterm
+                                  , minterm, mask
                                   , driver->display_gfxhidd
                                   , tmp_gc
                                   , GfxBase);

--- a/rom/graphics/bltbitmaprastport.c
+++ b/rom/graphics/bltbitmaprastport.c
@@ -38,7 +38,7 @@ static ULONG bitmap_render(APTR bitmap_rd, WORD srcx, WORD srcy,
      */
     res = int_bltbitmap(brd->srcbm, brd->srcbm_obj, srcx, srcy,
                         brd->rsi.curbm, dstbm_obj, rect->MinX, rect->MinY,
-                        width, height, brd->minterm, gfxhidd, dst_gc, GfxBase);
+                        width, height, brd->minterm, 0xFF, gfxhidd, dst_gc, GfxBase);
 
     return res ? width * height : 0;
 }

--- a/rom/graphics/gfxfuncsupport.c
+++ b/rom/graphics/gfxfuncsupport.c
@@ -352,8 +352,8 @@ LONG fillrect_pendrmd(struct RastPort *rp, WORD x1, WORD y1, WORD x2, WORD y2,
 
 BOOL int_bltbitmap(struct BitMap *srcBitMap, OOP_Object *srcbm_obj, WORD xSrc, WORD ySrc,
                    struct BitMap *dstBitMap, OOP_Object *dstbm_obj, WORD xDest, WORD yDest,
-                   WORD xSize, WORD ySize, ULONG minterm, OOP_Object *gfxhidd, OOP_Object *gc,
-                   struct GfxBase *GfxBase)
+                   WORD xSize, WORD ySize, ULONG minterm, UBYTE mask, OOP_Object *gfxhidd,
+                   OOP_Object *gc, struct GfxBase *GfxBase)
 {
     HIDDT_DrawMode drmd;
 
@@ -364,6 +364,8 @@ BOOL int_bltbitmap(struct BitMap *srcBitMap, OOP_Object *srcbm_obj, WORD xSrc, W
     BOOL dst_colmap_set = FALSE;
     BOOL success = TRUE;
     BOOL colmaps_ok = TRUE;
+    ULONG old_colmask = GC_COLMASK(gc);
+    ULONG srcdepth = GetBitMapAttr(srcBitMap, BMA_DEPTH);
 
     drmd = MINTERM_TO_GCDRMD(minterm);
 
@@ -395,6 +397,23 @@ BOOL int_bltbitmap(struct BitMap *srcBitMap, OOP_Object *srcbm_obj, WORD xSrc, W
         //bug("driver_intbltbitmap: dest is amiga bitmap\n");
         /* Amiga BM */
         dstflags |= FLG_PALETTE;
+    }
+
+    /*
+     * Only pens have planes, so neither rule below means anything on a
+     * truecolor destination, where the whole pixel is written.
+     */
+    if(!(dstflags & FLG_TRUECOLOR)) {
+        /*
+         * A blit covers min(src, dst) planes, so a source shallower than the
+         * destination leaves the planes above its own depth alone.
+         */
+        if(srcdepth < GetBitMapAttr(dstBitMap, BMA_DEPTH))
+            GC_COLMASK(gc) &= (1UL << srcdepth) - 1;
+
+        /* Likewise for the planes mask deselects. */
+        if(mask != 0xFF)
+            GC_COLMASK(gc) &= mask;
     }
 
     if((srcflags == FLG_PALETTE || srcflags == FLG_STATICPALETTE)) {
@@ -506,6 +525,9 @@ BOOL int_bltbitmap(struct BitMap *srcBitMap, OOP_Object *srcbm_obj, WORD xSrc, W
 
     if(dst_colmap_set)
         HIDD_BM_SetColorMap(dstbm_obj, NULL);
+
+    /* The GC can be a cached one, so do not leave the mask behind in it. */
+    GC_COLMASK(gc) = old_colmask;
 
     ULOCK_BLIT
 

--- a/rom/graphics/gfxfuncsupport.h
+++ b/rom/graphics/gfxfuncsupport.h
@@ -183,8 +183,8 @@ LONG fillrect_pendrmd(struct RastPort *tp, WORD x1, WORD y1, WORD x2, WORD y2,
 
 BOOL int_bltbitmap(struct BitMap *srcBitMap, OOP_Object *srcbm_obj, WORD xSrc, WORD ySrc,
                    struct BitMap *dstBitMap, OOP_Object *dstbm_obj, WORD xDest, WORD yDest,
-                   WORD xSize, WORD ySize, ULONG minterm, OOP_Object *gfxhidd, OOP_Object *gc,
-                   struct GfxBase *GfxBase);
+                   WORD xSize, WORD ySize, ULONG minterm, UBYTE mask, OOP_Object *gfxhidd,
+                   OOP_Object *gc, struct GfxBase *GfxBase);
 
 
 LONG write_pixels_8(struct RastPort *rp, UBYTE *array, ULONG modulo,

--- a/rom/graphics/graphics_inline.h
+++ b/rom/graphics/graphics_inline.h
@@ -79,7 +79,14 @@ static inline OOP_Object *GetDriverData(struct RastPort *rp, struct GfxBase *Gfx
     }
     GC_DRMD(gc)   = vHidd_GC_DrawMode_Copy;
     GC_COLEXP(gc) = 0;
-    GC_COLMASK(gc) = ~0;
+    /*
+     * rp->Mask selects bitplanes, so it only means anything where a pixel is
+     * a pen. On a truecolor bitmap the bits are color components and the mask
+     * has no counterpart, so leave every bit writable there -- as for the
+     * usual 0xFF, which drivers can then recognize as "no mask at all".
+     */
+    GC_COLMASK(gc) = (rp->Mask != 0xFF && rp->BitMap &&
+                      rp->BitMap->Depth <= 8) ? rp->Mask : ~0;
 
     /* Now set GC's DrawMode (effectively ROP) and color expansion (actually transparency) flags */
     if (rp->DrawMode & JAM2)

--- a/rom/graphics/rectfill.c
+++ b/rom/graphics/rectfill.c
@@ -68,25 +68,36 @@
             /* When rastport has areaptrn, let BltPattern do the job */
             BltPattern(rp, NULL, xMin, yMin, xMax, yMax, 0);
         } else {
-            OOP_Object *gc  = GetDriverData(rp, GfxBase);
-            struct Rectangle rr;
-            HIDDT_Pixel oldfg = 0;
+            /*
+             * Without an AreaPtrn the fill pattern is all ones, so INVERSVID
+             * clears it: JAM1 then writes nothing at all, and JAM2 writes
+             * BPen everywhere. COMPLEMENT inverts the destination wherever
+             * the mode writes, whichever pen it would have used.
+             */
+            BOOL inversvid = (rp->DrawMode & INVERSVID) != 0;
+            BOOL jam2 = (rp->DrawMode & JAM2) != 0;
 
-            if(rp->DrawMode & INVERSVID) {
-                oldfg = GC_FG(gc);
-                GC_FG(gc) = GC_BG(gc);
-            }
+            if(jam2 || !inversvid) {
+                OOP_Object *gc  = GetDriverData(rp, GfxBase);
+                struct Rectangle rr;
+                HIDDT_Pixel oldfg = GC_FG(gc);
 
-            /* This is the same as fillrect_pendrmd() */
+                if(inversvid) {
+                    GC_FG(gc) = GC_BG(gc);
+                }
+                if(rp->DrawMode & COMPLEMENT) {
+                    GC_DRMD(gc) = vHidd_GC_DrawMode_Invert;
+                }
 
-            rr.MinX = xMin;
-            rr.MinY = yMin;
-            rr.MaxX = xMax;
-            rr.MaxY = yMax;
+                /* This is the same as fillrect_pendrmd() */
 
-            do_render_with_gc(rp, NULL, &rr, fillrect_render, NULL, gc, TRUE, FALSE, GfxBase);
+                rr.MinX = xMin;
+                rr.MinY = yMin;
+                rr.MaxX = xMax;
+                rr.MaxY = yMax;
 
-            if(rp->DrawMode & INVERSVID) {
+                do_render_with_gc(rp, NULL, &rr, fillrect_render, NULL, gc, TRUE, FALSE, GfxBase);
+
                 GC_FG(gc) = oldfg;
             }
         }

--- a/rom/hidds/gfx/gfx_hiddclass.c
+++ b/rom/hidds/gfx/gfx_hiddclass.c
@@ -1372,6 +1372,7 @@ static IPTR copyboxmasked_impl(OOP_Class *cl, OOP_Object *obj, struct pHidd_Gfx_
     HIDDT_Color *ctab = NULL;
     ULONG bytes_per_line, lines_per_step, doing_lines, lines_done;
     IPTR mask_align, mask_bpr;
+    HIDDT_Pixel pixmask = ~0;
     UBYTE *srcbuf;
 
     OOP_GetAttr(msg->src , aHidd_BitMap_PixFmt, (IPTR *)&src_pf);
@@ -1430,6 +1431,16 @@ static IPTR copyboxmasked_impl(OOP_Class *cl, OOP_Object *obj, struct pHidd_Gfx_
 
     mask_align--;
     mask_bpr = ((mask_bpr + mask_align) & ~mask_align) >> 3;
+
+    /* How wide a source value is, for the ANBC minterm to complement within */
+    if (src_colmod == vHidd_ColorModel_Palette)
+    {
+        IPTR srcdepth;
+
+        OOP_GetAttr(msg->src, aHidd_BitMap_Depth, &srcdepth);
+        if (srcdepth < 32)
+            pixmask = (1UL << srcdepth) - 1;
+    }
 
     /*
      * TODO: Here we use a temporary buffer to perform the operation. This is slow and
@@ -1492,6 +1503,7 @@ static IPTR copyboxmasked_impl(OOP_Class *cl, OOP_Object *obj, struct pHidd_Gfx_
             {
             case vHidd_GC_DrawMode_Or:   /* (ABC|ABNC|ANBC) if copy source and blit thru mask */
             case vHidd_GC_DrawMode_Copy: /* (ABC|ABNC = 0xC0) - compatibility with AOS3 */
+            case vHidd_GC_DrawMode_AndInverted: /* (ANBC) if invert source and blit thru mask */
                 for (y = 0; y < doing_lines; y++)
                 {
                     for (x = 0; x < msg->width; x++)
@@ -1499,6 +1511,14 @@ static IPTR copyboxmasked_impl(OOP_Class *cl, OOP_Object *obj, struct pHidd_Gfx_
                         if (mask[XCOORD_TO_BYTEIDX(msg->srcX + x)] & XCOORD_TO_MASK(msg->srcX + x))
                         {
                             HIDDT_Pixel pix = *srcpixelbuf;
+
+                            /*
+                             * ANBC inverts the source. What gets complemented
+                             * is the pen, before the colormap below, not the
+                             * color the pen maps to.
+                             */
+                            if (drawmode == vHidd_GC_DrawMode_AndInverted)
+                                pix = ~pix & pixmask;
 
                             if (ctab)
                             {
@@ -1534,10 +1554,6 @@ static IPTR copyboxmasked_impl(OOP_Class *cl, OOP_Object *obj, struct pHidd_Gfx_
                     }
                     mask += mask_bpr;
                 }
-                break;
-
-            case vHidd_GC_DrawMode_AndInverted: /* (ANBC) if invert source and blit thru mask */
-                D(bug("CopyBoxMasked does not support ANBC minterm yet"));
                 break;
 
             default:


### PR DESCRIPTION
Four rendering bugs in `graphics.library` and `hidd.gfx`, found by running a
P96 driver conformance suite against AROS and comparing pixel for pixel with
what Picasso96's own software rasterizer produces for the same primitives.

Each is independent, and each is one commit.

### `RectFill()` drawmodes

Without an `AreaPtrn` the fill pattern is all ones, so `INVERSVID` clears it:
`JAM1` must then write nothing at all, and `JAM2` writes BPen. AROS treated
`INVERSVID` as a pen swap in both cases. Separately, `GetDriverData()` tests
`JAM2` before `COMPLEMENT`, so `JAM2 | COMPLEMENT` collapsed to a plain `JAM2`
fill and lost the inversion. Four of the eight mode combinations were wrong:

| mode | expected | was |
|---|---|---|
| `JAM1\|INVERSVID` | untouched | BPen |
| `JAM1\|INVERSVID\|COMPLEMENT` | untouched | inverted |
| `JAM2\|COMPLEMENT` | inverted | APen |
| `JAM2\|INVERSVID\|COMPLEMENT` | inverted | BPen |

### `rp->Mask` never reached a driver

`GetDriverData()` pinned `GC_COLMASK` to `~0`, so the write mask never left
graphics.library. The GC field and the generic per-pixel handling for it
already existed; nothing populated it. It is now set from `rp->Mask` for
palette bitmaps, and honoured in the p96gfx and amigavideo fills.

Left as `~0` on truecolor, where a plane mask has no counterpart, and for the
usual `0xFF`, so the existing `== ~0` fast paths still hit.

`setmaxpen.c` computes `rp->Mask` from the maximum pen precisely so that
rendering can skip the planes above it, which until now had no effect.

### `BltBitMap()` ignored plane counts

A blit covers `min(src, dst)` planes and skips the ones `mask` deselects. The
planar path in `bltbitmap.c` does both; the HIDD path did neither. It wrote
every destination plane, so a depth-3 source onto a depth-8 screen cleared the
top five planes instead of leaving them, and the `mask` argument was never
passed to `int_bltbitmap()` at all.

Both rules are now expressed as `GC_COLMASK`, which makes the two paths agree.

### `CopyBoxMasked()` did not implement the ANBC minterm

It is one of only the two minterms `BltMaskBitMapRastPort()` is defined for,
and the case was a stub that logged and fell through, so an inverted stencil
blit drew nothing.

What gets complemented is the pen, before the colormap lookup, not the color
the pen maps to. On a truecolor destination the two differ: a source pen of
`0x47` complements to `0xB8`, which maps to `00FCAA`, whereas inverting the
mapped color gives `FF0355`. The complement is masked to the source bitmap's
depth, since `~pen` on a `HIDDT_Pixel` would otherwise index the colormap far
out of bounds.

## Testing

Tested on m68k under an emulated A4000 with a Z3660 RTG board, at 640x480x8
and 640x480x24, against reference images captured from `rtg.library`.

Flipped from failing to passing at 8 bits: `RectFill-drawmodes`,
`BltBitMap-planemask`, `BltBitMap-shallow`, `BltBitMap-stencil` and
`BltBitMap-minterms`. Nothing regressed at either depth.

`BltBitMap-minterms` is worth a note: it fails on this board under AmigaOS
because the card driver's blit hooks ignore the minterm, and it passes here
because AROS falls through to the per-pixel path, which gets it right.

Still failing, and untouched by this PR: `BltTemplate-masks` and
`BltPattern-drawmodes` sweep `rp->Mask` through `PutTemplate` and
`PutPattern`, which need the same treatment as the fills; `BltBitMap-planemask`
and `-shallow` still fail at 24 bits, where the source pen has to be masked
before the ColorIndexMapping rather than the destination protected; and
`DrawLine-complement` is a bug in the card driver, failing identically under
AmigaOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
