### PR TITLE
sdcard: drive the BCM2711 card slot through its SDHCI controller

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
@@ -7,6 +7,18 @@
 
 #define ARASAN_BASE                     (ARM_PERIIOBASE + 0x300000)
 
+/*
+ * BCM2711 routes the card slot to a second controller with the same standard
+ * SDHCI register layout, in its own window and with its own clock and IRQ.
+ */
+#define EMMC2_BASE                      (ARM_PERIIOBASE + 0x340000)
+
+/* Both windows share one interrupt line on the BCM2711 (GIC SPI 126). */
+#define IRQ_BCM2711_SDHCI               158
+
+/* Identification clock, used until the card reports what it can take. */
+#define BCM2708SDCLOCK_MIN              400000
+
 #define ARASAN_CMD                      (ARASAN_BASE + 0x00)
 #define ARASAN_ARG	                (ARASAN_BASE + 0x04)
 #define ARASAN_TIMEOUT	                (ARASAN_BASE + 0x08)

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
@@ -54,6 +54,12 @@
 #define VCCLOCK_SDRAM           8
 #define VCCLOCK_PIXEL           9
 #define VCCLOCK_PWM             10
+#define VCCLOCK_EMMC2           12
+
+/* Power domain ids for the VCTAG_*POWER tags */
+#define VCPOWER_SDHCI           0
+#define VCPOWER_STATE_ON        (1 << 0)
+#define VCPOWER_STATE_WAIT      (1 << 1)
 
 #define VCTAG_GETCLKSTATE       0x00030001
 #define VCTAG_GETCLKRATE        0x00030002

--- a/arch/arm-native/soc/broadcom/2708/sdcard/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/mmakefile.src
@@ -5,21 +5,24 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_INCLUDES := -I$(SRCDIR)/$(CURDIR) -I$(SRCDIR)/rom/devs/sdcard
 
-# Arasan SDHCI controller (default)
-BCM2708FILES = \
-    sdcard_bcm2708init \
-    sdcard_bcm2708bus \
+BCM2708COMMONFILES = \
     sdcard_bcm2708time
 
-# BCM2835 SDHOST controller (alternative — frees Arasan for WiFi)
+# Standard SDHCI controller: Arasan on the BCM2835/6/7, EMMC2 on the BCM2711
+BCM2708SDHCIFILES = \
+    sdcard_bcm2708init \
+    sdcard_bcm2708bus
+
+# BCM2835 SDHOST controller (frees Arasan for WiFi)
 BCM2708SDHOSTFILES = \
     sdcard_sdhost_init \
-    sdcard_sdhost_bus \
-    sdcard_bcm2708time
+    sdcard_sdhost_bus
 
-# Uncomment ONE of these to select the SD controller:
-#BCM2708BUILDFILES := $(BCM2708FILES)
-BCM2708BUILDFILES := $(BCM2708SDHOSTFILES)
+BCM2708BUILDFILES := $(BCM2708SDHOSTFILES) $(BCM2708COMMONFILES)
+
+# The aarch64 target covers both the Pi 2/3 and the Pi 4, so it carries both
+# controllers and picks one at run time from the peripheral base.
+BCM2708BUILDFILES64 := $(BCM2708SDHOSTFILES) $(BCM2708SDHCIFILES) $(BCM2708COMMONFILES)
 
 %build_archspecific \
   mainmmake=kernel-sdcard maindir=rom/devs/sdcard \
@@ -34,6 +37,6 @@ BCM2708BUILDFILES := $(BCM2708SDHOSTFILES)
 %build_archspecific \
   mainmmake=kernel-sdcard maindir=rom/devs/sdcard \
   arch=raspi-aarch64 modname=sdcard \
