### PR TITLE
graphics:  Fix RectFill INVERSVID regression affecting scrolling

### DIFF
--- a/rom/graphics/rectfill.c
+++ b/rom/graphics/rectfill.c
@@ -68,38 +68,31 @@
             /* When rastport has areaptrn, let BltPattern do the job */
             BltPattern(rp, NULL, xMin, yMin, xMax, yMax, 0);
         } else {
-            /*
-             * Without an AreaPtrn the fill pattern is all ones, so INVERSVID
-             * clears it: JAM1 then writes nothing at all, and JAM2 writes
-             * BPen everywhere. COMPLEMENT inverts the destination wherever
-             * the mode writes, whichever pen it would have used.
-             */
+            /* Without an AreaPtrn, INVERSVID selects the background pen. */
             BOOL inversvid = (rp->DrawMode & INVERSVID) != 0;
-            BOOL jam2 = (rp->DrawMode & JAM2) != 0;
+            OOP_Object *gc  = GetDriverData(rp, GfxBase);
+            struct Rectangle rr;
+            HIDDT_Pixel oldfg = GC_FG(gc);
+            HIDDT_DrawMode olddrmd = GC_DRMD(gc);
 
-            if(jam2 || !inversvid) {
-                OOP_Object *gc  = GetDriverData(rp, GfxBase);
-                struct Rectangle rr;
-                HIDDT_Pixel oldfg = GC_FG(gc);
-
-                if(inversvid) {
-                    GC_FG(gc) = GC_BG(gc);
-                }
-                if(rp->DrawMode & COMPLEMENT) {
-                    GC_DRMD(gc) = vHidd_GC_DrawMode_Invert;
-                }
-
-                /* This is the same as fillrect_pendrmd() */
-
-                rr.MinX = xMin;
-                rr.MinY = yMin;
-                rr.MaxX = xMax;
-                rr.MaxY = yMax;
-
-                do_render_with_gc(rp, NULL, &rr, fillrect_render, NULL, gc, TRUE, FALSE, GfxBase);
-
-                GC_FG(gc) = oldfg;
+            if(inversvid) {
+                GC_FG(gc) = GC_BG(gc);
             }
+            if(rp->DrawMode & COMPLEMENT) {
+                GC_DRMD(gc) = vHidd_GC_DrawMode_Invert;
+            }
+
+            /* This is the same as fillrect_pendrmd() */
+
+            rr.MinX = xMin;
+            rr.MinY = yMin;
+            rr.MaxX = xMax;
+            rr.MaxY = yMax;
+
+            do_render_with_gc(rp, NULL, &rr, fillrect_render, NULL, gc, TRUE, FALSE, GfxBase);
+
+            GC_FG(gc) = oldfg;
+            GC_DRMD(gc) = olddrmd;
         }
     } /* if ((xMax >= xMin) && (yMax >= yMin)) */
 


### PR DESCRIPTION
## Summary

  Fixes a graphics regression introduced by `a9072ed70386db03e7247c725a5f54b60483c11c`.

  That change made `RectFill()` with `JAM1 | INVERSVID` and no `AreaPtrn`
  perform no drawing. However, existing graphics.library functions including
  `ScrollRaster()`, `ClearEOL()` and `ClearScreen()` deliberately toggle
  `INVERSVID` before calling `RectFill()` to fill an area with the background
  pen.

  As a result, DOpus 4 scrolling no longer cleared newly exposed rows. New text
  was drawn over stale pixels, producing severe visual corruption.

  ## Changes

  - Restore the established background-pen fill behavior for `INVERSVID`
    without an `AreaPtrn`.
  - Retain the `COMPLEMENT` support added by the original change.
  - Save and restore the shared HIDD GC draw mode after temporarily selecting
    `Invert`, preventing subsequent operations from inheriting it.

  ## Testing

  Tested with DOpus 4 using an A500 AROS ROM configuration. Scrolling now clears
  and redraws exposed rows correctly without the previous corruption.

  The author of the original change is mentioned for review because this
  restores the previous `JAM1 | INVERSVID` semantics relied upon by existing
  graphics.library callers.

After the fix:

https://github.com/user-attachments/assets/9c7de56c-a8e8-42e0-982a-8600b0cd2b5f



@codewiz I'll wait for your confirmation that I did not break anything you fixed in the original PR before removing the draft state :)

Fixes #893 