### PR TITLE
m68k-amiga: add Paula serial.hidd, make SER: work

### DIFF
--- a/arch/m68k-amiga/hidd/serial/SerialClass.c
+++ b/arch/m68k-amiga/hidd/serial/SerialClass.c
@@ -1,0 +1,103 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Paula serial hidd class implementation.
+*/
+
+#define __OOP_NOATTRBASES__
+
+#include <proto/exec.h>
+#include <proto/oop.h>
+#include <exec/libraries.h>
+
+#include <utility/tagitem.h>
+#include <hidd/serial.h>
+
+#include "serial_intern.h"
+
+#include <aros/debug.h>
+
+/*** HIDDSerial::NewUnit() *************************************************/
+
+OOP_Object *AmigaSer__Hidd_Serial__NewUnit(OOP_Class *cl, OOP_Object *obj,
+                                           struct pHidd_Serial_NewUnit *msg)
+{
+    struct class_static_data *csd = CSD(cl->UserData);
+    struct HIDDSerialData *data = OOP_INST_DATA(cl, obj);
+    OOP_Object *su = NULL;
+    ULONG unitnum = -1;
+
+    EnterFunc(bug("HIDDSerial::NewUnit()\n"));
+
+    D(bug("Request for unit number %d\n", msg->unitnum));
+
+    if (msg->unitnum >= 0 && msg->unitnum < SER_MAX_UNITS)
+    {
+        unitnum = msg->unitnum;
+
+        if (0 != (data->usedunits & (1 << unitnum)))
+            unitnum = -1;
+    }
+    else if (msg->unitnum == -1)
+    {
+        /* search for the next available unit */
+        unitnum = 0;
+
+        while (unitnum < SER_MAX_UNITS)
+        {
+            if (0 == (data->usedunits & (1 << unitnum)))
+                break;
+
+            unitnum++;
+        }
+    }
+
+    if (unitnum >= 0 && unitnum < SER_MAX_UNITS)
+    {
+        struct TagItem tags[] =
+        {
+            {aHidd_SerialUnit_Unit, unitnum},
+            {TAG_DONE                      }
+        };
+
+        su = OOP_NewObject(NULL, CLID_Hidd_SerialUnit, tags);
+        data->SerialUnits[unitnum] = su;
+
+        /* Mark it as used */
+        data->usedunits |= (1 << unitnum);
+    }
+
+    ReturnPtr("HIDDSerial::NewUnit", OOP_Object *, su);
+}
+
+/*** HIDDSerial::DisposeUnit() *********************************************/
+
+VOID AmigaSer__Hidd_Serial__DisposeUnit(OOP_Class *cl, OOP_Object *obj,
+                                        struct pHidd_Serial_DisposeUnit *msg)
+{
+    struct HIDDSerialData *data = OOP_INST_DATA(cl, obj);
+    OOP_Object *su = msg->unit;
+
+    EnterFunc(bug("HIDDSerial::DisposeUnit()\n"));
+
+    if (su)
+    {
+        ULONG unitnum = 0;
+
+        while (unitnum < SER_MAX_UNITS)
+        {
+            if (data->SerialUnits[unitnum] == su)
+            {
+                D(bug("Disposing SerialUnit!\n"));
+                OOP_DisposeObject(su);
+                data->SerialUnits[unitnum] = NULL;
+                data->usedunits &= ~(1 << unitnum);
+                break;
+            }
+
+            unitnum++;
+        }
+    }
+
+    ReturnVoid("HIDDSerial::DisposeUnit");
+}

