### PR TITLE
pcixhci: host bridge, 64-bit register and context fixes

### DIFF
--- a/rom/usb/pcixhci/xhci_controllerclass.c
+++ b/rom/usb/pcixhci/xhci_controllerclass.c
@@ -79,8 +79,23 @@ static BOOL XHCIController__Init(struct PCIController *hc)
     hc->hc_CPrivate = xhcic;
 
     /* Initialize hardware... */
-    OOP_GetAttr(hc->hc_PCIDeviceObject, aHidd_PCIDevice_Base0, (IPTR *)&hc->hc_RegBase);
+    {
+        IPTR barbase, barsize;
+
+        OOP_GetAttr(hc->hc_PCIDeviceObject, aHidd_PCIDevice_Base0, &barbase);
+        OOP_GetAttr(hc->hc_PCIDeviceObject, aHidd_PCIDevice_Size0, &barsize);
+
+        /* The BAR holds a bus address, which is not the CPU address on
+           every host bridge, so let the driver translate it. */
+        hc->hc_RegBase = MAPPCI(hc, hc->hc_PCIDriverObject, (APTR)barbase, (ULONG)barsize);
+    }
     xhciregs = (volatile struct xhci_hccapr *)hc->hc_RegBase;
+
+    if (!xhciregs) {
+        pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "Failed to map the register area" DEBUGCOLOR_RESET" \n");
+        xhciCloseTaskTimer(&timerport, &timerreq);
+        return FALSE;
+    }
 
     if(hc->hc_Unit) {
         pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "Initializing hardware for unit #%d" DEBUGCOLOR_RESET" \n",

--- a/rom/usb/pcixhci/xhci_controllerclass.c
+++ b/rom/usb/pcixhci/xhci_controllerclass.c
@@ -407,8 +407,8 @@ takeownership:
     /* Scratchpad buffer count decode (Hi/Lo per spec) */
     val = hcsparams2;
     {
-        ULONG sp_lo = (val >> 21) & 0x1F;
-        ULONG sp_hi = (val >> 27) & 0x1F;
+        ULONG sp_hi = (val >> 21) & 0x1F;
+        ULONG sp_lo = (val >> 27) & 0x1F;
         xhcic->xhc_NumScratchPads = (sp_hi << 5) | sp_lo;
     }
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "SPB = %u" DEBUGCOLOR_RESET" \n", xhcic->xhc_NumScratchPads);

--- a/rom/usb/pcixhci/xhci_controllerclass.c
+++ b/rom/usb/pcixhci/xhci_controllerclass.c
@@ -97,6 +97,8 @@ static BOOL XHCIController__Init(struct PCIController *hc)
         return FALSE;
     }
 
+    OOP_SetAttrs(hc->hc_PCIDeviceObject, (struct TagItem *)pciMemEnableAttrs); /* activate memory */
+
     if(hc->hc_Unit) {
         pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "Initializing hardware for unit #%d" DEBUGCOLOR_RESET" \n",
                         hc->hc_Unit->hu_UnitNo);
@@ -117,7 +119,6 @@ static BOOL XHCIController__Init(struct PCIController *hc)
     xhcic->xhc_XHCIIntR  = (APTR)((IPTR)xhciregs + AROS_LE2LONG(xhciregs->rrsoff) + 0x20);
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "  Interrupt Registers @ 0x%p" DEBUGCOLOR_RESET" \n", xhcic->xhc_XHCIIntR);
 
-    OOP_SetAttrs(hc->hc_PCIDeviceObject, (struct TagItem *)pciMemEnableAttrs); /* activate memory */
 
     /* Cache capability parameters once */
     ULONG hcsparams1 = AROS_LE2LONG(xhciregs->hcsparams1);

