### PR TITLE
graphics: clear with a pen instead of toggling INVERSVID

### DIFF
--- a/rom/graphics/cleareol.c
+++ b/rom/graphics/cleareol.c
@@ -53,13 +53,13 @@
 {
     AROS_LIBFUNC_INIT
 
-    ULONG oldDrMd = GetDrMd(rp);;
+    UBYTE oldFgPen = rp->FgPen;
     ULONG width = GetBitMapAttr(rp->BitMap, BMA_WIDTH);
 
-    SetDrMd(rp, oldDrMd ^ INVERSVID);
+    SetAPen(rp, bgfill_pen(rp));
     RectFill(rp, rp->cp_x, rp->cp_y - rp->TxBaseline, width - 1,
              rp->cp_y - rp->TxBaseline + rp->Font->tf_YSize - 1);
-    SetDrMd(rp, oldDrMd);
+    SetAPen(rp, oldFgPen);
 
     AROS_LIBFUNC_EXIT
 } /* ClearEOL */

--- a/rom/graphics/clearscreen.c
+++ b/rom/graphics/clearscreen.c
@@ -60,11 +60,11 @@
     ClearEOL(rp);
 
     if(height >= ymin) {
-        ULONG      oldDrMd = GetDrMd(rp);
+        UBYTE oldFgPen = rp->FgPen;
 
-        SetDrMd(rp, oldDrMd ^ INVERSVID);
+        SetAPen(rp, bgfill_pen(rp));
         RectFill(rp, 0, ymin, width - 1, height - 1);
-        SetDrMd(rp, oldDrMd);
+        SetAPen(rp, oldFgPen);
     }
 
     AROS_LIBFUNC_EXIT

--- a/rom/graphics/eraserect.c
+++ b/rom/graphics/eraserect.c
@@ -67,9 +67,13 @@
     struct Hook     *h = LAYERS_BACKFILL;
 
     if(!LayersBase) {
-        rp->DrawMode ^= INVERSVID;
+        UBYTE oldFgPen = rp->FgPen;
+
+        /* As ScrollRaster() does: the layer path below erases to the layer's
+           background, so without one BPen is the closest equivalent. */
+        SetAPen(rp, rp->BgPen);
         RectFill(rp, xMin, yMin, xMax, yMax);
-        rp->DrawMode ^= INVERSVID;
+        SetAPen(rp, oldFgPen);
         return;
     }
 

