### PR TITLE
gfx: break a line's Bresenham tie the way the blitter does

### DIFF
--- a/rom/hidds/gfx/gfx_bitmapclass.c
+++ b/rom/hidds/gfx/gfx_bitmapclass.c
@@ -1747,7 +1747,10 @@ VOID BM__Hidd_BitMap__DrawLine
                 }
             }
     
-            if(d <= 0)
+            /* The Amiga blitter's line mode tests the sign bit of the same
+               error term, so it steps diagonally on a tie. Matching it keeps
+               a line identical whether a driver accelerates it or not. */
+            if(d < 0)
             {
                 if(t == 1)
                 {


### PR DESCRIPTION
`BitMap::DrawLine`'s software renderer steps along the major axis when the
error term is exactly zero. The Amiga blitter's line mode tests the sign bit of
the same error term - its accumulator is `4*dy - 2*dx`, twice this one's `d`,
with `BLTBMOD = 4*dy` and `BLTAMOD = 4*(dy-dx)` matching `incrE` and `incrNE` -
so it steps diagonally on a tie. This makes the two agree.

That convention is what a conforming line is measured against: P96's software
rasterizer reproduces the blitter, so a driver that accelerates lines and one
that falls through to this renderer should place the same pixels.

Measured with [p96cts](https://github.com/codewiz/p96cts) on m68k under
Copperline at PAL 320x256x8, where a planar screen has no accelerated
`DrawLine` and every diagonal reaches this code. Differing pixels out of 64000,
on a 24-ray star:

| test | before | after |
|---|---|---|
| `DrawLine-solid` | 18 | 2 |
| `DrawLine-jam2` | 18 | 2 |
| `DrawLine-inversvid` | 17 | 1 |

The residue is unrelated and still being chased: one ray loses the two pixels
of its final row, which cannot be this loop - the major axis advances on every
iteration, so it cannot end early - and so comes from something above it.
`DrawLine-pattern` and `DrawLine-complement` are unchanged, being dominated by
that and by a separate double-inversion at the pentagram's shared vertices.