### PR TITLE
intuition: apply the default pointer speed

### DIFF
--- a/rom/intuition/intuition_misc.c
+++ b/rom/intuition/intuition_misc.c
@@ -135,14 +135,16 @@ void LoadDefaultPreferences(struct IntuitionBase * IntuitionBase)
     _intuitionBase->IControlPrefs.ic_ReqFalse    = 'B';
 
 
-    /*
-     * Mouse default.
-     */
-    _intuitionBase->DefaultPreferences.PointerTicks = 2;
-
     CopyMem(&IntuitionDefaultPreferences,
                 &_intuitionBase->DefaultPreferences,
                 sizeof(struct Preferences));
+
+    /*
+     * Mouse default. A pointer that tracks the reported movement one to
+     * one is unusable on anything but the lowest-resolution mice.
+     */
+    _intuitionBase->DefaultPreferences.PointerTicks = 2;
+
     CopyMem(&_intuitionBase->DefaultPreferences,
             &_intuitionBase->ActivePreferences,
             sizeof(struct Preferences));


### PR DESCRIPTION
`LoadDefaultPreferences()` sets the pointer divisor and then copies the static
default preferences over the top of it, so the assignment never survives:

```c
_intuitionBase->DefaultPreferences.PointerTicks = 2;

CopyMem(&IntuitionDefaultPreferences,
        &_intuitionBase->DefaultPreferences,
        sizeof(struct Preferences));
```

`IntuitionDefaultPreferences` carries `PointerTicks` of 1, and the input
handler divides mouse movement by that value, so out of the box the pointer
tracks reported movement one to one on any system with no saved input
preferences. That is tolerable with a 400 dpi mouse and unusable with a modern
one, which is how it was noticed.

Moving the assignment after the copy lets the intended default apply. The
comment above it already says what it is for.
