### PR TITLE
wanderer: leave named volumes off the desktop

### DIFF
--- a/workbench/system/Wanderer/Classes/iconlist_attributes.h
+++ b/workbench/system/Wanderer/Classes/iconlist_attributes.h
@@ -146,6 +146,10 @@ enum iconlist_LabelRenderModes
 #define MUIA_IconDrawerList_Drawer    (MUIB_IconDrawerList | 0x00000000)      /* Zune: V1  isg LONG     */
 
 /*** Identifier base ********************************************************/
-#define MUIB_IconVolumeList           (MUIB_ZUNE | 0x00044000)  
+#define MUIB_IconVolumeList           (MUIB_ZUNE | 0x00044000)
+
+/*** Attributes *************************************************************/
+/* Newline separated volume or device names to leave out of the list. */
+#define MUIA_IconVolumeList_HiddenVolumes (MUIB_IconVolumeList | 0x00000000)    /* Zune: V1  .sg STRPTR   */
 
 #endif /* _MUI_CLASSES_ICONLIST_ATTRIBUTES_H */

--- a/workbench/system/Wanderer/Classes/iconvolumelist.c
+++ b/workbench/system/Wanderer/Classes/iconvolumelist.c
@@ -471,6 +471,56 @@ IPTR IconVolumeList__OM_NEW(struct IClass *CLASS, Object * obj,
 
 ///
 
+///OM_DISPOSE()
+IPTR IconVolumeList__OM_DISPOSE(struct IClass * CLASS, Object * obj, Msg message)
+{
+    struct IconVolumeList_DATA *data = INST_DATA(CLASS, obj);
+
+    D(bug("[IconVolumeList]: %s()\n", __func__));
+
+    if (data->ivld_HiddenVolumes)
+        FreeVec(data->ivld_HiddenVolumes);
+
+    return DoSuperMethodA(CLASS, obj, message);
+}
+
+///
+
+///OM_SET()
+IPTR IconVolumeList__OM_SET(struct IClass * CLASS, Object * obj,
+    struct opSet * message)
+{
+    struct IconVolumeList_DATA *data = INST_DATA(CLASS, obj);
+    struct TagItem *tstate = message->ops_AttrList;
+    struct TagItem *tag;
+
+    D(bug("[IconVolumeList]: %s()\n", __func__));
+
+    while ((tag = NextTagItem((struct TagItem **)&tstate)) != NULL)
+    {
+        switch (tag->ti_Tag)
+        {
+        case MUIA_IconVolumeList_HiddenVolumes:
+            {
+                STRPTR names = (STRPTR) tag->ti_Data;
+                STRPTR copy = NULL;
+
+                if (names && (copy = AllocVec(strlen(names) + 1, MEMF_ANY)))
+                    strcpy(copy, names);
+
+                if (data->ivld_HiddenVolumes)
+                    FreeVec(data->ivld_HiddenVolumes);
+                data->ivld_HiddenVolumes = copy;
+            }
+            break;
+        }
+    }
+
+    return DoSuperMethodA(CLASS, obj, (Msg) message);
+}
+
+///
+
 static BOOL MatchIconlistNames(char *entryname, char *matchname)
 {
     char *enend;
@@ -489,6 +539,54 @@ static BOOL MatchIconlistNames(char *entryname, char *matchname)
 
     if ((enlen == mnlen)&& (strncasecmp(entryname, matchname, enlen) == 0))
         return TRUE;
+    return FALSE;
+}
+
+/*
+ * Is this volume named in the newline separated list of names to leave out?
+ * Either the volume name or the name of the device carrying it will do, so
+ * that a volume which has no name of its own can still be named.
+ */
+static BOOL VolumeIsHidden(CONST_STRPTR hidden, struct DOSVolumeNode *dvn)
+{
+    CONST_STRPTR entry = hidden;
+
+    if (!hidden)
+        return FALSE;
+
+    while (*entry)
+    {
+        CONST_STRPTR end = strchr(entry, '\n');
+        LONG len = end ? (LONG)(end - entry) : (LONG)strlen(entry);
+
+        /* Tolerate a trailing colon and surrounding blanks in the stored name */
+        while (len > 0 && (entry[len - 1] == ':' || entry[len - 1] == ' '
+                || entry[len - 1] == '\r' || entry[len - 1] == '\t'))
+            len--;
+        while (len > 0 && *entry == ' ')
+        {
+            entry++;
+            len--;
+        }
+
+        if (len > 0)
+        {
+            if ((dvn->dvn_VolName
+                    && strncasecmp(dvn->dvn_VolName, entry, len) == 0
+                    && (dvn->dvn_VolName[len] == ':'
+                        || dvn->dvn_VolName[len] == '\0'))
+                || (dvn->dvn_DosName
+                    && strncasecmp(dvn->dvn_DosName, entry, len) == 0
+                    && (dvn->dvn_DosName[len] == ':'
+                        || dvn->dvn_DosName[len] == '\0')))
+                return TRUE;
+        }
+
+        if (!end)
+            break;
+        entry = end + 1;
+    }
+
     return FALSE;
 }
 
@@ -522,7 +620,7 @@ MUIM_IconList_Update
 IPTR IconVolumeList__MUIM_IconList_Update(struct IClass * CLASS,
     Object * obj, struct MUIP_IconList_Update * message)
 {
-    //struct IconVolumeList_DATA *data = INST_DATA(CLASS, obj);
+    struct IconVolumeList_DATA *data = INST_DATA(CLASS, obj);
     struct IconEntry *this_Icon = NULL;
     struct DOSVolumeList *dvl = NULL;
     struct DOSVolumeNode *dvn = NULL;
@@ -554,6 +652,13 @@ IPTR IconVolumeList__MUIM_IconList_Update(struct IClass * CLASS,
 
                     D(bug("[IconVolumeList] %s: DOSList Entry '%s'\n",
                             __func__, dvn->dvn_VolName));
+
+                    if (VolumeIsHidden(data->ivld_HiddenVolumes, dvn))
+                    {
+                        D(bug("[IconVolumeList] %s: '%s' is hidden\n",
+                                __func__, dvn->dvn_VolName));
+                        continue;
+                    }
 
                     if (dvn->dvn_Flags & ICONENTRY_VOL_OFFLINE)
                         devname = dvn->dvn_VolName;
@@ -783,6 +888,9 @@ IPTR IconVolumeList__OM_GET(struct IClass * CLASS, Object * obj,
     case MUIA_Revision:
         STORE = (IPTR) 3;
         return 1;
+    case MUIA_IconVolumeList_HiddenVolumes:
+        STORE = (IPTR) ((struct IconVolumeList_DATA *)INST_DATA(CLASS, obj))->ivld_HiddenVolumes;
+        return 1;
     }
 
     return DoSuperMethodA(CLASS, obj, (Msg) message);
@@ -798,6 +906,10 @@ BOOPSI_DISPATCHER(IPTR, IconVolumeList_Dispatcher, CLASS, obj, message)
     {
     case OM_NEW:
         return IconVolumeList__OM_NEW(CLASS, obj, (struct opSet *)message);
+    case OM_DISPOSE:
+        return IconVolumeList__OM_DISPOSE(CLASS, obj, message);
+    case OM_SET:
+        return IconVolumeList__OM_SET(CLASS, obj, (struct opSet *)message);
     case OM_GET:
         return IconVolumeList__OM_GET(CLASS, obj, (struct opGet *)message);
     case MUIM_IconList_Update:

--- a/workbench/system/Wanderer/Classes/iconvolumelist.conf
+++ b/workbench/system/Wanderer/Classes/iconvolumelist.conf
@@ -16,6 +16,8 @@ classdatatype struct IconVolumeList_DATA
 
 ##begin methodlist
 OM_NEW
+OM_DISPOSE
+OM_SET
 OM_GET
 MUIM_IconList_Update
 MUIM_IconList_UpdateEntry

--- a/workbench/system/Wanderer/Classes/iconvolumelist_private.h
+++ b/workbench/system/Wanderer/Classes/iconvolumelist_private.h
@@ -6,7 +6,7 @@
 /*** Instance data **********************************************************/
 struct IconVolumeList_DATA
 {
-    int dummy;
+    STRPTR ivld_HiddenVolumes;
 };
 
 #endif /* _ICONVOLUMELIST_PRIVATE_H_ */

--- a/workbench/system/Wanderer/iconwindow_attributes.h
+++ b/workbench/system/Wanderer/iconwindow_attributes.h
@@ -79,6 +79,12 @@
 
 #define MUIA_IconWindowExt_ScreenTitle_String                   (MUIB_IconWindowExt_UserFiles | 0x00000003) /* ISG */
 
+/*** Identifier Base ********************************************************/
+#define MUIB_IconWindowExt_Volumes                              (MUIB_IconWindowExt | 0x500000)
+
+/* Newline separated volume or device names to leave off the desktop. */
+#define MUIA_IconWindowExt_Volumes_Hidden                       (MUIB_IconWindowExt_Volumes | 0x00000001) /* ISG */
+
 #define IWD_MAX_DIRECTORYPATHLEN                                1024
 
 #endif /* _ICONWINDOW_ATTRIBUTES_H_ */

--- a/workbench/system/Wanderer/iconwindow_volumelist.c
+++ b/workbench/system/Wanderer/iconwindow_volumelist.c
@@ -70,6 +70,8 @@ struct IconWindowVolumeList_DATA
     Object                      *iwcd_ViewPrefs_NotificationObject;
     struct Hook                 iwvcd_UpdateNetworkPrefs_hook;
 
+    struct Hook                 iwvcd_UpdateHiddenVolumes_hook;
+
     IPTR                        iwvcd_ShowNetworkBrowser;
     IPTR                        iwvcd_ShowUserFolder;
 
@@ -232,6 +234,57 @@ AROS_UFH3(
     }
     AROS_USERFUNC_EXIT
 }
+
+///IconWindowVolumeList__HookFunc_UpdateHiddenVolumesFunc()
+AROS_UFH3(
+    void, IconWindowVolumeList__HookFunc_UpdateHiddenVolumesFunc,
+    AROS_UFHA(struct Hook *,    hook,   A0),
+    AROS_UFHA(APTR *,           obj,    A2),
+    AROS_UFHA(APTR,             param,  A1)
+)
+{
+    AROS_USERFUNC_INIT
+
+    Object *self = ( Object *)obj;
+    Object *prefs = NULL;
+    Class *CLASS = *( Class **)param;
+
+    SETUP_INST_DATA;
+
+    D(bug("[Wanderer:VolumeList]: %s()\n", __func__));
+
+    GET(_app(self), MUIA_Wanderer_Prefs, &prefs);
+
+    if (prefs)
+    {
+        IPTR prefs_Processing = 0;
+        IPTR current_Hidden = 0, prefs_Hidden = 0;
+
+        GET(prefs, MUIA_WandererPrefs_Processing, &prefs_Processing);
+
+        GET(self, MUIA_IconVolumeList_HiddenVolumes, &current_Hidden);
+        GET(prefs, MUIA_IconWindowExt_Volumes_Hidden, &prefs_Hidden);
+
+        if ((current_Hidden == 0) != (prefs_Hidden == 0)
+            || (current_Hidden && prefs_Hidden
+                && strcmp((STRPTR)current_Hidden, (STRPTR)prefs_Hidden) != 0))
+        {
+            D(bug("[Wanderer:VolumeList] %s: hidden volumes changed - updating ..\n", __func__));
+
+            SET(self, MUIA_IconVolumeList_HiddenVolumes, prefs_Hidden);
+
+            if (!prefs_Processing)
+            {
+                DoMethod(self, MUIM_IconList_Update);
+                DoMethod(self, MUIM_IconList_Sort);
+            }
+            else if (data->iwcd_IconWindow)
+                SET(data->iwcd_IconWindow, MUIA_IconWindow_Changed, TRUE);
+        }
+    }
+    AROS_USERFUNC_EXIT
+}
+///
 
 #define BDRPLINELEN_MAX 1024
 BOOL IconWindowVolumeList__Func_ParseBackdrop(Object *self, struct IconEntry *bdrp_direntry, struct List* entryList)
@@ -561,6 +614,23 @@ IPTR IconWindowVolumeList__MUIM_Setup
             (IPTR) self, 3,
             MUIM_CallHook, &((struct IconWindowVolumeList_DATA *)data)->iwvcd_UpdateNetworkPrefs_hook, (IPTR)CLASS
           );
+
+        ((struct IconWindowVolumeList_DATA *)data)->iwvcd_UpdateHiddenVolumes_hook.h_Entry = ( HOOKFUNC )IconWindowVolumeList__HookFunc_UpdateHiddenVolumesFunc;
+
+        DoMethod
+          (
+            prefs, MUIM_Notify, MUIA_IconWindowExt_Volumes_Hidden, MUIV_EveryTime,
+            (IPTR) self, 3,
+            MUIM_CallHook, &((struct IconWindowVolumeList_DATA *)data)->iwvcd_UpdateHiddenVolumes_hook, (IPTR)CLASS
+          );
+
+        {
+            IPTR hidden = 0;
+
+            GET(prefs, MUIA_IconWindowExt_Volumes_Hidden, &hidden);
+            if (hidden)
+                SET(self, MUIA_IconVolumeList_HiddenVolumes, hidden);
+        }
     }
 
     if (muiRenderInfo(self))
@@ -623,6 +693,11 @@ IPTR IconWindowVolumeList__MUIM_Cleanup
           (
             prefs,
             MUIM_KillNotifyObj, MUIA_IconWindowExt_NetworkBrowser_Show, (IPTR) self
+          );
+        DoMethod
+          (
+            prefs,
+            MUIM_KillNotifyObj, MUIA_IconWindowExt_Volumes_Hidden, (IPTR) self
           );
     }
     D(bug("[Wanderer:VolumeList] %s: Removing Disk Event Handler\n", __func__));

