### PR TITLE
m68k-amiga/parallel: share the unit attribute base between both classes

### DIFF
--- a/arch/m68k-amiga/hidd/parallel/ParallelClass.c
+++ b/arch/m68k-amiga/hidd/parallel/ParallelClass.c
@@ -20,16 +20,13 @@
 #include <aros/debug.h>
 
 
-/*static AttrBase HiddGCAttrBase;*/
-
-static OOP_AttrBase HiddParallelUnitAB;
-
 /*** HIDDParallel::NewUnit() *********************************************************/
 
 
 OOP_Object *AmigaPar__Hidd_Parallel__NewUnit(OOP_Class *cl, OOP_Object *obj,
                                           struct pHidd_Parallel_NewUnit *msg)
 {
+        struct class_static_data *csd = CSD(cl->UserData);
         OOP_Object *su = NULL;
         struct HIDDParallelData * data = OOP_INST_DATA(cl, obj);
         ULONG unitnum = -1;

--- a/arch/m68k-amiga/hidd/parallel/ParallelUnitClass.c
+++ b/arch/m68k-amiga/hidd/parallel/ParallelUnitClass.c
@@ -36,17 +36,10 @@ void parallelunit_write_more_data();
 
 /*************************** Classes *****************************/
 
-static OOP_AttrBase HiddParallelUnitAB;
-
-static struct OOP_ABDescr attrbases[] =
-{
-    { IID_Hidd_ParallelUnit, &HiddParallelUnitAB },
-    { NULL,     NULL }
-};
-
 /******* ParallelUnit::New() ***********************************/
 OOP_Object *AmigaParUnit__Root__New(OOP_Class *cl, OOP_Object *obj, struct pRoot_New *msg)
 {
+        struct class_static_data *csd = CSD(cl->UserData);
         struct TagItem *tag, *tstate;
         ULONG unitnum = 0;
 
@@ -203,13 +196,21 @@ UWORD AmigaParUnit__Hidd_ParallelUnit__GetStatus(OOP_Class *cl, OOP_Object *o, s
 
 static int AmigaParUnit_Init(LIBBASETYPEPTR LIBBASE)
 {
-    ReturnInt("AmigaParUnit_Init", ULONG, OOP_ObtainAttrBases(attrbases));
+    struct class_static_data *csd = &LIBBASE->hdg_csd;
+
+    HiddParallelUnitAB = OOP_ObtainAttrBase(IID_Hidd_ParallelUnit);
+
+    ReturnInt("AmigaParUnit_Init", ULONG, HiddParallelUnitAB != 0);
 }
 
 
 static int AmigaParUnit_Expunge(LIBBASETYPEPTR LIBBASE)
 {
-    OOP_ReleaseAttrBases(attrbases);
+    struct class_static_data *csd = &LIBBASE->hdg_csd;
+
+    OOP_ReleaseAttrBase(IID_Hidd_ParallelUnit);
+    HiddParallelUnitAB = 0;
+
     ReturnInt("AmigaParUnit_Expunge", int, TRUE);
 }
 

--- a/arch/m68k-amiga/hidd/parallel/parallel_intern.h
+++ b/arch/m68k-amiga/hidd/parallel/parallel_intern.h
@@ -33,6 +33,7 @@ struct class_static_data
 {
     OOP_Class		 *parallelhiddclass;
     OOP_Class		 *parallelunitclass;
+    OOP_AttrBase	 hiddParallelUnitAB;
 };
 
 struct HIDDParallelUnitData
@@ -59,6 +60,14 @@ struct IntHIDDParallelBase
 };
 
 
-#define CSD(x) ((struct class_static_data *)x)
+#define CSD(x) (&((struct IntHIDDParallelBase *)x)->hdg_csd)
+
+/*
+ * Both classes need the unit attribute base, so it lives in the class static
+ * data: a per-file static leaves whichever file never obtains it expanding to
+ * zero, which turns aHidd_ParallelUnit_Unit into TAG_DONE. Functions using the
+ * aHidd_ParallelUnit_* macros need a local named "csd".
+ */
+#define HiddParallelUnitAB (csd->hiddParallelUnitAB)
 
 #endif /* PARALLEL_HIDD_INTERN_H */


### PR DESCRIPTION
`ParallelClass.c` declared its own `static OOP_AttrBase HiddParallelUnitAB` that nothing ever obtained, so `aHidd_ParallelUnit_Unit` expanded to 0 and the unit tag passed to `OOP_NewObject()` read as `TAG_DONE`. Latent rather than user-visible: with `PAR_MAX_UNITS` at 1, `ParallelUnit::New()` defaults to unit 0 regardless.

Moves the base into `class_static_data` so both classes share one copy, and fixes `CSD()`, which cast the library base straight to `struct class_static_data *` instead of reaching `hdg_csd`. It had no callers, so nothing depended on the old behaviour.

Spotted while writing a Paula serial hidd modelled on this one.