### PR TITLE
con-handler: no completion requesters without a window

### DIFF
--- a/rom/filesys/console_handler/completion.c
+++ b/rom/filesys/console_handler/completion.c
@@ -736,7 +736,12 @@ void Completion(struct filehandle *fh, BOOL withinfo)
 
         if (!ci->dirpart[0] && !ci->filepart[0])
         {
-            DoFileReq(fh, ci);
+            /* With nothing typed yet there is nothing to expand, and all that
+               is left to offer is a file requester. A console running over a
+               device has no window to put one over, so leave the line alone
+               rather than opening a requester somewhere the user is not. */
+            if (fh->window)
+                DoFileReq(fh, ci);
         }
         else
         {
@@ -754,8 +759,10 @@ void Completion(struct filehandle *fh, BOOL withinfo)
 
                     doprint = TRUE;
                 }
-                else if (ci->nummatchnodes > 1)
+                else if (ci->nummatchnodes > 1 && fh->window)
                 {
+                    /* Choosing between matches is a windowed requester, and it
+                       reads the screen out of fh->window. */
                     doprint = DoChooseReq(fh, ci);
                 }
 


### PR DESCRIPTION
Tab completion falls back to a requester when it cannot expand the word
on its own: a file requester when nothing has been typed yet, and a
list to pick from when several names match.

Both need a window. The file requester passes `fh->window` as
`ASLFR_Window`, and `DoChooseReq()` reads the screen straight out of it:

    if ((dri = GetScreenDrawInfo(ci->fh->window->WScreen)))

On a console running over a device there is no window, so the first
opened a requester on the default public screen, where the user of a
serial console cannot see it, and the second dereferenced NULL.

Both are now skipped when there is no window. Expanding a single match
still works everywhere, since that only edits the input buffer.

Doing nothing is the conservative half of the fix: printing the matches
as text would be a better answer for a serial console, but no text
output path exists in the completion code today, so that belongs in a
change of its own.

Tested on amiga-m68k over AUX0:, and on a normal CON: window to check
the requesters still appear there.