--- a/arch/m68k-amiga/hidd/serial/SerialUnitClass.c
+++ b/arch/m68k-amiga/hidd/serial/SerialUnitClass.c
@@ -1,0 +1,397 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Paula serial unit hidd class implementation.
+*/
+
+/*
+  This driver talks to Paula's UART: one write register (SERDAT), one read
+  register (SERDATR), one baud divisor (SERPER) and two interrupts, TBE and
+  RBF, which the kernel dispatches from level 1 and level 5 respectively
+  (see arch/m68k-amiga/kernel/amiga_irq.c).
+
+  Write() hands the UART one byte and returns 1; serial.device then keeps the
+  request active and feeds the rest from the TBE interrupt. Paula double
+  buffers SERDAT against its shift register, so one byte in flight per
+  interrupt keeps the line saturated.
+
+  The port stays shared with the kernel's own debug output, which writes SERDAT
+  directly from krnPutC(). That works because krnPutC() only writes once TBE
+  says the buffer is free, and because every drain raises TBE regardless of who
+  filled it: a debug character simply causes one extra callback, which sends
+  the next queued byte early rather than losing it. The short spin in Write()
+  covers the converse race, where krnPutC() takes the buffer between the
+  interrupt firing and us refilling it; without it a lost TBE would strand the
+  write queue permanently.
+*/
+
+#define __OOP_NOATTRBASES__
+
+#include <proto/exec.h>
+#include <proto/utility.h>
+#include <proto/oop.h>
+
+#include <exec/libraries.h>
+#include <exec/interrupts.h>
+#include <aros/symbolsets.h>
+
+#include <utility/tagitem.h>
+#include <hidd/serial.h>
+#include <hardware/intbits.h>
+#include <devices/serial.h>
+
+#include "serial_intern.h"
+
+#include LC_LIBDEFS_FILE
+
+#include <aros/debug.h>
+
+/******* SerialUnit::New() *************************************************/
+OOP_Object *AmigaSerUnit__Root__New(OOP_Class *cl, OOP_Object *obj,
+                                    struct pRoot_New *msg)
+{
+    struct class_static_data *csd = CSD(cl->UserData);
+    struct TagItem *tag, *tstate;
+    ULONG unitnum = 0;
+
+    EnterFunc(bug("SerialUnit::New()\n"));
+
+    tstate = msg->attrList;
+    while ((tag = NextTagItem(&tstate)))
+    {
+        ULONG idx;
+
+        if (IS_HIDDSERIALUNIT_ATTR(tag->ti_Tag, idx))
+        {
+            switch (idx)
+            {
+                case aoHidd_SerialUnit_Unit:
+                    unitnum = (ULONG)tag->ti_Data;
+                break;
+            }
+        }
+    }
+
+    if (unitnum != 0)
+        ReturnPtr("SerialUnit::New()", OOP_Object *, NULL);
+
+    obj = (OOP_Object *)OOP_DoSuperMethod(cl, obj, (OOP_Msg)msg);
+
+    if (obj)
+    {
+        struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, obj);
+
+        data->unitnum = unitnum;
+    }
+
+    ReturnPtr("SerialUnit::New()", OOP_Object *, obj);
+}
+
+/******* SerialUnit::Dispose() *********************************************/
+OOP_Object *AmigaSerUnit__Root__Dispose(OOP_Class *cl, OOP_Object *obj,
+                                        OOP_Msg msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, obj);
+
+    EnterFunc(bug("SerialUnit::Dispose()\n"));
+
+    if (data->intsadded)
+    {
+        RemIntServer(INTB_RBF, &data->rbfint);
+        RemIntServer(INTB_TBE, &data->tbeint);
+        data->intsadded = FALSE;
+    }
+
+    OOP_DoSuperMethod(cl, obj, (OOP_Msg)msg);
+    ReturnPtr("SerialUnit::Dispose()", OOP_Object *, obj);
+}
+
+/*
+ * The kernel clears INTREQ before running the server chain, so this only has
+ * to collect the byte. SERDATR keeps the data until the next one arrives.
+ */
+static AROS_INTH1(serial_rbf_interrupt, struct HIDDSerialUnitData *, data)
+{
+    AROS_INTFUNC_INIT
+
+    UBYTE c = SERDATR_DB8_of(custom_r(SERDATR));
+
+    if (data->DataReceivedCallBack)
+        data->DataReceivedCallBack(&c, 1, data->unitnum, data->DataReceivedUserData);
+
+    return FALSE;
+
+    AROS_INTFUNC_EXIT
+}
+
+/*
+ * SERDAT has drained. Ask the upper layer for the next byte; it answers by
+ * calling Write() below. Debug output raises this too, in which case there is
+ * usually no pending write and the callback does nothing.
+ */
+static AROS_INTH1(serial_tbe_interrupt, struct HIDDSerialUnitData *, data)
+{
+    AROS_INTFUNC_INIT
+
+    if (data->DataWriteCallBack)
+        data->DataWriteCallBack(data->unitnum, data->DataWriteUserData);
+
+    return FALSE;
+
+    AROS_INTFUNC_EXIT
+}
+
+/******* SerialUnit::Init() ************************************************/
+BOOL AmigaSerUnit__Hidd_SerialUnit__Init(OOP_Class *cl, OOP_Object *o,
+                                         struct pHidd_SerialUnit_Init *msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, o);
+
+    EnterFunc(bug("SerialUnit::Init()\n"));
+
+    Disable();
+    data->DataReceivedCallBack = msg->DataReceived;
+    data->DataReceivedUserData = msg->DataReceivedUserData;
+    data->DataWriteCallBack    = msg->WriteData;
+    data->DataWriteUserData    = msg->WriteDataUserData;
+    Enable();
+
+    if (!data->intsadded)
+    {
+        data->rbfint.is_Node.ln_Pri = 0;
+        data->rbfint.is_Node.ln_Type = NT_INTERRUPT;
+        data->rbfint.is_Node.ln_Name = "ser rx";
+        data->rbfint.is_Code = (VOID_FUNC)serial_rbf_interrupt;
+        data->rbfint.is_Data = data;
+
+        data->tbeint.is_Node.ln_Pri = 0;
+        data->tbeint.is_Node.ln_Type = NT_INTERRUPT;
+        data->tbeint.is_Node.ln_Name = "ser tx";
+        data->tbeint.is_Code = (VOID_FUNC)serial_tbe_interrupt;
+        data->tbeint.is_Data = data;
+
+        /* Unmasks the bit for us, and RemIntServer() masks it again once
+           the chain empties. */
+        AddIntServer(INTB_RBF, &data->rbfint);
+        AddIntServer(INTB_TBE, &data->tbeint);
+        data->intsadded = TRUE;
+    }
+
+    ReturnBool("SerialUnit::Init()", TRUE);
+}
+
+/******* SerialUnit::Write() ***********************************************/
+ULONG AmigaSerUnit__Hidd_SerialUnit__Write(OOP_Class *cl, OOP_Object *o,
+                                           struct pHidd_SerialUnit_Write *msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, o);
+
+    EnterFunc(bug("SerialUnit::Write()\n"));
+
+    /* If the output is currently stopped just don't do anything here. */
+    if (TRUE == data->stopped || msg->Length < 1)
+        return 0;
+
+    /*
+     * Normally TBE is already set, since this runs either from the interrupt
+     * that reported the drain or with the line idle. It is only not set when
+     * debug output slipped a character in first, and then the wait is bounded
+     * by one character time. Returning 0 here instead would end the write: the
+     * byte that would have raised the next TBE never gets sent.
+     */
+    while ((custom_r(SERDATR) & SERDATR_TBE) == 0)
+        ;
+
+    custom_w(SERDAT, SERDAT_STP8 | SERDAT_DB8(msg->Outbuffer[0]));
+
+    ReturnInt("SerialUnit::Write()", ULONG, 1);
+}
+
+/***************************************************************************/
+
+/*
+ * Anything the 15-bit SERPER divisor can express. The bottom end is where the
+ * divisor saturates; the top is Paula's documented ceiling.
+ */
+static ULONG valid_baudrates[] =
+{
+    (SERPER_BASE_PAL / (SERPER_DIVISOR_MAX + 1)) | LIMIT_LOWER_BOUND,
+    115200 | LIMIT_UPPER_BOUND,
+    ~0
+};
+
+static ULONG valid_datalengths[] =
+{
+    8,
+    ~0
+};
+
+/******* SerialUnit::SetBaudrate() *****************************************/
+BOOL AmigaSerUnit__Hidd_SerialUnit__SetBaudrate(OOP_Class *cl, OOP_Object *o,
+                                                struct pHidd_SerialUnit_SetBaudrate *msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, o);
+    ULONG divisor;
+
+    EnterFunc(bug("SerialUnit::SetBaudrate()\n"));
+
+    if (msg->baudrate == 0)
+        ReturnBool("SerialUnit::SetBaudrate()", FALSE);
+
+    divisor = SERPER_BAUD(SERPER_BASE_PAL, msg->baudrate);
+
+    if (divisor > SERPER_DIVISOR_MAX)
+        ReturnBool("SerialUnit::SetBaudrate()", FALSE);
+
+    /*
+     * SERPER is the whole of Paula's line configuration and it is shared with
+     * the kernel's debug output, which never reprograms it. Anything but the
+     * rate the bootstrap chose therefore rebauds the debug stream as well.
+     */
+    custom_w(SERPER, (UWORD)divisor);
+    data->baudrate = msg->baudrate;
+
+    ReturnBool("SerialUnit::SetBaudrate()", TRUE);
+}
+
+/******* SerialUnit::SetParameters() ***************************************/
+BOOL AmigaSerUnit__Hidd_SerialUnit__SetParameters(OOP_Class *cl, OOP_Object *o,
+                                                  struct pHidd_SerialUnit_SetParameters *msg)
+{
+    struct TagItem *tag, *tstate = msg->tags;
+
+    EnterFunc(bug("SerialUnit::SetParameters()\n"));
+
+    /*
+     * 8N1 only. Paula can do 7 or 9 data bits and 2 stop bits, but nothing
+     * here needs them yet.
+     */
+    while ((tag = NextTagItem(&tstate)))
+    {
+        switch (tag->ti_Tag)
+        {
+            case TAG_DATALENGTH:
+                if (tag->ti_Data != 8)
+                    ReturnBool("SerialUnit::SetParameters()", FALSE);
+            break;
+
+            case TAG_STOP_BITS:
+                if (tag->ti_Data != 1)
+                    ReturnBool("SerialUnit::SetParameters()", FALSE);
+            break;
+
+            case TAG_PARITY:
+                ReturnBool("SerialUnit::SetParameters()", FALSE);
+            break;
+        }
+    }
+
+    ReturnBool("SerialUnit::SetParameters()", TRUE);
+}
+
+/******* SerialUnit::SendBreak() *******************************************/
+BYTE AmigaSerUnit__Hidd_SerialUnit__SendBreak(OOP_Class *cl, OOP_Object *o,
+                                              struct pHidd_SerialUnit_SendBreak *msg)
+{
+    EnterFunc(bug("SerialUnit::SendBreak()\n"));
+
+    return SerErr_LineErr;
+}
+
+/******* SerialUnit::Start() ***********************************************/
+VOID AmigaSerUnit__Hidd_SerialUnit__Start(OOP_Class *cl, OOP_Object *o,
+                                          struct pHidd_SerialUnit_Start *msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, o);
+
+    EnterFunc(bug("SerialUnit::Start()\n"));
+
+    /*
+     * Allow output again and pull whatever queued up while stopped. The flag
+     * has to be cleared first or the Write() that callback drives would refuse
+     * the data all over again.
+     */
+    if (TRUE == data->stopped)
+    {
+        data->stopped = FALSE;
+
+        if (NULL != data->DataWriteCallBack)
+            data->DataWriteCallBack(data->unitnum, data->DataWriteUserData);
+    }
+}
+
+/******* SerialUnit::Stop() ************************************************/
+VOID AmigaSerUnit__Hidd_SerialUnit__Stop(OOP_Class *cl, OOP_Object *o,
+                                         struct pHidd_SerialUnit_Stop *msg)
+{
+    struct HIDDSerialUnitData *data = OOP_INST_DATA(cl, o);
+
+    EnterFunc(bug("SerialUnit::Stop()\n"));
+
+    data->stopped = TRUE;
+}
+
+/****** SerialUnit::GetCapabilities ****************************************/
+VOID AmigaSerUnit__Hidd_SerialUnit__GetCapabilities(OOP_Class *cl, OOP_Object *o,
+                                                    struct TagItem *tags)
+{
+    if (NULL != tags)
+    {
+        int i = 0;
+        BOOL end = FALSE;
+
+        while (FALSE == end)
+        {
+            switch (tags[i].ti_Tag)
+            {
+                case HIDDA_SerialUnit_BPSRate:
+                    tags[i].ti_Data = (STACKIPTR)valid_baudrates;
+                break;
+
+                case HIDDA_SerialUnit_DataLength:
+                    tags[i].ti_Data = (STACKIPTR)valid_datalengths;
+                break;
+
+                case TAG_DONE:
+                    end = TRUE;
+                break;
+            }
+            i++;
+        }
+    }
+}
+
+/****** SerialUnit::GetStatus **********************************************/
+UWORD AmigaSerUnit__Hidd_SerialUnit__GetStatus(OOP_Class *cl, OOP_Object *o,
+                                               struct pHidd_SerialUnit_GetStatus *msg)
+{
+    /*
+     * CIA-B port A carries DSR, CTS, CD and DTR on bits 3, 4, 5 and 7, which
+     * is where io_Status wants them; they are just active low.
+     */
+    return (UWORD)((~(*CIAB_PRA)) & CIAB_PRA_HANDSHAKE);
+}
+
+/******* init_serialunitclass **********************************************/
+
+static int AmigaSerUnit_Init(LIBBASETYPEPTR LIBBASE)
+{
+    struct class_static_data *csd = &LIBBASE->hdg_csd;
+
+    __IHidd_SerialUnitAB = OOP_ObtainAttrBase(IID_Hidd_SerialUnit);
+
+    ReturnInt("AmigaSerUnit_Init", int, __IHidd_SerialUnitAB != 0);
+}
+
+static int AmigaSerUnit_Expunge(LIBBASETYPEPTR LIBBASE)
+{
+    struct class_static_data *csd = &LIBBASE->hdg_csd;
+
+    OOP_ReleaseAttrBase(IID_Hidd_SerialUnit);
+    __IHidd_SerialUnitAB = 0;
+
+    ReturnInt("AmigaSerUnit_Expunge", int, TRUE);
+}
+
+ADD2INITLIB(AmigaSerUnit_Init, 0)
+ADD2EXPUNGELIB(AmigaSerUnit_Expunge, 0)

