### PR TITLE
aarch64: implement CachePostDMA

### DIFF
--- a/arch/aarch64-native/exec/cachepostdma.c
+++ b/arch/aarch64-native/exec/cachepostdma.c
@@ -1,0 +1,42 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: CachePostDMA() - Do what is necessary for DMA (AArch64).
+*/
+
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <exec/types.h>
+#include <aros/libcall.h>
+
+#include "exec_intern.h"
+
+/* See rom/exec/cachepostdma.c for documentation */
+
+#include <proto/exec.h>
+
+AROS_LH3(void, CachePostDMA,
+    AROS_LHA(APTR,    address, A0),
+    AROS_LHA(ULONG *, length,  A1),
+    AROS_LHA(ULONG,   flags,  D0),
+    struct ExecBase *, SysBase, 128, Exec)
+{
+    AROS_LIBFUNC_INIT
+
+    D(bug("[exec] CachePostDMA(%p, %d, %c)\n", address, *length,
+          flags & DMA_ReadFromRAM ? 'R' : 'W'));
+
+    /*
+     * When the device wrote to memory, the lines covering the buffer
+     * may still hold what was there before the transfer; drop them so
+     * the reader sees the device's data. Clean-and-invalidate rather
+     * than plain invalidate: an unaligned buffer shares its edge lines
+     * with neighbours whose dirty data must survive, and a clean line
+     * writes back nothing.
+     */
+    if (!(flags & DMA_ReadFromRAM))
+        CacheClearE(address, *length, CACRF_ClearD);
+
+    AROS_LIBFUNC_EXIT
+} /* CachePostDMA() */

--- a/arch/aarch64-native/exec/mmakefile.src
+++ b/arch/aarch64-native/exec/mmakefile.src
@@ -26,7 +26,7 @@ PRIV_EXEC_INCLUDES = \
     -I$(SRCDIR)/rom/kernel
 
 CFILES          := \
-        platform_init exec_idle superstate userstate coldreboot cachepredma cachecleare \
+        platform_init exec_idle superstate userstate coldreboot cachepredma cachepostdma cachecleare \
         preparecontext
 
 #MM kernel-exec-raspi-aarch64 : kernel-kernel-aarch64-includes kernel-kernel-includes


### PR DESCRIPTION
`CachePostDMA()` on aarch64 was falling through to the generic version in
`rom/exec/`, which is a deliberate no-op: it documents that it exists for the
strong cache coherency of x86, where the CPU snoops the bus and no action is
needed.

That assumption does not hold here. A bus master writing to memory on a
non-coherent aarch64 machine leaves the CPU reading whatever its cache still
holds, so a driver that follows the documented `CachePreDMA()`/`CachePostDMA()`
contract silently reads stale data. It cost a while to find, because the
symptom is a device that appears to work while returning zeros: a USB
configuration descriptor that reported a total length of zero, so enumeration
stopped without an error anywhere.

Clean and invalidate rather than plain invalidate: an unaligned buffer shares
its first and last cache lines with neighbouring data that must survive, and a
clean line writes back nothing.

Affects every non-coherent aarch64 target, not only the one this was found on.

Part of a series bringing up AROS on the Raspberry Pi 4, alongside #887.
