### PR TITLE
con-handler: serve clients on a port of its own

### DIFF
--- a/rom/dos/fs_driver.c
+++ b/rom/dos/fs_driver.c
@@ -57,7 +57,12 @@ LONG fs_Open(struct FileHandle *handle, struct MsgPort *port, BPTR lock, LONG mo
     status = dopacket3(DOSBase, &error, port, action, MKBADDR(handle), lock, bstrname);
     FREEC2BSTR(bstrname);
 
-    handle->fh_Type = port;
+    /* A handler that serves its clients on a port other than the one we
+     * found it on says so by filling in fh_Type itself. Handlers that do
+     * not care leave it alone and keep talking on the port we used here.
+     */
+    if (!handle->fh_Type)
+        handle->fh_Type = port;
     return status ? 0 : error;
 }
 

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -1149,7 +1149,12 @@ LONG CONMain(struct ExecBase *SysBase)
                     replypkt2(dp, DOSTRUE, ERROR_ACTION_NOT_KNOWN);
                     break;
                 default:
-                    bug("[con:handler] unknown action %d\n", dp->dp_Type);
+                    /* Saying no is a normal answer here: capability probes
+                     * ask for actions a console has no use for. */
+                    DACTION(bug("[con:handler] unknown action %d from '%s'\n",
+                            dp->dp_Type, dp->dp_Port && dp->dp_Port->mp_SigTask
+                                ? dp->dp_Port->mp_SigTask->tc_Node.ln_Name
+                                : "?"));
                     replypkt2(dp, DOSFALSE, ERROR_ACTION_NOT_KNOWN);
                     break;
                 }

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -668,7 +668,8 @@ static void stopread(struct filehandle *fh, struct DosPacket *waitingdp)
 
 LONG CONMain(struct ExecBase *SysBase)
 {
-    struct MsgPort *mp;
+    struct MsgPort *mp = NULL;
+    struct MsgPort *procmp;
     struct DosPacket *dp;
     struct Message *mn;
     struct FileHandle *dosfh;
@@ -678,10 +679,22 @@ LONG CONMain(struct ExecBase *SysBase)
     struct DosPacket *waitingdp = NULL;
 
     D(bug("[con:handler] started\n"));
-    mp = &((struct Process*) FindTask(NULL))->pr_MsgPort;
-    WaitPort(mp);
-    dp = (struct DosPacket*) GetMsg(mp)->mn_Node.ln_Name;
-    D(bug("[con:handler] startup message received. port=0x%p path='%b'\n", mp, dp->dp_Arg1));
+    procmp = &((struct Process*) FindTask(NULL))->pr_MsgPort;
+    WaitPort(procmp);
+    dp = (struct DosPacket*) GetMsg(procmp)->mn_Node.ln_Name;
+    D(bug("[con:handler] startup message received. port=0x%p path='%b'\n", procmp, dp->dp_Arg1));
+
+    /* Clients get a port of their own. The process port cannot serve both,
+     * because DoPkt() replies land there too: TAB completion looks up
+     * directories, and a client packet arriving during one of those lookups
+     * would be taken for the reply and alerted as AN_AsyncPkt.
+     */
+    mp = CreateMsgPort();
+    if (!mp) {
+        error = ERROR_NO_FREE_STORE;
+        D(bug("[con:handler] no packet port\n"));
+        goto end;
+    }
 
     fh = open_con(dp, &error);
     if (!fh) {
@@ -705,7 +718,7 @@ LONG CONMain(struct ExecBase *SysBase)
 #endif
         ULONG conreadmask = 1L << fh->conreadmp->mp_SigBit;
         ULONG timermask = 1L << fh->timermp->mp_SigBit;
-        ULONG packetmask = 1L << mp->mp_SigBit;
+        ULONG packetmask = (1L << mp->mp_SigBit) | (1L << procmp->mp_SigBit);
         ULONG winmask = fh->window ? 1L << fh->window->UserPort->mp_SigBit : 0L;
         ULONG appwindowmask = fh->appmsgport ? 1L << fh->appmsgport->mp_SigBit : 0L;
         ULONG i, insertedlen;
@@ -922,6 +935,13 @@ LONG CONMain(struct ExecBase *SysBase)
                     startread(fh);
             }
 
+            /* DOS addresses a handler by the port it was started on until
+             * it has a file handle to go by, so the first open still turns
+             * up here. Move those over and serve everything from one place.
+             */
+            while ((mn = GetMsg(procmp)))
+                PutMsg(mp, mn);
+
             while ((mn = GetMsg(mp))) {
                 dp = (struct DosPacket*) mn->mn_Node.ln_Name;
                 dp->dp_Res2 = 0;
@@ -947,6 +967,8 @@ LONG CONMain(struct ExecBase *SysBase)
                     dosfh = BADDR(dp->dp_Arg1);
                     dosfh->fh_Interactive = DOSTRUE;
                     dosfh->fh_Arg1 = (SIPTR) fh;
+                    /* Talk to us here from now on, not on the process port. */
+                    dosfh->fh_Type = mp;
                     fh->usecount++;
                     fh->breaktask = dp->dp_Port->mp_SigTask;
                     DACTION(bug("[con:handler] Find fh=%x. Usecount=%d\n", dosfh, fh->usecount));
@@ -1171,6 +1193,9 @@ end:
         D(bug("[con:handler] Replying packet 0x%p, error %ld\n", dp, error));
         replypkt2(dp, DOSFALSE, error);
     }
+
+    if (mp)
+        DeleteMsgPort(mp);
 
     D(bug("[con:handler] 0x%p closed\n", fh));
     return 0;


### PR DESCRIPTION
A console handler answered its clients on its process port. That is also
where `DoPkt()` delivers replies, and the handler makes DOS calls of its own:
TAB completion looks up directories, and the icon-drop path calls
`NameFromLock()`. A client writing to the console during one of those had its
packet mistaken for the reply, and DOS alerted `AN_AsyncPkt`.

Clients now get a port of their own, which the handler hands out in `fh_Type`
when it answers the open. DOS keeps filling that field in as before for
handlers that leave it alone, so nothing changes for the other handlers.

The second commit quiets a `bug()` that fired for every unrecognised action.
Refusing an action is a normal answer rather than a fault: the C runtime
probes each standard stream with `ACTION_GET_FILE_POSITION64` as it starts,
which put three lines on the log for every program run from a console.

Tested on amiga-m68k.
