### PR TITLE
aarch64: BCM2711 (Raspberry Pi 4) platform support

### DIFF
--- a/arch/aarch64-native/hidd/vcgfx/mmakefile.src
+++ b/arch/aarch64-native/hidd/vcgfx/mmakefile.src
@@ -1,0 +1,18 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+#MM kernel-hidd-vcgfx : kernel-hidd-gfx-includes
+
+FILES	:=	\
+	vcgfx_init \
+	vcgfx_hiddclass \
+	vcgfx_displayclass \
+	vcgfx_support \
+	vcgfx_bitmapclass
+
+USER_CPPFLAGS := \
+               -D__OOP_NOATTRBASES__
+
+%build_module mmake=kernel-hidd-vcgfx \
+  modname=vcgfx modtype=hidd \
+  files=$(FILES)

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx.conf
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx.conf
@@ -1,0 +1,67 @@
+##begin config
+basename	VCGfx
+libbasetype	struct VCGfxBase
+version		45.5
+residentpri     9
+classptr_field  vsd.vcgfxclass
+classdatatype	struct VCGfxHiddData
+classid         CLID_Hidd_Gfx_VCFB
+superclass      CLID_Hidd_Gfx
+##end config
+
+##begin cdefprivate
+#include "vcgfx_intern.h"
+#include "vcgfx_hidd.h"
+#include "vcgfx_display.h"
+##end cdefprivate
+
+##begin methodlist
+.interface Root
+New
+Dispose
+Get
+##end methodlist
+
+
+##begin class
+##begin config
+basename VCGfxDisplay
+type hidd
+classptr_field vsd.displayclass
+classid         CLID_Hidd_Display_VCFB
+superclass CLID_Hidd_Display
+classdatatype struct VCGfxDisplayData
+##end config
+
+##begin methodlist
+.interface Root
+New
+Get
+.interface Hidd_Display
+CreateObject
+Show
+##end methodlist
+##end class
+
+
+##begin class
+##begin config
+basename VCGfxBM
+type hidd
+classptr_field vsd.bmclass
+classid         CLID_Hidd_BitMap_VCFB
+superclass CLID_Hidd_ChunkyBM
+classdatatype struct VCGfxBitMapData
+##end config
+
+##begin methodlist
+.interface Root
+New
+Dispose
+Get
+Set
+.interface Hidd_BitMap
+SetColors
+UpdateRect
+##end methodlist
+##end class

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_bitmap.h
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_bitmap.h
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+*/
+
+#ifndef VCFBGFX_BITMAP_H
+#define VCFBGFX_BITMAP_H
+
+#include <hidd/gfx.h>
+
+#define CLID_Hidd_BitMap_VCFB        "hidd.bitmap.vcfb"
+#define IID_Hidd_BitMap_VCFB         "hidd.bitmap.vcfb"
+
+#define IS_BM_ATTR(attr, idx) ( ( (idx) = (attr) - HiddBitMapAttrBase) < num_Hidd_BitMap_Attrs)
+
+/*
+   This structure is used as instance data for the bitmap class.
+*/
+struct VCGfxBitMapData
+{
+    UBYTE   	    	*VideoData;	/* Pointing to video data */
+    LONG		width;		/* Bitmap size */
+    LONG   	    	height;
+    UBYTE   	    	bytesperpix;
+    ULONG   	    	bytesperline;
+    UBYTE *   	    	DAC;   		/* Hardware palette registers */
+    BYTE    	    	bpp;         	/* Cached bits per pixel */
+    BYTE    	    	disp;        	/* !=0 - displayable */
+    OOP_Object	    	*pixfmtobj;	/* Cached pixelformat object */
+    OOP_Object	    	*displayhidd;	/* display object */
+    LONG		disp_width;	/* Display size */
+    LONG		disp_height;
+    LONG		xoffset;	/* Bitmap offset */
+    LONG		yoffset;
+};
+
+#endif /* VCFBGFX_BITMAP_H */

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_bitmapclass.c
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_bitmapclass.c
@@ -1,0 +1,218 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Bitmap class for VCFB Gfx hidd.
+*/
+
+#include <proto/oop.h>
+#include <proto/utility.h>
+#include <assert.h>
+#include <exec/memory.h>
+#include <exec/lists.h>
+#include <graphics/rastport.h>
+#include <graphics/gfx.h>
+#include <hidd/gfx.h>
+#include <oop/oop.h>
+#include <aros/symbolsets.h>
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <string.h>
+
+#include "vcgfx_hidd.h"
+
+#include LC_LIBDEFS_FILE
+
+#define MNAME_ROOT(x) VCGfxBM__Root__ ## x
+#define MNAME_BM(x) VCGfxBM__Hidd_BitMap__ ## x
+
+/*********** BitMap::New() *************************************/
+OOP_Object *MNAME_ROOT(New)(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    EnterFunc(bug("VCGfx.BitMap::New()\n"));
+    
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg) msg);
+    if (o)
+    {
+        OOP_MethodID       disp_mid;
+        struct VCGfxBitMapData *data;
+        HIDDT_ModeID       modeid;
+        OOP_Object        *sync, *pf, *dmenum;
+
+        data = OOP_INST_DATA(cl, o);
+
+        /* Get attr values */
+        OOP_GetAttr(o, aHidd_BitMap_Display , (APTR)&data->displayhidd);
+        OOP_GetAttr(o, aHidd_BitMap_PixFmt  , (APTR)&data->pixfmtobj);
+        OOP_GetAttr(o, aHidd_BitMap_ModeID  , &modeid);
+        OOP_GetAttr(o, aHidd_ChunkyBM_Buffer, (IPTR *)&data->VideoData);
+
+        OOP_GetAttr(data->displayhidd, aHidd_Display_DMEnumerator, (APTR)&dmenum);
+        HIDD_DMEnum_GetMode(dmenum, modeid, &sync, &pf);
+
+        data->width        = OOP_GET(o, aHidd_BitMap_Width);
+        data->height       = OOP_GET(o, aHidd_BitMap_Height);
+        data->bytesperline = OOP_GET(o, aHidd_BitMap_BytesPerRow);
+        data->bytesperpix  = OOP_GET(data->pixfmtobj, aHidd_PixFmt_BytesPerPixel);
+        data->bpp          = OOP_GET(data->pixfmtobj, aHidd_PixFmt_BitsPerPixel);
+        data->disp_width   = OOP_GET(sync, aHidd_Sync_HDisp);
+        data->disp_height  = OOP_GET(sync, aHidd_Sync_VDisp);
+
+        D(bug("[VCGfx:BitMap] Bitmap %ld x %ld, %u bytes per pixel, %u bytes per line\n",
+              data->width, data->height, data->bytesperpix, data->bytesperline));
+        D(bug("[VCGfx:BitMap] Video data at 0x%p (%u bytes)\n", data->VideoData, data->bytesperline * data->height));
+
+        if (OOP_GET(data->pixfmtobj, aHidd_PixFmt_ColorModel) != vHidd_ColorModel_Palette)
+            ReturnPtr("VCGfx.BitMap::New()", OOP_Object *, o);
+
+        data->DAC = AllocMem(768, MEMF_ANY);
+        D(bug("[VCGfx:BitMap] Palette data at 0x%p\n", data->DAC));
+        if (data->DAC)
+            ReturnPtr("VCGfx.BitMap::New()", OOP_Object *, o);
+
+        disp_mid = OOP_GetMethodID(IID_Root, moRoot_Dispose);
+
+        OOP_CoerceMethod(cl, o, (OOP_Msg) &disp_mid);
+        o = NULL;
+    } /* if created object */
+
+    ReturnPtr("VCGfx.BitMap::New()", OOP_Object *, o);
+}
+
+/**********  Bitmap::Dispose()  ***********************************/
+VOID MNAME_ROOT(Dispose)(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
+{
+    struct VCGfxBitMapData *data = OOP_INST_DATA(cl, o);
+
+    D(bug("[VCGfx:BitMap] Dispose(0x%p)\n", o));
+
+    if (data->DAC)
+        FreeMem(data->DAC, 768);
+
+    OOP_DoSuperMethod(cl, o, msg);
+
+    ReturnVoid("VCGfx.BitMap::Dispose");
+}
+
+/*** BitMap::Get() *******************************************/
+
+VOID MNAME_ROOT(Get)(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
+{
+    struct VCGfxBitMapData *data = OOP_INST_DATA(cl, o);
+    ULONG              idx;
+
+    if (IS_BM_ATTR(msg->attrID, idx))
+    {
+        switch (idx)
+        {
+        case aoHidd_BitMap_Visible:
+            *msg->storage = data->disp;
+            return;
+        }
+    }
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+/*** BitMap::Set() *******************************************/
+
+VOID MNAME_ROOT(Set)(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg)
+{
+    struct VCGfxBitMapData *data = OOP_INST_DATA(cl, o);
+    struct TagItem  *tag, *tstate;
+    ULONG           idx;
+    IPTR xoffset = data->xoffset;
+    IPTR yoffset = data->yoffset;
+
+    tstate = msg->attrList;
+    while((tag = NextTagItem(&tstate)))
+    {
+        if(IS_BM_ATTR(tag->ti_Tag, idx))
+        {
+            switch(idx)
+            {
+            case aoHidd_BitMap_Visible:
+                D(bug("[VCGfx:BitMap] Setting Visible to %d\n", tag->ti_Data));
+                data->disp = tag->ti_Data;
+                if (data->disp) {
+                    if (data->DAC)
+                        DACLoad(XSD(cl), data->DAC, 0, 256);
+                }
+                break;
+            }
+        }
+    }
+
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+
+    /* Bring local X/Y offsets back into sync with validated values */
+    OOP_GetAttr(o, aHidd_BitMap_LeftEdge, &xoffset);
+    OOP_GetAttr(o, aHidd_BitMap_TopEdge, &yoffset);
+
+    if ((xoffset != data->xoffset) || (yoffset != data->yoffset))
+    {
+        D(bug("[VCGfx:BitMap] Scroll to (%d, %d)\n", xoffset, yoffset));
+        data->xoffset = xoffset;
+        data->yoffset = yoffset;
+
+        if (data->disp)
+        {
+            LOCK_FRAMEBUFFER(XSD(cl));
+            vcfbDoRefreshArea(&XSD(cl)->data, data, 0, 0, data->width, data->height);
+            UNLOCK_FRAMEBUFFER(XSD(cl));
+        }
+    }
+}
+
+/*** BitMap::SetColors() *************************************/
+
+BOOL MNAME_BM(SetColors)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_SetColors *msg)
+{
+    struct VCGfxBitMapData *data = OOP_INST_DATA(cl, o);
+    struct HWData *hwdata = &XSD(cl)->data;
+    ULONG xc_i, col_i;
+    UBYTE p_shift;
+    UWORD red, green, blue;
+
+    D(bug("[VCGfx:BitMap] SetColors(%u, %u)\n", msg->firstColor, msg->numColors));
+
+    if (!OOP_DoSuperMethod(cl, o, (OOP_Msg)msg)) {
+        D(bug("[VCGfx:BitMap] DoSuperMethod() failed\n"));
+        return FALSE;
+    }
+
+    if ((msg->firstColor + msg->numColors) > (1 << data->bpp))
+        return FALSE;
+
+    if (data->DAC) {
+        for ( xc_i = msg->firstColor, col_i = 0;
+              col_i < msg->numColors;
+              xc_i ++, col_i ++) {
+            red   = msg->colors[col_i].red   >> 8;
+            green = msg->colors[col_i].green >> 8;
+            blue  = msg->colors[col_i].blue  >> 8;
+
+            /* Update DAC register values */
+            p_shift = 8 - hwdata->palettewidth;
+            data->DAC[xc_i*3] = red >> p_shift;
+            data->DAC[xc_i*3+1] = green >> p_shift;
+            data->DAC[xc_i*3+2] = blue >> p_shift;
+        }
+
+        /* Upload palette to the DAC if the current bitmap is on display */
+        if (data->disp)
+            DACLoad(XSD(cl), data->DAC, msg->firstColor, msg->numColors);
+    }
+    return TRUE;
+}
+
+VOID MNAME_BM(UpdateRect)(OOP_Class *cl, OOP_Object *o, struct pHidd_BitMap_UpdateRect *msg)
+{
+    struct VCGfxBitMapData *data = OOP_INST_DATA(cl, o);
+
+    D(bug("[VCGfx:BitMap] UpdateRect(%d, %d, %d, %d), bitmap 0x%p\n", msg->x, msg->y, msg->width, msg->height, o));
+    if (data->disp) {
+        LOCK_FRAMEBUFFER(XSD(cl));
+        vcfbDoRefreshArea(&XSD(cl)->data, data, msg->x, msg->y, msg->x + msg->width, msg->y + msg->height);
+        UNLOCK_FRAMEBUFFER(XSD(cl));
+    }
+}

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_display.h
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_display.h
@@ -1,0 +1,21 @@
+#ifndef VCFBGFX_DISPLAY_H
+#define VCFBGFX_DISPLAY_H
+
+/*
+    Copyright (C) 2016-2026, The AROS Development Team. All rights reserved.
+
+    Desc: VCFB Gfx display class data.
+    Lang: English.
+*/
+
+#include <exec/types.h>
+
+#define CLID_Hidd_Display_VCFB	"hidd.display.vcfb"
+#define IID_Hidd_Display_VCFB	"hidd.display.vcfb"
+
+struct VCGfxDisplayData
+{
+    void *pad;
+};
+
+#endif /* VCFBGFX_DISPLAY_H */

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_displayclass.c
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_displayclass.c
@@ -1,0 +1,221 @@
+/*
+    Copyright (C) 2016-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Display class for VCFB.
+    Lang: English.
+*/
+
+#include <aros/asmcall.h>
+#include <proto/exec.h>
+#include <proto/oop.h>
+#include <proto/utility.h>
+#include <aros/symbolsets.h>
+#include <devices/inputevent.h>
+#include <exec/alerts.h>
+#include <exec/memory.h>
+#include <hardware/custom.h>
+#include <hidd/hidd.h>
+#include <hidd/gfx.h>
+#include <oop/oop.h>
+#include <clib/alib_protos.h>
+#include <string.h>
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#ifndef __OOP_NOATTRBASES__
+#define __OOP_NOATTRBASES__
+#endif
+
+#include "vcgfx_hidd.h"
+#include "vcgfx_support.h"
+
+#include LC_LIBDEFS_FILE
+
+OOP_Object *VCGfxDisplay__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    struct TagItem pftags[] =
+    {
+        {aHidd_PixFmt_RedShift,     0}, /*  0 */
+        {aHidd_PixFmt_GreenShift,   0}, /*  1 */
+        {aHidd_PixFmt_BlueShift,    0}, /*  2 */
+        {aHidd_PixFmt_AlphaShift,   0}, /*  3 */
+        {aHidd_PixFmt_RedMask,      0}, /*  4 */
+        {aHidd_PixFmt_GreenMask,    0}, /*  5 */
+        {aHidd_PixFmt_BlueMask,     0}, /*  6 */
+        {aHidd_PixFmt_AlphaMask,    0}, /*  7 */
+        {aHidd_PixFmt_ColorModel,   0}, /*  8 */
+        {aHidd_PixFmt_Depth,        0}, /*  9 */
+        {aHidd_PixFmt_BytesPerPixel,0}, /* 10 */
+        {aHidd_PixFmt_BitsPerPixel, 0}, /* 11 */
+        {aHidd_PixFmt_StdPixFmt,    vHidd_StdPixFmt_Native}, /* 12 */
+        {aHidd_PixFmt_CLUTShift,    0}, /* 13 */
+        {aHidd_PixFmt_CLUTMask,     0}, /* 14 */
+        {aHidd_PixFmt_BitMapType,   vHidd_BitMapType_Chunky}, /* 15 */
+        {TAG_DONE, 0UL }
+    };
+    struct TagItem sync_mode[] =
+    {
+        {aHidd_Sync_PixelClock,         0                       },
+        {aHidd_Sync_HTotal,             0                       },
+        {aHidd_Sync_HDisp,              0                       },
+        {aHidd_Sync_VDisp,              0                       },
+        {aHidd_Sync_HMax,               16384                   },
+        {aHidd_Sync_VMax,               16384                   },
+        {aHidd_Sync_Description,        (IPTR)"VCFB:%hx%v"      },
+        {TAG_DONE,                      0UL                     }
+    };
+    struct TagItem modetags[] =
+    {
+        {aHidd_DMEnum_PixFmtTags, (IPTR)pftags},
+        {aHidd_DMEnum_SyncTags,   (IPTR)sync_mode},
+        {TAG_DONE, 0UL}
+    };
+    struct TagItem dispTags[] =
+    {
+        {aHidd_Display_ModeTags, (IPTR)modetags},
+        {TAG_MORE, 0UL}
+    };
+    struct pRoot_New newdispMsg;
+
+    D(bug("[VCGfx:Display] %s()\n", __func__));
+
+    /* Do not allow more than one object instance to be created */
+    if (XSD(cl)->vcfbdisplay)
+        return NULL;
+
+    pftags[0].ti_Data = XSD(cl)->data.redshift;
+    pftags[1].ti_Data = XSD(cl)->data.greenshift;
+    pftags[2].ti_Data = XSD(cl)->data.blueshift;
+    pftags[4].ti_Data = XSD(cl)->data.redmask;
+    pftags[5].ti_Data = XSD(cl)->data.greenmask;
+    pftags[6].ti_Data = XSD(cl)->data.bluemask;
+    pftags[8].ti_Data = (XSD(cl)->data.depth > 8) ? vHidd_ColorModel_TrueColor : vHidd_ColorModel_Palette;
+    pftags[9].ti_Data = (XSD(cl)->data.depth > 24) ? 24 : XSD(cl)->data.depth;
+    pftags[10].ti_Data = XSD(cl)->data.bytesperpixel;
+    pftags[11].ti_Data = (XSD(cl)->data.bitsperpixel > 24) ? 24 : XSD(cl)->data.bitsperpixel;
+    pftags[14].ti_Data = (1 << XSD(cl)->data.depth) - 1;
+
+    sync_mode[0].ti_Data = 60 * XSD(cl)->data.width * XSD(cl)->data.height;
+    sync_mode[1].ti_Data = XSD(cl)->data.width;
+    sync_mode[2].ti_Data = XSD(cl)->data.width;
+    sync_mode[3].ti_Data = XSD(cl)->data.height;
+
+    if ((dispTags[1].ti_Data = (IPTR)msg->attrList) == 0)
+        dispTags[1].ti_Tag = TAG_DONE;
+
+    newdispMsg.mID = msg->mID;
+    newdispMsg.attrList = dispTags;
+
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&newdispMsg);
+
+    D(bug("[VCGfx:Display] %s: obj @ 0x%p\n", __func__, o));
+    return o;
+}
+
+VOID VCGfxDisplay__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
+{
+    ULONG idx;
+
+    Hidd_Switch (msg->attrID, idx)
+    {
+    case aoHidd_Name:
+        *msg->storage = (IPTR)"VCFB Display";
+        return;
+    }
+
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+/*********  Display::CreateObject()  ***************************/
+
+OOP_Object *VCGfxDisplay__Hidd_Display__CreateObject(OOP_Class *cl, OOP_Object *o, struct pHidd_Display_CreateObject *msg)
+{
+    OOP_Object      *object = NULL;
+
+    D(bug("[VCGfx:Display] %s()\n", __func__));
+    D(bug("[VCGfx:Display] %s: requested class 0x%p\n", __func__, msg->cl));
+    D(bug("[VCGfx:Display] %s: base bitmap class 0x%p\n", __func__, XSD(cl)->basebm));
+
+    if (msg->cl == XSD(cl)->basebm)
+    {
+        BOOL displayable;
+        struct TagItem tags[2] =
+        {
+            {TAG_IGNORE, 0                  },
+            {TAG_MORE  , (IPTR)msg->attrList}
+        };
+        struct pHidd_Display_CreateObject p;
+
+        displayable = GetTagData(aHidd_BitMap_Displayable, FALSE, msg->attrList);
+        if (displayable)
+        {
+            /* Only displayable bitmaps are bitmaps of our class */
+            tags[0].ti_Tag  = aHidd_BitMap_ClassPtr;
+            tags[0].ti_Data = (IPTR)XSD(cl)->bmclass;
+        }
+        else
+        {
+            /* Non-displayable friends of our bitmaps are plain chunky bitmaps */
+            OOP_Object *friend = (OOP_Object *)GetTagData(aHidd_BitMap_Friend, 0, msg->attrList);
+
+            if (friend && (OOP_OCLASS(friend) == XSD(cl)->bmclass))
+            {
+                tags[0].ti_Tag  = aHidd_BitMap_ClassID;
+                tags[0].ti_Data = (IPTR)CLID_Hidd_ChunkyBM;
+            }
+        }
+
+        p.mID = msg->mID;
+        p.cl = msg->cl;
+        p.attrList = tags;
+
+        object = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&p);
+    }
+    else
+        object = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+
+    ReturnPtr("VCGfx.Display::CreateObject", OOP_Object *, object);
+}
+
+/*********  Display::Show()  ***************************/
+
+OOP_Object *VCGfxDisplay__Hidd_Display__Show(OOP_Class *cl, OOP_Object *o, struct pHidd_Display_Show *msg)
+{
+    struct VCGfx_staticdata *data = XSD(cl);
+    struct TagItem tags[] = {
+        {aHidd_BitMap_Visible, FALSE},
+        {TAG_DONE            , 0    }
+    };
+
+    D(bug("[VCGfx:Display] Show(0x%p), old visible 0x%p\n", msg->bitMap, data->visible));
+
+    LOCK_FRAMEBUFFER(data);
+
+    /* Remove old bitmap from the screen */
+    if (data->visible)
+    {
+        D(bug("[VCGfx:Display] Hiding old bitmap\n"));
+        OOP_SetAttrs(data->visible, tags);
+    }
+
+    if (msg->bitMap)
+    {
+        /* If we have a bitmap to show, set it as visible */
+        D(bug("[VCGfx:Display] Showing new bitmap\n"));
+        tags[0].ti_Data = TRUE;
+        OOP_SetAttrs(msg->bitMap, tags);
+    }
+    else
+    {
+        D(bug("[VCGfx:Display] Blanking screen\n"));
+        /* Otherwise simply clear the framebuffer */
+        ClearBuffer(&data->data);
+    }
+
+    data->visible = msg->bitMap;
+    UNLOCK_FRAMEBUFFER(data);
+
+    D(bug("[VCGfx:Display] Show() done\n"));
+    return msg->bitMap;
+}

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_hidd.h
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_hidd.h
@@ -1,0 +1,25 @@
+#ifndef VCFBGFX_HIDD_H
+#define VCFBGFX_HIDD_H
+
+/*
+    Copyright © 2017, The AROS Development Team. All rights reserved.
+    $Id$
+
+    Desc: VCFB Gfx Hidd data.
+    Lang: English.
+*/
+
+#include <exec/interrupts.h>
+
+#include "vcgfx_bitmap.h"
+#include "vcgfx_support.h"
+
+#define IID_Hidd_Gfx_VCFB  "hidd.gfx.vcfb"
+#define CLID_Hidd_Gfx_VCFB "hidd.gfx.vcfb"
+
+struct VCGfxHiddData
+{
+    struct Interrupt ResetInterrupt;
+};
+
+#endif /* VCFBGFX_HIDD_H */

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_hiddclass.c
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_hiddclass.c
@@ -1,0 +1,125 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Class for VCFB.
+*/
+
+#include <aros/asmcall.h>
+#include <proto/exec.h>
+#include <proto/oop.h>
+#include <proto/utility.h>
+#include <aros/symbolsets.h>
+#include <devices/inputevent.h>
+#include <exec/alerts.h>
+#include <exec/memory.h>
+#include <hardware/custom.h>
+#include <hidd/hidd.h>
+#include <hidd/gfx.h>
+#include <oop/oop.h>
+#include <clib/alib_protos.h>
+#include <string.h>
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include "vcgfx_hidd.h"
+#include "vcgfx_support.h"
+
+#include LC_LIBDEFS_FILE
+
+AROS_INTH1(ResetHandler, struct HWData *, hwdata)
+{
+    AROS_INTFUNC_INIT
+
+    ClearBuffer(hwdata);
+
+    return FALSE;
+
+    AROS_INTFUNC_EXIT
+}
+
+OOP_Object *VCGfx__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    struct TagItem msgNewTags[] =
+    {
+        { aHidd_Name            , (IPTR)"vcgfx.hidd"                 },
+        { aHidd_HardwareName    , (IPTR)"VCFB Compatible Controller"   },
+        { aHidd_ProducerName    , (IPTR)"vcfb.org"                     },
+        {TAG_MORE, 0UL}
+    };
+    struct pRoot_New msgNew;
+
+    EnterFunc(bug("VCGfx::New()\n"));
+
+    /* Protect against some stupid programmer wishing to
+       create one more VCFB driver */
+    if (XSD(cl)->vcgfxhidd)
+        return NULL;
+
+    if ((msgNewTags[3].ti_Data = (IPTR)msg->attrList) == 0)
+        msgNewTags[3].ti_Tag = TAG_DONE;
+
+    msgNew.mID = msg->mID;
+    msgNew.attrList = msgNewTags;
+
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&msgNew);
+    if (o)
+    {
+        struct VCGfxHiddData *data = OOP_INST_DATA(cl, o);
+        struct TagItem displaytags[] =
+        {
+            { aHidd_Display_GfxHidd, (IPTR)o },
+            { TAG_DONE,              0       }
+        };
+
+        D(bug("Got object from super\n"));
+
+        XSD(cl)->vcfbdisplay = OOP_NewObject(XSD(cl)->displayclass, NULL, displaytags);
+        if (XSD(cl)->vcfbdisplay)
+        {
+            D(bug("[VCGfx:Driver] %s: display @ 0x%p\n", __func__, XSD(cl)->vcfbdisplay));
+            XSD(cl)->vcgfxhidd = o;
+
+            data->ResetInterrupt.is_Node.ln_Name = cl->ClassNode.ln_Name;
+            data->ResetInterrupt.is_Code = (VOID_FUNC)ResetHandler;
+            data->ResetInterrupt.is_Data = &XSD(cl)->data;
+            AddResetCallback(&data->ResetInterrupt);
+        }
+        else
+        {
+            OOP_MethodID dispose_mid = XSD(cl)->mid_Dispose;
+            OOP_CoerceMethod(cl, o, (OOP_Msg)&dispose_mid);
+            o = NULL;
+        }
+    }
+    ReturnPtr("VCGfx::New", OOP_Object *, o);
+}
+
+VOID VCGfx__Root__Dispose(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
+{
+    struct VCGfxHiddData *data = OOP_INST_DATA(cl, o);
+
+    RemResetCallback(&data->ResetInterrupt);
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    XSD(cl)->vcgfxhidd = NULL;
+}
+
+VOID VCGfx__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
+{
+    ULONG idx;
+
+    if (IS_GFX_ATTR(msg->attrID, idx))
+    {
+        switch (idx)
+        {
+            case aoHidd_Gfx_NoFrameBuffer:
+                *msg->storage = TRUE;
+                return;
+
+            case aoHidd_Gfx_DisplayDefault:
+                *msg->storage = (IPTR)XSD(cl)->vcfbdisplay;
+                return;
+        }
+    }
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_init.c
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_init.c
@@ -1,0 +1,128 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: VCFB Gfx Hidd for standalone i386 AROS
+*/
+
+#include <proto/exec.h>
+#include <proto/graphics.h>
+#include <proto/oop.h>
+
+#include <exec/types.h>
+#include <exec/lists.h>
+#include <graphics/driver.h>
+#include <graphics/gfxbase.h>
+#include <hidd/gfx.h>
+#include <oop/oop.h>
+#include <utility/utility.h>
+#include <aros/symbolsets.h>
+
+#include "vcgfx_support.h"
+#include "vcgfx_hidd.h"
+
+#include LC_LIBDEFS_FILE
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+/*
+ * The following two functions are candidates for inclusion into oop.library.
+ * For slightly other implementation see incomplete Android-hosted graphics driver.
+ */
+static void FreeAttrBases(const STRPTR *iftable, OOP_AttrBase *bases, ULONG num)
+{
+    ULONG i;
+    
+    for (i = 0; i < num; i++)
+    {
+        if (bases[i])
+            OOP_ReleaseAttrBase(iftable[i]);
+    }
+}
+
+static BOOL GetAttrBases(const STRPTR *iftable, OOP_AttrBase *bases, ULONG num)
+{
+    ULONG i;
+
+    for (i = 0; i < num; i++)
+    {
+        bases[i] = OOP_ObtainAttrBase(iftable[i]);
+        if (!bases[i])
+        {
+            FreeAttrBases(iftable, bases, i);
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+/* These must stay in the same order as attrBases[] entries assignment in vcgfxclass.h */
+static const STRPTR interfaces[ATTRBASES_NUM] =
+{
+    IID_Hidd_ChunkyBM,
+    IID_Hidd_BitMap,
+    IID_Hidd_Gfx,
+    IID_Hidd_PixFmt,
+    IID_Hidd_Sync,
+    IID_Hidd,
+    IID_Hidd_Display,
+    IID_Hidd_DMEnum
+};
+
+static int VCGfx_Init(LIBBASETYPEPTR LIBBASE)
+{
+    struct VCGfx_staticdata *xsd = &LIBBASE->vsd;
+    struct GfxBase *GfxBase;
+    ULONG err;
+    int res = FALSE;
+
+    /*
+     * Open graphics.library ourselves because we will close it
+     * after adding the driver.
+     * Autoinit code would close it only upon driver expunge.
+     */
+    GfxBase = (struct GfxBase *)TaggedOpenLibrary(TAGGEDOPEN_GRAPHICS);
+    if (GfxBase)
+    {
+        if (initVCGfxHW(&xsd->data))
+        {
+            if (GetAttrBases(interfaces, xsd->attrBases, ATTRBASES_NUM))
+            {
+                xsd->basebm = OOP_FindClass(CLID_Hidd_BitMap);
+                xsd->mid_Dispose = OOP_GetMethodID(IID_Root, moRoot_Dispose);
+                D(bug("[VCGfx] BitMap class @ 0x%p\n", xsd->basebm));
+
+                InitSemaphore(&xsd->framebufferlock);
+                InitSemaphore(&xsd->HW_acc);
+
+                D(bug("[VCGfx] Init: Everything OK, installing driver\n"));
+                
+                /*
+                 * It is unknown (and no way to know) what hardware part this driver uses.
+                 * In order to avoid conflicts with disk-based native-mode hardware
+                 * drivers it needs to be removed from the system when some other driver
+                 * is installed.
+                 * This is done by graphics.library if DDRV_BootMode is set to TRUE.
+                 */
+                err = AddDisplayDriver(xsd->vcgfxclass, NULL, DDRV_BootMode, TRUE, TAG_DONE);
+
+                D(bug("[VCGfx] AddDisplayDriver() result: %u\n", err));
+                if (!err)
+                {
+                    /* expunge protection */
+                    LIBBASE->library.lib_OpenCnt = 1;
+                    res = TRUE;
+                }
+            }
+        }
+        CloseLibrary(&GfxBase->LibNode);
+    }
+    else
+    {
+        D(bug("[VCGfx] Failed to open graphics.library!\n"));
+    }
+    return res;
+}
+
+ADD2INITLIB(VCGfx_Init, 0)

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_intern.h
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_intern.h
@@ -1,0 +1,76 @@
+#ifndef VCFBGFX_INTERN_H
+#define VCFBGFX_INTERN_H
+
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: VCFB Gfx private data.
+    Lang: English.
+*/
+
+#ifndef EXEC_LIBRARIES_H
+#   include <exec/libraries.h>
+#endif
+
+#ifndef OOP_OOP_H
+#   include <oop/oop.h>
+#endif
+
+#ifndef EXEC_SEMAPHORES_H
+#   include <exec/semaphores.h>
+#endif
+
+#include <hidd/gfx.h>
+
+#include "vcgfx_support.h"
+
+#define ATTRBASES_NUM 8
+
+struct VCGfx_staticdata
+{
+    OOP_Class 	    	    *basebm;            /* baseclass for CreateObject */
+    
+    OOP_Class 	    	    *vcgfxclass;
+    OOP_Class 	    	    *displayclass;
+    OOP_Class 	    	    *bmclass;
+    OOP_Object      	    *vcgfxhidd;
+    OOP_Object      	    *vcfbdisplay;
+    OOP_Object       	    *visible;		/* Currently visible bitmap */
+    struct HWData   	    data;
+    struct SignalSemaphore  framebufferlock;
+    struct SignalSemaphore  HW_acc;
+    OOP_MethodID	    mid_Dispose;
+    OOP_AttrBase	    attrBases[ATTRBASES_NUM];
+};
+
+struct VCGfxBase
+{
+    struct Library library;
+    struct VCGfx_staticdata vsd;
+};
+
+#define LOCK_FRAMEBUFFER(xsd)	ObtainSemaphore(&xsd->framebufferlock)
+#define UNLOCK_FRAMEBUFFER(xsd) ReleaseSemaphore(&xsd->framebufferlock)
+
+#define XSD(cl)	(&((struct VCGfxBase *)cl->UserData)->vsd)
+
+#undef HiddChunkyBMAttrBase
+#undef HiddBitMapAttrBase
+#undef HiddGfxAttrBase
+#undef HiddPixFmtAttrBase
+#undef HiddSyncAttrBase
+#undef HiddAttrBase
+#undef HiddDisplayAttrBase
+#undef HiddDMEnumAttrBase
+
+/* These must stay in the same order as interfaces[] array in vcgfx_init.c */
+#define HiddChunkyBMAttrBase	  XSD(cl)->attrBases[0]
+#define HiddBitMapAttrBase	  XSD(cl)->attrBases[1]
+#define HiddGfxAttrBase		  XSD(cl)->attrBases[2]
+#define HiddPixFmtAttrBase	  XSD(cl)->attrBases[3]
+#define HiddSyncAttrBase	  XSD(cl)->attrBases[4]
+#define HiddAttrBase		  XSD(cl)->attrBases[5]
+#define HiddDisplayAttrBase	  XSD(cl)->attrBases[6]
+#define HiddDMEnumAttrBase	  XSD(cl)->attrBases[7]
+
+#endif /* VCFBGFX_INTERN_H */

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_support.c
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_support.c
@@ -1,0 +1,119 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: VideoCore framebuffer gfx HIDD hardware support. The kernel already
+          brings up the mailbox framebuffer (arch/aarch64-native/kernel/fb.c);
+          this driver reuses that linear surface (both are linked into the one
+          kickstart image, so the symbols resolve directly).
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+#include <proto/exec.h>
+#include <string.h>
+
+#include "vcgfx_intern.h"
+#include "vcgfx_hidd.h"
+
+/* Provided by the kickstart kernel (fb.c). */
+extern int krn_fb_init(unsigned int w, unsigned int h);
+extern unsigned int krn_fb_width(void);
+extern unsigned int krn_fb_height(void);
+extern unsigned int krn_fb_pitch(void);
+extern unsigned long long krn_fb_base(void);
+
+BOOL initVCGfxHW(struct HWData *data)
+{
+    if (!krn_fb_base())
+    {
+        if (!krn_fb_init(640, 480))
+        {
+            D(bug("[VCGfx] HwInit: framebuffer not available\n"));
+            return FALSE;
+        }
+    }
+
+    data->framebuffer  = (APTR)(IPTR)krn_fb_base();
+    data->width        = krn_fb_width();
+    data->height       = krn_fb_height();
+    data->bytesperline = krn_fb_pitch();
+    data->depth        = 32;
+    data->bitsperpixel = 32;
+    data->bytesperpixel = 4;
+
+    /*
+     * The VideoCore surface displays byte order R,G,B,x (see fb.c put()), so
+     * the pixel masks are red@0-7, green@8-15, blue@16-23. AROS's MAP_COLCOMP
+     * shift convention is (mask << shift) == 0xFF000000, i.e. shift = 24 minus
+     * the mask's bit position - NOT the bit position itself.
+     */
+    data->redmask   = 0x000000FF; data->redshift   = 24;
+    data->greenmask = 0x0000FF00; data->greenshift = 16;
+    data->bluemask  = 0x00FF0000; data->blueshift  = 8;
+    data->palettewidth = 8;
+    data->fbsize = data->height * data->bytesperline;
+
+    D(bug("[VCGfx] HwInit: %ux%ux%u linear FB @ 0x%p, pitch %u\n",
+          data->width, data->height, data->depth,
+          data->framebuffer, data->bytesperline));
+
+    ClearBuffer(data);
+    return TRUE;
+}
+
+/* Copy the (possibly partial) bitmap buffer to the visible framebuffer. */
+void vcfbDoRefreshArea(struct HWData *hwdata, struct VCGfxBitMapData *data,
+                       LONG x1, LONG y1, LONG x2, LONG y2)
+{
+    UBYTE *src, *dst;
+    ULONG srcmod, dstmod;
+    LONG y, w, h, sx, sy;
+
+    x1 += data->xoffset; y1 += data->yoffset;
+    x2 += data->xoffset; y2 += data->yoffset;
+
+    if ((x1 >= data->disp_width) || (x2 < 1) ||
+        (y1 >= data->disp_height) || (y2 < 1))
+        return;
+    if (x1 < 0) x1 = 0;
+    if (y1 < 0) y1 = 0;
+    if (x2 > data->disp_width)  x2 = data->disp_width;
+    if (y2 > data->disp_height) y2 = data->disp_height;
+
+    w = x2 - x1;
+    h = y2 - y1;
+    sx = x1 - data->xoffset;
+    sy = y1 - data->yoffset;
+    w *= data->bytesperpix;
+
+    srcmod = data->bytesperline;
+    dstmod = hwdata->bytesperline;
+    src = data->VideoData + sy * data->bytesperline + sx * data->bytesperpix;
+    dst = (UBYTE *)hwdata->framebuffer + y1 * hwdata->bytesperline + x1 * hwdata->bytesperpixel;
+
+    if ((srcmod != dstmod) || (srcmod != (ULONG)w))
+    {
+        for (y = 0; y < h; y++)
+        {
+            CopyMem(src, dst, w);
+            src += srcmod;
+            dst += dstmod;
+        }
+    }
+    else
+    {
+        CopyMem(src, dst, w * h);
+    }
+}
+
+/* Truecolor only: no hardware palette to load. */
+void DACLoad(struct VCGfx_staticdata *xsd, UBYTE *DAC, unsigned char first, int num)
+{
+    (void)xsd; (void)DAC; (void)first; (void)num;
+}
+
+void ClearBuffer(struct HWData *data)
+{
+    if (data->framebuffer)
+        memset(data->framebuffer, 0, data->height * data->bytesperline);
+}

--- a/arch/aarch64-native/hidd/vcgfx/vcgfx_support.h
+++ b/arch/aarch64-native/hidd/vcgfx/vcgfx_support.h
@@ -1,0 +1,46 @@
+#ifndef VCFBGFX_SUPPORT_H
+#define VCFBGFX_SUPPORT_H
+
+#include <exec/types.h>
+#include <oop/oop.h>
+
+#define PCI_VENDOR_S3 0x5333
+
+#define vgaIOBase 0x3d0
+
+struct HWData
+{
+    APTR	 framebuffer;
+    ULONG	 fbsize;
+    ULONG	 width;
+    ULONG	 height;
+    ULONG	 depth;
+    ULONG	 bytesperpixel;
+    ULONG	 bitsperpixel;
+    ULONG	 redmask;
+    ULONG	 greenmask;
+    ULONG	 bluemask;
+    ULONG	 redshift;
+    ULONG	 greenshift;
+    ULONG	 blueshift;
+    ULONG	 bytesperline;
+    BOOL	 owned;
+    UBYTE	 palettewidth;
+    UBYTE	 DAC[768];
+    /* Used by PCI scanning routine */
+    OOP_AttrBase pciDeviceAttrBase;
+};
+
+#undef HiddPCIDeviceAttrBase
+#define HiddPCIDeviceAttrBase sd->pciDeviceAttrBase
+
+struct VCGfx_staticdata;
+struct VCGfxBitMapData;
+
+BOOL initVCGfxHW(struct HWData *);
+void DACLoad(struct VCGfx_staticdata *, UBYTE *, unsigned char, int);
+void ClearBuffer(struct HWData *data);
+void vcfbDoRefreshArea(struct HWData *hwdata, struct VCGfxBitMapData *data,
+		       LONG x1, LONG y1, LONG x2, LONG y2);
+
+#endif /* VCFBGFX_SUPPORT_H */

--- a/arch/aarch64-native/kernel/kernel_arch.h
+++ b/arch/aarch64-native/kernel/kernel_arch.h
@@ -3,8 +3,12 @@
  */
 #include "kernel_cpu.h"
 
-/* Number of IRQs used in the machine. Needed by kernel_base.h */
-#define IRQ_COUNT 72
+/* Number of IRQs used in the machine. Needed by kernel_base.h.
+   A GIC presents shared peripheral interrupts well above the range of the
+   earlier Broadcom controller: the SD host lands at 158 and PCIe legacy
+   interrupts at 175, and a handler for anything beyond this count is
+   silently refused. */
+#define IRQ_COUNT 256
 
 /*
  * Interrupt controller functions.

--- a/arch/aarch64-native/kernel/kernel_startup.c
+++ b/arch/aarch64-native/kernel/kernel_startup.c
@@ -128,9 +128,14 @@ static void __attribute__((used)) __clear_bss(struct TagItem *msg)
     }
 }
 
+/* PL011 base for the early bring-up prints. The Pi 2/3 puts it at
+   0x3f201000, the Pi 4 (BCM2711) at 0xfe201000; it is selected from the
+   platform id before the first character goes out. */
+static uintptr_t dbg_uart = 0x3f201000;
+
 static inline void uart_putc(char c)
 {
-    volatile uint32_t *uart = (volatile uint32_t *)0x3f201000;
+    volatile uint32_t *uart = (volatile uint32_t *)dbg_uart;
     while (uart[0x18/4] & (1 << 5)) ; /* wait for TXFF clear */
     if (c == '\n') { uart[0] = '\r'; while (uart[0x18/4] & (1 << 5)) ; }
     uart[0] = c;
@@ -144,6 +149,10 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
     struct MemHeader *mh;
     long unsigned int memlower = 0, memupper = 0, protlower = 0, protupper = 0;
     char *cmdline = NULL;
+
+    for (struct TagItem *t = msg; t->ti_Tag != TAG_DONE; t++)
+        if (t->ti_Tag == KRN_Platform && t->ti_Data == 0xc44)
+            dbg_uart = 0xfe201000;
 
     uart_puts("[Kernel] kernel_cstart entered\n");
     BootMsg = msg;

--- a/arch/aarch64-native/kernel/mmakefile.src
+++ b/arch/aarch64-native/kernel/mmakefile.src
@@ -54,7 +54,7 @@ CFILES := \
         font8x14 \
         devicetree
 
-PLATFILES := platform_bcm2708
+PLATFILES := platform_bcm2708 platform_bcm2711
 
 AFILES := vectors
 

--- a/arch/aarch64-native/kernel/platform_bcm2708.c
+++ b/arch/aarch64-native/kernel/platform_bcm2708.c
@@ -65,7 +65,7 @@ struct cpu_ipidata
 struct cpu_ipidata *bcm2708_cpuipid[4] = { 0, 0, 0, 0 };
 #endif
 
-static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
+void bcm2708_init(APTR _kernelBase, APTR _sysBase)
 {
     struct ExecBase *SysBase = (struct ExecBase *)_sysBase;
     struct KernelBase *KernelBase = (struct KernelBase *)_kernelBase;
@@ -153,7 +153,7 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
     }
 }
 
-static void bcm2708_init_cpu(APTR _kernelBase, APTR _sysBase)
+void bcm2708_init_cpu(APTR _kernelBase, APTR _sysBase)
 {
     struct ExecBase *SysBase = (struct ExecBase *)_sysBase;
     struct KernelBase *KernelBase = (struct KernelBase *)_kernelBase;
@@ -180,7 +180,7 @@ static void bcm2708_init_cpu(APTR _kernelBase, APTR _sysBase)
 #endif
 }
 
-static unsigned int bcm2708_get_time(void)
+unsigned int bcm2708_get_time(void)
 {
     return rd32le(SYSTIMER_CLO);
 }
@@ -206,7 +206,7 @@ static void bcm2708_irq_init(void)
     wr32le(GPUIRQ_DIBL1, ~0);
 }
 
-static void bcm2708_send_ipi(uint32_t ipi, uint32_t ipi_data, uint32_t cpumask)
+void bcm2708_send_ipi(uint32_t ipi, uint32_t ipi_data, uint32_t cpumask)
 {
     int cpu;
 
@@ -306,7 +306,7 @@ static void bcm2708_irq_process()
     }
 }
 
-static void bcm2708_fiq_process()
+void bcm2708_fiq_process()
 {
     int cpunum = GetCPUNumber();
     uint32_t fiq, fiq_data;
@@ -337,7 +337,7 @@ static void bcm2708_fiq_process()
     }
 }
 
-static void bcm2708_toggle_led(int LED, int state)
+void bcm2708_toggle_led(int LED, int state)
 {
     if (__arm_arosintern.ARMI_PeripheralBase == (APTR)BCM2836_PERIPHYSBASE)
     {
@@ -453,7 +453,7 @@ static inline void bcm2708_ser_waitout()
     }
 }
 
-static void bcm2708_ser_putc(uint8_t chr)
+void bcm2708_ser_putc(uint8_t chr)
 {
     bcm2708_ser_waitout();
 
@@ -465,7 +465,7 @@ static void bcm2708_ser_putc(uint8_t chr)
     wr32le(PL011_0_BASE + PL011_DR, chr);
 }
 
-static int bcm2708_ser_getc(void)
+int bcm2708_ser_getc(void)
 {
     if ((rd32le(PL011_0_BASE + PL011_FR) & PL011_FR_RXFE) == 0)
         return (int)rd32le(PL011_0_BASE + PL011_DR);

--- a/arch/aarch64-native/kernel/platform_bcm2711.c
+++ b/arch/aarch64-native/kernel/platform_bcm2711.c
@@ -115,11 +115,16 @@ static void bcm2711_irq_disable(int irq)
     GICD(GICD_ICENABLER + 4 * (irq / 32)) = 1u << (irq % 32);
 }
 
+/*
+ * A source that is never acknowledged is re-presented as a fresh exception
+ * rather than looping inside one dispatch, so the run length has to be
+ * tracked across calls to be seen at all.
+ */
+static uint32_t irq_last = GIC_SPURIOUS;
+static unsigned int irq_repeats;
+
 static void bcm2711_irq_process(void)
 {
-    uint32_t last = GIC_SPURIOUS;
-    unsigned int repeats = 0;
-
     for (;;)
     {
         uint32_t iar = GICC(GICC_IAR);
@@ -134,22 +139,24 @@ static void bcm2711_irq_process(void)
 
         /*
          * A level-triggered source that nobody acknowledges would be
-         * re-presented forever and wedge the machine here. Mask it after
-         * it proves it is not being cleared.
+         * re-presented forever and wedge the machine. Mask it once it has
+         * proved it is not being cleared. Any other interrupt arriving in
+         * between, the timer included, clears the count.
          */
-        if (intid == last)
+        if (intid == irq_last)
         {
-            if (++repeats > 100)
+            if (++irq_repeats > 10000)
             {
                 bcm2711_irq_disable(intid);
                 bug("[Kernel] IRQ %u not cleared by its handler, masked\n", intid);
+                irq_repeats = 0;
                 break;
             }
         }
         else
         {
-            last = intid;
-            repeats = 0;
+            irq_last = intid;
+            irq_repeats = 0;
         }
     }
 }

--- a/arch/aarch64-native/kernel/platform_bcm2711.c
+++ b/arch/aarch64-native/kernel/platform_bcm2711.c
@@ -1,0 +1,205 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    BCM2711 (Raspberry Pi 4) platform support for AArch64.
+
+    The Pi 4 differs from the Pi 2/3 (bcm2708/2836/2837) in two ways that
+    matter to the kernel: the peripheral base moves to 0xFE000000 (low-
+    peripheral mode) and interrupts are delivered by a real ARM GIC-400
+    (GICv2) instead of the legacy Broadcom controller. The mailbox,
+    framebuffer and PL011 are the same peripherals at the new base, so this
+    file reuses bcm2708's SoC-common code and only replaces the interrupt
+    controller (GIC-400) and the timer (ARM generic timer / CNTP, PPI 30).
+*/
+
+#include <aros/kernel.h>
+#include <aros/symbolsets.h>
+
+#include "kernel_base.h"
+
+#include <proto/kernel.h>
+#include <proto/exec.h>
+
+#include <inttypes.h>
+#include <hardware/intbits.h>
+
+#include "kernel_intern.h"
+#include "kernel_debug.h"
+#include "kernel_cpu.h"
+#include "kernel_interrupts.h"
+#include "kernel_intr.h"
+#include "kernel_fb.h"
+#include "tls.h"
+#include "io.h"
+
+#include "exec_platform.h"
+
+#define DTIMER(x)
+
+/* ---- SoC-common bits reused from platform_bcm2708.c (now non-static) ---- */
+extern void bcm2708_init(APTR, APTR);
+extern void bcm2708_init_cpu(APTR, APTR);
+extern void bcm2708_fiq_process(void);
+extern void bcm2708_send_ipi(uint32_t, uint32_t, uint32_t);
+extern unsigned int bcm2708_get_time(void);
+extern void bcm2708_toggle_led(int, int);
+extern void bcm2708_ser_putc(uint8_t);
+extern int bcm2708_ser_getc(void);
+
+/* ---- GIC-400 (GICv2), Pi 4 fixed physical addresses ---- */
+#define GICD_BASE   0xFF841000UL
+#define GICC_BASE   0xFF842000UL
+#define GICD(o)     (*(volatile uint32_t *)(GICD_BASE + (o)))
+#define GICC(o)     (*(volatile uint32_t *)(GICC_BASE + (o)))
+
+#define GICD_CTLR       0x000
+#define GICD_ISENABLER  0x100
+#define GICD_ICENABLER  0x180
+#define GICD_IPRIORITYR 0x400
+
+#define GICC_CTLR   0x000
+#define GICC_PMR    0x004
+#define GICC_IAR    0x00C
+#define GICC_EOIR   0x010
+
+#define GIC_SPURIOUS 1023
+
+/* ARM generic timer (EL1 physical, CNTP) -> scheduling heartbeat. PPI 30. */
+#define GENTIMER_PPI    30
+#define GENTIMER_HZ     50
+
+static uint64_t gentimer_interval;
+
+/* -------------------------- GIC-400 driver -------------------------- */
+
+static void bcm2711_irq_init(void)
+{
+    /* Distributor + CPU interface: mask everything, then enable, PMR open. */
+    GICD(GICD_CTLR) = 0;
+    GICC(GICC_CTLR) = 0;
+    GICC(GICC_PMR) = 0xF0;
+    GICD(GICD_CTLR) = 1;
+    GICC(GICC_CTLR) = 1;
+}
+
+static void bcm2711_irq_enable(int irq)
+{
+    *((volatile uint8_t *)(GICD_BASE + GICD_IPRIORITYR + irq)) = 0xA0;
+    GICD(GICD_ISENABLER + 4 * (irq / 32)) = 1u << (irq % 32);
+}
+
+static void bcm2711_irq_disable(int irq)
+{
+    GICD(GICD_ICENABLER + 4 * (irq / 32)) = 1u << (irq % 32);
+}
+
+static void bcm2711_irq_process(void)
+{
+    for (;;)
+    {
+        uint32_t iar = GICC(GICC_IAR);
+        uint32_t intid = iar & 0x3FF;
+
+        if (intid >= GIC_SPURIOUS)
+            break;
+
+        krnRunIRQHandlers(KernelBase, intid);
+
+        GICC(GICC_EOIR) = iar;
+    }
+}
+
+/* --------------- ARM generic timer (CNTP) scheduler tick --------------- */
+
+static void bcm2711_gentimer_handler(unsigned int irq, void *unused)
+{
+    (void)irq; (void)unused;
+
+    /* Reload the compare for the next quantum. */
+    __asm__ volatile("msr cntp_tval_el0, %0" :: "r"(gentimer_interval));
+
+    /* Drive the exec scheduler quantum (same mechanism as bcm2708). */
+    core_Cause(INTB_VERTB, 1L << INTB_VERTB);
+}
+
+static APTR bcm2711_init_gentimer(APTR _kernelBase)
+{
+    struct KernelBase *KernelBase = (struct KernelBase *)_kernelBase;
+    struct IntrNode *TimerHandle;
+    uint64_t freq;
+
+    DTIMER(bug("[Kernel:BCM2711] %s\n", __func__));
+
+    __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(freq));
+    gentimer_interval = freq / GENTIMER_HZ;
+
+    TimerHandle = AllocMem(sizeof(struct IntrNode), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!TimerHandle)
+        return NULL;
+
+    TimerHandle->in_Handler = bcm2711_gentimer_handler;
+    TimerHandle->in_HandlerData = (void *)(uintptr_t)GENTIMER_PPI;
+    TimerHandle->in_HandlerData2 = KernelBase;
+    TimerHandle->in_type = it_interrupt;
+    TimerHandle->in_nr = GENTIMER_PPI;
+
+    ADDHEAD(&KernelBase->kb_Interrupts[GENTIMER_PPI], &TimerHandle->in_Node);
+
+    /* Program the first interval, enable the timer, unmask the PPI in the GIC. */
+    __asm__ volatile("msr cntp_tval_el0, %0" :: "r"(gentimer_interval));
+    __asm__ volatile("msr cntp_ctl_el0, %0" :: "r"((uint64_t)1));
+    ictl_enable_irq(GENTIMER_PPI, KernelBase);
+
+    return TimerHandle;
+}
+
+/* ------------------------------- probe ------------------------------- */
+
+static IPTR bcm2711_probe(struct ARM_Implementation *krnARMImpl, struct TagItem *msg)
+{
+    void *bootPutC = NULL;
+
+    while (msg->ti_Tag != TAG_DONE)
+    {
+        switch (msg->ti_Tag)
+        {
+        case KRN_FuncPutC:
+            bootPutC = (void *)msg->ti_Data;
+            break;
+        }
+        msg++;
+    }
+
+    /* BCM2711 (Raspberry Pi 4) uses platform ID 0xc44 (set by the boot when
+       the device tree reports a bcm2711). */
+    if (krnARMImpl->ARMI_Platform != 0xc44)
+        return FALSE;
+
+    krnARMImpl->ARMI_PeripheralBase = (APTR)0xFE000000;
+    krnARMImpl->ARMI_InitCore = &bcm2708_init_cpu;
+    krnARMImpl->ARMI_FIQProcess = &bcm2708_fiq_process;
+    krnARMImpl->ARMI_SendIPI = &bcm2708_send_ipi;
+
+    krnARMImpl->ARMI_GetTime = &bcm2708_get_time;
+    krnARMImpl->ARMI_InitTimer = &bcm2711_init_gentimer;
+    krnARMImpl->ARMI_LED_Toggle = &bcm2708_toggle_led;
+
+    krnARMImpl->ARMI_SerPutChar = &bcm2708_ser_putc;
+    krnARMImpl->ARMI_SerGetChar = &bcm2708_ser_getc;
+
+    if ((krnARMImpl->ARMI_PutChar = bootPutC) != NULL)
+    {
+        krnARMImpl->ARMI_PutChar(0xFF); /* Clear the display */
+    }
+
+    krnARMImpl->ARMI_IRQInit = &bcm2711_irq_init;
+    krnARMImpl->ARMI_IRQEnable = &bcm2711_irq_enable;
+    krnARMImpl->ARMI_IRQDisable = &bcm2711_irq_disable;
+    krnARMImpl->ARMI_IRQProcess = &bcm2711_irq_process;
+
+    krnARMImpl->ARMI_Init = &bcm2708_init;
+
+    return TRUE;
+}
+
+ADD2SET(bcm2711_probe, ARMPLATFORMS, 0);

--- a/arch/aarch64-native/kernel/platform_bcm2711.c
+++ b/arch/aarch64-native/kernel/platform_bcm2711.c
@@ -56,6 +56,12 @@ extern int bcm2708_ser_getc(void);
 #define GICD_ISENABLER  0x100
 #define GICD_ICENABLER  0x180
 #define GICD_IPRIORITYR 0x400
+#define GICD_ITARGETSR  0x800
+#define GICD_ICFGR      0xC00
+
+/* INTIDs below this are private to a core (SGIs and PPIs); at and above
+   it they are shared and need explicit routing and trigger configuration. */
+#define GIC_FIRST_SPI   32
 
 #define GICC_CTLR   0x000
 #define GICC_PMR    0x004
@@ -85,6 +91,22 @@ static void bcm2711_irq_init(void)
 static void bcm2711_irq_enable(int irq)
 {
     *((volatile uint8_t *)(GICD_BASE + GICD_IPRIORITYR + irq)) = 0xA0;
+
+    if (irq >= GIC_FIRST_SPI)
+    {
+        /*
+         * A shared interrupt reaches no core until it is targeted at one,
+         * and peripheral lines on this SoC are level triggered.
+         */
+        uint32_t cfg;
+
+        *((volatile uint8_t *)(GICD_BASE + GICD_ITARGETSR + irq)) = 0x01;
+
+        cfg = GICD(GICD_ICFGR + 4 * (irq / 16));
+        cfg &= ~(2u << ((irq % 16) * 2));
+        GICD(GICD_ICFGR + 4 * (irq / 16)) = cfg;
+    }
+
     GICD(GICD_ISENABLER + 4 * (irq / 32)) = 1u << (irq % 32);
 }
 
@@ -95,6 +117,9 @@ static void bcm2711_irq_disable(int irq)
 
 static void bcm2711_irq_process(void)
 {
+    uint32_t last = GIC_SPURIOUS;
+    unsigned int repeats = 0;
+
     for (;;)
     {
         uint32_t iar = GICC(GICC_IAR);
@@ -106,6 +131,26 @@ static void bcm2711_irq_process(void)
         krnRunIRQHandlers(KernelBase, intid);
 
         GICC(GICC_EOIR) = iar;
+
+        /*
+         * A level-triggered source that nobody acknowledges would be
+         * re-presented forever and wedge the machine here. Mask it after
+         * it proves it is not being cleared.
+         */
+        if (intid == last)
+        {
+            if (++repeats > 100)
+            {
+                bcm2711_irq_disable(intid);
+                bug("[Kernel] IRQ %u not cleared by its handler, masked\n", intid);
+                break;
+            }
+        }
+        else
+        {
+            last = intid;
+            repeats = 0;
+        }
     }
 }
 

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -316,9 +316,24 @@ void query_memory()
 
         if (p != NULL && p->op_length)
         {
-            uint32_t *addr = p->op_value;
-            uint32_t lower = AROS_BE2LONG(*addr++);
-            uint32_t upper = AROS_BE2LONG(*addr++);
+            /* The number of 32-bit cells making up an address and a size is
+               taken from the root node. The Pi 4 (BCM2711) uses 2 address
+               cells (addresses exceed 32 bits), unlike the Pi 2/3. */
+            of_node_t *rootn = dt_find_node("/");
+            of_property_t *acp = dt_find_property(rootn, "#address-cells");
+            of_property_t *scp = dt_find_property(rootn, "#size-cells");
+            uint32_t ac = acp ? AROS_BE2LONG(*(uint32_t *)acp->op_value) : 1;
+            uint32_t sc = scp ? AROS_BE2LONG(*(uint32_t *)scp->op_value) : 1;
+            volatile uint32_t *addr = p->op_value;
+            uint64_t base = 0, size = 0;
+
+            for (uint32_t i = 0; i < ac; i++)
+                base = (base << 32) | AROS_BE2LONG(*addr++);
+            for (uint32_t i = 0; i < sc; i++)
+                size = (size << 32) | AROS_BE2LONG(*addr++);
+
+            uint32_t lower = (uint32_t)base;
+            uint32_t upper = (uint32_t)(base + size);
 
             kprintf("[BOOT] System memory range: %08x-%08x\n", lower, upper-1);
 
@@ -376,17 +391,34 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         if (p == NULL)
             while(1) asm volatile("wfe");
 
-        uint32_t *ranges = p->op_value;
-        int32_t len = p->op_length;
+        /* Each ranges entry is <child-address, parent-address, size>. The
+           child and size widths come from /soc, the parent width from the
+           root. On the Pi 4 the root uses 2 address cells (the peripheral
+           window sits above 4 GB in the bus map), so an entry is 4 cells
+           rather than the 3 of the Pi 2/3. Reading it with the wrong widths
+           mis-maps the MMIO window and serial dies the moment the MMU loads. */
+        of_node_t *rootn = dt_find_node("/");
+        of_property_t *cacp = dt_find_property(e, "#address-cells");
+        of_property_t *cscp = dt_find_property(e, "#size-cells");
+        of_property_t *pacp = dt_find_property(rootn, "#address-cells");
+        uint32_t child_ac = cacp ? AROS_BE2LONG(*(uint32_t *)cacp->op_value) : 1;
+        uint32_t child_sc = cscp ? AROS_BE2LONG(*(uint32_t *)cscp->op_value) : 1;
+        uint32_t parent_ac = pacp ? AROS_BE2LONG(*(uint32_t *)pacp->op_value) : 1;
+        uint32_t entry_cells = child_ac + parent_ac + child_sc;
 
-        while(len > 0)
+        volatile uint32_t *ranges = p->op_value;
+        int32_t cells = p->op_length / 4;
+
+        while (cells >= (int32_t)entry_cells)
         {
-            uint32_t addr_bus, addr_cpu;
-            uint32_t addr_len;
+            uint64_t addr_bus = 0, addr_cpu = 0, addr_len = 0;
 
-            addr_bus = AROS_BE2LONG(*ranges++);
-            addr_cpu = AROS_BE2LONG(*ranges++);
-            addr_len = AROS_BE2LONG(*ranges++);
+            for (uint32_t i = 0; i < child_ac; i++)
+                addr_bus = (addr_bus << 32) | AROS_BE2LONG(*ranges++);
+            for (uint32_t i = 0; i < parent_ac; i++)
+                addr_cpu = (addr_cpu << 32) | AROS_BE2LONG(*ranges++);
+            for (uint32_t i = 0; i < child_sc; i++)
+                addr_len = (addr_len << 32) | AROS_BE2LONG(*ranges++);
 
             (void)addr_bus;
 
@@ -400,7 +432,7 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
              * accesses on real hardware) */
             mmu_map_section(addr_cpu, addr_cpu, addr_len, 0, 0, 3, 0);
 
-            len -= 12;
+            cells -= entry_cells;
         }
     }
     else
