### PR TITLE
dos: implement SYS_CliNumPtr

### DIFF
--- a/rom/dos/systemtaglist.c
+++ b/rom/dos/systemtaglist.c
@@ -468,6 +468,15 @@
                 if (WaitPkt() != dp)
                     Alert(AN_QPktFail);
 
+                /* The shell has run CliInit by the time it replies the
+                   startup packet, so its CLI number is valid here. */
+                {
+                    LONG *cliNumPtr = (LONG *)GetTagData(SYS_CliNumPtr, (IPTR)NULL, tags);
+
+                    if (cliNumPtr)
+                        *cliNumPtr = cliproc->pr_TaskNum;
+                }
+
                 if (fh && oldSignal) {
                     DoPkt(fh->fh_Type, ACTION_CHANGE_SIGNAL, (SIPTR)fh->fh_Arg1, oldSignal, 0, 0, 0);
                 }


### PR DESCRIPTION
`dos/dostags.h` documents the tag as:

> (LONG *) ti_Data points to a memory location in which SystemTagList will store the Cli number of the newly created cli process

Nothing ever stored it. A caller passing the tag gets its variable back untouched, with no indication that the tag did nothing.

The shell has run `CliInit` by the time it replies the startup packet, so the number is valid exactly where that reply is awaited. A caller holding it can find the process again with `FindCliProc` for as long as it lives, which is what is needed to send a break signal to a shell one has started, or otherwise address it after the fact.

Reads the tag from the caller's list rather than the filtered one, the `SYS_` tags not being passed through to `CreateNewProc`. Tested on hosted aarch64: the number comes back, `FindCliProc` resolves it, and a break delivered that way interrupts a running command in the started shell.