--- a/workbench/system/Wanderer/wandererprefs.c
+++ b/workbench/system/Wanderer/wandererprefs.c
@@ -54,6 +54,8 @@
 
 static CONST_STRPTR     wandererPrefs_PrefsFile = "ENV:SYS/Wanderer/global.prefs";
 static CONST_STRPTR     wandererPrefs_FontsPrefsFile = "ENV:SYS/Font.prefs";
+static CONST_STRPTR     wandererPrefs_HiddenVolumesFile = "ENV:SYS/Wanderer/hiddenvolumes.prefs";
+static CONST_STRPTR     wandererPrefs_HiddenVolumesVar = "SYS/Wanderer/hiddenvolumes.prefs";
 
 struct TagItem32 {
     ULONG ti_Tag;
@@ -69,6 +71,7 @@ struct WandererPrefs_DATA
     ULONG                       wpd_ShowNetwork;
     ULONG                       wpd_ShowUserFiles;
     ULONG                       wpd_ScreenTitleString[IFF_CHUNK_BUFFER_SIZE];
+    char                        wpd_HiddenVolumes[IFF_CHUNK_BUFFER_SIZE];
 
     struct List                 wpd_ViewSettings;
 
@@ -77,6 +80,9 @@ struct WandererPrefs_DATA
     
     struct NotifyRequest        wpd_FontPrefsNotifyRequest;
     struct Wanderer_FSHandler   wpd_FontPrefsFSHandler;
+
+    struct NotifyRequest        wpd_HiddenVolumesNotifyRequest;
+    struct Wanderer_FSHandler   wpd_HiddenVolumesFSHandler;
 
     BOOL                        wpd_PROCESSING;
 
@@ -442,6 +448,12 @@ IPTR WandererPrefs__HandleFSUpdate(Object *prefs, struct NotifyMessage *msg)
     return 0;
 }
 
