### PR TITLE
pcixhci: build without debug output by default

### DIFF
--- a/rom/usb/pcixhci/mmakefile.src
+++ b/rom/usb/pcixhci/mmakefile.src
@@ -39,7 +39,7 @@ endif
 -include $(SRCDIR)/$(CURDIR)/make.opts
 
 USER_LDFLAGS := -static
-USER_CPPFLAGS += -DDEBUG=1 -DPCIUSB_XHCI_DEBUG
+#USER_CPPFLAGS += -DDEBUG=1 -DPCIUSB_XHCI_DEBUG
 
 %build_module mmake=kernel-usb-pcixhci \
     modname=pcixhci modtype=device \


### PR DESCRIPTION
The driver is currently built with `-DDEBUG=1 -DPCIUSB_XHCI_DEBUG`, so every system carrying `pcixhci.device` prints the full xHCI transfer trace at runtime and pays for the strings in the binary.

This was my mistake: the flag was flipped in fb10baf2e9, a commit that had nothing else to do with the driver and should never have touched this file. Sorry about that.

Restoring the commented-out form takes the module from 190,648 bytes back to 131,960 on aarch64, and stops the trace.