### PR TITLE
graphics: honour FRST_DOT so a polyline's vertices complement once

### DIFF
--- a/rom/graphics/draw.c
+++ b/rom/graphics/draw.c
@@ -70,13 +70,15 @@ static ULONG draw_render(APTR draw_rd, WORD srcx, WORD srcy,
     RESULT
 
     NOTES
+        Move() sets FRST_DOT and this clears it, so a run of Draw() calls
+        paints the vertex between two segments once rather than twice. Only
+        COMPLEMENT can see the difference - drawing the same pen twice looks
+        the same as drawing it once - and there it is the difference between
+        a vertex and a hole.
+
         Not yet implemented:
 
           - handle layer->Scroll_X/Scroll_Y.
-
-          - handle FRST_DOT which indicates whether to draw
-            or to don't draw first pixel of line. Important
-            for COMPLEMENT drawmode.
 
     EXAMPLE
 
@@ -138,6 +140,22 @@ static ULONG draw_render(APTR draw_rd, WORD srcx, WORD srcy,
           GC_BG(gc)));
 
     do_render_with_gc(rp, NULL, &rr, draw_render, &drd, gc, TRUE, FALSE, GfxBase);
+
+    /*
+     * FRST_DOT clear means the starting point belongs to the segment before
+     * this one, which has already drawn it. Complementing it a second time
+     * would take it back to the background, so undo that dot - but only if
+     * the line pattern actually laid it down.
+     */
+    if(!(rp->Flags & FRST_DOT)
+            && (rp->DrawMode & COMPLEMENT)
+            && (GC_LINEPAT(gc) & (1 << (GC_LINEPATCNT(gc) & 15)))) {
+        fillrect_pendrmd(rp, x1, y1, x1, y1, GC_FG(gc),
+                         vHidd_GC_DrawMode_Invert, TRUE, GfxBase);
+    }
+
+    /* Whatever comes next continues from this segment's end point. */
+    rp->Flags &= ~FRST_DOT;
 
     dx = (drd.x2 > drd.y2) ? drd.x2 : drd.y2;
 

--- a/rom/graphics/move.c
+++ b/rom/graphics/move.c
@@ -58,6 +58,9 @@
     rp->cp_y = y;
     rp->linpatcnt = 15;
 
+    /* A fresh line, so the next Draw() owns its starting point. */
+    rp->Flags |= FRST_DOT;
+
     AROS_LIBFUNC_EXIT
 
 } /* Move */


### PR DESCRIPTION
`Move()` starts a fresh line and `Draw()` continues one, so consecutive
segments share their joining point. Drawing that point twice is invisible in
JAM1 and JAM2, where the second write lays down the same pen, but under
COMPLEMENT it inverts back to the background and the vertex becomes a hole.
`FRST_DOT` is the flag that says whose point it is; nothing read it.

`Move()` now sets it and `Draw()` clears it. Rather than teach every driver's
line routine to skip a pixel, `Draw()` renders the whole line and then undoes
the starting dot with a 1x1 invert, which only arises under COMPLEMENT and
only when the line pattern laid that pixel down in the first place.

Found with the p96cts conformance suite, whose `DrawLine-complement` scene
draws a closed pentagram: four of its five vertices are joins, and all four
came out at the background value. Fixed on AROS/m68k at 640x480 in 8 and 24
bit on a Z3660; the scene failed with exactly those four pixels on every
board and depth tested, this being above the drivers.
