### PR TITLE
Assign: make DISMOUNT remove the node instead of stopping the handler

### DIFF
--- a/workbench/c/Assign.c
+++ b/workbench/c/Assign.c
@@ -491,41 +491,6 @@ int doAssign(struct localdata *ld, STRPTR name, STRPTR *target, BOOL dismount, B
         BOOL cancel = FALSE;
         BOOL success = TRUE;
 
-        if (dismount)
-        {
-                struct MsgPort *dp;
-                struct Process *tp;
-
-                tp=(struct Process *)FindTask(NULL);
-                tp->pr_WindowPtr = (APTR)-1;
-                dp = DeviceProc(name);
-                DEBUG_ASSIGN(Printf("doassign: dp <%08X>\n",dp));
-                if (dp)
-                {
-                        struct InfoData did;
-                        success = DoPkt(dp,ACTION_DISK_INFO,(SIPTR)MKBADDR(&did),0,0,0,0);
-                        if (!(success) || !(did.id_InUse))
-                        {
-                                success = DoPkt(dp,ACTION_INHIBIT,DOSTRUE,0,0,0,0);
-                                ioerr = IoErr();
-                                if (success)
-                                {
-                                        success = DoPkt(dp,ACTION_DIE,0,0,0,0,0);
-                                        ioerr = IoErr();
-                                        DEBUG_ASSIGN(Printf("doassign: ACTION_DIE returned %ld\n", success));
-                                        if (!(success) && (ioerr != RETURN_OK))
-                                        {
-                                               DoPkt(dp,ACTION_INHIBIT,DOSFALSE,0,0,0,0); 
-                                        }
-                                }
-                        }
-                        else
-                        {
-                                ioerr = ERROR_OBJECT_IN_USE;
-                        }
-                }
-        }
-
         colon = strchr(name, ':');
 
         *colon = '\0';        /* Remove trailing colon; name[] is changed! */
@@ -538,29 +503,34 @@ int doAssign(struct localdata *ld, STRPTR name, STRPTR *target, BOOL dismount, B
 
         if (dismount)
         {
-                if ((!success) && (ioerr == ERROR_ACTION_NOT_KNOWN))
+                struct DosList *dl;
+                struct DosList *fdl;
+
+                /* DISMOUNT only takes the entry out of the list, and leaves any
+                 * handler running: stopping one is a separate operation, so
+                 * that a node can be dismounted without waking its handler
+                 * just to ask it to go away.
+                 */
+                DEBUG_ASSIGN(PutStr("Removing device node\n"));
+                dl = LockDosList(LDF_VOLUMES | LDF_DEVICES | LDF_WRITE);
+
+                fdl = FindDosEntry(dl, name, LDF_VOLUMES | LDF_DEVICES);
+
+                if (fdl)
                 {
-                        struct DosList *dl;
-                        struct DosList *fdl;
-
-                        DEBUG_ASSIGN(PutStr("Removing device node\n"));
-                        dl = LockDosList(LDF_VOLUMES | LDF_DEVICES | LDF_WRITE);
-
-                        fdl = FindDosEntry(dl, name, LDF_VOLUMES | LDF_DEVICES);
-
-                        /* Note the ! for conversion to boolean value */
-                        if (fdl)
-                        {
-                                success = RemDosEntry(fdl);
-                                if (success)
-                                        FreeDosEntry(fdl);
-                                else
-                                        ioerr = ERROR_OBJECT_IN_USE;
-                        } else
-                                ioerr = ERROR_OBJECT_NOT_FOUND;
-
-                        UnLockDosList(LDF_VOLUMES | LDF_DEVICES | LDF_WRITE);
+                        success = RemDosEntry(fdl);
+                        if (success)
+                                FreeDosEntry(fdl);
+                        else
+                                ioerr = ERROR_OBJECT_IN_USE;
                 }
+                else
+                {
+                        success = FALSE;
+                        ioerr = ERROR_OBJECT_NOT_FOUND;
+                }
+
+                UnLockDosList(LDF_VOLUMES | LDF_DEVICES | LDF_WRITE);
         }
         else
         {


### PR DESCRIPTION
DISMOUNT takes an entry out of the DOS list and leaves any handler
running; stopping a handler is a separate operation. The AmigaOS 3.2
documentation for `Mount SHUTDOWN` describes the split:

> MOUNT HD5: SHUTDOWN && ASSIGN HD5: DISMOUNT
>
> Completely and "cleanly" unmounts the HD5: volume. The ASSIGN command
> will typically leave the handler running, SHUTDOWN attempts to shut it
> down.

Assign did the opposite: it sent `ACTION_INHIBIT` and `ACTION_DIE`, and
removed the node only as a fallback, when the handler did not understand
`ACTION_DIE`.

Two consequences:

- It reached the handler through `DeviceProc()`, which *starts* one that
  is not running. Dismounting an idle device loaded the handler, opened
  its device and its driver, and then asked it to go away.
- A device whose handler did understand `ACTION_DIE` kept its node, so
  the entry was still listed afterwards.

A failure to remove the entry was also silent: `success` stayed TRUE, so
the command returned RETURN_OK and printed nothing.

The matching `Mount SHUTDOWN` keyword is not implemented here; that is
worth a separate change. With this one, a handler that AROS has no way
to stop is at least no longer stopped by the command that should not be
stopping it.

Tested on amiga-m68k with a con-handler that implements `ACTION_DIE`
(#914) and with one that does not.
