### PR TITLE
amigavideo: flush the pixel cache before reading the planes back

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -766,6 +766,10 @@ VOID AmigaVideoBM__Hidd_BitMap__GetImageLUT(OOP_Class *cl, OOP_Object *o,
     
     data = OOP_INST_DATA(cl, o);
 
+    /* Reading the planes straight out, so anything a previous draw left
+     * sitting in the pixel cache has to reach them first. */
+    CLEARCACHE;
+
     D(bug("[AmigaVideo:Bitmap] %s: Get %dx%d to %dx%d from %d planes to buffer at %p\n",
                         __func__, msg->x, msg->y, msg->x + msg->width - 1, msg->y + msg->height - 1, data->depth, msg->pixels));
 


### PR DESCRIPTION
Pixel writes are gathered into a chunk of a plane row and written out when the
next operation starts, so every bitmap entry point calls `CLEARCACHE` on the
way in -- `PutPixel`, `GetPixel`, `DrawLine`, `PutPattern`, `PutImage`,
`PutImageLUT`, `FillRect`, `PutTemplate`. `GetImageLUT` reads the planes
directly and did not, so it returned whatever the last drawing had left in the
cache as unset.

Anything that draws and then reads a native planar bitmap back can lose the
last pixels it wrote. p96cts caught it on the line scenes, whose final
operation is a run of CPU pixel writes: the last ray of the star ends two
pixels inside one cached chunk, and nothing follows to flush it.

p96cts `DrawLine-solid`, `-pattern`, `-jam2` and `-inversvid` failed on the
native chipset and pass with this. The RTG boards were never affected -- they
draw lines on the card and do not use this cache.

Refs #936.

Tested on amiga-m68k.
