### PR TITLE
x86_64: boot on Above-4G Decoding / Resizable BAR systems (framebuffer above 4 GiB)

### DIFF
--- a/arch/all-native/bootconsole/common.c
+++ b/arch/all-native/bootconsole/common.c
@@ -19,9 +19,9 @@
 __attribute__((section(".data"))) unsigned char scr_Type = SCR_UNKNOWN;
 __attribute__((section(".data"))) static unsigned char bcdebugflags = 0;
 
-void con_InitVESA(unsigned short version, struct vbe_mode *mode)
+void con_InitVESAEx(unsigned short version, struct vbe_mode *mode, void *fb_override)
 {
-    scr_FrameBuffer = (version >= 0x0200) ? (void *)(unsigned long)mode->phys_base : NULL;
+    scr_FrameBuffer = fb_override ? fb_override : ((version >= 0x0200) ? (void *)(unsigned long)mode->phys_base : NULL);
 
     if (mode->mode_attributes & VM_GRAPHICS)
     {
@@ -59,6 +59,11 @@ void con_InitVESA(unsigned short version, struct vbe_mode *mode)
     /* We must have valid framebuffer address here */
     if (!scr_FrameBuffer)
         scr_Type = SCR_UNKNOWN;
+}
+
+void con_InitVESA(unsigned short version, struct vbe_mode *mode)
+{
+    con_InitVESAEx(version, mode, NULL);
 }
 
 void con_InitVGA(void)

--- a/arch/all-native/bootconsole/include/bootconsole.h
+++ b/arch/all-native/bootconsole/include/bootconsole.h
@@ -29,6 +29,7 @@ void con_InitMultiboot(struct multiboot *mb);
 void con_InitMultiboot2(void *mb);
 void con_InitTagList(const struct TagItem *tags);
 void con_InitVESA(unsigned short version, struct vbe_mode *mode);
+void con_InitVESAEx(unsigned short version, struct vbe_mode *mode, void *fb_override);
 void con_InitVGA(void);
 void con_InitSerial(char *cmdline);
 

--- a/arch/all-native/bootconsole/init_multiboot2.c
+++ b/arch/all-native/bootconsole/init_multiboot2.c
@@ -45,24 +45,39 @@ void con_InitMultiboot2(void *mb)
 
     if (fb)
     {
-        /* Framebuffer was given, use it */
-        scr_FrameBuffer = (void *)fb->framebuffer_addr;
+        /*
+         * Bootconsole runs as 32-bit code — pointers are 32-bit.
+         * If framebuffer is above 4 GiB (common on UEFI with ReBAR/large VRAM),
+         * skip it here. The 64-bit kernel vesagfx driver will use KRN_FBAddr.
+         */
+#ifdef MULTIBOOT_64BIT
+        int fb_reachable = (fb->framebuffer_addr <= 0xFFFFFFFFULL);
+#else
+        int fb_reachable = (fb->framebuffer_addr_high == 0);
+#endif
 
-        switch (fb->framebuffer_type)
+        if (fb_reachable)
         {
-        case MB2_FRAMEBUFFER_TEXT:
-            /* Text framebuffer, size in characters */
-            scr_Width  = fb->framebuffer_width;
-            scr_Height = fb->framebuffer_height;
-            scr_Type   = SCR_TEXT;
-            txt_Clear();
-            break;
+            /* Framebuffer was given and fits in 32-bit pointer, use it */
+            scr_FrameBuffer = (void *)(unsigned long)fb->framebuffer_addr;
 
-        default:
-            /* Graphical framebuffer, size in pixels */
-            scr_Type = SCR_GFX;
-            fb_Init(fb->framebuffer_width, fb->framebuffer_height, fb->framebuffer_bpp, fb->framebuffer_pitch);
+            switch (fb->framebuffer_type)
+            {
+            case MB2_FRAMEBUFFER_TEXT:
+                /* Text framebuffer, size in characters */
+                scr_Width  = fb->framebuffer_width;
+                scr_Height = fb->framebuffer_height;
+                scr_Type   = SCR_TEXT;
+                txt_Clear();
+                break;
+
+            default:
+                /* Graphical framebuffer, size in pixels */
+                scr_Type = SCR_GFX;
+                fb_Init(fb->framebuffer_width, fb->framebuffer_height, fb->framebuffer_bpp, fb->framebuffer_pitch);
+            }
         }
+        /* else: >4GB framebuffer — no early bootconsole display */
     }
     else if (vbe)
         con_InitVESA(vbe->vbe_control_info.version, &vbe->vbe_mode_info);

--- a/arch/all-native/bootconsole/init_taglist.c
+++ b/arch/all-native/bootconsole/init_taglist.c
@@ -45,12 +45,8 @@ void con_InitTagList(const struct TagItem *tags)
 
     if (vbemode)
     {
-        con_InitVESA(vbever, vbemode);
-
-        /* Override with full 64-bit address from GOP/multiboot2.
-         * VBEModeInfo.phys_base is 32-bit and truncates on >4GB systems. */
-        if (fb_addr)
-            scr_FrameBuffer = (void *)fb_addr;
+        /* Use full 64-bit GOP framebuffer address when available, before any fb init. */
+        con_InitVESAEx(vbever, vbemode, fb_addr ? (void *)fb_addr : NULL);
     }
     else
         con_InitVGA();

--- a/arch/all-native/bootconsole/init_taglist.c
+++ b/arch/all-native/bootconsole/init_taglist.c
@@ -19,6 +19,7 @@ void con_InitTagList(const struct TagItem *tags)
     struct vbe_mode *vbemode = NULL;
     /* By default we have 2.0 data (framebuffer pointer filled in) */
     unsigned short vbever = 0x0200;
+    IPTR fb_addr = 0;
 
     while ((tag = LibNextTagItem((struct TagItem **)&tags)))
     {
@@ -35,11 +36,22 @@ void con_InitTagList(const struct TagItem *tags)
         case KRN_VBEControllerInfo:
             vbever = ((struct vbe_controller *)tag->ti_Data)->version;
             break;
+
+        case KRN_FBAddr:
+            fb_addr = tag->ti_Data;
+            break;
         }
     }
 
     if (vbemode)
+    {
         con_InitVESA(vbever, vbemode);
+
+        /* Override with full 64-bit address from GOP/multiboot2.
+         * VBEModeInfo.phys_base is 32-bit and truncates on >4GB systems. */
+        if (fb_addr)
+            scr_FrameBuffer = (void *)fb_addr;
+    }
     else
         con_InitVGA();
 }

--- a/arch/all-native/kernel/kernel_bootmem.c
+++ b/arch/all-native/kernel/kernel_bootmem.c
@@ -33,7 +33,9 @@ void *krnAllocBootMemAligned(unsigned long size, unsigned int align)
     {
         /* Our allocation must succeed. We can't continue without it. */
         krnPanic(NULL, "Not enough memory for boot information\n"
-                       "Increase reserved space in bootstrap");
+                       "Increase reserved space in bootstrap\n"
+                       "BootMemPtr=0x%p request=%lu end=0x%p limit=0x%p",
+                       BootMemPtr, size, end, BootMemLimit);
     }
 #endif
 

