### PR TITLE
graphics: honour rp->Mask in patterned and template fills

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
@@ -507,6 +507,7 @@ BOOL blit_puttemplate(struct amigavideo_staticdata *data, struct BitMap *bm, str
     OOP_Object *gc = tmpl->gc;
     HIDDT_Pixel fgpen = GC_FG(tmpl->gc);
     HIDDT_Pixel bgpen = GC_BG(tmpl->gc);
+    ULONG colmask = GC_COLMASK(tmpl->gc);
 
     UBYTE type, i;
     BYTE shift;
@@ -610,6 +611,11 @@ BOOL blit_puttemplate(struct amigavideo_staticdata *data, struct BitMap *bm, str
         if (bm->Planes[i] == (UBYTE*)0x00000000 || bm->Planes[i] == (UBYTE*)0xffffffff)
             continue;
 
+        /* The write mask protects the planes it clears. It is a UBYTE, so it
+           says nothing about a ninth plane and beyond: leave those writable. */
+        if (i < 8 && !(colmask & (1 << i)))
+            continue;
+
         chmask = 0x0700;
         shiftbv = shiftb;
  
@@ -711,6 +717,7 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
     UBYTE type;
     UBYTE fgpen = GC_FG(pat->gc);
     UBYTE bgpen = GC_BG(pat->gc);
+    ULONG colmask = GC_COLMASK(pat->gc);
 
     UBYTE i;
     UWORD shifta, shiftb;
@@ -803,9 +810,14 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
         if (bm->Planes[i] == (UBYTE*)0x00000000 || bm->Planes[i] == (UBYTE*)0xffffffff)
             continue;
 
+        /* The write mask protects the planes it clears. It is a UBYTE, so it
+           says nothing about a ninth plane and beyond: leave those writable. */
+        if (i < 8 && !(colmask & (1 << i)))
+            continue;
+
         fg = fgpen & 1;
         bg = bgpen & 1;
-        
+
         chmask = pat->mask ? 0x0f00 : 0x0300;
  
         minterm = getminterm(type, fg, bg);

--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
@@ -1448,6 +1448,7 @@ VOID P96GFXBitmap__Hidd_BitMap__PutPattern(OOP_Class *cl, OOP_Object *o,
     struct p96gfx_staticdata *csd = CSD(cl);
     HIDDT_Pixel fg = GC_FG(msg->gc);
     HIDDT_Pixel bg = GC_BG(msg->gc);
+    ULONG colmask = GC_COLMASK(msg->gc);
     struct Pattern pat;
     UBYTE drawmode;
     BOOL v = FALSE;
@@ -1526,11 +1527,20 @@ VOID P96GFXBitmap__Hidd_BitMap__PutPattern(OOP_Class *cl, OOP_Object *o,
 
                 LOCK_HW
 
-                v = BlitPattern(cid, &ri, &pat, msg->x, msg->y, msg->width, msg->height, 0xff, data->rgbformat);
+                v = BlitPattern(cid, &ri, &pat, msg->x, msg->y, msg->width, msg->height, (UBYTE)colmask, data->rgbformat);
 
                 UNLOCK_HW
             }
         }
+    }
+
+    /* The memory fallbacks below write whole pixels, so a partial mask has to
+       go to the superclass instead. */
+    if (!v && colmask != ~0)
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        UNLOCK_BITMAP(data)
+        return;
     }
 
     if (!v) switch(data->bytesperpixel)