@@ -567,17 +599,33 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     e = dt_find_node("/chosen");
     if (e)
     {
+        /* linux,initrd-start/-end are sized like the root address cells: a
+           single 32-bit cell on the Pi 2/3, but 64-bit on the Pi 4. Read the
+           width the property actually carries. */
+        /* DT property values are only 32-bit aligned. A 64-bit cell must be
+           read as two big-endian words: the MMU is still off here, so memory
+           is Device-typed and a 64-bit load on a 4-byte boundary faults. The
+           volatile pointer stops the compiler folding the pair into one. */
+        uintptr_t initrd_start = 0, initrd_end = 0;
         of_property_t *p = dt_find_property(e, "linux,initrd-start");
         if (p)
-            pkg_image = (void*)(uintptr_t)AROS_BE2LONG((*((uint32_t *)p->op_value)));
-        else
-            pkg_image = NULL;
+        {
+            volatile uint32_t *v = p->op_value;
+            initrd_start = (p->op_length >= 8)
+                ? (((uintptr_t)AROS_BE2LONG(v[0]) << 32) | AROS_BE2LONG(v[1]))
+                : (uintptr_t)AROS_BE2LONG(v[0]);
+        }
+        pkg_image = (void *)initrd_start;
 
         p = dt_find_property(e, "linux,initrd-end");
         if (p)
-            pkg_size = AROS_BE2LONG(*((uint32_t *)p->op_value)) - (uintptr_t)pkg_image;
-        else
-            pkg_size = 0;
+        {
+            volatile uint32_t *v = p->op_value;
+            initrd_end = (p->op_length >= 8)
+                ? (((uintptr_t)AROS_BE2LONG(v[0]) << 32) | AROS_BE2LONG(v[1]))
+                : (uintptr_t)AROS_BE2LONG(v[0]);
+        }
+        pkg_size = initrd_end - initrd_start;
     }
 
     kprintf("[BOOT] BSP image: %08x-%08x\n", pkg_image, (uintptr_t)pkg_image + pkg_size - 1);

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -415,9 +415,36 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         kprintf("[BOOT] Booted on %s\n", model ? (const char *)model->op_value : "unknown");
     }
 