--- a/arch/all-pc/bootstrap/bootstrap.c
+++ b/arch/all-pc/bootstrap/bootstrap.c
@@ -89,7 +89,7 @@ const struct bootstrap_mb2_header __header_v2 __attribute__((used,section(".aros
         sizeof(struct mb2_header_tag_framebuffer),
         0,    /* width  = 0: let bootloader pick best available GOP mode */
         0,    /* height = 0: avoids requesting modes that don't exist on UEFI */
-        0     /* depth  = 0: any color depth is acceptable */
+        32    /* depth  = 32: prefer truecolor GOP modes to avoid 24bpp quirks */
     },
     {
         MB2_HEADER_TAG_END,
@@ -599,7 +599,7 @@ static void __bootstrap(unsigned int magic, void *mb)
     D(kprintf("[%s] Code %u, data %u\n", str_Bootstrap, ro_size, rw_size);)
 
     /*
-     * Total kickstart size + alignment window (page size - 1) + some free space (512KB) for
+     * Total kickstart size + alignment window (page size - 1) + some free space for
      * boot-time memory allocator.
      * TODO: This is a temporary thing. Currently our kernel expects that it can use addresses beyond
      * KRN_KernelHighest to store boot-time private data, supervisor stack, segment descriptors, MMU stuff, etc.
@@ -607,7 +607,12 @@ static void __bootstrap(unsigned int magic, void *mb)
      * and can safely be marked as read-only for users.
      * Boot-time allocator needs to be smarter.
      */
-    ksize = ro_size + rw_size + PAGE_SIZE - 1 + 0x80000;
+    /*
+     * Reserve extra room for kernel boot-time allocations.
+     * GOP/UEFI boots may need substantially more early memory because of
+     * larger boot data relocation and MMU/GDT/TSS setup.
+     */
+    ksize = ro_size + rw_size + PAGE_SIZE - 1 + 0x10000000;
 
     /* Now locate the highest appropriate region */
     while (len >= sizeof(struct mb_mmap))

--- a/arch/all-pc/bootstrap/bootstrap.c
+++ b/arch/all-pc/bootstrap/bootstrap.c
@@ -87,9 +87,9 @@ const struct bootstrap_mb2_header __header_v2 __attribute__((used,section(".aros
         MB2_HEADER_TAG_FRAMEBUFFER,
         MBTF_OPTIONAL,
         sizeof(struct mb2_header_tag_framebuffer),
-        640,
-        200,
-        32
+        0,    /* width  = 0: let bootloader pick best available GOP mode */
+        0,    /* height = 0: avoids requesting modes that don't exist on UEFI */
+        0     /* depth  = 0: any color depth is acceptable */
     },
     {
         MB2_HEADER_TAG_END,

--- a/arch/all-pc/bootstrap/multiboot1.c
+++ b/arch/all-pc/bootstrap/multiboot1.c
@@ -18,6 +18,51 @@
 #define str_BSMultiboot "bootstrap:multiboot"
 #endif
 
+static void mb1_fill_vbe_from_fb(const struct multiboot *mb)
+{
+    VBEModeInfo.mode_attributes             = VM_SUPPORTED|VM_COLOR|VM_GRAPHICS|VM_NO_VGA_HW|VM_NO_VGA_MEM|VM_LINEAR_FB;
+    VBEModeInfo.bytes_per_scanline          = mb->framebuffer_pitch;
+    VBEModeInfo.x_resolution                = mb->framebuffer_width;
+    VBEModeInfo.y_resolution                = mb->framebuffer_height;
+    VBEModeInfo.bits_per_pixel              = mb->framebuffer_bpp;
+    VBEModeInfo.memory_model                = VMEM_RGB;
+    VBEModeInfo.red_mask_size               = mb->framebuffer_red_mask_size;
+    VBEModeInfo.red_field_position          = mb->framebuffer_red_field_position;
+    VBEModeInfo.green_mask_size             = mb->framebuffer_green_mask_size;
+    VBEModeInfo.green_field_position        = mb->framebuffer_green_field_position;
+    VBEModeInfo.blue_mask_size              = mb->framebuffer_blue_mask_size;
+    VBEModeInfo.blue_field_position         = mb->framebuffer_blue_field_position;
+    {
+        UBYTE maxend = 0;
+        UBYTE rend = mb->framebuffer_red_field_position + mb->framebuffer_red_mask_size;
+        UBYTE gend = mb->framebuffer_green_field_position + mb->framebuffer_green_mask_size;
+        UBYTE bend = mb->framebuffer_blue_field_position + mb->framebuffer_blue_mask_size;
+        if (rend > maxend) maxend = rend;
+        if (gend > maxend) maxend = gend;
+        if (bend > maxend) maxend = bend;
+        if (mb->framebuffer_bpp > maxend)
+        {
+            VBEModeInfo.reserved_mask_size      = mb->framebuffer_bpp - maxend;
+            VBEModeInfo.reserved_field_position = maxend;
+        }
+        else
+        {
+            VBEModeInfo.reserved_mask_size      = 0;
+            VBEModeInfo.reserved_field_position = 0;
+        }
+    }
+    VBEModeInfo.phys_base                     = mb->framebuffer_addr;
+    VBEModeInfo.linear_bytes_per_scanline     = mb->framebuffer_pitch;
+    VBEModeInfo.linear_red_mask_size          = mb->framebuffer_red_mask_size;
+    VBEModeInfo.linear_red_field_position     = mb->framebuffer_red_field_position;
+    VBEModeInfo.linear_green_mask_size        = mb->framebuffer_green_mask_size;
+    VBEModeInfo.linear_green_field_position   = mb->framebuffer_green_field_position;
+    VBEModeInfo.linear_blue_mask_size         = mb->framebuffer_blue_mask_size;
+    VBEModeInfo.linear_blue_field_position    = mb->framebuffer_blue_field_position;
+    VBEModeInfo.linear_reserved_mask_size     = VBEModeInfo.reserved_mask_size;
+    VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
+}
+
 unsigned long mb1_parse(struct multiboot *mb, struct mb_mmap **mmap_addr, unsigned long *mmap_len)
 {
     const char *cmdline = NULL;
@@ -89,18 +134,48 @@ unsigned long mb1_parse(struct multiboot *mb, struct mb_mmap **mmap_addr, unsign
 
     if (ParseCmdLine(cmdline))
     {
-        /* No VESA mode was set by command line arguments, supply what we already have */
-        if (mb->flags & MB_FLAGS_GFX)
+        int have_vbe = (mb->flags & MB_FLAGS_GFX) != 0;
+        struct vbe_mode *vbe_mode = have_vbe ? (struct vbe_mode *)mb->vbe_mode_info : NULL;
+        int have_graphics_vbe = vbe_mode && (vbe_mode->mode_attributes & VM_GRAPHICS);
+        int fb_rgb = ((mb->flags & MB_FLAGS_FB) && (mb->framebuffer_type == MB_FRAMEBUFFER_RGB));
+        int choose_gop = 0;
+
+        if (fb_rgb && (!have_graphics_vbe || ((mb->framebuffer_addr >> 32) != 0)))
+            choose_gop = 1;
+
+        if (choose_gop)
+        {
+            kprintf("[bootstrap:multiboot1] smartfb: using GOP framebuffer (%ux%ux%u @ 0x%016llX)%s%s\n",
+                mb->framebuffer_width,
+                mb->framebuffer_height,
+                mb->framebuffer_bpp,
+                mb->framebuffer_addr,
+                have_vbe ? " with VBE data present;" : "",
+                ((mb->framebuffer_addr >> 32) != 0) ? " FB above 4GB" : "");
+
+            mb1_fill_vbe_from_fb(mb);
+
+            tag->ti_Tag = KRN_VBEModeInfo;
+            tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
+            tag++;
+        }
+        else if (have_graphics_vbe)
         {
             /* We prefer complete VBE data if present */
             D(
                 kprintf("[%s] Got VESA display mode 0x%x from the bootstrap\n", str_BSMultiboot, mb->vbe_mode);
                 kprintf("[%s]   Mode info 0x%p, controller into 0x%p\n", str_BSMultiboot, mb->vbe_mode_info, mb->vbe_control_info);
                 kprintf("[%s]   VBE version 0x%04X\n", str_BSMultiboot, ((struct vbe_controller *)mb->vbe_control_info)->version);
-                kprintf("[%s]   Resolution %d x %d\n", str_BSMultiboot, ((struct vbe_mode  *)mb->vbe_mode_info)->x_resolution, ((struct vbe_mode  *)mb->vbe_mode_info)->y_resolution);
-                kprintf("[%s]   Mode flags 0x%04X, framebuffer 0x%p\n", str_BSMultiboot, ((struct vbe_mode  *)mb->vbe_mode_info)->mode_attributes, ((struct vbe_mode *)mb->vbe_mode_info)->phys_base);
-                kprintf("[%s]   Windows A 0x%04X B 0x%04X\n", str_BSMultiboot, ((struct vbe_mode *)mb->vbe_mode_info)->win_a_segment, ((struct vbe_mode *)mb->vbe_mode_info)->win_b_segment);
+                kprintf("[%s]   Resolution %d x %d\n", str_BSMultiboot, vbe_mode->x_resolution, vbe_mode->y_resolution);
+                kprintf("[%s]   Mode flags 0x%04X, framebuffer 0x%p\n", str_BSMultiboot, vbe_mode->mode_attributes, vbe_mode->phys_base);
+                kprintf("[%s]   Windows A 0x%04X B 0x%04X\n", str_BSMultiboot, vbe_mode->win_a_segment, vbe_mode->win_b_segment);
             )
+            kprintf("[bootstrap:multiboot1] smartfb: using VBE mode 0x%x (%ux%ux%u, fb=0x%08X)\n",
+                mb->vbe_mode,
+                vbe_mode->x_resolution,
+                vbe_mode->y_resolution,
+                vbe_mode->bits_per_pixel,
+                vbe_mode->phys_base);
 
             /*
              * We are already running in VESA mode set by the bootloader.
@@ -140,54 +215,31 @@ unsigned long mb1_parse(struct multiboot *mb, struct mb_mmap **mmap_addr, unsign
              * pass it to the bootstrap and handle it there (how? Is it I/O port
              * address or memory-mapped I/O address?)
              */
-            if (mb->framebuffer_type == MB_FRAMEBUFFER_RGB)
+            if (fb_rgb)
             {
-                                VBEModeInfo.mode_attributes             = VM_SUPPORTED|VM_COLOR|VM_GRAPHICS|VM_NO_VGA_HW|VM_NO_VGA_MEM|VM_LINEAR_FB;
-                                VBEModeInfo.bytes_per_scanline          = mb->framebuffer_pitch;
-                                VBEModeInfo.x_resolution                = mb->framebuffer_width;
-                                VBEModeInfo.y_resolution                = mb->framebuffer_height;
-                                VBEModeInfo.bits_per_pixel              = mb->framebuffer_bpp;
-                                VBEModeInfo.memory_model                = VMEM_RGB;
-                                VBEModeInfo.red_mask_size               = mb->framebuffer_red_mask_size;
-                                VBEModeInfo.red_field_position          = mb->framebuffer_red_field_position;
-                                VBEModeInfo.green_mask_size             = mb->framebuffer_green_mask_size;
-                                VBEModeInfo.green_field_position        = mb->framebuffer_green_field_position;
-                                VBEModeInfo.blue_mask_size              = mb->framebuffer_blue_mask_size;
-                                VBEModeInfo.blue_field_position         = mb->framebuffer_blue_field_position;
-                                {
-                                    UBYTE maxend = 0;
-                                    UBYTE rend = mb->framebuffer_red_field_position + mb->framebuffer_red_mask_size;
-                                    UBYTE gend = mb->framebuffer_green_field_position + mb->framebuffer_green_mask_size;
-                                    UBYTE bend = mb->framebuffer_blue_field_position + mb->framebuffer_blue_mask_size;
-                                    if (rend > maxend) maxend = rend;
-                                    if (gend > maxend) maxend = gend;
-                                    if (bend > maxend) maxend = bend;
-                                    if (mb->framebuffer_bpp > maxend)
-                                    {
-                                        VBEModeInfo.reserved_mask_size      = mb->framebuffer_bpp - maxend;
-                                        VBEModeInfo.reserved_field_position = maxend;
-                                    }
-                                    else
-                                    {
-                                        VBEModeInfo.reserved_mask_size      = 0;
-                                        VBEModeInfo.reserved_field_position = 0;
-                                    }
-                                }
-                                VBEModeInfo.phys_base                   = mb->framebuffer_addr;
-                                VBEModeInfo.linear_bytes_per_scanline   = mb->framebuffer_pitch;
-                                VBEModeInfo.linear_red_mask_size        = mb->framebuffer_red_mask_size;
-                                VBEModeInfo.linear_red_field_position   = mb->framebuffer_red_field_position;
-                                VBEModeInfo.linear_green_mask_size      = mb->framebuffer_green_mask_size;
-                                VBEModeInfo.linear_green_field_position = mb->framebuffer_green_field_position;
-                                VBEModeInfo.linear_blue_mask_size       = mb->framebuffer_blue_mask_size;
-                                VBEModeInfo.linear_blue_field_position  = mb->framebuffer_blue_field_position;
-                                VBEModeInfo.linear_reserved_mask_size   = VBEModeInfo.reserved_mask_size;
-                                VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
-                        
-                                tag->ti_Tag = KRN_VBEModeInfo;
-                                tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
-                                tag++;
-                        }
+                kprintf("[bootstrap:multiboot1] smartfb: using framebuffer-only path (%ux%ux%u @ 0x%016llX)\n",
+                    mb->framebuffer_width,
+                    mb->framebuffer_height,
+                    mb->framebuffer_bpp,
+                    mb->framebuffer_addr);
+                mb1_fill_vbe_from_fb(mb);
+                tag->ti_Tag = KRN_VBEModeInfo;
+                tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
+                tag++;
+            }
+            else
+            {
+                kprintf("[bootstrap:multiboot1] smartfb: unsupported framebuffer type %u\n",
+                    mb->framebuffer_type);
+            }
+        }
+
+        if (fb_rgb)
+        {
+            tag->ti_Tag = KRN_FBAddr;
+            tag->ti_Data = (unsigned long long)mb->framebuffer_addr;
+            tag++;
+            kprintf("[bootstrap:multiboot1] smartfb: KRN_FBAddr=0x%016llX\n", mb->framebuffer_addr);
         }
     }
 

--- a/arch/all-pc/bootstrap/multiboot1.c
+++ b/arch/all-pc/bootstrap/multiboot1.c
@@ -154,6 +154,25 @@ unsigned long mb1_parse(struct multiboot *mb, struct mb_mmap **mmap_addr, unsign
                                 VBEModeInfo.green_field_position        = mb->framebuffer_green_field_position;
                                 VBEModeInfo.blue_mask_size              = mb->framebuffer_blue_mask_size;
                                 VBEModeInfo.blue_field_position         = mb->framebuffer_blue_field_position;
+                                {
+                                    UBYTE maxend = 0;
+                                    UBYTE rend = mb->framebuffer_red_field_position + mb->framebuffer_red_mask_size;
+                                    UBYTE gend = mb->framebuffer_green_field_position + mb->framebuffer_green_mask_size;
+                                    UBYTE bend = mb->framebuffer_blue_field_position + mb->framebuffer_blue_mask_size;
+                                    if (rend > maxend) maxend = rend;
+                                    if (gend > maxend) maxend = gend;
+                                    if (bend > maxend) maxend = bend;
+                                    if (mb->framebuffer_bpp > maxend)
+                                    {
+                                        VBEModeInfo.reserved_mask_size      = mb->framebuffer_bpp - maxend;
+                                        VBEModeInfo.reserved_field_position = maxend;
+                                    }
+                                    else
+                                    {
+                                        VBEModeInfo.reserved_mask_size      = 0;
+                                        VBEModeInfo.reserved_field_position = 0;
+                                    }
+                                }
                                 VBEModeInfo.phys_base                   = mb->framebuffer_addr;
                                 VBEModeInfo.linear_bytes_per_scanline   = mb->framebuffer_pitch;
                                 VBEModeInfo.linear_red_mask_size        = mb->framebuffer_red_mask_size;
@@ -162,6 +181,8 @@ unsigned long mb1_parse(struct multiboot *mb, struct mb_mmap **mmap_addr, unsign
                                 VBEModeInfo.linear_green_field_position = mb->framebuffer_green_field_position;
                                 VBEModeInfo.linear_blue_mask_size       = mb->framebuffer_blue_mask_size;
                                 VBEModeInfo.linear_blue_field_position  = mb->framebuffer_blue_field_position;
+                                VBEModeInfo.linear_reserved_mask_size   = VBEModeInfo.reserved_mask_size;
+                                VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
                         
                                 tag->ti_Tag = KRN_VBEModeInfo;
                                 tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;

--- a/arch/all-pc/bootstrap/multiboot2.c
+++ b/arch/all-pc/bootstrap/multiboot2.c
@@ -227,6 +227,25 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
                 VBEModeInfo.green_field_position        = fb->framebuffer_green_field_position;
                 VBEModeInfo.blue_mask_size              = fb->framebuffer_blue_mask_size;
                 VBEModeInfo.blue_field_position         = fb->framebuffer_blue_field_position;
+                {
+                    UBYTE maxend = 0;
+                    UBYTE rend = fb->framebuffer_red_field_position + fb->framebuffer_red_mask_size;
+                    UBYTE gend = fb->framebuffer_green_field_position + fb->framebuffer_green_mask_size;
+                    UBYTE bend = fb->framebuffer_blue_field_position + fb->framebuffer_blue_mask_size;
+                    if (rend > maxend) maxend = rend;
+                    if (gend > maxend) maxend = gend;
+                    if (bend > maxend) maxend = bend;
+                    if (fb->common.framebuffer_bpp > maxend)
+                    {
+                        VBEModeInfo.reserved_mask_size      = fb->common.framebuffer_bpp - maxend;
+                        VBEModeInfo.reserved_field_position = maxend;
+                    }
+                    else
+                    {
+                        VBEModeInfo.reserved_mask_size      = 0;
+                        VBEModeInfo.reserved_field_position = 0;
+                    }
+                }
                 VBEModeInfo.phys_base                   = fb->common.framebuffer_addr;
                 VBEModeInfo.linear_bytes_per_scanline   = fb->common.framebuffer_pitch;
                 VBEModeInfo.linear_red_mask_size        = fb->framebuffer_red_mask_size;
@@ -235,6 +254,8 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
                 VBEModeInfo.linear_green_field_position = fb->framebuffer_green_field_position;
                 VBEModeInfo.linear_blue_mask_size       = fb->framebuffer_blue_mask_size;
                 VBEModeInfo.linear_blue_field_position  = fb->framebuffer_blue_field_position;
+                VBEModeInfo.linear_reserved_mask_size   = VBEModeInfo.reserved_mask_size;
+                VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
 
                 tag->ti_Tag  = KRN_VBEModeInfo;
                 tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;

--- a/arch/all-pc/bootstrap/multiboot2.c
+++ b/arch/all-pc/bootstrap/multiboot2.c
@@ -202,13 +202,24 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
             )
 
             /*
+             * Check if framebuffer is above 4 GiB. VBEModeInfo.phys_base is 32-bit,
+             * so we must skip framebuffer setup entirely when the address doesn't fit.
+             * This is common on EFI systems with ReBAR or large VRAM GPUs.
+             */
+#ifdef MULTIBOOT_64BIT
+            int fb_reachable = (fb->common.framebuffer_addr <= 0xFFFFFFFFULL);
+#else
+            int fb_reachable = (fb->common.framebuffer_addr_high == 0);
+#endif
+
+            /*
              * AROS VESA driver supports only RGB framebuffer because we are
              * unlikely to have VGA palette registers for other cases.
              * FIXME: we have some pointer to palette registers. We just need to
              * pass it to the bootstrap and handle it there (how? Is it I/O port
              * address or memory-mapped I/O address?)
              */
-            if (fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB)
+            if (fb_reachable && fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB)
             {
                 /*
                  * We have a framebuffer but no VBE information.

--- a/arch/all-pc/bootstrap/multiboot2.c
+++ b/arch/all-pc/bootstrap/multiboot2.c
@@ -21,6 +21,51 @@ D(
 #define str_BSMultiboot2 "bootstrap:multiboot2"
 )
 
+static void mb2_fill_vbe_from_fb(const struct mb2_tag_framebuffer *fb)
+{
+    VBEModeInfo.mode_attributes             = VM_SUPPORTED|VM_COLOR|VM_GRAPHICS|VM_NO_VGA_HW|VM_NO_VGA_MEM|VM_LINEAR_FB;
+    VBEModeInfo.bytes_per_scanline          = fb->common.framebuffer_pitch;
+    VBEModeInfo.x_resolution                = fb->common.framebuffer_width;
+    VBEModeInfo.y_resolution                = fb->common.framebuffer_height;
+    VBEModeInfo.bits_per_pixel              = fb->common.framebuffer_bpp;
+    VBEModeInfo.memory_model                = VMEM_RGB;
+    VBEModeInfo.red_mask_size               = fb->framebuffer_red_mask_size;
+    VBEModeInfo.red_field_position          = fb->framebuffer_red_field_position;
+    VBEModeInfo.green_mask_size             = fb->framebuffer_green_mask_size;
+    VBEModeInfo.green_field_position        = fb->framebuffer_green_field_position;
+    VBEModeInfo.blue_mask_size              = fb->framebuffer_blue_mask_size;
+    VBEModeInfo.blue_field_position         = fb->framebuffer_blue_field_position;
+    {
+        UBYTE maxend = 0;
+        UBYTE rend = fb->framebuffer_red_field_position + fb->framebuffer_red_mask_size;
+        UBYTE gend = fb->framebuffer_green_field_position + fb->framebuffer_green_mask_size;
+        UBYTE bend = fb->framebuffer_blue_field_position + fb->framebuffer_blue_mask_size;
+        if (rend > maxend) maxend = rend;
+        if (gend > maxend) maxend = gend;
+        if (bend > maxend) maxend = bend;
+        if (fb->common.framebuffer_bpp > maxend)
+        {
+            VBEModeInfo.reserved_mask_size      = fb->common.framebuffer_bpp - maxend;
+            VBEModeInfo.reserved_field_position = maxend;
+        }
+        else
+        {
+            VBEModeInfo.reserved_mask_size      = 0;
+            VBEModeInfo.reserved_field_position = 0;
+        }
+    }
+    VBEModeInfo.phys_base                     = fb->common.framebuffer_addr;
+    VBEModeInfo.linear_bytes_per_scanline     = fb->common.framebuffer_pitch;
+    VBEModeInfo.linear_red_mask_size          = fb->framebuffer_red_mask_size;
+    VBEModeInfo.linear_red_field_position     = fb->framebuffer_red_field_position;
+    VBEModeInfo.linear_green_mask_size        = fb->framebuffer_green_mask_size;
+    VBEModeInfo.linear_green_field_position   = fb->framebuffer_green_field_position;
+    VBEModeInfo.linear_blue_mask_size         = fb->framebuffer_blue_mask_size;
+    VBEModeInfo.linear_blue_field_position    = fb->framebuffer_blue_field_position;
+    VBEModeInfo.linear_reserved_mask_size     = VBEModeInfo.reserved_mask_size;
+    VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
+}
+
 /*
  * AROS expects memory map in original format. However, we won't bother
  * adding more and more new kernel tags. We convert the memory map instead.
@@ -173,14 +218,44 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
 
     if (ParseCmdLine(cmdline))
     {
-        if (vbe)
+        BOOL fb_rgb = (fb && (fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB));
+        BOOL vbe_graphics = (vbe && (vbe->vbe_mode_info.mode_attributes & VM_GRAPHICS));
+        BOOL choose_gop = FALSE;
+
+        if (fb_rgb)
+        {
+            if (!vbe_graphics || mb2_efi_systable != 0 || (fb->common.framebuffer_addr >> 32) != 0)
+                choose_gop = TRUE;
+        }
+
+        if (choose_gop)
+        {
+            kprintf("[bootstrap:multiboot2] smartfb: using GOP framebuffer (%ux%ux%u @ 0x%016llX pitch=%u)%s%s%s\n",
+                fb->common.framebuffer_width,
+                fb->common.framebuffer_height,
+                fb->common.framebuffer_bpp,
+                fb->common.framebuffer_addr,
+                fb->common.framebuffer_pitch,
+                vbe ? " with VBE data present;" : "",
+                (mb2_efi_systable != 0) ? " EFI boot;" : "",
+                ((fb->common.framebuffer_addr >> 32) != 0) ? " FB above 4GB" : "");
+
+            mb2_fill_vbe_from_fb(fb);
+
+            tag->ti_Tag  = KRN_VBEModeInfo;
+            tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
+            tag++;
+        }
+        else if (vbe_graphics)
         {
             D(kprintf("[%s] Got VESA display mode 0x%x from the bootstrap\n", str_BSMultiboot2, vbe->vbe_mode);)
+            kprintf("[bootstrap:multiboot2] smartfb: using VBE mode 0x%x (%ux%ux%u, fb=0x%08X)\n",
+                vbe->vbe_mode,
+                vbe->vbe_mode_info.x_resolution,
+                vbe->vbe_mode_info.y_resolution,
+                vbe->vbe_mode_info.bits_per_pixel,
+                vbe->vbe_mode_info.phys_base);
 
-            /*
-             * We are already running in VESA mode set by the bootloader.
-             * Pass on the mode information to AROS.
-             */
             tag->ti_Tag  = KRN_VBEModeInfo;
             tag->ti_Data = (unsigned long)&vbe->vbe_mode_info;
             tag++;
@@ -208,66 +283,39 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
              * pass it to the bootstrap and handle it there (how? Is it I/O port
              * address or memory-mapped I/O address?)
              */
-            if (fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB)
+            if (fb_rgb)
             {
-                /*
-                 * We have a framebuffer but no VBE information.
-                 * Looks like we are running on EFI machine with no VBE support (Mac).
-                 * Convert framebuffer data to VBEModeInfo and hand it to AROS.
-                 */
-                VBEModeInfo.mode_attributes             = VM_SUPPORTED|VM_COLOR|VM_GRAPHICS|VM_NO_VGA_HW|VM_NO_VGA_MEM|VM_LINEAR_FB;
-                VBEModeInfo.bytes_per_scanline          = fb->common.framebuffer_pitch;
-                VBEModeInfo.x_resolution                = fb->common.framebuffer_width;
-                VBEModeInfo.y_resolution                = fb->common.framebuffer_height;
-                VBEModeInfo.bits_per_pixel              = fb->common.framebuffer_bpp;
-                VBEModeInfo.memory_model                = VMEM_RGB;
-                VBEModeInfo.red_mask_size               = fb->framebuffer_red_mask_size;
-                VBEModeInfo.red_field_position          = fb->framebuffer_red_field_position;
-                VBEModeInfo.green_mask_size             = fb->framebuffer_green_mask_size;
-                VBEModeInfo.green_field_position        = fb->framebuffer_green_field_position;
-                VBEModeInfo.blue_mask_size              = fb->framebuffer_blue_mask_size;
-                VBEModeInfo.blue_field_position         = fb->framebuffer_blue_field_position;
-                {
-                    UBYTE maxend = 0;
-                    UBYTE rend = fb->framebuffer_red_field_position + fb->framebuffer_red_mask_size;
-                    UBYTE gend = fb->framebuffer_green_field_position + fb->framebuffer_green_mask_size;
-                    UBYTE bend = fb->framebuffer_blue_field_position + fb->framebuffer_blue_mask_size;
-                    if (rend > maxend) maxend = rend;
-                    if (gend > maxend) maxend = gend;
-                    if (bend > maxend) maxend = bend;
-                    if (fb->common.framebuffer_bpp > maxend)
-                    {
-                        VBEModeInfo.reserved_mask_size      = fb->common.framebuffer_bpp - maxend;
-                        VBEModeInfo.reserved_field_position = maxend;
-                    }
-                    else
-                    {
-                        VBEModeInfo.reserved_mask_size      = 0;
-                        VBEModeInfo.reserved_field_position = 0;
-                    }
-                }
-                VBEModeInfo.phys_base                   = fb->common.framebuffer_addr;
-                VBEModeInfo.linear_bytes_per_scanline   = fb->common.framebuffer_pitch;
-                VBEModeInfo.linear_red_mask_size        = fb->framebuffer_red_mask_size;
-                VBEModeInfo.linear_red_field_position   = fb->framebuffer_red_field_position;
-                VBEModeInfo.linear_green_mask_size      = fb->framebuffer_green_mask_size;
-                VBEModeInfo.linear_green_field_position = fb->framebuffer_green_field_position;
-                VBEModeInfo.linear_blue_mask_size       = fb->framebuffer_blue_mask_size;
-                VBEModeInfo.linear_blue_field_position  = fb->framebuffer_blue_field_position;
-                VBEModeInfo.linear_reserved_mask_size   = VBEModeInfo.reserved_mask_size;
-                VBEModeInfo.linear_reserved_field_position = VBEModeInfo.reserved_field_position;
+                kprintf("[bootstrap:multiboot2] smartfb: using framebuffer-only path (%ux%ux%u @ 0x%016llX)\n",
+                    fb->common.framebuffer_width,
+                    fb->common.framebuffer_height,
+                    fb->common.framebuffer_bpp,
+                    fb->common.framebuffer_addr);
+
+                mb2_fill_vbe_from_fb(fb);
 
                 tag->ti_Tag  = KRN_VBEModeInfo;
                 tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
                 tag++;
-
-                /* Pass full 64-bit framebuffer address via dedicated tag.
-                 * phys_base above is 32-bit and truncates on >4GB systems (ReBAR, large VRAM).
-                 * bootloader.resource uses this to override the truncated value. */
-                tag->ti_Tag  = KRN_FBAddr;
-                tag->ti_Data = (unsigned long long)fb->common.framebuffer_addr;
-                tag++;
             }
+            else
+            {
+                kprintf("[bootstrap:multiboot2] smartfb: unsupported framebuffer type %u\n",
+                    fb->common.framebuffer_type);
+            }
+        }
+
+        if (fb_rgb)
+        {
+            /*
+             * Pass full 64-bit framebuffer address regardless of whether we are using
+             * VBE data or synthesized GOP data. This allows the kernel/bootloader.resource
+             * to override 32-bit phys_base fields when framebuffer is above 4GB.
+             */
+            tag->ti_Tag  = KRN_FBAddr;
+            tag->ti_Data = (unsigned long long)fb->common.framebuffer_addr;
+            tag++;
+
+            kprintf("[bootstrap:multiboot2] smartfb: KRN_FBAddr=0x%016llX\n", fb->common.framebuffer_addr);
         }
     }
 

--- a/arch/all-pc/bootstrap/multiboot2.c
+++ b/arch/all-pc/bootstrap/multiboot2.c
@@ -202,24 +202,13 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
             )
 
             /*
-             * Check if framebuffer is above 4 GiB. VBEModeInfo.phys_base is 32-bit,
-             * so we must skip framebuffer setup entirely when the address doesn't fit.
-             * This is common on EFI systems with ReBAR or large VRAM GPUs.
-             */
-#ifdef MULTIBOOT_64BIT
-            int fb_reachable = (fb->common.framebuffer_addr <= 0xFFFFFFFFULL);
-#else
-            int fb_reachable = (fb->common.framebuffer_addr_high == 0);
-#endif
-
-            /*
              * AROS VESA driver supports only RGB framebuffer because we are
              * unlikely to have VGA palette registers for other cases.
              * FIXME: we have some pointer to palette registers. We just need to
              * pass it to the bootstrap and handle it there (how? Is it I/O port
              * address or memory-mapped I/O address?)
              */
-            if (fb_reachable && fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB)
+            if (fb->common.framebuffer_type == MB2_FRAMEBUFFER_RGB)
             {
                 /*
                  * We have a framebuffer but no VBE information.
@@ -249,6 +238,13 @@ unsigned long mb2_parse(void *mb, struct mb_mmap **mmap_addr, unsigned long *mma
 
                 tag->ti_Tag  = KRN_VBEModeInfo;
                 tag->ti_Data = KERNEL_OFFSET | (unsigned long)&VBEModeInfo;
+                tag++;
+
+                /* Pass full 64-bit framebuffer address via dedicated tag.
+                 * phys_base above is 32-bit and truncates on >4GB systems (ReBAR, large VRAM).
+                 * bootloader.resource uses this to override the truncated value. */
+                tag->ti_Tag  = KRN_FBAddr;
+                tag->ti_Data = (unsigned long long)fb->common.framebuffer_addr;
                 tag++;
             }
         }

--- a/arch/i386-pc/boot/grub2/grub-efi.cfg
+++ b/arch/i386-pc/boot/grub2/grub-efi.cfg
@@ -1,7 +1,6 @@
 # On EFI we must always have graphics drivers.
 # Otherwise GRUB can't set up display mode for the kickstart.
-insmod efi_gop
-insmod efi_uga
+insmod all_video
 
 if loadfont /EFI/BOOT/grub/fonts/unicode.pf2 ; then
 	insmod gfxterm

--- a/arch/x86_64-pc/boot/grub2/grub.cfg
+++ b/arch/x86_64-pc/boot/grub2/grub.cfg
@@ -1,13 +1,12 @@
 if [ "$grub_platform" = "efi" ]; then
     set bl_path="/@EFIDIR@/@BOOTDIR@/grub"
     test -e $bl_path
-    insmod efi_gop
-    insmod efi_uga
+    insmod all_video
     set vesa_supported=false
     set bootstrap_flags="forceusbpower"
 else
     set bl_path="/boot/grub"
-    insmod vbe
+    insmod all_video
     set vesa_supported=true
     bootstrap_flags=
 fi

--- a/arch/x86_64-pc/bootstrap/cpu.c
+++ b/arch/x86_64-pc/bootstrap/cpu.c
@@ -46,12 +46,12 @@ static struct
  * The MMU pages and directories. They are stored at fixed location and may be either reused in the
  * 64-bit kernel, or replaced by it.
  *
- * 64 PDP entries × 512 PDEs each = 32768 2MB pages = 64 GiB identity map.
- * EFI firmware (especially with ReBAR / large-VRAM GPUs) may place GRUB2-loaded
- * kernel modules above 4 GiB, so the bootstrap page tables must cover enough
- * address space for the ljmp into the 64-bit kernel to succeed.
+ * 512 PDP entries × 512 PDEs each = 262144 2MB pages = 512 GiB identity map.
+ * EFI firmware (especially with ReBAR / large-VRAM GPUs) may place GOP framebuffers
+ * far above 4 GiB. Keeping a wider early identity map avoids triple-fault resets
+ * when bootconsole touches a high framebuffer before the kernel rebuilds MMU tables.
  */
-#define BOOTSTRAP_PDP_COUNT 64
+#define BOOTSTRAP_PDP_COUNT 512
 
 static struct PML4E PML4[512]                    __attribute__((used,aligned(4096),section(".bss.aros.tables")));
 static struct PDPE  PDP[512]                     __attribute__((used,aligned(4096),section(".bss.aros.tables")));
@@ -61,7 +61,7 @@ static struct PDE2M PDE[BOOTSTRAP_PDP_COUNT][512] __attribute__((used,aligned(40
  * The 64-bit long mode may be activated only, when MMU paging is enabled. Therefore the basic
  * MMU tables have to be prepared first.
  *
- * This routine creates a 64 GiB identity map using 2MB pages so that the ljmp into the 64-bit
+ * This routine creates a 512 GiB identity map using 2MB pages so that the ljmp into the 64-bit
  * kernel succeeds even when GRUB2/EFI places kernel modules above 4 GiB.
  *
  * This mapping may be changed later by the 64-bit kernel, in order to provide separate address spaces,

--- a/arch/x86_64-pc/bootstrap/cpu.c
+++ b/arch/x86_64-pc/bootstrap/cpu.c
@@ -44,33 +44,40 @@ static struct
 
 /*
  * The MMU pages and directories. They are stored at fixed location and may be either reused in the
- * 64-bit kernel, or replaced by it. Four PDE directories (PDE2M structures) are enough to map whole
- * 4GB address space.
+ * 64-bit kernel, or replaced by it.
+ *
+ * 64 PDP entries × 512 PDEs each = 32768 2MB pages = 64 GiB identity map.
+ * EFI firmware (especially with ReBAR / large-VRAM GPUs) may place GRUB2-loaded
+ * kernel modules above 4 GiB, so the bootstrap page tables must cover enough
+ * address space for the ljmp into the 64-bit kernel to succeed.
  */
-static struct PML4E PML4[512]   __attribute__((used,aligned(4096),section(".bss.aros.tables")));
-static struct PDPE  PDP[512]    __attribute__((used,aligned(4096),section(".bss.aros.tables")));
-static struct PDE2M PDE[4][512] __attribute__((used,aligned(4096),section(".bss.aros.tables")));
+#define BOOTSTRAP_PDP_COUNT 64
+
+static struct PML4E PML4[512]                    __attribute__((used,aligned(4096),section(".bss.aros.tables")));
+static struct PDPE  PDP[512]                     __attribute__((used,aligned(4096),section(".bss.aros.tables")));
+static struct PDE2M PDE[BOOTSTRAP_PDP_COUNT][512] __attribute__((used,aligned(4096),section(".bss.aros.tables")));
 
 /*
  * The 64-bit long mode may be activated only, when MMU paging is enabled. Therefore the basic
- * MMU tables have to be prepared first. This routine uses 6 tables (2048 + 5 entries) in order
- * to map the first 4GB of address space as user-accessible executable RW area.
+ * MMU tables have to be prepared first.
+ *
+ * This routine creates a 64 GiB identity map using 2MB pages so that the ljmp into the 64-bit
+ * kernel succeeds even when GRUB2/EFI places kernel modules above 4 GiB.
  *
  * This mapping may be changed later by the 64-bit kernel, in order to provide separate address spaces,
  * protect kernel from being overwritten and so on and so forth.
  *
  * To simplify things down we will use 2MB memory page size. In this mode the address is broken up into 4 fields:
- * - Bits 63–48 sign extension of bit 47 as required for canonical address forms.
- * - Bits 47–39 index into the 512-entry page-map level-4 table.
- * - Bits 38–30 index into the 512-entry page-directory-pointer table.
- * - Bits 29–21 index into the 512-entry page-directory table.
- * - Bits 20–0  byte offset into the physical page.
+ * - Bits 63-48 sign extension of bit 47 as required for canonical address forms.
+ * - Bits 47-39 index into the 512-entry page-map level-4 table.
+ * - Bits 38-30 index into the 512-entry page-directory-pointer table.
+ * - Bits 29-21 index into the 512-entry page-directory table.
+ * - Bits 20-0  byte offset into the physical page.
  * Let's remember that our topmost address is  0xFFFFF000, as specified by GDT.
 */
 void setup_mmu(void)
 {
     int i;
-    struct PDE2M *pdes[] = { &PDE[0][0], &PDE[1][0], &PDE[2][0], &PDE[3][0] };
 
     D(kprintf("[BOOT] Setting up MMU, kickstart base 0x%p\n", kick_base);)
     D(kprintf("[BOOT] cr0: 0x%p cr3: 0x%p cr4: 0x%p\n", rdcr(cr0), rdcr(cr3), rdcr(cr4));)
@@ -102,7 +109,7 @@ void setup_mmu(void)
     GDT.super_ds.base_mid   = 0;
     GDT.super_ds.base_high  = 0;
 
-    D(kprintf("[BOOT] Mapping first 4G area with MMU\n");)
+    D(kprintf("[BOOT] Mapping first %dG area with MMU\n", BOOTSTRAP_PDP_COUNT);)
     D(kprintf("[BOOT] PML4 0x%p, PDP 0x%p, PDE 0x%p\n", PML4, PDP, PDE);)
 
     /*
@@ -125,17 +132,19 @@ void setup_mmu(void)
 
     /*
      * Page directory pointer entries.
-     * Our address contains usable bits 30 and 31, so there are four of them.
+     * We map BOOTSTRAP_PDP_COUNT GiB (one PDP entry = 1 GiB with 512 × 2MB pages).
      */
-    for (i=0; i < 4; i++)
+    for (i = 0; i < BOOTSTRAP_PDP_COUNT; i++)
     {
         int j;
+        struct PDE2M *pde = &PDE[i][0];
 
-        D(kprintf("[BOOT] PDE[%u] 0x%p\n", i, pdes[i]);)
+        D(if ((i & 15) == 0) kprintf("[BOOT] PDP[%u] PDE 0x%p\n", i, pde);)
 
         /*
          * Set the PDP entry up and point to the PDE table.
-         * Field meanings are analogous to PML4, just 'base' points to page directory tables
+         * Bootstrap BSS is always below 4 GiB (loaded by GRUB2 in low memory),
+         * so base_high for the PDE table pointer is always 0.
          */
         PDP[i].p         = 1;
         PDP[i].rw        = 1;
@@ -144,30 +153,34 @@ void setup_mmu(void)
         PDP[i].pcd       = 0;
         PDP[i].a         = 0;
         PDP[i].mbz       = 0;
-        PDP[i].base_low  = (unsigned int)pdes[i] >> 12;
+        PDP[i].base_low  = (unsigned int)pde >> 12;
         PDP[i].nx        = 0;
         PDP[i].avail     = 0;
         PDP[i].base_high = 0;
 
-        for (j=0; j < 512; j++)
+        for (j = 0; j < 512; j++)
         {
-            /* Build a complete PDE set (512 entries) for every PDP entry */
-            struct PDE2M *PDE = pdes[i];
+            /*
+             * Build a complete PDE set (512 entries) for every PDP entry.
+             * Use unsigned long long for the physical base address since
+             * we're in 32-bit mode but mapping addresses above 4 GiB.
+             */
+            unsigned long long base = ((unsigned long long)i << 30) | ((unsigned long long)j << 21);
 
-            PDE[j].p         = 1;
-            PDE[j].rw        = 1;
-            PDE[j].us        = 1;
-            PDE[j].pwt       = 0;
-            PDE[j].pcd       = 0;
-            PDE[j].a         = 0;
-            PDE[j].d         = 0;       /* Clear write tracking bit                                                        */
-            PDE[j].g         = 0;       /* Page is global                                                                  */
-            PDE[j].pat       = 0;       /* Most significant PAT bit                                                        */
-            PDE[j].ps        = 1;       /* It's PDE (not PTE) and page size will be 2MB (after we enable PAE)              */
-            PDE[j].base_low  = ((i << 30) + (j << 21)) >> 13;   /* Base address of the physical page. This is 1:1 mapping. */
-            PDE[j].avail     = 0;
-            PDE[j].nx        = 0;
-            PDE[j].base_high = 0;
+            pde[j].p         = 1;
+            pde[j].rw        = 1;
+            pde[j].us        = 1;
+            pde[j].pwt       = 0;
+            pde[j].pcd       = 0;
+            pde[j].a         = 0;
+            pde[j].d         = 0;
+            pde[j].g         = 0;
+            pde[j].pat       = 0;
+            pde[j].ps        = 1;       /* 2MB page size                                                                   */
+            pde[j].base_low  = (unsigned int)(base >> 13);  /* Physical page base address bits [31:13]                     */
+            pde[j].avail     = 0;
+            pde[j].nx        = 0;
+            pde[j].base_high = (unsigned int)((base >> 32) & 0x000FFFFF); /* Physical page base address bits [51:32]       */
         }
     }
 

--- a/arch/x86_64-pc/kernel/kernel_intern.h
+++ b/arch/x86_64-pc/kernel/kernel_intern.h
@@ -81,7 +81,7 @@ void PlatformPostInit(void);
 /** CPU Related Functions **/
 void core_SetupGDT(struct KernBootPrivate *, apicid_t, APTR, APTR, APTR);
 
-void core_SetupMMU(struct CPUMMUConfig *, IPTR memtop);
+void core_SetupMMU(struct CPUMMUConfig *, IPTR memtop, IPTR maptop);
 void core_InitMMU(struct CPUMMUConfig *);
 void core_LoadMMU(struct CPUMMUConfig *);
 

--- a/arch/x86_64-pc/kernel/kernel_startup.c
+++ b/arch/x86_64-pc/kernel/kernel_startup.c
@@ -127,7 +127,8 @@ static void boot_start(struct TagItem *msg)
     fb_Mirror = (void *)LibGetTagData(KRN_ProtAreaEnd, 0x101000, msg);
 
     con_InitTagList(msg);
-    boot_dump_video_info(msg);
+    while (0)
+        boot_dump_video_info(msg);
 
     kernel_cstart(msg);
 }

--- a/arch/x86_64-pc/kernel/kernel_startup.c
+++ b/arch/x86_64-pc/kernel/kernel_startup.c
@@ -46,6 +46,7 @@ static APTR core_BSPAllocTLS(struct KernBootPrivate *);
 static APTR core_BSPAllocTSS(struct KernBootPrivate *);
 static APTR core_BSPAllocGDT(struct KernBootPrivate *);
 static APTR core_AllocIDT(struct KernBootPrivate *);
+static void boot_dump_video_info(const struct TagItem *msg);
 
 /* Common IBM PC memory layout (64bit version) */
 static const struct MemRegion PC_Memory[] =
@@ -126,8 +127,57 @@ static void boot_start(struct TagItem *msg)
     fb_Mirror = (void *)LibGetTagData(KRN_ProtAreaEnd, 0x101000, msg);
 
     con_InitTagList(msg);
+    boot_dump_video_info(msg);
 
     kernel_cstart(msg);
+}
+
+static void boot_dump_video_info(const struct TagItem *msg)
+{
+    struct TagItem *tag;
+    struct vbe_mode *vmode = NULL;
+    UWORD vbemode = 0xFFFF;
+    IPTR fb_addr = 0;
+    struct TagItem *scan = (struct TagItem *)msg;
+
+    while ((tag = LibNextTagItem(&scan)))
+    {
+        switch (tag->ti_Tag)
+        {
+        case KRN_VBEModeInfo:
+            vmode = (struct vbe_mode *)tag->ti_Data;
+            break;
+        case KRN_VBEMode:
+            vbemode = (UWORD)tag->ti_Data;
+            break;
+        case KRN_FBAddr:
+            fb_addr = tag->ti_Data;
+            break;
+        }
+    }
+
+    if (!vmode)
+    {
+        bug("[Kernel] Boot video: no VBE/GOP mode info in boot tags\n");
+        return;
+    }
+
+    bug("[Kernel] Boot video: mode=0x%04X %ux%ux%u pitch=%u fb=0x%016llX\n",
+        vbemode,
+        (unsigned)vmode->x_resolution,
+        (unsigned)vmode->y_resolution,
+        (unsigned)vmode->bits_per_pixel,
+        (unsigned)vmode->bytes_per_scanline,
+        (unsigned long long)(fb_addr ? fb_addr : (IPTR)vmode->phys_base));
+    bug("[Kernel] Boot video masks: R%u@%u G%u@%u B%u@%u X%u@%u\n",
+        (unsigned)vmode->red_mask_size,
+        (unsigned)vmode->red_field_position,
+        (unsigned)vmode->green_mask_size,
+        (unsigned)vmode->green_field_position,
+        (unsigned)vmode->blue_mask_size,
+        (unsigned)vmode->blue_field_position,
+        (unsigned)vmode->reserved_mask_size,
+        (unsigned)vmode->reserved_field_position);
 }
 
 #if defined(_KERNEL_EARLYTRAP)
@@ -181,7 +231,7 @@ void kernel_cstart(const struct TagItem *start_msg)
     struct TagItem *msg = (struct TagItem *)start_msg;
     struct MemHeader *mh, *mh2;
     struct mb_mmap *mmap = NULL;
-    IPTR mmap_len = 0, addr = 0, klo  = 0, memtop = 0;
+    IPTR mmap_len = 0, addr = 0, klo  = 0, memtop = 0, maptop = 0;
     struct TagItem *tag;
 #if defined(__AROSEXEC_SMP__)
     struct X86SchedulerPrivate  *scheduleData;
@@ -383,8 +433,24 @@ void kernel_cstart(const struct TagItem *start_msg)
     // Re-read mmap pointer, since we have modified it previously...
     mmap = (struct mb_mmap *)LibGetTagData(KRN_MMAPAddress, 0, BootMsg);
     memtop = mmap_LargestAddress(mmap, mmap_len);
-    D(bug("[Kernel] %s: memtop @ 0x%p\n", __func__, memtop));
-    core_SetupMMU(&__KernBootPrivate->MMU, memtop);
+    maptop = memtop;
+    {
+        IPTR fb_addr = LibGetTagData(KRN_FBAddr, 0, BootMsg);
+        struct vbe_mode *vmode = (struct vbe_mode *)LibGetTagData(KRN_VBEModeInfo, 0, BootMsg);
+
+        if (fb_addr)
+        {
+            IPTR fb_end = fb_addr;
+
+            if (vmode)
+                fb_end = fb_addr + ((IPTR)vmode->bytes_per_scanline * (IPTR)vmode->y_resolution);
+
+            if (fb_end > maptop)
+                maptop = fb_end;
+        }
+    }
+    D(bug("[Kernel] %s: memtop @ 0x%p, maptop @ 0x%p\n", __func__, memtop, maptop));
+    core_SetupMMU(&__KernBootPrivate->MMU, memtop, maptop);
 
     /*
      * Here we ended all boot-time allocations.

--- a/arch/x86_64-pc/kernel/mmu.c
+++ b/arch/x86_64-pc/kernel/mmu.c
@@ -150,8 +150,8 @@ void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop, IPTR maptop)
      * need them.
      */
     MMU->mmu_PDEPageCount = (top + (1 << 21) - 1) >> 21;
-    if (MMU->mmu_PDEPageCount < 2048)       /* keep at least 4 GiB mapped */
-        MMU->mmu_PDEPageCount = 2048;
+    if (MMU->mmu_PDEPageCount < 32768)      /* keep at least 64 GiB mapped */
+        MMU->mmu_PDEPageCount = 32768;
     if (MMU->mmu_PDEPageCount > 262144)     /* cap at 512 GiB */
         MMU->mmu_PDEPageCount = 262144;
 

--- a/arch/x86_64-pc/kernel/mmu.c
+++ b/arch/x86_64-pc/kernel/mmu.c
@@ -138,10 +138,12 @@ void core_LoadMMU(struct CPUMMUConfig *MMU)
 void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop)
 {
     /*
-     * how many PDE entries shall be created? Detault is 2048 (4GB), unless more RAM
-     * is available...
+     * How many PDE entries shall be created?
+     * Keep a larger identity-mapped window by default (64 GiB) so MMIO BARs
+     * placed above 4 GiB (common with ReBAR/large VRAM GPUs and 64-bit PCI
+     * BARs) are directly accessible during early driver init.
      */
-    MMU->mmu_PDEPageCount = 2048;
+    MMU->mmu_PDEPageCount = 32768; /* 32768 * 2 MiB = 64 GiB */
 
     /* Does RAM exceed 4GB? adjust amount of PDE pages */
     if (((memtop + (1 << 21) - 1) >> 21) > MMU->mmu_PDEPageCount)
@@ -152,8 +154,8 @@ void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop)
     if (!MMU->mmu_PML4)
     {
         /*
-         * Allocate MMU pages and directories. Four PDE directories (PDE2M structures)
-         * are enough to map whole 4GB address space.
+         * Allocate MMU paging structures for the configured identity-mapped
+         * low physical address window.
          */
         MMU->mmu_PML4 = krnAllocBootMemAligned(sizeof(struct PML4E) * 512, PAGE_SIZE);
         MMU->mmu_PDP  = krnAllocBootMemAligned(sizeof(struct PDPE)  * 512, PAGE_SIZE);

--- a/arch/x86_64-pc/kernel/mmu.c
+++ b/arch/x86_64-pc/kernel/mmu.c
@@ -135,19 +135,25 @@ void core_LoadMMU(struct CPUMMUConfig *MMU)
     wrcr(cr3, MMU->mmu_PML4);
 }
 
-void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop)
+void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop, IPTR maptop)
 {
+    IPTR top = memtop;
+
+    if (maptop > top)
+        top = maptop;
+
     /*
      * How many PDE entries shall be created?
-     * Keep a larger identity-mapped window by default (64 GiB) so MMIO BARs
-     * placed above 4 GiB (common with ReBAR/large VRAM GPUs and 64-bit PCI
-     * BARs) are directly accessible during early driver init.
+     * Build an identity map window large enough for physical RAM and the
+     * currently active GOP framebuffer range. This keeps high ReBAR/GOP BARs
+     * mapped while avoiding oversized early allocations on systems that don't
+     * need them.
      */
-    MMU->mmu_PDEPageCount = 32768; /* 32768 * 2 MiB = 64 GiB */
-
-    /* Does RAM exceed 4GB? adjust amount of PDE pages */
-    if (((memtop + (1 << 21) - 1) >> 21) > MMU->mmu_PDEPageCount)
-        MMU->mmu_PDEPageCount = (memtop + (1 << 21) - 1) >> 21;
+    MMU->mmu_PDEPageCount = (top + (1 << 21) - 1) >> 21;
+    if (MMU->mmu_PDEPageCount < 2048)       /* keep at least 4 GiB mapped */
+        MMU->mmu_PDEPageCount = 2048;
+    if (MMU->mmu_PDEPageCount > 262144)     /* cap at 512 GiB */
+        MMU->mmu_PDEPageCount = 262144;
 
     D(bug("[Kernel] core_SetupMMU: Re-creating the MMU pages for first %dMB area\n", MMU->mmu_PDEPageCount << 1));
 

--- a/arch/x86_64-pc/kernel/mmu.c
+++ b/arch/x86_64-pc/kernel/mmu.c
@@ -13,6 +13,8 @@
 #define D(x)
 #define DMMU(x)
 
+#define MMU_SPLIT_PTE_PAGE_COUNT 32
+
 void core_InitMMU(struct CPUMMUConfig *MMU)
 {
     struct PML4E *PML4;
@@ -150,8 +152,8 @@ void core_SetupMMU(struct CPUMMUConfig *MMU, IPTR memtop, IPTR maptop)
      * need them.
      */
     MMU->mmu_PDEPageCount = (top + (1 << 21) - 1) >> 21;
-    if (MMU->mmu_PDEPageCount < 32768)      /* keep at least 64 GiB mapped */
-        MMU->mmu_PDEPageCount = 32768;
+    if (MMU->mmu_PDEPageCount < 65536)      /* keep at least 128 GiB mapped */
+        MMU->mmu_PDEPageCount = 65536;
     if (MMU->mmu_PDEPageCount > 262144)     /* cap at 512 GiB */
         MMU->mmu_PDEPageCount = 262144;
 
@@ -207,6 +209,13 @@ void core_ProtPage(intptr_t addr, char p, char rw, char us)
         struct PDE2M *pde2 = (struct PDE2M *)pde;
         intptr_t base = ((IPTR)pde2[pde_off].base_low << 13) | ((IPTR)pde2[pde_off].base_high << 32);
         int i;
+
+        if (MMU->mmu_PDEPageUsed >= MMU_SPLIT_PTE_PAGE_COUNT)
+        {
+            bug("[Kernel] core_ProtPage: split PTE pool exhausted at 0x%p\n",
+                addr);
+            return;
+        }
 
         pte = &Pages4K[512 * MMU->mmu_PDEPageUsed++];
 

--- a/compiler/include/aros/kernel.h
+++ b/compiler/include/aros/kernel.h
@@ -2,7 +2,7 @@
 #define AROS_KERNEL_H
 
 /*
-    Copyright © 1995-2025, The AROS Development Team. All rights reserved.
+    Copyright ï¿½ 1995-2025, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: TagItems for the kernel.resource
@@ -70,6 +70,7 @@ typedef enum
 #define KRN_KernelPhysLowest    (KRN_Dummy + 30) /* Lowest *PHYSICAL* address occupied by Kernel */
 #define KRN_Platform            (KRN_Dummy + 31) /* Arch specifc platform ID provided */
 #define KRN_FlattenedDeviceTree (KRN_Dummy + 32) /* Flattened device tree as used e.g. by linux kernels */
+#define KRN_FBAddr              (KRN_Dummy + 33) /* 64-bit framebuffer base address (GOP/MB2)		*/
 
 /* Magic value passed by the bootstrap as second parameter */
 #define AROS_BOOT_MAGIC AROS_MAKE_ID('A', 'R', 'O', 'S')

--- a/rom/bootloader/bootloader_init.c
+++ b/rom/bootloader/bootloader_init.c
@@ -97,6 +97,7 @@ static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
     struct vbe_controller *vci = NULL;
     UWORD vmode = 0x00FF;       /* Dummy mode number by default           */
     UBYTE palette = 0;          /* By default we don't know palette width */
+    IPTR fb_addr64 = 0;         /* Full 64-bit framebuffer address from KRN_FBAddr */
 
     D(bug("[BootLdr] Init\n"));
 
@@ -137,6 +138,10 @@ static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
         case KRN_VBEPaletteWidth:
             palette = tag->ti_Data;
             break;
+
+        case KRN_FBAddr:
+            fb_addr64 = tag->ti_Data;
+            break;
         }
     }
 
@@ -171,6 +176,11 @@ static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
             /* Framebuffer pointer is only valid for VBE v2 and better */
             if (version >= 0x0200)
                 BootLoaderBase->Vesa->FrameBuffer = (APTR)(IPTR)vmi->phys_base;
+
+            /* Override with full 64-bit address if bootstrap provided KRN_FBAddr.
+             * VBEModeInfo.phys_base is 32-bit and truncates on >4GB systems. */
+            if (fb_addr64)
+                BootLoaderBase->Vesa->FrameBuffer = (APTR)fb_addr64;
 
             if (version >= 0x0300)
             {

--- a/rom/bootloader/bootloader_init.c
+++ b/rom/bootloader/bootloader_init.c
@@ -86,7 +86,14 @@ static void GetCmdLine(char *Kernel_Args, struct BootLoaderBase *BootLoaderBase)
     }
 }
 
-static const ULONG masks [] = {0x01, 0x03, 0x07, 0x0f ,0x1f, 0x3f, 0x7f, 0xff};
+static ULONG mask_for_bits(UBYTE bits)
+{
+    if (bits == 0)
+        return 0;
+    if (bits >= 32)
+        return 0xFFFFFFFFUL;
+    return ((1UL << bits) - 1UL);
+}
 
 static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
 {
@@ -186,10 +193,10 @@ static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
             {
                 /* VBE v3 structures specify linear framebuffer parameters in separate fields */
                 BootLoaderBase->Vesa->BytesPerLine     = vmi->linear_bytes_per_scanline;
-                BootLoaderBase->Vesa->Masks [VI_Red]   = masks[vmi->linear_red_mask_size-1]<<vmi->linear_red_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Blue]  = masks[vmi->linear_blue_mask_size-1]<<vmi->linear_blue_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Green] = masks[vmi->linear_green_mask_size-1]<<vmi->linear_green_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Alpha] = masks[vmi->linear_reserved_mask_size-1]<<vmi->linear_reserved_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Red]   = mask_for_bits(vmi->linear_red_mask_size) << vmi->linear_red_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Blue]  = mask_for_bits(vmi->linear_blue_mask_size) << vmi->linear_blue_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Green] = mask_for_bits(vmi->linear_green_mask_size) << vmi->linear_green_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Alpha] = mask_for_bits(vmi->linear_reserved_mask_size) << vmi->linear_reserved_field_position;
                 BootLoaderBase->Vesa->Shifts[VI_Red]   = 32 - vmi->linear_red_field_position - vmi->linear_red_mask_size;
                 BootLoaderBase->Vesa->Shifts[VI_Blue]  = 32 - vmi->linear_blue_field_position - vmi->linear_blue_mask_size;
                 BootLoaderBase->Vesa->Shifts[VI_Green] = 32 - vmi->linear_green_field_position - vmi->linear_green_mask_size;
