### PR TITLE
p96gfx: fix the two swapped entries in the drawmode-to-minterm table

### DIFF
--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_rtg.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_rtg.c
@@ -17,8 +17,13 @@
 #include "p96gfx_rtg.h"
 #include "p96call.h"
 
+/*
+ * GC drawmode back to the minterm's truth table. MINTERM_TO_GCDRMD() built
+ * the drawmode by reversing the minterm's four bits, and reversing is its own
+ * inverse, so entry i is i with its bits reversed.
+ */
 const UBYTE modetable[16] =
-        {  0, 8, 4, 12,  2, 10, 6, 14,  7, 9, 5, 13,  3, 11, 1, 15 };
+        {  0, 8, 4, 12,  2, 10, 6, 14,  1, 9, 5, 13,  3, 11, 7, 15 };
 
 static AROS_UFH1(ULONG, RTGCall_Default,
     AROS_UFHA(APTR, boardinfo, A0))


### PR DESCRIPTION
`modetable[]` turns a GC drawmode back into the minterm's truth table for the
board. `MINTERM_TO_GCDRMD()` built that drawmode by reversing the minterm's
four bits, and reversing is its own inverse, so entry i has to be i with its
bits reversed. Entries 8 and 14 held each other's value instead.

The board therefore got NOR where the caller asked for NAND, and NAND where it
asked for NOR. It only shows on a blit with both bitmaps in card memory, since
that is the one path through `modetable[]`; a planar source goes to the
conversion hooks and was always right.

Found with the p96cts conformance suite on AROS/m68k with a Z3660 under
Copperline. `BltBitMap-friend`, which sweeps all sixteen minterms from a
source in the screen's own format, failed on exactly two of them by the same
number of pixels each; it passes with this, and the board is now clean across
the suite at 640x480 in 8 and 24 bit.