-  files="$(BCM2708BUILDFILES)"
+  files="$(BCM2708BUILDFILES64)"
 
 %common

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
@@ -90,3 +90,29 @@ void FNAME_BCMSDCBUS(BCMMMIOWriteLong)(ULONG reg, ULONG val, struct sdcard_Bus *
 {
     FNAME_BCMSDCBUS(BCM283xWriteLong)(reg, val, bus);
 }
+
+/* EMMC2 does not have the inter-write timing bug; write straight through. */
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteByte)(ULONG reg, UBYTE val, struct sdcard_Bus *bus)
+{
+    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
+    ULONG shift = (reg & 3) << 3;
+    ULONG mask = 0xFF << shift;
+    ULONG newval = (currval & ~mask) | (val << shift);
+
+    *(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3) = AROS_LONG2LE(newval);
+}
+
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteWord)(ULONG reg, UWORD val, struct sdcard_Bus *bus)
+{
+    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
+    ULONG shift = ((reg >> 1) & 1) << 4;
+    ULONG mask = 0xFFFF << shift;
+    ULONG newval = (currval & ~mask) | (val << shift);
+
+    *(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3) = AROS_LONG2LE(newval);
+}
+
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteLong)(ULONG reg, ULONG val, struct sdcard_Bus *bus)
+{
+    *(volatile ULONG *)((IPTR)bus->sdcb_IOBase + reg) = AROS_LONG2LE(val);
+}

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -18,8 +18,15 @@
 #include <hardware/arasan.h>
 #include <hardware/videocore.h>
 
-APTR            MBoxBase;
-IPTR            __arm_periiobase __attribute__((used)) = 0 ;
+extern APTR     MBoxBase;
+extern IPTR     __arm_periiobase;
+
+/* Does the controller in this window report a card in the slot? */
+static BOOL FNAME_BCMSDC(CardPresent)(IPTR base)
+{
+    return (AROS_LE2LONG(*(volatile ULONG *)(base + SDHCI_PRESENT_STATE)) &
+            SDHCI_PS_CARD_PRESENT) ? TRUE : FALSE;
+}
 
 /* SDHCI-specific scan-time init: set interrupt mask, clock, power, bus width */
 static void FNAME_BCMSDC(SDBusInit)(struct sdcard_Bus *bus)
@@ -72,6 +79,9 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
 {
     struct sdcard_Bus   *__BCM2708Bus;
     int                 retVal = FALSE;
+    IPTR                ctrlBase;
+    ULONG               ctrlClock, ctrlIRQ;
+    BOOL                isEMMC2;
     unsigned int *MBoxMessage_ = AllocMem(8*4+16, MEMF_PUBLIC | MEMF_CLEAR);
     unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + 15) & ~15);
 
@@ -79,11 +89,56 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
 
     __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
+    isEMMC2 = (__arm_periiobase == BCM2711_PERIIOBASE);
+    if (isEMMC2)
+    {
+        /*
+         * The card slot sits on EMMC2, but the legacy window is still wired
+         * up and carries the card on some implementations, so fall back to it
+         * when EMMC2 reports an empty slot.
+         */
+        if (!FNAME_BCMSDC(CardPresent)(EMMC2_BASE) &&
+             FNAME_BCMSDC(CardPresent)(ARASAN_BASE))
+        {
+            DINIT(bug("[SDCard--] %s: card is on the legacy window\n", __PRETTY_FUNCTION__));
+            isEMMC2 = FALSE;
+        }
+    }
+
+    if (isEMMC2)
+    {
+        ctrlBase  = EMMC2_BASE;
+        ctrlClock = VCCLOCK_EMMC2;
+        ctrlIRQ   = IRQ_BCM2711_SDHCI;
+    }
+    else if (__arm_periiobase == BCM2711_PERIIOBASE)
+    {
+        ctrlBase  = ARASAN_BASE;
+        ctrlClock = VCCLOCK_EMMC;
+        ctrlIRQ   = IRQ_BCM2711_SDHCI;
+    }
+    else
+    {
+        /*
+         * Earlier SoCs drive the card slot through SDHOST, which keeps this
+         * controller free for SDIO. Report success so the remaining init
+         * functions still run.
+         */
+        D(bug("[SDCard--] %s: card slot is on SDHOST for this SoC\n", __PRETTY_FUNCTION__));
+        if (MBoxMessage_)
+            FreeMem(MBoxMessage_, 8*4+16);
+        return TRUE;
+    }
+
     if ((MBoxBase = OpenResource("mbox.resource")) == NULL)
     {
         bug("[SDCard--] %s: Failed to open mbox.resource\n", __PRETTY_FUNCTION__);
         goto bcminit_fail;
     }
