### PR TITLE
Wanderer: queue a lister's removal only once

### DIFF
--- a/workbench/libs/muimaster/classes/notify.h
+++ b/workbench/libs/muimaster/classes/notify.h
@@ -2,7 +2,7 @@
 #define _MUI_CLASSES_NOTIFY_H
 
 /*
-    Copyright © 2002-2012, The AROS Development Team. All rights reserved.
+    Copyright (C) 2002-2012, The AROS Development Team. All rights reserved.
     $Id$
 */
 

--- a/workbench/system/Wanderer/iconwindow.c
+++ b/workbench/system/Wanderer/iconwindow.c
@@ -1398,6 +1398,32 @@ IPTR IconWindow__MUIM_IconWindow_UnselectAll
 }
 ///
 
+///IconWindow__MUIM_IconWindow_RequestClose()
+IPTR IconWindow__MUIM_IconWindow_RequestClose
+(
+  Class *CLASS, Object *self, Msg message
+)
+{
+  SETUP_ICONWINDOW_INST_DATA;
+
+  D(bug("[Wanderer:IconWindow]: %s()\n", __PRETTY_FUNCTION__));
+
+  /* The window closes on a pushed method, so it stays open and keeps
+   * asking until the application gets round to it. Queue one removal
+   * only: a second would dispose an object that is already gone.
+   */
+  if (data->iwd_Flags & IWDFLAG_CLOSING)
+    return TRUE;
+
+  data->iwd_Flags |= IWDFLAG_CLOSING;
+
+  DoMethod(_app(self), MUIM_Application_PushMethod,
+           (IPTR)self, 1, MUIM_IconWindow_Remove);
+
+  return TRUE;
+}
+///
+
 ///IconWindow__MUIM_IconWindow_Remove()
 IPTR IconWindow__MUIM_IconWindow_Remove
 (
@@ -1675,6 +1701,7 @@ ICONWINDOW_CUSTOMCLASS
   MUIM_IconWindow_Clicked,                    Msg,
   MUIM_IconWindow_DirectoryUp,                Msg,
   MUIM_IconWindow_AppWindowDrop,              Msg,
+  MUIM_IconWindow_RequestClose,               Msg,
   MUIM_IconWindow_Remove,                     Msg,
   MUIM_IconWindow_RateLimitRefresh,           Msg,
   MUIM_IconWindow_Snapshot,                   struct MUIP_IconWindow_Snapshot *,

--- a/workbench/system/Wanderer/iconwindow.h
+++ b/workbench/system/Wanderer/iconwindow.h
@@ -2,7 +2,7 @@
 #define _ICONWINDOW_H_
 
 /*
-    Copyright © 2004 - 2011, The AROS Development Team. All rights reserved.
+    Copyright (C) 2004 - 2011, The AROS Development Team. All rights reserved.
     $Id$
 */
 
@@ -28,6 +28,7 @@
 #define MUIM_IconWindow_Remove                             (MUIB_IconWindow | 0x00000007)
 #define MUIM_IconWindow_RateLimitRefresh                   (MUIB_IconWindow | 0x00000008)
 #define MUIM_IconWindow_Snapshot                           (MUIB_IconWindow | 0x00000009)
+#define MUIM_IconWindow_RequestClose                       (MUIB_IconWindow | 0x0000000a)
 
 #define MUIM_IconWindow_BackFill_Register                  (MUIB_IconWindow | 0x00000010)
 #define MUIM_IconWindow_BackFill_Setup                     (MUIB_IconWindow | 0x00000012)
@@ -131,6 +132,7 @@ struct IconWindow_DATA
 #define IWDFLAG_NEEDSUPDATE             (1<<1)
 #define IWDFLAG_ISROOT                  (1<<4)
 #define IWDFLAG_ISBACKDROP              (1<<5)
+#define IWDFLAG_CLOSING                 (1<<6)
     UBYTE                                iwd_Flags;
     UBYTE                                iwd_VolViewMode;
 };
@@ -173,7 +175,8 @@ and temporarily placed here */
                            m18, m18_msg_type,                        \
                            m19, m19_msg_type,                        \
                            m20, m20_msg_type,                        \
-                           m21, m21_msg_type)                        \
+                           m21, m21_msg_type,                       \
+                           m22, m22_msg_type)                       \
     __ZUNE_CUSTOMCLASS_START(name)                                   \
     __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m1, m1, m1_msg_type);    \
     __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m2, m2, m2_msg_type);    \
@@ -196,6 +199,7 @@ and temporarily placed here */
     __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m19, m19, m19_msg_type); \
     __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m20, m20, m20_msg_type); \
     __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m21, m21, m21_msg_type); \
+    __ZUNE_CUSTOMCLASS_METHOD(name ## __ ## m22, m22, m22_msg_type); \
     __ZUNE_CUSTOMCLASS_END(name, base, parent_name, parent_class)    \
 
 IPTR IconWindow__MUIM_IconWindow_BackFill_Register(Class *CLASS, Object *self, struct MUIP_IconWindow_BackFill_Register *message);

--- a/workbench/system/Wanderer/wanderer.c
+++ b/workbench/system/Wanderer/wanderer.c
@@ -4014,7 +4014,7 @@ D(bug("[Wanderer] %s: isWorkbenchWindow\n", __func__));
             DoMethod
             (
                 window, MUIM_Notify, MUIA_Window_CloseRequest, TRUE,
-                (IPTR)_app(self), 4, MUIM_Application_PushMethod, (IPTR)window, 1, MUIM_IconWindow_Remove
+                (IPTR)window, 1, MUIM_IconWindow_RequestClose
             );
         }
 


### PR DESCRIPTION
Closing a lister notifies on `MUIA_Window_CloseRequest`, and the notification
pushes `MUIM_IconWindow_Remove` to run on the next application loop. Until
that runs the window is still open and still notifying: the attribute carries
no state -- `OM_GET` always answers FALSE, and MUI sets it afresh on every
`IDCMP_CLOSEWINDOW` -- and `MUIM_Application_PushMethod` does not collapse
duplicates. A second click therefore queues a second removal, and
`DisposeObject()` runs twice on the same window.

The second dispose walks instance data that the first one already released,
so the damage is wide: `IconWindow__OM_DISPOSE` frees `iwd_BackFill_hook`
again, String gadgets inside the window free their buffers again, and notify
lists are walked after their nodes are gone. Since these are `AllocVec()`
blocks, the second `FreeVec()` reads its size out of a block that is back on
the free list, and the free list's own link becomes the byte count:

```
[MM] Attempt to free 118302800 bytes at 0x070d2780
[MM] The block does not belong to any MemHeader
```

Reaching it needs a window slow enough to be clicked twice before the queue
drains, which is why listers hit it and dialogs do not, and why it looked
intermittent.

The notification now goes to the window's own `MUIM_IconWindow_RequestClose`,
which pushes the removal at most once, guarded by a flag in the window's
instance data. Notifications still arrive on every click; only the first
starts a teardown. `ICONWINDOW_CUSTOMCLASS` takes one method per macro
argument, so it grows by one to carry the new method.

Fixes #926.

Tested on amiga-m68k: repeated rapid close/reopen of listers, which
previously produced the above within a few tries.