--- a/rom/usb/pcixhci/xhci_hcd.c
+++ b/rom/usb/pcixhci/xhci_hcd.c
@@ -1732,8 +1732,13 @@ ULONG xhciInitEP(struct PCIController *hc, struct pciusbXHCIDevice *devCtx,
         UBYTE ival = xhciCalcInterval(interval, flags, type);
         if(ival)
             ep->ctx[0] |= ((ULONG)ival << 16);
-    } else
+    } else {
         devCtx->dc_EP0MaxPacket = maxpacket;
+        /* Average TRB Length is not optional for EP0: eight per the
+           specification. A controller that checks it rejects Address
+           Device with a parameter error. */
+        ep->length = 8;
+    }
 
     /*
      * Endpoint Context DW1 programming:

--- a/rom/usb/pcixhci/xhci_hcd.c
+++ b/rom/usb/pcixhci/xhci_hcd.c
@@ -3270,7 +3270,7 @@ static AROS_INTH1(xhciIntCode, struct PCIController *, hc)
             next_dma  = (UQUAD)(IPTR)xhcic->xhc_DMAERS;
             next_dma += (UQUAD)(idx) * (UQUAD)sizeof(struct xhci_trb);
 
-            xhciSetPointer(hc, ir->erdp, (IPTR)(next_dma | (UQUAD)XHCIF_IR_ERDP_EHB));
+            xhciSetPointerMMIO(hc, ir->erdp, (IPTR)(next_dma | (UQUAD)XHCIF_IR_ERDP_EHB));
         }
 
         if(maxwork == 0) {
@@ -3390,10 +3390,10 @@ void xhciReset(struct PCIController *hc, struct PCIUnit *hu,
 
     hcopr->config = AROS_LONG2LE(xhcic->xhc_NumSlots);
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "  Setting DCBAA to 0x%p" DEBUGCOLOR_RESET" \n", xhcic->xhc_DMADCBAA);
-    xhciSetPointer(hc, hcopr->dcbaap, xhcic->xhc_DMADCBAA);
+    xhciSetPointerMMIO(hc, hcopr->dcbaap, xhcic->xhc_DMADCBAA);
     xhciDumpStatus(AROS_LE2LONG(hcopr->usbsts));
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "  Setting CRCR to 0x%p" DEBUGCOLOR_RESET" \n", xhcic->xhc_DMAOPR);
-    xhciSetPointer(hc, hcopr->crcr, ((IPTR)xhcic->xhc_DMAOPR | 1));
+    xhciSetPointerMMIO(hc, hcopr->crcr, ((IPTR)xhcic->xhc_DMAOPR | 1));
 
     volatile struct pcisusbXHCIRing *xring = (volatile struct pcisusbXHCIRing *)xhcic->xhc_OPRp;
     xhciInitRing(hc, (struct pcisusbXHCIRing *)xring);
@@ -3409,8 +3409,8 @@ void xhciReset(struct PCIController *hc, struct PCIUnit *hu,
     xhciir->erstsz = AROS_LONG2LE(1);
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "  Setting ERDP to 0x%p" DEBUGCOLOR_RESET" \n", xhcic->xhc_DMAERS);
     pciusbXHCIDebug("xHCI", DEBUGCOLOR_SET "  Setting ERSTBA to 0x%p" DEBUGCOLOR_RESET" \n", xhcic->xhc_DMAERST);
-    xhciSetPointer(hc, xhciir->erdp, ((IPTR)xhcic->xhc_DMAERS | (IPTR)XHCIF_IR_ERDP_EHB));
-    xhciSetPointer(hc, xhciir->erstba, ((IPTR)xhcic->xhc_DMAERST));
+    xhciSetPointerMMIO(hc, xhciir->erdp, ((IPTR)xhcic->xhc_DMAERS | (IPTR)XHCIF_IR_ERDP_EHB));
+    xhciSetPointerMMIO(hc, xhciir->erstba, ((IPTR)xhcic->xhc_DMAERST));
 
     xring = (volatile struct pcisusbXHCIRing *)xhcic->xhc_ERSp;
     xhciInitRing(hc, (struct pcisusbXHCIRing *)xring);

--- a/rom/usb/pcixhci/xhci_hw.c
+++ b/rom/usb/pcixhci/xhci_hw.c
@@ -138,9 +138,10 @@ LONG xhciCmdSubmit(struct PCIController *hc,
         /* Wait for completion with a bounded timeout to avoid hanging */
         for(ULONG waitms = 0; waitms < 1000; waitms++) {
             if(xhcic->xhc_CmdResults[queued].status != 0xFFFFFFFF) {
-                /* Invalidate any output contexts that may have been updated */
-                if(dmaaddr) {
-                    /* For commands that update contexts, invalidate cache */
+                /* Only the context commands are handed a CPU address;
+                   Set TR Dequeue Pointer carries a bus address with the
+                   cycle state in bit 0, which is not ours to invalidate. */
+                if(dmaaddr && needs_context) {
                     CacheClearE(dmaaddr, 2048, CACRF_InvalidateD);
                 }
 

--- a/rom/usb/pcixhci/xhci_hw.c
+++ b/rom/usb/pcixhci/xhci_hw.c
@@ -361,7 +361,7 @@ LONG xhciCmdContextEvaluate(struct PCIController *hc, ULONG slot, APTR dmaaddr,
 LONG xhciCmdNoOp(struct PCIController *hc, ULONG slot, APTR dmaaddr,
                  struct timerequest *timerreq)
 {
-    ULONG flags = TRBF_FLAG_TRTYPE_NOOP;
+    ULONG flags = TRBF_FLAG_CRTYPE_NOOP;
 
     pciusbXHCIDebug("xHCI", DEBUGFUNCCOLOR_SET "%s(%u)" DEBUGCOLOR_RESET" \n", __func__, slot);
 

--- a/rom/usb/pcixhci/xhciproto.h
+++ b/rom/usb/pcixhci/xhciproto.h
@@ -363,6 +363,19 @@ void xhciDumpCC(UBYTE completioncode);
     y.addr_hi = 0
 #endif
 
+/*
+ * The 64-bit operational registers are programmed as two 32-bit
+ * accesses, low half first: not every bridge or controller carries an
+ * eight byte register write whole. Pointer fields that live in memory
+ * are not affected.
+ */
+#define xhciSetPointerMMIO(x,y,z) \
+    do { \
+        y.addr_lo = AROS_LONG2LE((ULONG)((UQUAD)(IPTR)(z) & 0xFFFFFFFF)); \
+        y.addr_hi = ((x)->hc_Flags & HCF_ADDR64) ? \
+            AROS_LONG2LE((ULONG)((UQUAD)(IPTR)(z) >> 32)) : 0; \
+    } while (0)
+
 static inline struct xhci_trb *
 xhciTRBPointer(struct PCIController *hc, volatile struct xhci_trb *trb)
 {

--- a/rom/usb/pcixhci/xhciproto.h
+++ b/rom/usb/pcixhci/xhciproto.h
@@ -262,7 +262,7 @@ static inline LONG xhciCmdSetTRDequeuePtr(struct PCIController *hc, ULONG slot, 
 #define xhciCmdContextEvaluate(hc,slot,dmaaddr,timerreq) \
     xhciCmdSubmit(hc, dmaaddr, (slot << 24) | TRBF_FLAG_CRTYPE_EVALUATE_CONTEXT, NULL, timerreq)
 #define xhciCmdNoOp(hc,slot,dmaaddr,timerreq) \
-    xhciCmdSubmit(hc, dmaaddr, TRBF_FLAG_TRTYPE_NOOP, NULL, timerreq)
+    xhciCmdSubmit(hc, dmaaddr, TRBF_FLAG_CRTYPE_NOOP, NULL, timerreq)
 #endif
 
 #if defined(PCIUSB_XHCI_DEBUG)


### PR DESCRIPTION
Seven independent fixes to the xHCI driver, found while bringing it up on a
host bridge whose bus addresses do not match CPU addresses and whose
controller does not accept 64-bit register writes. None of them are specific
to that machine.

- **Map the register BAR through the host bridge.** A base address register
  holds a bus address; using it directly as a pointer only works where the
  two address spaces coincide.
- **Enable the device before reading its registers.** The capability
  registers were read with memory decoding still disabled, which only
  answers on a host that had already enabled the device.
- **Read the scratchpad buffer count as the register is laid out.** The high
  and low halves were taken from each other's field, so a controller asking
  for 31 buffers was given 992.
- **Write the 64-bit registers as two 32-bit accesses.** Some bridges do not
  carry an eight byte register write whole and the controller latches half a
  pointer. Low half first, as the reference drivers do.
- **Invalidate only the buffers the CPU can address.** Set TR Dequeue Pointer
  is handed a bus address with the cycle state in bit 0; the completion path
  treated it as a pointer and invalidated 2048 bytes at whatever lives there.
- **Give EP0 an average TRB length.** Programmed for every other endpoint and
  left at zero for EP0, which a controller that validates it refuses with a
  parameter error.
- **Use the command ring no-op TRB type.** The transfer ring no-op was queued
  on the command ring, which a conforming controller completes with a TRB
  error.

Tested on a VIA VL805 behind a Broadcom BCM2711 root complex, where the
driver now enumerates a hub, a keyboard and a mouse. Builds for
raspi-aarch64.