+IPTR WandererPrefs__HandleHiddenVolumesFSUpdate(Object *prefs, struct NotifyMessage *msg)
+{
+    DoMethod(prefs, MUIM_WandererPrefs_ReloadHiddenVolumes);
+    return 0;
+}
+
 IPTR WandererPrefs__HandleFontPrefsFSUpdate(Object *prefs, struct NotifyMessage *msg)
 {
     DoMethod(prefs, MUIM_WandererPrefs_ReloadFontPrefs);
@@ -511,6 +523,29 @@ Object *WandererPrefs__OM_NEW(Class *CLASS, Object *self, struct opSet *message)
             }
         }
 
+        /* Setup notification on the hidden volumes prefs file -------------------*/
+        if (_wandererPrefs__FSNotifyPort != 0)
+        {
+            data->wpd_HiddenVolumesFSHandler.target                         = self;
+            data->wpd_HiddenVolumesFSHandler.fshn_Node.ln_Name              = (STRPTR)ExpandEnvName(wandererPrefs_HiddenVolumesFile);
+            data->wpd_HiddenVolumesFSHandler.HandleFSUpdate                 = WandererPrefs__HandleHiddenVolumesFSUpdate;
+            data->wpd_HiddenVolumesNotifyRequest.nr_Name                    = data->wpd_HiddenVolumesFSHandler.fshn_Node.ln_Name;
+            data->wpd_HiddenVolumesNotifyRequest.nr_Flags                   = NRF_SEND_MESSAGE;
+            data->wpd_HiddenVolumesNotifyRequest.nr_stuff.nr_Msg.nr_Port    = (struct MsgPort *)_wandererPrefs__FSNotifyPort;
+            data->wpd_HiddenVolumesNotifyRequest.nr_UserData                = (IPTR)&data->wpd_HiddenVolumesFSHandler;
+
+            if (StartNotify(&data->wpd_HiddenVolumesNotifyRequest))
+            {
+                D(bug("[Wanderer:Prefs] Wanderer__OM_NEW: Prefs-notification setup on '%s'\n", data->wpd_HiddenVolumesNotifyRequest.nr_Name));
+            }
+            else
+            {
+                D(bug("[Wanderer:Prefs] Wanderer__OM_NEW: FAILED to setup Prefs-notification!\n"));
+                data->wpd_HiddenVolumesFSHandler.fshn_Node.ln_Name = NULL;
+                data->wpd_HiddenVolumesNotifyRequest.nr_Name = NULL;
+            }
+        }
+
         D(bug("[Wanderer:Prefs]:New - reloading\n"));
 
         NewList(&data->wpd_ViewSettings);
