### PR TITLE
lowlevel: keep the input reply port's signal bit

### DIFF
--- a/workbench/libs/lowlevel/lowlevel_init.c
+++ b/workbench/libs/lowlevel/lowlevel_init.c
@@ -80,8 +80,6 @@ BOOL LowLevelInputInit(LIBBASETYPEPTR LowLevelBase)
     if ((LowLevelBase->ll_InputMP = CreateMsgPort()))
     {
         D(bug("[lowlevel] %s: Input MsgPort @ 0x%p\n", __func__, LowLevelBase->ll_InputMP);)
-        FreeSignal(LowLevelBase->ll_InputMP->mp_SigBit);
-        LowLevelBase->ll_InputMP->mp_SigBit = -1;
 
         if ((LowLevelBase->ll_InputIO = (struct IOStdReq *)CreateIORequest(LowLevelBase->ll_InputMP, sizeof (struct IOStdReq))))
         {


### PR DESCRIPTION
`LowLevelInputInit()` freed the signal bit of `ll_InputMP` (setting `mp_SigBit = -1`) and then issued `DoIO(IND_ADDHANDLER)` on input.device through that same port. input.device does not complete `IND_ADDHANDLER` quick -- it queues the request to its task -- so `DoIO()` falls through to `WaitIO()`, which does `Wait(1 << mp_SigBit)`. With `mp_SigBit == -1` that is `Wait(1 << -1)`, i.e. `Wait(0)` on m68k, which nothing can ever wake: the boot (`RTF_COLDSTART`) task hangs inside lowlevel.library init.

The bug is latent -- it only bites when input.device has not already replied by the time `WaitIO()` checks. It surfaced on m68k under Copperline's JIT (and at high emulated CPU clocks), where the `Signal()` that wakes the higher-priority input.device is delivered as a deferred software interrupt instead of switching synchronously, so the reply has not arrived when `WaitIO()` waits on the dead signal -- a reproducible hang at boot.

The timer port is left as-is: it is only used to `OpenDevice()` for `ReadEClock` and never does `DoIO()`, so freeing its signal bit is harmless.

Regression from de9ebde93ffc4a6b7553ea3ac029badd019b9818.

Tested: with this change AROS m68k boots to Wanderer under Copperline's JIT and at high emulated CPU clocks; without it the bootstrap task deadlocks in lowlevel init.
