### PR TITLE
Mount: report failures on the console, with the reason

### DIFF
--- a/workbench/c/Mount.c
+++ b/workbench/c/Mount.c
@@ -238,7 +238,6 @@ void ShowFault(LONG code, const char *s, ...);
 struct DosLibrary *DOSBase;
 struct IntuitionBase *IntuitionBase;
 UtilityBase_t UtilityBase;
-struct Process *MyProcess;
 
 ULONG StartupValue;
 char *StartupString = NULL;
@@ -268,6 +267,8 @@ int main(void)
 
   if ((DOSBase = (struct DosLibrary *)OpenLibrary("dos.library",37))!=0)
   {
+    IsCli = (Cli() != NULL);
+
     if ((UtilityBase = (UtilityBase_t)OpenLibrary("utility.library",50)))
     {
         SetMem(&flagargs, 0, sizeof(flagargs));

--- a/workbench/c/Mount.c
+++ b/workbench/c/Mount.c
@@ -465,7 +465,7 @@ int main(void)
 
           if (error && error != ERROR_NO_MORE_ENTRIES && error < ERR_SPECIAL)
           {
-            ShowFault(error, "ERROR");
+            ShowFault(error, "Mount");
 
             error = RETURN_FAIL;
           }
@@ -497,7 +497,7 @@ int main(void)
                 error=readmountfile(params, _WBenchMsg->sm_ArgList[i].wa_Name);
                 DEBUG_MOUNT(KPrintF("Mount: readmountfile returned %ld\n", error));
                 if (error && error != ERROR_NO_MORE_ENTRIES && error < ERR_SPECIAL)
-                  ShowFault(error, "ERROR");
+                  ShowFault(error, "Mount");
 
                 (void) CurrentDir(olddir);
               }
@@ -1898,10 +1898,12 @@ void ShowFault(LONG code, const char *s, ...)
         int l;
 
         AROS_SLOWSTACKFORMAT_PRE(s);
-        l = VSNPrintf(buf, NAMESTR_MAX - 2, s, (RAWARG)AROS_SLOWSTACKFORMAT_ARG(s));
+        VSNPrintf(buf, NAMESTR_MAX - 2, s, (RAWARG)AROS_SLOWSTACKFORMAT_ARG(s));
         AROS_SLOWSTACKFORMAT_POST(s);
 
-        Strlcpy(&buf[l], ": ", NAMESTR_MAX);
+        /* VSNPrintf() counts the terminator, so ask the string itself. */
+        l = strlen(buf);
+        Strlcpy(&buf[l], ": ", NAMESTR_MAX - l);
         l += 2;
         Fault(code, NULL, &buf[l], NAMESTR_MAX - l);
         if (buf[l] == 0)


### PR DESCRIPTION
Mount reported every failure through an EasyRequest window, even from a
shell, and the requester said only "ERROR" with no reason.

Two independent causes:

- `IsCli` was declared but never assigned, so both `ShowError()` and
  `ShowFault()` always took the requester path.
- `ShowFault()` appended the reason at `buf[VSNPrintf(...)]`, but
  `VSNPrintf()` returns the size *including* the terminator. The reason
  was written one byte past the end of the string, so `PutStr()` and the
  requester both stopped at "ERROR".

`mount DEVS:AUX0` on an already-mounted device now prints

    Mount: object already exists

instead of popping a window saying "ERROR". Tested on amiga-m68k.

Also drops the unused `MyProcess`, and replaces the "ERROR" prefix with
the command name, matching how other commands report.