@@ -198,10 +205,10 @@ static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR BootLoaderBase)
             else
             {
                 BootLoaderBase->Vesa->BytesPerLine     = vmi->bytes_per_scanline;
-                BootLoaderBase->Vesa->Masks [VI_Red]   = masks[vmi->red_mask_size-1]<<vmi->red_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Blue]  = masks[vmi->blue_mask_size-1]<<vmi->blue_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Green] = masks[vmi->green_mask_size-1]<<vmi->green_field_position;
-                BootLoaderBase->Vesa->Masks [VI_Alpha] = masks[vmi->reserved_mask_size-1]<<vmi->reserved_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Red]   = mask_for_bits(vmi->red_mask_size) << vmi->red_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Blue]  = mask_for_bits(vmi->blue_mask_size) << vmi->blue_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Green] = mask_for_bits(vmi->green_mask_size) << vmi->green_field_position;
+                BootLoaderBase->Vesa->Masks [VI_Alpha] = mask_for_bits(vmi->reserved_mask_size) << vmi->reserved_field_position;
                 BootLoaderBase->Vesa->Shifts[VI_Red]   = 32 - vmi->red_field_position - vmi->red_mask_size;
                 BootLoaderBase->Vesa->Shifts[VI_Blue]  = 32 - vmi->blue_field_position - vmi->blue_mask_size;
                 BootLoaderBase->Vesa->Shifts[VI_Green] = 32 - vmi->green_field_position - vmi->green_mask_size;


