### PR TITLE
graphics: invert the whole area for a COMPLEMENT JAM2 pattern fill

### DIFF
--- a/rom/graphics/bltpattern.c
+++ b/rom/graphics/bltpattern.c
@@ -98,6 +98,33 @@ static ULONG bltpattern_render(APTR bpr_data, WORD srcx, WORD srcy,
 {
     AROS_LIBFUNC_INIT
 
+    /*
+     * COMPLEMENT inverts the destination and uses neither pen, and JAM2 asks
+     * for both phases of the pattern to be drawn. Together they invert the
+     * whole area, and the pattern has nothing left to say. Under JAM1 only
+     * the pattern's set bits are drawn, so only those invert, which the
+     * pattern path below already gets right.
+     */
+    if((rp->DrawMode & (COMPLEMENT | JAM2)) == (COMPLEMENT | JAM2)) {
+        if(mask) {
+            ULONG old_drawmode = GetDrMd(rp);
+
+            /* JAM1 leaves COMPLEMENT to reach the driver, so the template's
+             * set bits, and only those, invert. */
+            SetDrMd(rp, JAM1 | COMPLEMENT);
+            BltTemplate(mask, 0, byteCnt, rp, xMin, yMin,
+                        xMax - xMin + 1, yMax - yMin + 1);
+            SetDrMd(rp, old_drawmode);
+        } else {
+            OOP_Object *gc = GetDriverData(rp, GfxBase);
+
+            fillrect_pendrmd(rp, xMin, yMin, xMax, yMax, GC_FG(gc),
+                             vHidd_GC_DrawMode_Invert, TRUE, GfxBase);
+        }
+
+        return;
+    }
+
     if(rp->AreaPtrn) {
         BOOL solidpattern = FALSE;
 


### PR DESCRIPTION
`COMPLEMENT` inverts the destination and uses neither pen, while `JAM2` asks
for both phases of the pattern to be drawn. Together they invert the whole
rectangle, and the pattern has nothing left to say. `BltPattern()` rendered an
ordinary two-pen pattern fill instead.

The draw mode never reached the driver. `GetDriverData()` builds the GC with

```c
    if (rp->DrawMode & JAM2)
        GC_COLEXP(gc) = vHidd_GC_ColExp_Opaque;
    else if (rp->DrawMode & COMPLEMENT)
        GC_DRMD(gc) = vHidd_GC_DrawMode_Invert;
```

so once `JAM2` is set the `COMPLEMENT` branch is unreachable, the GC asks for
a plain opaque fill, and every driver faithfully draws one. That is why the
scene failed with the same pixel count on the native chipset and on both RTG
boards: all three render the wrong request correctly.

Each `PutPattern` implementation does have a complement path, but it inverts
only where the pattern sets a bit -- the `JAM1` answer. Reaching the opaque
case through them would mean a second complement mode in the generic bitmap
class, in the Amiga blitter and in p96gfx alike. Since the pattern plays no
part in the result, `BltPattern()` can do it directly: a rectangle fill in
invert mode, or, when a mask is given, a template blit under `JAM1` so that
`COMPLEMENT` survives the same conversion and only the mask's set bits invert.

`JAM1 | COMPLEMENT` is unaffected -- it reaches the second branch today and
already inverts exactly the pattern's set bits.

Found by the p96cts `BltPattern-drawmodes` scene, whose golden gives the rule
directly: under `JAM1 | COMPLEMENT` only pattern pixels invert, under
`JAM2 | COMPLEMENT` the whole tile does, background bands included.

Refs #936.

Tested on amiga-m68k: the scene passes on the native chipset, and this is the
same code path the Z3660 and ZZ9000 runs took.
