### PR TITLE
cgfx: honour srcx/srcy on WritePixelArray()'s LUT8 path

### DIFF
--- a/workbench/libs/cgfx/writepixelarray.c
+++ b/workbench/libs/cgfx/writepixelarray.c
@@ -161,8 +161,13 @@ static ULONG RenderHook(struct render_data *data, LONG srcx, LONG srcy,
     
     if (RECTFMT_LUT8 == srcformat)
     {
-        /* Actually this is the same as WriteChunkyPixels() with return value */
-        return WritePixels8(rp, src, srcmod,
+        /* Actually this is the same as WriteChunkyPixels() with return value.
+           (srcx, srcy) has to be applied here, since this returns before the
+           start_offset the other formats share below. WriteLUTPixelArray()
+           offsets its own source the same way. */
+        return WritePixels8(rp,
+                            (UBYTE *)src + CHUNKY8_COORD_TO_BYTEIDX(srcx, srcy, srcmod),
+                            srcmod,
                             destx, desty,
                             destx + width - 1, desty + height - 1,
                             NULL, TRUE);


### PR DESCRIPTION
The `RECTFMT_LUT8` branch of `WritePixelArray()` returns before the
`start_offset` computation the other formats share, so `WritePixels8()`
receives the unadjusted source pointer:

```c
if (RECTFMT_LUT8 == srcformat)
{
    /* Actually this is the same as WriteChunkyPixels() with return value */
    return WritePixels8(rp, src, srcmod, ...);   /* <- bare src */
}

bppix = GetRectFmtBytesPerPixel(srcformat, rp, CyberGfxBase);
start_offset = ((ULONG)srcy) * srcmod + srcx * bppix;   /* <- other formats */
data.array = ((UBYTE *)src) + start_offset;
```

Any LUT8 blit from a source origin other than `(0,0)` therefore reads from
the wrong place in the array. `RECTFMT_RGB`/`RGBA`/`ARGB` are unaffected,
and `WriteLUTPixelArray()` already offsets its own source with the same
`CHUNKY8_COORD_TO_BYTEIDX()` macro this patch uses.

The cybergraphics autodoc documents the arguments as
"(SrcX,SrcY) - starting point in the source rectangle", so applying the
offset is the expected behaviour.

Found with [p96cts](https://github.com/codewiz/p96cts), a P96/RTG driver
conformance suite that compares rendered scenes against references from
P96 own software rasteriser. Its `PixelArray-lut8` scene blits eight
rectangles from eight different source origins; on AROS every blitted
pixel differed (3132 of them, exactly the total blitted area), and the
values matched what the source pattern produces when walked from `(0,0)`
rather than from the requested origin. With this patch the scene passes
on `PAL 320x256x8`.