### PR TITLE
amigavideo: take BltPattern's word masks from the mask, not the destination

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_blitter.c
@@ -794,16 +794,29 @@ BOOL blit_putpattern(struct amigavideo_staticdata *csd, struct BitMap *bm, struc
         maskx2 &= 15;
         shift = dstx - maskx;
 
+        /*
+         * The word masks trim channel A, which carries the mask and is read
+         * before the shifter, so they have to be expressed where A's words
+         * are - in the mask's coordinates, not the destination's. The two
+         * differ by exactly the shift. Trimming there covers the destination
+         * as well: where A is clear the minterm leaves D as C, so a bit the
+         * mask does not reach is a bit the blit does not write.
+         *
+         * Whichever operand spans more words sets the blit's width, and when
+         * that is the destination the final word has no mask behind it. There
+         * is nothing to keep from it, and reading past the mask would shift
+         * whatever follows into the pixels after the rectangle.
+         */
+        width = dstwidth >= maskwidth ? dstwidth : maskwidth;
+        shifta = shift < 0 ? (-shift) << 12 : shift << 12;
+
         if (shift < 0) {
             reverse = TRUE;
-            shift = -shift;
-            width = dstwidth >= maskwidth ? dstwidth : maskwidth;
-            shifta = shift << 12;
-            afwm = rightmask[dstx2];
-            alwm = leftmask[dstx];
+            afwm = rightmask[maskx2];
+            alwm = width > maskwidth ? 0 : leftmask[maskx];
         } else {
-            width = dstwidth >= maskwidth ? dstwidth : maskwidth;
-            shifta = shift << 12;
+            afwm = leftmask[maskx];
+            alwm = width > maskwidth ? 0 : rightmask[maskx2];
         }
     }
 


### PR DESCRIPTION
`blit_putpattern()` feeds the blit mask in on channel A and leaves the
pattern in BLTBDAT, so `bltafwm`/`bltalwm` trim the mask. They are applied
before the barrel shifter, which means they have to name bit positions where
A's words sit - in the mask's coordinates - and they were taken from the
destination's instead. The two differ by exactly the shift between them, so
a rectangle starting part way into a word lost the leading pixels of every
row: the bits that should have shifted into them were masked away first.

Trimming A in the mask's coordinates covers the destination as well. Where A
is clear the minterm leaves D as C, and the mask's span is the destination's
span shifted, so a bit the mask cannot reach is a bit the blit does not
write.

The other half is a destination spanning more words than the mask, where the
blit's last word has no mask behind it. Nothing should be kept from it;
`rightmask[]` of a destination edge kept part of whatever followed the mask
in memory and shifted it into the pixels past the rectangle.

Found with the p96cts conformance suite on AROS/m68k, PAL 320x256x8 under
Copperline. `BltPattern-mask` and `BltPattern-phase` failed on exactly the
leading partial word of each filled rectangle and the columns just past its
right edge; both pass with this. `BltPattern-drawmodes` and the BltTemplate
scenes, which share the path, still pass, and the RTG boards are unaffected.
