### PR TITLE
p96gfx: pass the pointer position to the card's SetSpritePosition

### DIFF
--- a/arch/m68k-amiga/hidd/p96gfx/p96gfx_card.c
+++ b/arch/m68k-amiga/hidd/p96gfx/p96gfx_card.c
@@ -437,15 +437,28 @@ BOOL SetSprite(struct p96gfx_carddata *cid, BOOL activate)
         AROS_LCA(ULONG, *cid->rgbformat, D7));
 }
 
+/*
+ * The position goes in D0/D1 as well as in the BoardInfo. A card driver is
+ * free to take it from the registers - both the ZZ9000 and the Z3660 do, and
+ * then write it back over the BoardInfo's copy - so leaving them unset puts
+ * the sprite wherever the registers happened to point.
+ */
 BOOL SetSpritePosition(struct p96gfx_carddata *cid)
 {
+    WORD x = (WORD)gw(cid->boardinfo + PSSO_BoardInfo_MouseX);
+    WORD y = (WORD)gw(cid->boardinfo + PSSO_BoardInfo_MouseY);
+
     if (cid->CardBase)
-        return AROS_CALL2(BOOL, __cardFunc(cid, PSSO_BoardInfo_SetSpritePosition),
+        return AROS_CALL4(BOOL, __cardFunc(cid, PSSO_BoardInfo_SetSpritePosition),
             AROS_LCA(APTR, cid->boardinfo, A0),
+            AROS_LCA(WORD, x, D0),
+            AROS_LCA(WORD, y, D1),
             AROS_LCA(ULONG, *cid->rgbformat, D7),
             struct Library*, cid->CardBase);
-    return P96_LC2(BOOL, cid->p96romvector, 37,
+    return P96_LC4(BOOL, cid->p96romvector, 37,
         AROS_LCA(APTR, cid->boardinfo, A0),
+        AROS_LCA(WORD, x, D0),
+        AROS_LCA(WORD, y, D1),
         AROS_LCA(ULONG, *cid->rgbformat, D7));
 }
 


### PR DESCRIPTION
Fixes #955.

The mouse pointer is invisible on a P96 board once the Workbench screen has
been opened: it tracks the mouse and can still click, but the hardware sprite
sits far off screen and never moves.

`SetSpritePosition()` called the card's function with the BoardInfo in A0 and
the format in D7, and nothing else. The position also belongs in D0 and D1 -
both the ZZ9000 and the Z3660 drivers declare

```c
void SetSpritePosition(__REGA0(struct BoardInfo *b), __REGD0(WORD x),
                       __REGD1(WORD y), __REGD7(RGBFTYPE format))
```

and open with `b->MouseX = x; b->MouseY = y;`, so they took whatever the
registers held and wrote it back over the coordinates the caller had just put
in the BoardInfo. The result is a constant nonsense position, which is why it
looks identical on both boards and why moving the mouse never helps.

Read the two words back out of the BoardInfo and pass them, so callers that
already fill those fields need no change.

This also explains the bisect in the issue. What lands in D0/D1 is whatever
the caller happened to leave there, so the sprite's position is luck, and the
luck depends on the path that reached it. Before the Workbench screen is
reopened the registers hold something survivable and the pointer appears;
reopening it - which is all ScreenModePrefs_Handler does that matters here -
comes through a different path and leaves something off screen. Neither the
pointer prefs nor the sprite image were ever involved, which is why removing
ENVARC:SYS/pointer.prefs and disabling PointerPrefs_Handler changed nothing.

Found on AROS/m68k under Copperline with a Z3660, by logging the board's own
per-frame sprite state: enabled, all 256 pixels present, right size, at
-7998,-1 on every frame. With this it follows the mouse.