+
+    /* EMMC2 is powered by the firmware; only the Arasan block is switchable. */
+    if (isEMMC2)
+        goto bcminit_clock;
 
     MBoxMessage[0] = AROS_LONG2LE(8 * 4);
     MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
@@ -124,12 +179,13 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
         }
     }
 
+bcminit_clock:
     MBoxMessage[0] = AROS_LONG2LE(8 * 4);
     MBoxMessage[1] = AROS_LONG2LE(VCTAG_REQ);
     MBoxMessage[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);
     MBoxMessage[3] = AROS_LONG2LE(8);
     MBoxMessage[4] = AROS_LONG2LE(4);
-    MBoxMessage[5] = AROS_LONG2LE(VCCLOCK_SDHCI);
+    MBoxMessage[5] = AROS_LONG2LE(ctrlClock);
     MBoxMessage[6] = 0;
 
     MBoxMessage[7] = 0; // terminate tag
@@ -144,8 +200,8 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
     if ((__BCM2708Bus = AllocPooled(SDCardBase->sdcard_MemPool, sizeof(struct sdcard_Bus))) != NULL)
     {
         __BCM2708Bus->sdcb_DeviceBase = SDCardBase;
-        __BCM2708Bus->sdcb_IOBase = (APTR)ARASAN_BASE;
-        __BCM2708Bus->sdcb_BusIRQ = IRQ_VC_ARASANSDIO;
+        __BCM2708Bus->sdcb_IOBase = (APTR)ctrlBase;
+        __BCM2708Bus->sdcb_BusIRQ = ctrlIRQ;
 
         __BCM2708Bus->sdcb_ClockMax = AROS_LE2LONG(MBoxMessage[6]);
         __BCM2708Bus->sdcb_ClockMin = BCM2708SDCLOCK_MIN;

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -211,9 +211,19 @@ bcminit_clock:
         __BCM2708Bus->sdcb_IOReadWord = FNAME_BCMSDCBUS(BCMMMIOReadWord);
         __BCM2708Bus->sdcb_IOReadLong = FNAME_BCMSDCBUS(BCMMMIOReadLong);
 
-        __BCM2708Bus->sdcb_IOWriteByte = FNAME_BCMSDCBUS(BCMMMIOWriteByte);
-        __BCM2708Bus->sdcb_IOWriteWord = FNAME_BCMSDCBUS(BCMMMIOWriteWord);
-        __BCM2708Bus->sdcb_IOWriteLong = FNAME_BCMSDCBUS(BCMMMIOWriteLong);
+        if (isEMMC2)
+        {
+            /* Only the earlier controller needs a delay between writes. */
+            __BCM2708Bus->sdcb_IOWriteByte = FNAME_BCMSDCBUS(BCMMMIODirectWriteByte);
+            __BCM2708Bus->sdcb_IOWriteWord = FNAME_BCMSDCBUS(BCMMMIODirectWriteWord);
+            __BCM2708Bus->sdcb_IOWriteLong = FNAME_BCMSDCBUS(BCMMMIODirectWriteLong);
+        }
+        else
+        {
+            __BCM2708Bus->sdcb_IOWriteByte = FNAME_BCMSDCBUS(BCMMMIOWriteByte);
+            __BCM2708Bus->sdcb_IOWriteWord = FNAME_BCMSDCBUS(BCMMMIOWriteWord);
+            __BCM2708Bus->sdcb_IOWriteLong = FNAME_BCMSDCBUS(BCMMMIOWriteLong);
+        }
 
         /* SDHCI controller-specific vtable */
         __BCM2708Bus->sdcb_SoftReset = FNAME_SDCBUS(SoftReset);

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708time.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708time.c
@@ -4,6 +4,11 @@
 
 #include "sdcard_intern.h"
 
+/* Shared by whichever controller drivers are built into this device. */
+APTR            MBoxBase;
+APTR            DMABase;
+IPTR            __arm_periiobase __attribute__((used)) = 0;
+
 #if defined(__aarch64__)
 #define NOP() asm volatile("yield\n")
 #else

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_intern.h
@@ -1,7 +1,7 @@
 #ifndef _SDCARDBCM2708_INTERN_H
 #define _SDCARDBCM2708_INTERN_H
 /*
-    Copyright © 2013-2015, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 2013-2015, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -44,5 +44,9 @@ ULONG FNAME_BCMSDCBUS(BCMMMIOReadLong)(ULONG, struct sdcard_Bus *);
 void FNAME_BCMSDCBUS(BCMMMIOWriteByte)(ULONG, UBYTE, struct sdcard_Bus *);
 void FNAME_BCMSDCBUS(BCMMMIOWriteWord)(ULONG, UWORD, struct sdcard_Bus *);
 void FNAME_BCMSDCBUS(BCMMMIOWriteLong)(ULONG, ULONG, struct sdcard_Bus *);
+
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteByte)(ULONG, UBYTE, struct sdcard_Bus *);
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteWord)(ULONG, UWORD, struct sdcard_Bus *);
+void FNAME_BCMSDCBUS(BCMMMIODirectWriteLong)(ULONG, ULONG, struct sdcard_Bus *);
 
 #endif // _SDCARDBCM2708_INTERN_H

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
@@ -34,9 +34,9 @@
 
 #define VCMB_PROPCHAN                   8
 
-APTR            MBoxBase;
-APTR            DMABase;
-IPTR            __arm_periiobase __attribute__((used)) = 0;
+extern APTR     MBoxBase;
+extern APTR     DMABase;
+extern IPTR     __arm_periiobase;
 
 
 /* GPIO Function Select: 3 bits per pin, 10 pins per register */
@@ -136,6 +136,18 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
     D(bug("[SDHost] %s()\n", __PRETTY_FUNCTION__));
 
     __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
+
+    /*
+     * On the BCM2711 the card slot is wired to EMMC2, not to this controller.
+     * Report success so the remaining init functions still run.
+     */
+    if (__arm_periiobase == BCM2711_PERIIOBASE)
+    {
+        D(bug("[SDHost] %s: not the card controller on this SoC\n", __PRETTY_FUNCTION__));
+        if (MBoxMessage_)
+            FreeMem(MBoxMessage_, 8*4+16);
+        return TRUE;
+    }
 
     if ((MBoxBase = OpenResource("mbox.resource")) == NULL)
     {

--- a/rom/devs/sdcard/sdcard.conf
+++ b/rom/devs/sdcard/sdcard.conf
@@ -1,6 +1,6 @@
 ##begin config
 basename        sdcard
-version		41.0
+version		41.1
 libbasetype     struct SDCardBase
 libbase         SDCardBase
 residentpri     4


### PR DESCRIPTION
The BCM2711 wires its card slot to a second controller, EMMC2, which has the standard SDHCI register layout but sits in its own window that the SDHOST driver cannot reach. This revives the SDHCI driver for it: it was carrying three constants that were used but never defined, so it had stopped building.

Both controllers now live in the same device and one is chosen at run time from the peripheral base, so earlier SoCs keep the existing behaviour of driving the slot through SDHOST and leaving the Arasan free for SDIO. The two windows share an interrupt line, and the slot is taken from whichever of them reports a card, so a board that wires it the other way still works.

The second commit is a performance fix. EMMC2 was inheriting a delay that exists for the earlier controller, which needs two SD clock cycles between chipset writes. EMMC2 has no such requirement, and because PIO data goes through the same write hook one long at a time, every 32-bit word of a block write was paying it, on the order of 0.77ms per 512-byte block. EMMC2 now gets direct writes; the delayed ones stay for the Arasan and for the case where the card turns up on the legacy window.

**On the interrupt.** An earlier version of this work carried two extra commits that polled for completion instead of sleeping on the interrupt, because on my board the SDHCI interrupt never arrived. Those are not here, and they are not needed: the cause was my own bug, the interrupt table being sized for the earlier Broadcom controller so that `KrnAddIRQHandler` silently refused every INTID above 71, including the SD host at 158. That was fixed in #890. I have retested on the hardware since and the controller interrupt is delivered, so the driver sleeps for it as it should and the workaround is gone rather than merely disabled.

Tested on a Raspberry Pi 4 Model B Rev 1.5: the card enumerates, reports 14768MB, mounts and boots the system. Builds clean against current master.