### PR TITLE
exec: name the caller when a free goes wrong

### DIFF
--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -690,6 +690,9 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
                     bug("[MM] Chunk allocator error\n");
                     bug("[MM] Attempt to free %u bytes at 0x%p from MemHeader 0x%p\n", byteSize, memoryBlock, freeList);
                     bug("[MM] Block overlaps (1) with chunk 0x%p (%u bytes)\n", p2, p2->mc_Bytes);
+                    bug("[MM] %s() called from 0x%p by '%s'\n",
+                        tp ? tp->function : "?", tp ? tp->caller : NULL,
+                        FindTask(NULL)->tc_Node.ln_Name);
 
                     Alert(AN_FreeTwice);
                     return;
@@ -715,6 +718,9 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
                 bug("[MM] Chunk allocator error\n");
                 bug("[MM] Attempt to free %u bytes at 0x%p from MemHeader 0x%p\n", byteSize, memoryBlock, freeList);
                 bug("[MM] Block overlaps (2) with chunk 0x%p (%u bytes)\n", p1, p1->mc_Bytes);
+                bug("[MM] %s() called from 0x%p by '%s'\n",
+                    tp ? tp->function : "?", tp ? tp->caller : NULL,
+                    FindTask(NULL)->tc_Node.ln_Name);
 
                 Alert(AN_FreeTwice);
                 return;

--- a/rom/exec/memory_nommu.c
+++ b/rom/exec/memory_nommu.c
@@ -241,6 +241,9 @@ void nommu_FreeMem(APTR memoryBlock, IPTR byteSize, struct TraceLocation *loc, s
     bug("[MM] Chunk allocator error\n");
     bug("[MM] Attempt to free %u bytes at 0x%p\n", byteSize, memoryBlock);
     bug("[MM] The block does not belong to any MemHeader\n");
+    bug("[MM] %s() called from 0x%p by '%s'\n",
+        loc ? loc->function : "?", loc ? loc->caller : NULL,
+        FindTask(NULL)->tc_Node.ln_Name);
 
     Alert(AN_BadFreeAddr);
 #endif
@@ -320,7 +323,7 @@ IPTR nommu_AvailMem(ULONG attributes, struct ExecBase *SysBase)
                         /*  2. The end (+1) of the current MemChunk must be lower than the start of the next one. */
                 if (mc->mc_Next && ((UBYTE *)mc + mc->mc_Bytes >= (UBYTE *)mc->mc_Next))
                 {
-                    bug("[MM] Chunk allocator error in MemHeader 0x%p\n");
+                    bug("[MM] Chunk allocator error in MemHeader 0x%p\n", mh);
                     bug("[MM] Overlapping chunks 0x%p (%u bytes) and 0x%p (%u bytes)\n", mc, mc->mc_Bytes, mc->mc_Next, mc->mc_Next->mc_Bytes);
 
                     Alert(AN_MemoryInsane|AT_DeadEnd);


### PR DESCRIPTION
A bad free prints the block, and sometimes the MemHeader it could not be
placed in. Neither says who freed it, and a double free is usually noticed
long after the code responsible has returned, so there is nowhere to start
looking.

`struct TraceLocation` already travels from `FreeMem()` down through
`InternalFreeMem()` into the allocator, carrying the calling function's name
and its return address. It simply was never printed. Reporting it turns

```
[MM] Chunk allocator error
[MM] Attempt to free 118302800 bytes at 0x070d2780
[MM] The block does not belong to any MemHeader
```

into the same thing plus

```
[MM] FreeVec() called from 0x07584008 by 'WANDERER:Wanderer'
```

The return address can then be resolved to a module and function the way
alert output already is. That is what identified the double free behind #926,
after the block address alone had led nowhere for some time.

Covers the three points where the allocator gives up: `nommu_FreeMem()`, and
both `AN_FreeTwice` paths in `stdDealloc()`.

One drive-by in the same file: a consistency check in `nommu_AvailMem()`
formats a MemHeader pointer without passing one, so it prints a stray vararg.

Tested on amiga-m68k.