-    /* first of all, store the arch for the kernel to use .. */
+    /*
+     * Store the SoC id for the kernel's platform probe. The peripheral base
+     * itself is taken from the device tree (/soc ranges) above, so it is
+     * already correct for either SoC; here we only distinguish the interrupt
+     * controller / timer family: BCM2836/2837 (Pi 2/3, legacy controller) vs
+     * BCM2711 (Pi 4, GIC-400), by scanning the root "compatible" list.
+     */
     boottag->ti_Tag = KRN_Platform;
-    boottag->ti_Data = (IPTR)0xc43; /* BCM2837 identifier */
+    {
+        of_node_t *r = dt_find_node("/");
+        of_property_t *compat = r ? dt_find_property(r, "compatible") : NULL;
+        IPTR plat = 0xc43; /* default: BCM2836/2837 (Raspberry Pi 2/3) */
+        if (compat)
+        {
+            const char *s = (const char *)compat->op_value;
+            int n = (int)compat->op_length, i;
+            for (i = 0; i + 7 <= n; i++)
+            {
+                if (s[i] == 'b' && s[i+1] == 'c' && s[i+2] == 'm' &&
+                    s[i+3] == '2' && s[i+4] == '7' && s[i+5] == '1' &&
+                    s[i+6] == '1')
+                {
+                    plat = 0xc44; /* BCM2711 (Raspberry Pi 4) */
+                    break;
+                }
+            }
+        }
+        boottag->ti_Data = plat;
+        kprintf("[BOOT] SoC platform id 0x%x\n", (unsigned)plat);
+    }
     boottag++;
 
     /*

--- a/arch/aarch64-raspi/boot/include/elf.h
+++ b/arch/aarch64-raspi/boot/include/elf.h
@@ -38,6 +38,7 @@ int loadElf(void *elf_file);
 #define R_AARCH64_MOVW_SABS_G0         270
 #define R_AARCH64_MOVW_SABS_G1         271
 #define R_AARCH64_MOVW_SABS_G2         272
+#define R_AARCH64_LD_PREL_LO19         273     /* LD-lit: S + A - P */
 #define R_AARCH64_ADR_PREL_LO21        274     /* ADR: S + A - P */
 #define R_AARCH64_ADR_PREL_PG_HI21     275     /* ADRP: Page(S+A) - Page(P) */
 #define R_AARCH64_ADR_PREL_PG_HI21_NC  276
