### PR TITLE
iprefs: Detach before the first prefs pass

### DIFF
--- a/workbench/c/iprefs/global.h
+++ b/workbench/c/iprefs/global.h
@@ -188,8 +188,7 @@ struct IPrefsSem
 
 /* main.c */
 
-void Cleanup(STRPTR msg);
-WORD ShowMessage(STRPTR title, STRPTR text, STRPTR gadtext);
+LONG ShowMessage(STRPTR title, STRPTR text, STRPTR gadtext);
 
 /* patches.c */
 

--- a/workbench/c/iprefs/main.c
+++ b/workbench/c/iprefs/main.c
@@ -58,7 +58,7 @@
 
 /*********************************************************************************************/
 
-static struct libinfo
+static const struct libinfo
 {
     APTR        var;
     STRPTR      name;
@@ -118,7 +118,7 @@ static void KillNotifications(void);
 
 /*********************************************************************************************/
 
-WORD ShowMessage(STRPTR title, STRPTR text, STRPTR gadtext)
+LONG ShowMessage(STRPTR title, STRPTR text, STRPTR gadtext)
 {
     struct EasyStruct es;
 
@@ -132,7 +132,7 @@ WORD ShowMessage(STRPTR title, STRPTR text, STRPTR gadtext)
 }
 /*********************************************************************************************/
 
-void Cleanup(STRPTR msg)
+static void Cleanup(STRPTR msg)
 {
     if (msg)
     {
@@ -156,7 +156,7 @@ void Cleanup(STRPTR msg)
 
 static void OpenLibs(void)
 {
-    struct libinfo *li;
+    const struct libinfo *li;
 
     for (li = libtable; li->var; li++)
     {
@@ -173,7 +173,7 @@ static void OpenLibs(void)
 
 static void CloseLibs(void)
 {
-    struct libinfo *li;
+    const struct libinfo *li;
 
     for(li = libtable; li->var; li++)
     {
@@ -358,8 +358,10 @@ int main(void)
     GetENVName();
     StartNotifications();
     PreparePatches();
+
+    Detach();  // No more console I/O beyond this point.
+
     HandleNotify();
-    Detach();
     HandleAll();
     Cleanup(NULL);
 


### PR DESCRIPTION
IPrefs held the Startup-Sequence open until it had applied every preference. The font pass can sit in a requester loop waiting for the user to close windows so the Workbench screen can be reset, and nothing later in the sequence runs until it gives up.

Nothing in HandleNotify() writes to the standard streams, so detach first and apply preferences on our own time.

Also const the library table and give ShowMessage() the LONG that EasyRequestArgs() returns.

Refs #913