@@ -1636,6 +1646,7 @@ VOID P96GFXBitmap__Hidd_BitMap__PutTemplate(OOP_Class *cl, OOP_Object *o, struct
     struct p96gfx_staticdata *csd = CSD(cl);
     HIDDT_Pixel fg = GC_FG(msg->gc);
     HIDDT_Pixel bg = GC_BG(msg->gc);
+    ULONG colmask = GC_COLMASK(msg->gc);
     BOOL v = FALSE;
 
     D(bug("[P96Gfx:Bitmap] %s()\n", __func__));
@@ -1676,8 +1687,17 @@ VOID P96GFXBitmap__Hidd_BitMap__PutTemplate(OOP_Class *cl, OOP_Object *o, struct
         tmpl.BgPen = bg;
 
         LOCK_HW
-        v = BlitTemplate(cid, &ri, &tmpl, msg->x, msg->y, msg->width, msg->height, 0xff, data->rgbformat);
+        v = BlitTemplate(cid, &ri, &tmpl, msg->x, msg->y, msg->width, msg->height, (UBYTE)colmask, data->rgbformat);
         UNLOCK_HW
+    }
+
+    /* The memory fallbacks below write whole pixels, so a partial mask has to
+       go to the superclass instead. */
+    if (!v && colmask != ~0)
+    {
+        OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        UNLOCK_BITMAP(data)
+        return;
     }
 
     if (!v) switch(data->bytesperpixel)

--- a/rom/hidds/gfx/gfx_bitmapclass.c
+++ b/rom/hidds/gfx/gfx_bitmapclass.c
@@ -3194,6 +3194,14 @@ VOID BM__Hidd_BitMap__PutAlphaImage(OOP_Class *cl, OOP_Object *o,
 
 *****************************************************************************************/
 
+/*
+ * Merge a rendered pixel into the destination through the GC's plane write
+ * mask. keepmask is just ~colmask, kept alongside it so the inner loops below
+ * do not have to compute it per pixel.
+ */
+#define PUTMASKED(dst, val, d) \
+    ((dst) = (((val) & (d)->colmask) | ((dst) & (d)->keepmask)))
+
 struct ptb_data
 {
     void *bitarray;
@@ -3201,6 +3209,8 @@ struct ptb_data
     ULONG modulo;
     ULONG fg;
     ULONG bg;
+    ULONG colmask;
+    ULONG keepmask;
     UWORD invert;
 };
 
@@ -3217,7 +3227,7 @@ static void JAM1TemplateBuffered(ULONG *xbuf, UWORD starty, UWORD width, UWORD h
         for (x = 0; x < width; x++)
         {
             if ((bitword & mask) == (data->invert & mask))
-                xbuf[x] = data->fg;
+                PUTMASKED(xbuf[x], data->fg, data);
 
             mask >>= 1;
             if (!mask)
@@ -3246,7 +3256,7 @@ static void ComplementTemplateBuffered(ULONG *xbuf, UWORD starty, UWORD width, U
         for (x = 0; x < width; x++)
         {
             if ((bitword & mask) == (data->invert & mask))
-                 xbuf[x] = ~xbuf[x];
+                 PUTMASKED(xbuf[x], ~xbuf[x], data);
 
             mask >>= 1;
             if (!mask)
@@ -3275,9 +3285,9 @@ static void JAM2TemplateBuffered(ULONG *xbuf, UWORD starty, UWORD width, UWORD h
         for (x = 0; x < width; x++)
         {
             if ((bitword & mask) == (data->invert & mask))
-                xbuf[x] = data->fg;
+                PUTMASKED(xbuf[x], data->fg, data);
             else
-                xbuf[x] = data->bg;
+                PUTMASKED(xbuf[x], data->bg, data);
 
             mask >>= 1;
             if (!mask)
@@ -3325,7 +3335,13 @@ VOID BM__Hidd_BitMap__PutTemplate(OOP_Class *cl, OOP_Object *o, struct pHidd_Bit
     data.modulo   = msg->modulo;
     data.fg       = GC_FG(msg->gc);
     data.bg       = GC_BG(msg->gc);
+    data.colmask  = GC_COLMASK(gc);
+    data.keepmask = ~data.colmask;
     data.invert   = msg->inverttemplate ? 0 : 0xFFFF;
+
+    /* Preserving the masked-out planes means having to read them first. */
+    if (data.colmask != ~0)
+        get = TRUE;
 
     DoBufferedOperation(cl, o, msg->x, msg->y, msg->width, msg->height, get, vHidd_StdPixFmt_Native32, (VOID_FUNC)op, &data);
 
@@ -3579,6 +3595,8 @@ struct ppb_data
     ULONG  maskmodulo;
     ULONG  fg;
     ULONG  bg;
+    ULONG  colmask;
+    ULONG  keepmask;
     UWORD  patmask;
     UWORD  maskmask;
     UWORD  patterndepth;
@@ -3603,7 +3621,7 @@ static void JAM1PatternBuffered(ULONG *xbuf, UWORD starty, UWORD width, UWORD he
             if (maskword & mmask)
             {
                 if ((patword & pmask) == (data->invert & pmask))
-                    xbuf[x] = data->fg;
+                    PUTMASKED(xbuf[x], data->fg, data);
             }
 
             if (marray)
@@ -3648,7 +3666,7 @@ static void ComplementPatternBuffered(ULONG *xbuf, UWORD starty, UWORD width, UW
             if (maskword & mmask)
             {
                 if ((patword & pmask) == (data->invert & pmask))
-                    xbuf[x] = ~xbuf[x];
+                    PUTMASKED(xbuf[x], ~xbuf[x], data);
             }
 
             if (marray)
@@ -3693,9 +3711,9 @@ static void JAM2PatternBuffered(ULONG *xbuf, UWORD starty, UWORD width, UWORD he
             if (maskword & mmask)
             {
                 if ((patword & pmask) == (data->invert & pmask))
-                    xbuf[x] = data->fg;
+                    PUTMASKED(xbuf[x], data->fg, data);
                 else
-                    xbuf[x] = data->bg;
+                    PUTMASKED(xbuf[x], data->bg, data);
             }
 
             if (marray)
@@ -3754,7 +3772,7 @@ static void ColorPatternBuffered(ULONG *xbuf, UWORD starty, UWORD width, UWORD h
                 if (data->patternlut)
                     pixel = data->patternlut[pixel];
 
-                xbuf[x] = pixel;
+                PUTMASKED(xbuf[x], pixel, data);
             }
 
             if (marray)
@@ -3828,7 +3846,13 @@ VOID BM__Hidd_BitMap__PutPattern(OOP_Class *cl, OOP_Object *o,
     data.maskmodulo    = msg->maskmodulo;
     data.fg            = GC_FG(msg->gc);
     data.bg            = GC_BG(msg->gc);
+    data.colmask       = GC_COLMASK(msg->gc);
+    data.keepmask      = ~data.colmask;
     data.invert        = msg->invertpattern ? 0 : 0xFFFF;
+
+    /* Preserving the masked-out planes means having to read them first. */
+    if (data.colmask != ~0)
+        get = TRUE;
 
     if (data.maskarray)
     {


### PR DESCRIPTION
Follow-up to #886, which taught `RectFill()` and the HIDD `BltBitMap()` path to
honour `rp->Mask`. The patterned and template fills were left out, so the write
mask still stopped at the driver boundary there.

`BltTemplate()` and `BltPattern()` already reach the driver with a correct mask
in the GC -- they render through `do_render_func()`, which uses the
`GetDriverData()` GC -- but nothing downstream looked at it:

- The template and pattern loops in `hidd.gfx`'s bitmap class wrote whole
  pixels. They now merge through `GC_COLMASK` using the same expression
  `DrawPixel` has always used. A partial mask has to preserve the planes it
  protects, so it also forces the destination read that the JAM2 and colour
  cases previously skipped.
- p96gfx passed a hardcoded `0xff` to the card's `BlitPattern`/`BlitTemplate`.
  It now passes the real mask, and a partial mask with no acceleration goes to
  the superclass rather than to the memory fallbacks, which write whole pixels.
- amigavideo's `blit_puttemplate()`/`blit_putpattern()` now skip the planes the
  mask clears, as `blit_fillrect()` already did.

`Text()` renders through `PutTemplate()`, so this is also what makes `rp->Mask`
apply to text.

## Testing

m68k under an emulated A4000 with a Z3660 RTG board, at 640x480x8 and
640x480x24, against reference images captured from `rtg.library`.

`BltTemplate-masks` goes from failing 11520 pixels to passing. Nothing
regressed at either depth; the remaining 24-bit failures have pixel counts
identical to before, since `GC_COLMASK` is `~0` on a truecolor bitmap and every
change here is a no-op there.

`BltPattern-drawmodes` improves from 20497 to 19860 pixels but still fails, for
a reason unrelated to masks: with a NULL mask AROS paints only the last three
pixels of the rectangle. Under `rp->Mask = 0x0F` the pixels it does paint now
come out correctly masked, so the mask handling in that path is right and the
width is not. A NULL mask is the only case that reaches the card's accelerated
`BlitPattern` hook -- the scenes that pass an explicit mask land in
`PutMemPattern8` and pass -- so that hook is where the remaining bug is. Left
for a separate change.