@@ -50,6 +51,9 @@ int loadElf(void *elf_file);
 #define R_AARCH64_JUMP26        282     /* B: S + A - P */
 #define R_AARCH64_CALL26        283     /* BL: S + A - P */
 #define R_AARCH64_CONDBR19      280     /* B.cond: S + A - P */
+#define R_AARCH64_TSTBR14       279     /* TBZ/TBNZ: S + A - P */
+#define R_AARCH64_ADR_GOT_PAGE  311     /* ADRP: Page(G(S+A)) - Page(P) */
+#define R_AARCH64_LD64_GOT_LO12_NC 312  /* LD64: G(S+A) & 0xFF8 */
 
 /* ELF64 relocation macros */
 #define ELF64_R_SYM(i)         ((uint32_t)((i) >> 32))

--- a/arch/aarch64-raspi/timer/timer_init.c
+++ b/arch/aarch64-raspi/timer/timer_init.c
@@ -85,12 +85,18 @@ int vblank_Init(struct TimerBase *LIBBASE);
 
 static int Timer_Init(struct TimerBase *TimerBase)
 {
+    unsigned int timerIRQ;
+
     D(bug("[Timer] Timer_Init: kernel.resource @ 0x%p\n", KernelBase));
 
     TimerBase->tb_Platform.tbp_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
     /* Install timer IRQ handler */
-    TimerBase->tb_TimerIRQHandle = KrnAddIRQHandler(IRQ_TIMER0 + TICK_TIMER, Timer1Tick, TimerBase, SysBase);
+    timerIRQ = IRQ_TIMER0 + TICK_TIMER;
+    if (TimerBase->tb_Platform.tbp_periiobase == BCM2711_PERIIOBASE)
+        timerIRQ += BCM2711_GPUIRQ_OFFSET;
+
+    TimerBase->tb_TimerIRQHandle = KrnAddIRQHandler(timerIRQ, Timer1Tick, TimerBase, SysBase);
     if (!TimerBase->tb_TimerIRQHandle)
         return FALSE;
 

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -26,6 +26,17 @@
    caller must provide ARM_PERIIOBASE
 */
 
+/* Peripheral window of the BCM2711, which differs from the earlier SoCs. */
+#define BCM2711_PERIIOBASE                              0xFE000000
+
+/*
+ * The BCM2711 presents the GPU interrupts of the earlier controller as
+ * GIC shared interrupts, offset by this much: GPU interrupt n arrives as
+ * INTID n + 96. Anything using an IRQ_* number below has to add it when
+ * running on that SoC.
+ */
+#define BCM2711_GPUIRQ_OFFSET                           96
+
 #define SYSTIMER_BASE                                   (ARM_PERIIOBASE + 0x003000)
 #define ARMTIMER_BASE                                   (ARM_PERIIOBASE + 0x00b000)
 #define IRQ_BASE                                        (ARM_PERIIOBASE + 0x00b200)

--- a/rom/usb/pcixhci/mmakefile.src
+++ b/rom/usb/pcixhci/mmakefile.src
@@ -39,7 +39,7 @@ endif
 -include $(SRCDIR)/$(CURDIR)/make.opts
 
 USER_LDFLAGS := -static
-#USER_CPPFLAGS += -DDEBUG=1
+USER_CPPFLAGS += -DDEBUG=1 -DPCIUSB_XHCI_DEBUG
 
 %build_module mmake=kernel-usb-pcixhci \
     modname=pcixhci modtype=device \


### PR DESCRIPTION
Platform support for the BCM2711, the SoC in the Raspberry Pi 4. The existing
aarch64 Raspberry Pi port covers the Pi 3 and earlier, whose interrupt
controller is Broadcom's own; the Pi 4 has a GIC-400 and a different
peripheral window, so it needs its own platform alongside `platform_bcm2708`.

- **GIC-400 and the ARM generic timer.** A new platform selected by SoC
  identifier, reusing the shared BCM2708 helpers where the hardware is the
  same.
- **Device tree parsing for the Pi 4.** Its root uses two address cells, so
  memory, the peripheral window and the initrd bounds are all wider than on
  the Pi 3. The MMU is off while this runs, so the 64-bit values are read as
  two aligned 32-bit words: a plain 64-bit load on device memory faults.
- **Size the interrupt table for a GIC.** It was 72 entries, which silently
  refused every handler above that number. The interrupt this port needs most
  is 175.
- **Name a CPU for shared interrupts.** Without a target in `GICD_ITARGETSR`
  a shared interrupt is enabled but delivered nowhere.
- **Track the unacknowledged interrupt run length by rate rather than by
  count.** A plain repeat count cannot tell a storm from a timer doing its
  job, and masked the scheduler tick.
- **Correct the system timer interrupt number.** The BCM2711 presents the
  older controller's GPU interrupts as GIC shared interrupts offset by 96.
  Using the unshifted number meant `timer.device` never ticked, so every timed
  wait in the system hung, which is a quiet and very confusing failure.

Boots to a Workbench screen on a Raspberry Pi 4 Model B.

Part of a series bringing up AROS on the Raspberry Pi 4, with #887, #888 and
#889.