--- a/arch/m68k-amiga/hidd/serial/mmakefile.src
+++ b/arch/m68k-amiga/hidd/serial/mmakefile.src
@@ -1,0 +1,14 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+FILES	:=	SerialClass SerialUnitClass
+
+#MM- workbench-devs-amiga-m68k: amiga-m68k-hidd-serial
+
+#USER_CPPFLAGS := -DDEBUG=1
+USER_LDFLAGS := -static
+
+%build_module mmake=amiga-m68k-hidd-serial \
+  modname=serial modtype=hidd \
+  files=$(FILES) \
+  uselibs="hiddstubs"

--- a/arch/m68k-amiga/hidd/serial/serial.conf
+++ b/arch/m68k-amiga/hidd/serial/serial.conf
@@ -1,0 +1,49 @@
+##begin config
+basename       AmigaSer
+libbasetype    struct IntHIDDSerialBase
+version	       1.0
+residentpri    9
+classptr_field hdg_csd.serialhiddclass
+classid        CLID_Hidd_Serial
+superclass     CLID_Root
+classdatatype  struct HIDDSerialData
+options        noexpunge
+##end config
+
+##begin cdefprivate
+#include "serial_intern.h"
+##end cdefprivate
+
+##begin methodlist
+.interface Hidd_Serial
+NewUnit
+DisposeUnit
+##end methodlist
+
+
+##begin class
+##begin config
+basename       AmigaSerUnit
+type           hidd
+classid        CLID_Hidd_SerialUnit
+superclass     CLID_Root
+classptr_field hdg_csd.serialunitclass
+classdatatype  struct HIDDSerialUnitData
+##end config
+
+##begin methodlist
+.interface Root
+New
+Dispose
+.interface Hidd_SerialUnit
+Init
+Write
+SetBaudrate
+SetParameters
+SendBreak
+Start
+Stop
+GetCapabilities
+GetStatus
+##end methodlist
+##end class

