### PR TITLE
dos: give a shell its console window for requesters

### DIFF
--- a/rom/dos/newcliproc.c
+++ b/rom/dos/newcliproc.c
@@ -16,6 +16,44 @@
 #include "dos_newcliproc.h"
 #include "fs_driver.h"
 
+/* Point requesters at the console this shell is running on.
+ *
+ * A console handler answers ACTION_DISK_INFO with its window in id_VolumeNode,
+ * which is how a program finds the window behind its console. Without this a
+ * shell leaves pr_WindowPtr at NULL and its requesters land on the default
+ * public screen, which is the wrong one whenever the console is not there.
+ */
+static void SetWindowPtrFromConsole(struct Process *me, BPTR fh, APTR DOSBase)
+{
+    struct MsgPort *port = ((struct FileHandle *)BADDR(fh))->fh_Type;
+    struct InfoData id;
+
+    if (!port)
+        return;
+
+    /* Only a console puts a Window there. On a filesystem the field is what it
+       claims to be, a BPTR to a volume node, and following that as a pointer
+       would draw requesters over nonsense. Ask what kind of handler this is
+       rather than matching id_DiskType: CON: is not the only console around,
+       and the type is whatever a handler cares to report. */
+    if (DoPkt(port, ACTION_IS_FILESYSTEM, 0, 0, 0, 0, 0))
+        return;
+
+    if (!DoPkt(port, ACTION_DISK_INFO, (SIPTR)MKBADDR(&id), 0, 0, 0, 0))
+        return;
+
+    /* Take whatever we are given, which is either a window to put requesters
+       over or -1 for a console that will never have one, and which means the
+       same thing here as it does in pr_WindowPtr: do not ask. An empty field
+       is the one answer to ignore, since a console opened AUTO has no window
+       until something writes to it, and would get one shortly. */
+    if (id.id_VolumeNode)
+        me->pr_WindowPtr = (APTR)id.id_VolumeNode;
+
+    D(bug("%s: type 0x%08lx vol 0x%p -> pr_WindowPtr 0x%p\n", __func__,
+        (unsigned long)id.id_DiskType, (APTR)id.id_VolumeNode, me->pr_WindowPtr));
+}
+
 ULONG internal_CliInitAny(struct DosPacket *dp, APTR DOSBase)
 {
     ULONG flags = 0;
@@ -215,6 +253,7 @@ ULONG internal_CliInitAny(struct DosPacket *dp, APTR DOSBase)
         D(bug("%s: cli_StandardInput is interactive\n", __func__));
         fs_ChangeSignal(cli->cli_StandardInput, me, DOSBase);
         SetVBuf(cli->cli_StandardInput, NULL, BUF_LINE, -1);
+        SetWindowPtrFromConsole(me, cli->cli_StandardInput, DOSBase);
         inter_in = TRUE;
     }
     if (IsInteractive(cli->cli_StandardOutput)) {

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -1090,7 +1090,15 @@ LONG CONMain(struct ExecBase *SysBase)
                         SetMem(id, 0, sizeof(struct InfoData));
                         id->id_DiskType =
                                 (fh->flags & FHFLG_RAW) ? AROS_MAKE_ID('R', 'A', 'W', 0) : AROS_MAKE_ID('C', 'O', 'N', 0);
-                        id->id_VolumeNode = (BPTR) fh->window;
+                        /* The window we hang off, for whoever wants to put
+                           something over it. Empty means we have none just
+                           now: a console opened AUTO gets its window when
+                           something first writes to it. Driving a device
+                           there will never be one, which is -1 rather than
+                           empty so that the two can be told apart. */
+                        id->id_VolumeNode = (fh->flags & FHFLG_DEVICEMODE)
+                                                ? (BPTR)(SIPTR)-1
+                                                : (BPTR)fh->window;
                         /* Anyone still holding a stream on us. Reporting the
                            IORequest here made us look busy for as long as we
                            were alive, so DISMOUNT could never proceed. */


### PR DESCRIPTION
A shell left `pr_WindowPtr` at NULL, so its requesters opened on the
default public screen instead of over its own console. On a console with
no window at all, such as one running over a serial line, they were
unreachable: `dir NOSUCH:` put a requester somewhere the user could not
see it and waited.

A console handler already answers ACTION_DISK_INFO with its window in
`id_VolumeNode`, so the shell asks for it at CLI init. Handlers are told
apart with ACTION_IS_FILESYSTEM rather than by matching `id_DiskType`,
since CON: is not the only console around and a filesystem really does
put a volume node in that field.

That left no way to say "there is no window and there never will be":
a console opened AUTO has none either, until something first writes to
it, and the boot console is AUTO. So con-handler now reports -1 rather
than an empty field when it is driving a device, which reads the same
way it does in `pr_WindowPtr`, and the shell passes the value straight
through.

Tested on amiga-m68k: requesters appear over the console on CON:, on the
AUTO boot console, and are suppressed on AUX0:.
