### PR TITLE
pipe-handler: mark pipe filehandles as interactive streams

### DIFF
--- a/workbench/fs/pipe/pipecreate.c
+++ b/workbench/fs/pipe/pipecreate.c
@@ -256,6 +256,11 @@ OPENMEMERR1:
 
 
   handle->fh_Arg1= (IPTR) pipekey;     /* for identification on Read, Write, Close */
+
+  /* A pipe is a stream, so it wants a stream's line buffering rather than the
+     full buffering dos gives a file. */
+  handle->fh_Interactive= DOSTRUE;
+
   pkt->dp_Res1= 1;
   pkt->dp_Res2= 0;     /* for successful open */
 


### PR DESCRIPTION
`rom/dos/open.c` gives a handle line buffering when `IsInteractive()` says so, and leaves it fully buffered otherwise. Only con-handler ever sets `fh_Interactive`, so every pipe is fully buffered.

The effect on a shell running with its streams on a pipe:

- its output is held in the buffer until the buffer fills, so a separate command's output appears only when the next command is entered, while a built-in's goes out with the shell's own;
- it prints no prompt, having concluded from its input that nobody is there.

Both follow from the buffering rather than from anything about pipes, and both go away once the handler marks its filehandles as the streams they are.

One line in `pipecreate.c` where the filehandle is already being filled in. Tested on hosted aarch64: a shell on a pipe gains a prompt and its output arrives as it is written; no change to the pipe protocol or to any other handler.