### PR TITLE
graphics: free a bitmap with the size it was allocated with

### DIFF
--- a/rom/graphics/allocbitmap.c
+++ b/rom/graphics/allocbitmap.c
@@ -329,7 +329,7 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
         SET_TAG(bm_tags, 7, TAG_DONE, 0);
 
         /* Allocate an extra planes for HIDD bitmap info */
-        nbm = AllocMem(sizeof(struct BitMap) + sizeof(PLANEPTR) * HIDD_BM_EXTRAPLANES, MEMF_ANY | MEMF_CLEAR);
+        nbm = AllocVec(sizeof(struct BitMap) + sizeof(PLANEPTR) * HIDD_BM_EXTRAPLANES, MEMF_ANY | MEMF_CLEAR);
         D(bug("[AllocBitMap] Allocated bitmap structure: 0x%p\n", nbm));
 
         if(nbm) {
@@ -477,13 +477,18 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
                 OOP_DisposeObject(bm_obj);
             } /* if (bitmap object allocated) */
 
-            FreeMem(nbm, sizeof(struct BitMap));
+            FreeVec(nbm);
             nbm = NULL;
 
         } /* if (nbm) */
 
     } else { /* Otherwise init a plain Amiga bitmap. TODO: BMF_INTERLEAVED support */
-        nbm = AllocMem(sizeof(struct BitMap) + ((depth > 8) ? (depth - 8) * sizeof(PLANEPTR) : 0),
+        /* Planes[] holds 8 entries, so a deeper bitmap needs room for the
+         * rest. AllocVec() remembers how much, so the cleanup paths below
+         * do not have to repeat the sum and cannot get it wrong.
+         */
+        nbm = AllocVec(sizeof(struct BitMap)
+                       + ((depth > 8) ? (depth - 8) * sizeof(PLANEPTR) : 0),
                        MEMF_ANY | MEMF_CLEAR);
 
         if(nbm) {
@@ -512,7 +517,7 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
                         }
                     } else {
                         /* Failed to allocate plane data storage ... */
-                        FreeMem(nbm, sizeof(struct BitMap));
+                        FreeVec(nbm);
                         nbm = NULL;
                     }
                 } else {
@@ -531,7 +536,7 @@ static HIDDT_StdPixFmt const cyber2hidd_pixfmt[] = {
                             if(nbm->Planes[plane])
                                 FreeRaster(nbm->Planes[plane], sizex, sizey);
 
-                        FreeMem(nbm, sizeof(struct BitMap));
+                        FreeVec(nbm);
                         nbm = NULL;
                     } else {
                         /* Clear remaining entries.. */

--- a/rom/graphics/freebitmap.c
+++ b/rom/graphics/freebitmap.c
@@ -73,7 +73,7 @@
         if(bmobj)
             OOP_DisposeObject(bmobj);
 
-        FreeMem(bm, sizeof(struct BitMap) + sizeof(PLANEPTR) * HIDD_BM_EXTRAPLANES);
+        FreeVec(bm);
     } else {
         ULONG plane;
         ULONG width;
@@ -101,8 +101,7 @@
 
         }
 
-        FreeMem(bm, sizeof(struct BitMap) +
-                ((bm->Depth > 8) ? (bm->Depth - 8) * sizeof(PLANEPTR) : 0));
+        FreeVec(bm);
     }
 
     AROS_LIBFUNC_EXIT


### PR DESCRIPTION
`AllocBitMap()` reserves room past `struct BitMap` for the extra plane
pointers a HIDD bitmap (eight of them) or a bitmap deeper than eight planes
needs -- but every one of its cleanup paths freed only
`sizeof(struct BitMap)`, which is 32 bytes short on m68k.

A short free does not fault where it happens. It leaves the allocator's chunk
boundaries out of step with the real allocations, so the damage lands on some
later, unrelated free:

```
[MM] Chunk allocator error
[MM] Attempt to free 118302800 bytes at 0x070d2780
[MM] The block does not belong to any MemHeader
```

`FreeBitMap()` had the sizes right, so this only ever triggered when creating
a bitmap failed. Found while chasing #926, though it turned out not to be the
cause of that one (see #934), so it stands on its own.

Rather than repeat the sum at each free, the structure is now claimed with
`AllocVec()` and released with `FreeVec()`. The size expression survives only
in the two places that allocate, and no free can disagree with it -- which
matters because the allocation and the free live in different functions, with
nothing shared but the bitmap itself. `FreeBitMap()` had been recomputing the
size from `bm->Depth`, and `graphics_intern.h` sets `BMDEPTH_COMPATIBILITY`,
under which `AllocBitMap()` deliberately clamps that field to 8. The two
paths do not currently overlap, but the invariant that free-time state still
describes the allocation is not one anything enforces.

Costs 8 bytes per bitmap, against plane data measured in kilobytes. The m68k
ROM came out 40 bytes smaller, since five call sites no longer compute a size.

Tested on amiga-m68k.