--- a/rom/graphics/gfxfuncsupport.c
+++ b/rom/graphics/gfxfuncsupport.c
@@ -815,7 +815,7 @@ BOOL MoveRaster(struct RastPort *rp, WORD dx, WORD dy, WORD x1, WORD y1,
 
         AROS_BEGIN_PROFILING(Blitting loop)
 
-#if USE_OLDMoveRaster
+#if USE_OLD_MoveRaster
 
         {
             struct ClipRect *LastHiddenCR;

--- a/rom/graphics/graphics_intern.h
+++ b/rom/graphics/graphics_intern.h
@@ -450,4 +450,17 @@ struct BlitWaitQNode {
     struct Task *task;
 };
 
+/*
+ * The pen ClearEOL() and ClearScreen() clear with: BPen in JAM2, pen 0
+ * otherwise. Not the same rule as ScrollRaster(), which always uses BPen.
+ *
+ * Callers set this as the APen and leave the draw mode alone, so COMPLEMENT
+ * still inverts, and INVERSVID still clears the implicit all-ones pattern and
+ * so writes nothing in JAM1.
+ */
+static inline UBYTE bgfill_pen(struct RastPort *rp)
+{
+    return (rp->DrawMode & JAM2) ? rp->BgPen : 0;
+}
+
 #endif /* GRAPHICS_INTERN_H */

--- a/rom/graphics/scrollraster.c
+++ b/rom/graphics/scrollraster.c
@@ -116,13 +116,13 @@
 
     if((width < 1) || (height < 1)) return;
 
-    if((absdx >= width) || (absdy >= height)) {
-        SetABPenDrMd(rp, rp->BgPen, rp->BgPen, JAM1);
-        RectFill(rp, xMin, yMin, xMax, yMax);
-        SetABPenDrMd(rp, old_fgpen, rp->BgPen, old_drmd);
-
+    /*
+     * A distance that reaches the extent scrolls everything off, and the
+     * rectangle is then left exactly as it was: not scrolled, and not filled
+     * with BPen either.
+     */
+    if((absdx >= width) || (absdy >= height))
         return;
-    }
 
     if(!MoveRaster(rp, dx, dy, xMin, yMin, xMax, yMax, TRUE, GfxBase))
         return;

--- a/rom/graphics/scrollraster.c
+++ b/rom/graphics/scrollraster.c
@@ -67,7 +67,8 @@
 {
     AROS_LIBFUNC_INIT
 
-    ULONG old_drmd = GetDrMd(rp);
+    UBYTE old_fgpen = rp->FgPen;
+    UBYTE old_drmd = rp->DrawMode;
     LONG width, height, absdx, absdy;
 
     FIX_GFXCOORD(xMin);
@@ -116,9 +117,9 @@
     if((width < 1) || (height < 1)) return;
 
     if((absdx >= width) || (absdy >= height)) {
-        SetDrMd(rp, old_drmd ^ INVERSVID);
+        SetABPenDrMd(rp, rp->BgPen, rp->BgPen, JAM1);
         RectFill(rp, xMin, yMin, xMax, yMax);
-        SetDrMd(rp, old_drmd);
+        SetABPenDrMd(rp, old_fgpen, rp->BgPen, old_drmd);
 
         return;
     }
@@ -131,7 +132,12 @@
        RectFill()
      */
 
-    SetDrMd(rp, old_drmd ^ INVERSVID);
+    /*
+     * The vacated strip is BPen whatever the caller's draw mode: JAM1 with no
+     * AreaPtrn writes APen everywhere, and selecting it drops COMPLEMENT and
+     * INVERSVID with it.
+     */
+    SetABPenDrMd(rp, rp->BgPen, rp->BgPen, JAM1);
 
     /* was it scrolled left or right? */
     if(0 != dx) {
@@ -170,7 +176,7 @@
         }
     }
 
-    SetDrMd(rp, old_drmd);
+    SetABPenDrMd(rp, old_fgpen, rp->BgPen, old_drmd);
 
     AROS_LIBFUNC_EXIT
 } /* ScrollRaster */


### PR DESCRIPTION
Alternative to #894 for the #893 regression, fixing the callers rather than
`RectFill()`. Draft until p96cts covers these functions -- see Testing below.

a9072ed703 made `RectFill()` with `JAM1 | INVERSVID` and no `AreaPtrn` draw
nothing, which is correct: the pattern is implicitly all ones, `INVERSVID`
clears it, and JAM1 writes only where the pattern is set. `ClearEOL()`,
`ClearScreen()`, `ScrollRaster()` and `EraseRect()` were toggling `INVERSVID`
to pick the background pen, so they stopped filling at all on a JAM1 RastPort.

The toggle was never the right way to ask for this, and it is not how these
functions were originally written. Two 2005 commits replaced a direct pen
change with it, 46 minutes apart:

- ab28a8abd3 `ClearEOL()`, `ClearScreen()`: "To render with background color it
  used to change/restore apen. Now it changes (toggle INVERSVID) and restores
  drawmode instead."
- 7df302f47e `ScrollRaster()`: same change.

`EraseRect()` has no such history; its no-layer path was added in 861bbc1b79
already using the toggle.

This restores the pen approach. The four functions do not all share one rule,
so each gets its own:

- `ClearEOL()` and `ClearScreen()` clear with pen 0, or BPen in JAM2. That is
  what their own autodoc in this tree already says -- "Clearing means setting
  the colour to 0 (or to BgPen if the drawmode is JAM2)" -- and what the V40
  autodoc says for both. The pre-2005 code tested `DrawMode == JAM2` by
  equality; this masks, so `JAM2 | COMPLEMENT` is treated as JAM2 too.
- `ScrollRaster()` clears with BPen unconditionally, which is exactly what
  7df302f47e replaced, and it ignores the draw mode entirely -- `COMPLEMENT`
  does not invert the vacated strip and `INVERSVID` does not suppress it. The
  documentation is unqualified about this: "the area vacated by the data when it
  has been cropped and moved is filled with the background color (color in
  BgPen)". So the fill selects JAM1 as well as the pen.
- `EraseRect()` follows `ScrollRaster()`. Its layer path erases to the layer's
  backfill hook, so BPen is the closest equivalent when there is no layer. This
  one is a judgement call rather than something restored or documented.

The draw mode is left alone throughout, so `COMPLEMENT` still inverts, and a
JAM1 RastPort with `INVERSVID` set is still not cleared -- which is the
behaviour a9072ed703 introduced and this PR keeps.

Worth noting the old code was wrong twice over: besides depending on
`RectFill()` treating `INVERSVID` as a pen swap, it filled BPen in JAM1 where
the documented pen is 0. Those coincide in a default RastPort, so the second
half went unnoticed.

`GC_DRMD` is still left dirty by `RectFill()` after a `COMPLEMENT` fill, as
#894 points out. That is a real bug and orthogonal to this one; it should be
fixed in `rectfill.c` either way.

## A second `ScrollRaster()` difference

The follow-up commit fixes something the new tests found rather than anything to
do with `INVERSVID`. `ScrollRaster()` short-circuited a distance that reaches the
extent being scrolled into a fill of the whole rectangle with BPen. The reference
leaves the rectangle alone in that case -- not scrolled and not filled -- so the
short-circuit now just returns.

That is measured, not reasoned: the suite renders one tile at one pixel past the
extent and another at 4096, and the reference declines both. Neither tile is a
flat fill, and a vacated rectangle would be a single colour.

It also spells the `USE_OLD_MoveRaster` guard the way it is defined. Both
spellings evaluate to 0, so this changes nothing; the misspelling just meant the
`#if` named something that does not exist.

## Testing

p96cts now has a `ScrollRaster` group -- four scroll directions, the eight draw
modes, and a sweep of scroll distances -- which it did not when this was opened.
Nothing had covered any of these four functions before, which is exactly why
a9072ed703 passed the suite while breaking them.

All three scenes pass with this branch on a Z3660 at 640x480x8 and 640x480x24,
and on the native chipset at 320x256x8. `ScrollRaster-drawmodes` is the scene
that fails on master, and `ScrollRaster-amounts` is the one the second commit
fixes. Nothing else moved: the failures left on those runs are `DrawLine-complement`,
`BltPattern-drawmodes` and, at 24 bits, three `BltBitMap` scenes, all of which
fail identically before and after.

`ClearEOL()`, `ClearScreen()` and `EraseRect()` remain uncovered, so their share
of this change rests on the documented pen rule rather than on a measurement.

Verification of the DOpus 4 symptom from #893 is still worth having from someone
with the repro.