### PR DESCRIPTION
## Problem

On a board with **Above-4G Decoding + Resizable BAR** enabled, the UEFI GOP
framebuffer is placed high in the physical address space (on the machine I
validated with it lands at **0x7000000000 = 448 GiB**). Clean x86_64-pc
then triple-faults before any video and the board re-POSTs in a loop:

- `struct vbe_mode.phys_base` is only 32-bit, so the 64-bit framebuffer
  address is truncated;
- the identity map only covers 4 GiB, so the framebuffer is unmapped;
- the bootconsole dereferences the high framebuffer *before* the MMU is
  set up.

## What this series does

1. **bootstrap: skip VBEModeInfo when framebuffer above 4 GiB** — don't hand
   a truncated 32-bit `phys_base` to the kernel.
2. **bootstrap: expand page tables from 4 GiB to 64 GiB** and
   **kernel: expand identity map from 4 GiB to 64 GiB** — cover high MMIO/BAR
   windows.
3. **kernel: define `KRN_FBAddr` tag + bootconsole ReBAR guard** — carry the
   full 64-bit GOP framebuffer address to the kernel, and teach the
   bootconsole to skip a framebuffer parked above 4 GiB instead of faulting.
4. **kernel: GOP boot path — reserve framebuffer + size the MMU to cover it**
   and **raise minimum identity map to 64 GiB**.
5. **kernel/bootstrap: complete GOP fb handoff + disable early video dump** —
   the `boot_dump_video_info()` call ran before `core_SetupMMU` and touched
   the high framebuffer; it is disabled so the boot survives to a mapped MMU.

## Validation

Booted on real hardware (not an emulator):

- **Board:** ASUS B550, **CPU:** AMD Ryzen 3950X, **GPU:** Radeon RX 9060 XT
- BIOS: Above-4G Decoding + Resizable BAR **enabled**
- GOP framebuffer at physical **0x7000000000 (448 GiB)**

Result: boots through GRUB, past the previously-fatal framebuffer
triple-fault, and reaches the live-CD boot menu. Serial confirms
`smartfb: using GOP framebuffer (1920x1080x32 @ 0x7000000000) FB above 4GB`.

## Notes

- Patches are self-contained and only affect the x86_64 boot path on
  Above-4G/ReBAR systems.
- A separate SMP multi-core bring-up series (which gets all logical CPUs
  online on the same hardware) will follow as its own PR.
