### PR TITLE
p96gfx: send the line pattern's bit number the way P96 counts it

### DIFF
--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_bitmapclass.c
@@ -865,10 +865,10 @@ VOID P96GFXBitmap__Hidd_BitMap__DrawLine(OOP_Class *cl, OOP_Object *o,
                                     - (horizontal ? adx : ady);
         renderLine.LinePtrn = GC_LINEPAT(msg->gc);
         /*
-         * The Amiga pattern counter selects a bit from the top down and P96
-         * counts from the bottom, so the two run in opposite directions.
+         * PatternShift is a bit number counted from the bottom: the first
+         * pixel of the line takes pattern bit (1 << PatternShift).
          */
-        renderLine.PatternShift = 15 - (GC_LINEPATCNT(msg->gc) & 15);
+        renderLine.PatternShift = GC_LINEPATCNT(msg->gc) & 15;
         renderLine.FgPen = GC_FG(msg->gc);
         renderLine.BgPen = GC_BG(msg->gc);
         renderLine.Horizontal = horizontal;


### PR DESCRIPTION
`PatternShift` names the pattern bit the first pixel of a line takes, counted
from the bottom: bit `(1 << PatternShift)`. That is what the rastport counter
already holds, but the card was handed `15 - counter` instead.

p96cts `DrawLine-pattern`, `-jam2` and `-inversvid` failed on a ZZ9000 board
and pass with this, on ZZ9000 and Z3660, at 8 and 24 bits. The hardware line
is still used rather than falling back to software. `DrawLine-solid` was never
affected, its pattern being all ones.

Refs #936.

Tested on amiga-m68k.