--- a/arch/m68k-amiga/hidd/serial/serial_intern.h
+++ b/arch/m68k-amiga/hidd/serial/serial_intern.h
@@ -1,0 +1,117 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Paula serial hidd private definitions.
+*/
+
+#ifndef SERIAL_HIDD_INTERN_H
+#define SERIAL_HIDD_INTERN_H
+
+#ifndef EXEC_LIBRARIES_H
+#   include <exec/libraries.h>
+#endif
+#ifndef OOP_OOP_H
+#   include <oop/oop.h>
+#endif
+#ifndef HIDD_SERIAL_H
+#   include <hidd/serial.h>
+#endif
+#include <exec/interrupts.h>
+#include <dos/dos.h>
+
+/* Paula has exactly one UART. */
+#define SER_MAX_UNITS   1
+
+/* Custom chip registers, same names as arch/m68k-amiga/kernel/kernel_debug.c. */
+#define SERDATR                 0x18
+#define   SERDATR_OVRUN         (1 << 15)       /* Overrun */
+#define   SERDATR_RBF           (1 << 14)       /* Rx Buffer Full */
+#define   SERDATR_TBE           (1 << 13)       /* Tx Buffer Empty */
+#define   SERDATR_TSRE          (1 << 12)       /* Tx Shift Empty */
+#define   SERDATR_DB8_of(x)     ((x) & 0xff)    /* 8-bit data */
+#define SERDAT                  0x30
+#define   SERDAT_STP8           (1 << 8)        /* Stop bit for 8 data bits */
+#define   SERDAT_DB8(x)         ((x) & 0xff)
+#define SERPER                  0x32
+
+/*
+ * The bootstrap programs SERPER from the PAL colour clock unconditionally
+ * (arch/m68k-amiga/boot/debug.c, arch/m68k-amiga/c/AROSBootstrap.c), so using
+ * the same base here means asking for the rate it already set reproduces its
+ * divisor exactly and leaves the debug stream untouched. On NTSC machines both
+ * are equally off, which is a pre-existing quirk rather than one added here.
+ */
+#define SERPER_BASE_PAL         3546895
+#define SERPER_BAUD(base, x)    ((((base) + (x)/2)/(x) - 1) & 0x7fff)
+#define SERPER_DIVISOR_MAX      0x7fff
+
+/* CIA-B port A carries the handshake lines, all active low. */
+#define CIAB_PRA                ((volatile UBYTE *)0xbfd000)
+#define   CIAB_PRA_HANDSHAKE    0xb8            /* DSR, CTS, CD, DTR */
+
+static inline void custom_w(ULONG reg, UWORD val)
+{
+    volatile UWORD *r = (volatile UWORD *)(0xdff000 + reg);
+
+    *r = val;
+}
+
+static inline UWORD custom_r(ULONG reg)
+{
+    volatile UWORD *r = (volatile UWORD *)(0xdff000 + reg);
+
+    return *r;
+}
+
+struct HIDDSerialData
+{
+    OOP_Class   *SerialHIDDClass;
+
+    OOP_Object  *SerialUnits[SER_MAX_UNITS];
+    UBYTE       usedunits;
+};
+
+struct class_static_data
+{
+    OOP_Class    *serialhiddclass;
+    OOP_Class    *serialunitclass;
+    OOP_AttrBase hiddSerialUnitAB;
+};
+
+struct HIDDSerialUnitData
+{
+    ULONG (*DataWriteCallBack)(ULONG unitnum, APTR userdata);
+    VOID  (*DataReceivedCallBack)(UBYTE *buffer, ULONG len, ULONG unitnum, APTR userdata);
+    VOID  *DataWriteUserData;
+    VOID  *DataReceivedUserData;
+
+    ULONG            unitnum;
+    ULONG            baudrate;
+    BOOL             stopped;
+
+    struct Interrupt rbfint;
+    struct Interrupt tbeint;
+    BOOL             intsadded;
+};
+
+/* Library base */
+
+struct IntHIDDSerialBase
+{
+    struct Library            hdg_LibNode;
+
+    struct class_static_data  hdg_csd;
+};
+
+#define CSD(x) (&((struct IntHIDDSerialBase *)x)->hdg_csd)
+
+/*
+ * hidd/serial.h spells the unit attribute base this way but leaves it to the
+ * driver to define, unlike hidd/parallel.h which declares its own. Keeping it
+ * in the class static data means both classes share the one base; a per-file
+ * static would leave whichever file never obtains it expanding to zero.
+ * Functions using the aHidd_SerialUnit_* macros need a local named "csd".
+ */
+#define __IHidd_SerialUnitAB    (csd->hiddSerialUnitAB)
+
+#endif /* SERIAL_HIDD_INTERN_H */