@@ -519,6 +554,7 @@ Object *WandererPrefs__OM_NEW(Class *CLASS, Object *self, struct opSet *message)
 
         DoMethod(self, MUIM_WandererPrefs_Reload);
         DoMethod(self, MUIM_WandererPrefs_ReloadFontPrefs);
+        DoMethod(self, MUIM_WandererPrefs_ReloadHiddenVolumes);
     }
 
     D(bug("[Wanderer:Prefs] obj = %ld\n", self));
@@ -532,6 +568,7 @@ IPTR WandererPrefs__OM_DISPOSE(Class *CLASS, Object *self, Msg message)
   SETUP_INST_DATA;
   EndNotify(&data->wpd_PrefsNotifyRequest);
   EndNotify(&data->wpd_FontPrefsNotifyRequest);
+  EndNotify(&data->wpd_HiddenVolumesNotifyRequest);
   return DoSuperMethodA(CLASS, self, (Msg)message);
 }
 ///
@@ -561,6 +598,17 @@ IPTR WandererPrefs__OM_SET(Class *CLASS, Object *self, struct opSet *message)
       case MUIA_IconWindowExt_ScreenTitle_String:
         strcpy((STRPTR)data->wpd_ScreenTitleString, (STRPTR)tag->ti_Data);
         //data->wpd_ScreenTitleString = (LONG)tag->ti_Data;
