### PR TITLE
raspi/aarch64-raspi: ship fd.library and dos64.library in the kickstart

### DIFF
--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -27,6 +27,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-package-raspi-aarch64-quick: \
 #MM linklibs-stdc-static-quick \
 #MM kernel-dos-quick \
+#MM kernel-dos64-quick \
 #MM kernel-bootloader-quick \
 #MM kernel-dosboot-quick \
 #MM kernel-oop-quick \
@@ -38,6 +39,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-cgxbootpic-quick \
 #MM workbench-libs-gadtools-quick \
 #MM workbench-libs-lowlevel-quick \
+#MM workbench-libs-fd-quick \
 #MM kernel-intuition-quick \
 #MM kernel-partition-quick \
 #MM kernel-layers-quick \
@@ -80,6 +82,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-package-raspi-aarch64: \
 #MM linklibs-stdc-static \
 #MM kernel-dos \
+#MM kernel-dos64 \
 #MM kernel-bootloader \
 #MM kernel-dosboot \
 #MM kernel-oop \
@@ -91,6 +94,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-cgxbootpic \
 #MM workbench-libs-gadtools \
 #MM workbench-libs-lowlevel \
+#MM workbench-libs-fd \
 #MM kernel-intuition \
 #MM kernel-partition \
 #MM kernel-layers \
@@ -157,7 +161,7 @@ RASPIWIFIFW_FILES  := brcm/brcmfmac43455-sdio.bin brcm/brcmfmac43455-sdio.txt \
                      brcm/brcmfmac43430-sdio.bin brcm/brcmfmac43430-sdio.txt \
                      LICENCE.broadcom_bcm43xx
 
-PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
+PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos dos64 poseidon cgxbootpic gadtools lowlevel fd
 PKG_LIBS_ARCH := expansion
 PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio bwfm
 PKG_RSRC_ARCH := processor

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -40,6 +40,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-package-raspi-arm-quick: \
 #MM linklibs-stdc-static-quick \
 #MM kernel-dos-quick \
+#MM kernel-dos64-quick \
 #MM kernel-bootloader-quick \
 #MM kernel-dosboot-quick \
 #MM kernel-oop-quick \
@@ -51,6 +52,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-cgxbootpic-quick \
 #MM workbench-libs-gadtools-quick \
 #MM workbench-libs-lowlevel-quick \
+#MM workbench-libs-fd-quick \
 #MM kernel-intuition-quick \
 #MM kernel-partition-quick \
 #MM kernel-layers-quick \
@@ -92,6 +94,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-package-raspi-arm: \
 #MM linklibs-stdc-static \
 #MM kernel-dos \
+#MM kernel-dos64 \
 #MM kernel-battclock \
 #MM kernel-bootloader \
 #MM kernel-dosboot \
@@ -104,6 +107,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-cgxbootpic \
 #MM workbench-libs-gadtools \
 #MM workbench-libs-lowlevel \
+#MM workbench-libs-fd \
 #MM kernel-intuition \
 #MM kernel-partition \
 #MM kernel-layers \
@@ -166,7 +170,7 @@ RASPIWIFIFW_FILES  := brcm/brcmfmac43455-sdio.bin brcm/brcmfmac43455-sdio.txt \
                      brcm/brcmfmac43430-sdio.bin brcm/brcmfmac43430-sdio.txt \
                      LICENCE.broadcom_bcm43xx
 
-PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos poseidon cgxbootpic gadtools lowlevel
+PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos dos64 poseidon cgxbootpic gadtools lowlevel fd
 PKG_LIBS_ARCH := expansion
 PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands mbox dma sdio bwfm
 PKG_RSRC_ARCH := processor battclock


### PR DESCRIPTION
Both libraries are built from source but never packaged: fd.library
(disk library, workbench-libs-fd) is reachable only through the
generic workbench-libs aggregate, not the raspi kernel-package
targets; dos64.library (kernel-dos64) is simply missing from
PKG_LIBS. A system built from these targets has neither library
present at all, so anything that OpenLibrary()s them - most notably
posixc.library's socket-ownership check on every read()/write() -
fails every time instead of finding a resident library.
