### PR TITLE
Raspi boot console and config files

### DIFF
--- a/arch/aarch64-native/kernel/kernel_debug.c
+++ b/arch/aarch64-native/kernel/kernel_debug.c
@@ -13,35 +13,20 @@
 
 /*
  * All bug()/KrnBug output ends up here. The generic rom/kernel stub discards
- * everything, leaving the kernel silent during boot. Emit via the configured
- * ARMI_PutChar (set to the bootstrap UART putchar), with a direct PL011 write
- * as a fallback so output works even before/without ARMI_PutChar. The UART
- * device mapping is accessible at EL1.
+ * everything, leaving the kernel silent during boot. ARMI_PutChar is the
+ * bootstrap's framebuffer console (KRN_FuncPutC), ARMI_SerPutChar the PL011;
+ * both are set by the platform probe, which runs before the first bug().
  */
 int krnPutC(int chr, struct KernelBase *KernelBase)
 {
     if (chr == 0x03)
-    {
-        /* Convention: 0x03 disables further low-level output. */
         __arm_arosintern.ARMI_PutChar = NULL;
-        return 1;
-    }
-
-    /*
-     * Write the PL011 directly. ARMI_PutChar points into the bootstrap image
-     * (KRN_FuncPutC tag) and emits nothing once the kernel is running, so use
-     * the same raw UART the early markers use. The device page is EL1-mapped.
-     */
+    else
     {
-        volatile uint32_t *uart = (volatile uint32_t *)0x3f201000;
-        if (chr == '\n')
-        {
-            while (uart[0x18 / 4] & (1 << 5)) ; /* wait for TXFF to clear */
-            uart[0] = '\r';
-        }
-        while (uart[0x18 / 4] & (1 << 5)) ;
-        uart[0] = chr;
+        if (__arm_arosintern.ARMI_PutChar)
+            __arm_arosintern.ARMI_PutChar(chr);
+        if (__arm_arosintern.ARMI_SerPutChar)
+            __arm_arosintern.ARMI_SerPutChar(chr);
     }
-
     return 1;
 }

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -140,7 +140,14 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 # ("MISMATCHED FILES: start.elf and fixup.dat do not fit to each other!").
 RASPIFW_BRANCH    := 1.20260521
 RASPIFW_URI       := https://github.com/raspberrypi/firmware/raw/$(RASPIFW_BRANCH)/boot
-RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb
+# start4.elf/fixup4.dat are the BCM2711 pair: the Pi 4 bootloader looks for
+# them by name and does not fall back to start.elf. The Zero 2 W ships under
+# two dtb names; which one the firmware picks depends on the board revision.
+RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf \
+                     fixup4.dat start4.elf \
+                     bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb \
+                     bcm2710-rpi-zero-2-w.dtb bcm2710-rpi-zero-2.dtb \
+                     bcm2711-rpi-4-b.dtb
 
 RASPIWIFIFW_BRANCH := buster
 RASPIWIFIFW_URI    := https://github.com/RPi-Distro/firmware-nonfree/blob/$(RASPIWIFIFW_BRANCH)
@@ -183,7 +190,7 @@ distfiles-raspi-aarch64le-bootimg: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 distfiles-raspi-aarch64le-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\ndtoverlay=disable-bt\ndtoverlay=sdhost\nenable_uart=1\narm_64bit=1\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\nenable_uart=1\narm_64bit=1\n" > $@
 
 $(AROSDIR)/aros-aarch64-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -147,7 +147,8 @@ RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf \
                      fixup4.dat start4.elf \
                      bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb \
                      bcm2710-rpi-zero-2-w.dtb bcm2710-rpi-zero-2.dtb \
-                     bcm2711-rpi-4-b.dtb
+                     bcm2711-rpi-4-b.dtb \
+                     bcm2712-rpi-5-b.dtb bcm2712-rpi-500.dtb
 
 RASPIWIFIFW_BRANCH := buster
 RASPIWIFIFW_URI    := https://github.com/RPi-Distro/firmware-nonfree/blob/$(RASPIWIFIFW_BRANCH)

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -143,9 +143,16 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-usb-usb2otg \
 #MM kernel-usb-romstrap-raspi
 
-RASPIFW_BRANCH    := master
+# Pin to a specific firmware release tag, not the rolling 'master' branch:
+# start.elf and fixup.dat are a version-matched pair, and fetching them from
+# master at different times (with wget -c never re-fetching) yields a mismatch
+# ("MISMATCHED FILES: start.elf and fixup.dat do not fit to each other!").
+RASPIFW_BRANCH    := 1.20260521
 RASPIFW_URI       := https://github.com/raspberrypi/firmware/blob/$(RASPIFW_BRANCH)/boot
-RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf bcm2709-rpi-2-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb
+# No BCM2711 dtb here: arm-native has no Pi 4 platform, only bcm2708.
+RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf \
+                     bcm2709-rpi-2-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2710-rpi-3-b.dtb \
+                     bcm2710-rpi-zero-2-w.dtb bcm2710-rpi-zero-2.dtb
 
 # Broadcom WiFi firmware for bwfm.device (loaded at runtime from DEVS:Firmware).
 # The "buster" branch keeps real files under brcm/ (newer branches symlink to
@@ -199,7 +206,7 @@ distfiles-raspi-armbe-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.im
 distfiles-raspi-armle-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x10000\ninitramfs $(ARM_BSP) 0x00800000\ndtoverlay=disable-bt\ndtoverlay=sdhost\narm_64bit=0\nhdmi_drive=2\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x10000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=0\nhdmi_drive=2\n" > $@
 
 $(AROSDIR)/aros-armeb-raspi.img: $(TARGETDIR)/core-be.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"


### PR DESCRIPTION
- Fixes console output during boot on aarch64 
- Adds dtb files for pi4 and zero 2w
- Removes overlay references in config.txt which are not used