--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -195,9 +195,13 @@ LONG checkLine(ShellState *ss, Buffer *in, Buffer *out, BOOL echo)
 {
     struct CommandLineInterface *cli = Cli();
     BOOL haveCommand = FALSE;
+    BOOL convertFailed = FALSE;
     LONG result;
 
     result = convertLine(ss, in, out, &haveCommand);
+
+    if (result != 0)
+        convertFailed = TRUE;
 
     if (result == 0)
     {
@@ -239,10 +243,18 @@ LONG checkLine(ShellState *ss, Buffer *in, Buffer *out, BOOL echo)
         D(bug("convertLine: error = %ld faillevel=%ld\n", result,
             cli->cli_FailLevel));
         cli->cli_Result2 = result;
+
+        /*
+         * executeLine() reports its own failures. Everything convertLine()
+         * rejects, above all a redirection whose file would not open, used to
+         * reach here and go no further than Result2, so the command simply did
+         * not run and said nothing about it.
+         */
+        if (convertFailed)
+            PrintFault(result, NULL);
     }
 
 exit:
-    /* FIXME error handling is bullshit */
 
     cliVarNum(ss, "RC", cli->cli_ReturnCode);
     cliVarNum(ss, "Result2", cli->cli_Result2);

--- a/workbench/devs/DOSDrivers/SER0
+++ b/workbench/devs/DOSDrivers/SER0
@@ -1,4 +1,4 @@
-Handler = port-handler
+EHandler = port-handler
 Priority = 5
 GlobVec  = -1
 Device   = serial.device

--- a/workbench/devs/DOSDrivers/SER1
+++ b/workbench/devs/DOSDrivers/SER1
@@ -1,4 +1,4 @@
-Handler = port-handler
+EHandler = port-handler
 Priority = 5
 GlobVec = -1
 Device   = serial.device

--- a/workbench/fs/port/port-handler.c
+++ b/workbench/fs/port/port-handler.c
@@ -9,6 +9,7 @@
 
 #include <aros/debug.h>
 
+#include <exec/errors.h>
 #include <intuition/preferences.h>      /* DEVNAME_SIZE */
 #include <devices/serial.h>
 #include <devices/printer.h>
@@ -270,6 +271,8 @@ static struct portArgs *portOpen(struct portBase *pb, struct portArgs *pa, BPTR 
     int len = AROS_BSTR_strlen(name);
     struct ExecBase *SysBase = pb->pb_SysBase;
 
+    *err = 0;
+
     if ((pa = AllocVec(sizeof(*pa) + len + 1, MEMF_ANY))) {
         CopyMem(&pb->pb_Defaults, pa, sizeof(*pa));
 
@@ -287,7 +290,10 @@ static struct portArgs *portOpen(struct portBase *pb, struct portArgs *pa, BPTR 
 
         if ((pa->pa_IOMsg = CreateMsgPort())) {
             if ((pa->pa_IO = (APTR)CreateIORequest(pa->pa_IOMsg, sizeof(*pa->pa_IO)))) {
-                if (0 == OpenDevice(pb->pb_DeviceName, pa->pa_DeviceUnit, (struct IORequest *)pa->pa_IO, pb->pb_DeviceFlags)) {
+                LONG ioerr;
+
+                ioerr = OpenDevice(pb->pb_DeviceName, pa->pa_DeviceUnit, (struct IORequest *)pa->pa_IO, pb->pb_DeviceFlags);
+                if (0 == ioerr) {
                     D(bug("%s: Device is open\n", __func__));
                     *err = 0;
                     if (pb->pb_Mode != PORT_SERIAL) {
@@ -313,7 +319,16 @@ static struct portArgs *portOpen(struct portBase *pb, struct portArgs *pa, BPTR 
                         AddTail(&pb->pb_Files, &pa->pa_Node);
                         return pa;
                     }
+                    /* The device is fine, it just would not take these
+                       settings: baud rate, data length or stop bits. */
+                    *err = ERROR_BAD_NUMBER;
                     CloseDevice((struct IORequest *)pa->pa_IO);
+                } else {
+                    /* IOERR_OPENFAIL says nothing beyond "no", but a device
+                       that reports anything else has a working driver and is
+                       refusing this particular unit. */
+                    *err = (ioerr == IOERR_OPENFAIL) ? ERROR_DEVICE_NOT_MOUNTED
+                                                     : ERROR_OBJECT_IN_USE;
                 }
                 DeleteIORequest((struct IORequest *)pa->pa_IO);
             }
@@ -322,8 +337,9 @@ static struct portArgs *portOpen(struct portBase *pb, struct portArgs *pa, BPTR 
         FreeVec(pa);
     }
 
-    D(bug("%s: Didn't open device\n", __func__));
-    *err = ERROR_NO_DISK;
+    D(bug("%s: Didn't open device, error %ld\n", __func__, *err));
+    if (*err == 0)
+        *err = ERROR_NO_FREE_STORE;
     return NULL;
 }
 

--- a/workbench/fs/port/port-handler.c
+++ b/workbench/fs/port/port-handler.c
@@ -177,13 +177,14 @@ static SIPTR decodeArgs(struct portBase *pb, struct portArgs *pa, BSTR args)
 
 static void portSerialDefaults(struct portArgs *pa)
 {
-#ifdef __mc68000
-    /* 9600 */
-    pa->pa_Serial.ps_Baud = 9600;
-#else
-    /* 115200 */
+    /*
+     * 115200. On m68k this used to be 9600, from before there was a serial
+     * driver to honour it. Paula's UART is also the kernel's debug console and
+     * its one baud register is shared, so a SER: open at any other rate takes
+     * the debug output down with it; 115200 is what the bootstrap sets, and
+     * what every other architecture already defaults to.
+     */
     pa->pa_Serial.ps_Baud = 115200;
-#endif
     /* 8N1 */
     pa->pa_Serial.ps_LenBits = 8;
     pa->pa_Serial.ps_StopBits = 1;


### PR DESCRIPTION
serial.device opens `DRIVERS:serial.hidd` and fails to initialise without one, and no m68k driver for Paula's UART existed, so `SER:` has never worked on Amiga hardware. The existing serial hidds are both 16550 drivers: `i386-pc` is the maintained one and served as the model, `ppc-sam440` no longer compiles.

Transmit and receive are both interrupt driven (`INTB_TBE` / `INTB_RBF`), which the kernel already dispatches from levels 1 and 5. The port stays usable alongside the kernel's debug output, which writes SERDAT directly from `krnPutC()`: that only writes once TBE reports the buffer free, and every drain raises TBE whoever caused it, so a debug character costs one extra callback rather than a lost byte. `Write()` keeps a short bounded spin on TBE to close the converse race, since `WBE_InterruptHandler` ends the transfer on a short write and nothing would then be in flight to raise the next interrupt.

`SetBaudrate()` programs SERPER from the same PAL colour clock the bootstrap uses, so requesting the rate it already set reproduces its divisor exactly and leaves the debug stream alone. Any other rate rebauds that stream too, since SERPER is the whole of Paula's line configuration. 8N1 only for now.

The remaining commits are the things that had to be fixed before `SER:` was actually usable, each independent of the driver:

- **DOSDrivers**: `SER0`/`SER1` declared `Handler = port-handler`, but Mount only builds a FileSysStartupMsg for `EHandler` and `FileSystem` entries, so their `Device`, `Unit`, `Baud` and `Control` were parsed and thrown away. Both fell back to port-handler's built-in default of serial.device unit 0, which made `SER1:` a second name for `SER0:`.
- **Shell**: a redirection whose file would not open set `Result2` and nothing else, so the command silently did not run. `echo >no/such/path` succeeded quietly.
- **port-handler**: every open failure returned `ERROR_NO_DISK`, so a busy unit and a rejected baud rate both surfaced as "no disk in drive".
- **port-handler**: `SER:` defaulted to 9600 on m68k only, from before there was a driver to honour it. Paula's single baud register is shared with the kernel debug console, so that rebauded debug output too.

Tested on Amiberry and Copperline: input and output both work, `SER1:` is refused with a sensible error, and failed redirections now report.