+        break;
+
+      case MUIA_IconWindowExt_Volumes_Hidden:
+        if (tag->ti_Data)
+        {
+            strncpy(data->wpd_HiddenVolumes, (STRPTR)tag->ti_Data,
+                sizeof(data->wpd_HiddenVolumes) - 1);
+            data->wpd_HiddenVolumes[sizeof(data->wpd_HiddenVolumes) - 1] = '\0';
+        }
+        else
+            data->wpd_HiddenVolumes[0] = '\0';
         break;
 
       case MUIA_IconWindow_WindowNavigationMethod:
@@ -597,6 +645,10 @@ IPTR WandererPrefs__OM_GET(Class *CLASS, Object *self, struct opGet *message)
 
     case MUIA_IconWindowExt_UserFiles_ShowFilesFolder:
       *store = (IPTR)data->wpd_ShowUserFiles;
+      break;
+
+    case MUIA_IconWindowExt_Volumes_Hidden:
+      *store = (IPTR)data->wpd_HiddenVolumes;
       break;
 
   case MUIA_IconWindowExt_ScreenTitle_String:
@@ -695,6 +747,7 @@ D(bug("[Wanderer:Prefs] WandererPrefs__ProccessScreenTitleChunk@@@@@@@@@: SCREEN
   return TRUE;
 }
 ///
+
 
 ///WandererPrefs_FindViewSettingsNode()
 struct WandererPrefs_ViewSettingsNode *WandererPrefs_FindViewSettingsNode(struct WandererPrefs_DATA *data, char *node_Name)
@@ -846,6 +899,10 @@ D(bug("[Wanderer:Prefs] WandererPrefs__MUIM_WandererPrefs_Reload: Context 0x%p\n
 
 D(bug("[Wanderer:Prefs] WandererPrefs__MUIM_WandererPrefs_Reload: ReadChunkBytes() Chunk matches Prefs Header size ..\n"));
 
+            /* The data chunk is read into the same fixed buffer */
+            if (this_chunk_size > IFF_CHUNK_BUFFER_SIZE)
+                this_chunk_size = IFF_CHUNK_BUFFER_SIZE;
+
             if ((this_chunk_name = AllocVec(strlen(this_header->wpIFFch_ChunkType) +1,MEMF_ANY|MEMF_CLEAR)))
             {
               strcpy(this_chunk_name, this_header->wpIFFch_ChunkType);
@@ -933,6 +990,36 @@ D(bug("[Wanderer:Prefs] Failed to open stream!, returncode %ld!\n", error));
   FreeIFF(handle);
 
   return success;
+}
+///
+
+///WandererPrefs__MUIM_WandererPrefs_ReloadHiddenVolumes()
+/*
+ * The names of the volumes to leave off the desktop are kept in an
+ * environment variable rather than the prefs file, as the toolbar setting
+ * is, so that they can be changed without a prefs editor.
+ */
+IPTR WandererPrefs__MUIM_WandererPrefs_ReloadHiddenVolumes
+(
+  Class *CLASS, Object *self, Msg message
+)
+{
+    SETUP_INST_DATA;
+    char buffer[IFF_CHUNK_BUFFER_SIZE];
+    LONG len;
+
+    D(bug("[Wanderer:Prefs] %s()\n", __func__));
+
+    len = GetVar((STRPTR)wandererPrefs_HiddenVolumesVar, buffer, sizeof(buffer) - 1,
+        GVF_GLOBAL_ONLY);
+
+    if (len < 0)
+        len = 0;
+    buffer[len] = '\0';
+
+    SET(self, MUIA_IconWindowExt_Volumes_Hidden, buffer);
+
+    return TRUE;
 }
 ///
 
@@ -1097,7 +1184,7 @@ D(bug("[Wanderer:Prefs] WandererPrefs__MUIM_WandererPrefs_ViewSettings_GetAttrib
 }
 ///
 /*** Setup ******************************************************************/
-ZUNE_CUSTOMCLASS_8
+ZUNE_CUSTOMCLASS_9
 (
   WandererPrefs, NULL, MUIC_Notify, NULL,
   OM_NEW,                                              struct opSet *,
@@ -1106,6 +1193,7 @@ ZUNE_CUSTOMCLASS_8
   OM_GET,                                              struct opGet *,
   MUIM_WandererPrefs_Reload,                           Msg,
   MUIM_WandererPrefs_ReloadFontPrefs,                  Msg,
+  MUIM_WandererPrefs_ReloadHiddenVolumes,              Msg,
   MUIM_WandererPrefs_ViewSettings_GetNotifyObject,     struct MUIP_WandererPrefs_ViewSettings_GetNotifyObject *,
   MUIM_WandererPrefs_ViewSettings_GetAttribute,        struct MUIP_WandererPrefs_ViewSettings_GetAttribute *
 );

--- a/workbench/system/Wanderer/wandererprefs.h
+++ b/workbench/system/Wanderer/wandererprefs.h
@@ -25,6 +25,7 @@
 /*** Public Methods *********************************************************/
 #define MUIM_WandererPrefs_Reload                            (MUIB_WandererPrefs | 0x00000000)
 #define MUIM_WandererPrefs_ReloadFontPrefs                   (MUIB_WandererPrefs | 0x00000001)
+#define MUIM_WandererPrefs_ReloadHiddenVolumes               (MUIB_WandererPrefs | 0x00000002)
 
 #define MUIM_WandererPrefs_ViewSettings_GetNotifyObject      (MUIB_WandererPrefs | 0x000000E0) /* --G */
 #define MUIM_WandererPrefs_ViewSettings_GetAttribute         (MUIB_WandererPrefs | 0x000000E1) /* --G */


### PR DESCRIPTION
Every mounted filesystem gets an icon on the Workbench backdrop and there is no way to leave one out. This came up on Slack: a machine booted through UEFI shows its EFI system partition next to the volumes its owner actually uses, and the answer was that Wanderer has no such setting.

`ENV:SYS/Wanderer/hiddenvolumes.prefs` now holds a list of names, one per line, and those volumes are skipped. Either the volume name or the name of the device carrying it will do, so a volume with no name of its own can still be named. A name only matches whole, so `Work` does not hide `Workbench`.

    SetEnv SAVE SYS/Wanderer/hiddenvolumes.prefs "EFI"

**On where the setting lives.** It is an environment variable rather than an entry in `global.prefs` because the prefs class in Wanderer only ever reads that file; the prefs editor is the only thing that writes it. Putting the list in a variable means it can be set without an editor, and it follows the same shape as the existing toolbar preference, which `panel_toolbar.c` reads with `GetVar` and the editor writes with `SetVar`. The prefs class watches the variable the way it already watches `Font.prefs`, so a change is picked up without restarting Wanderer.

I deliberately stopped short of adding a control to the Wanderer prefs editor. That needs a new catalog string, and the catalogs are a separate submodule (`aros-translation-team/wanderer-prefs`), so it would be a two-repository change. Happy to do it as a follow-up if you want it, and happy to move the whole setting into `global.prefs` instead if you would rather it lived there.

**Structure.** The filter is in `IconVolumeList`, which is where the DOS list is walked, driven by a new `MUIA_IconVolumeList_HiddenVolumes` attribute (the `MUIB_IconVolumeList` base already existed with nothing under it). `IconWindowVolumeList` feeds the attribute from the prefs object and refreshes on change, mirroring what the network browser setting does a few lines away. Skipping a volume during the update is enough for an existing icon to be destroyed, since anything not carried over to the new list is disposed of already.

**Testing.** On hosted AROS with four volumes mounted (RAM Disk, MacRW, MacRO, System). With the variable unset all four are enumerated and get icons. With it set to `MacRO`, the driver reports `MacRO: is hidden`, no icon is built for it, and the other three are unaffected. What I did not manage to exercise on this setup is the reload-on-change path: the harness writes the variable from outside AROS, where the filesystem raises no notification, so that part follows the font prefs pattern but is untested by me.