### PR TITLE
Bsek/vc4gallium

### DIFF
--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -196,8 +196,11 @@ distfiles-raspi-aarch64le-bootimg: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 #MM
 distfiles-raspi-aarch64le-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 
+# gpu_mem: the vc4 GL stack needs headroom in VideoCore RAM (full-res
+# framebuffer + overlay page ring + BO pools); 64 (the firmware default)
+# runs out during a full-screen GL session. 128 is the working minimum.
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\nenable_uart=1\narm_64bit=1\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\nenable_uart=1\narm_64bit=1\ngpu_mem=128\n" > $@
 
 $(AROSDIR)/aros-aarch64-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/LEGAL
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/LEGAL
@@ -1,0 +1,52 @@
+:License information for the VC4 Gallium 3D HIDD:
+
+All files in this directory and its subdirectories are original work of
+The AROS Development Team and are licensed under the APL license, with the
+exceptions noted below.
+
+(MIT-derived portions)
+
+The following file contains portions derived from the VC4 kernel-side
+validation sources authored by Broadcom:
+
+    vc4_drm_aros.c
+
+The derived portions are the V3D packet definitions, the command-list
+processing, the shader-record relocation, the render-control-list
+generation, and the QPU shader scan. They are based on these Broadcom
+sources:
+
+    vc4_packet.h, vc4_validate.c, vc4_render_cl.c,
+    vc4_validate_shaders.c, vc4_qpu_defines.h
+
+All of those files are licensed under the MIT license:
+
+    Copyright (C) 2014-2015 Broadcom
+
+They are published under the MIT license in both Mesa
+(src/gallium/drivers/vc4/kernel/ and src/gallium/drivers/vc4/) and the
+Linux kernel (drivers/gpu/drm/vc4/); every one carries the Broadcom
+copyright together with the MIT permission notice. The full Broadcom
+MIT copyright and permission notice is reproduced at the top of
+vc4_drm_aros.c, as required by the MIT license.
+
+(Hardware register and initialisation facts)
+
+vc4_v3d.h and vc4_v3d.c implement the V3D register map and the hardware
+initialisation / interrupt sequence from Broadcom's public hardware
+documentation, the VideoCore IV 3D Architecture Reference Guide
+(VideoCoreIV-AG100-R). Register offsets, bit-field positions and the
+required register writes are hardware facts taken from that guide and are
+not copyrightable expression.
+
+(DRM ABI)
+
+vc4_drm_aros.h mirrors the Linux DRM UAPI for VC4 (ioctl numbers and
+structure layouts) by ABI only, so the unmodified Mesa VC4 driver can
+call into this HIDD. That UAPI header (include/uapi/drm/vc4_drm.h) is
+itself MIT licensed; only the interface — not its source — is relied
+upon, and the structures here are re-expressed using AROS types.
+
+The remaining files reference the Mesa VC4 driver (which is itself MIT
+licensed) and implement the hardware access against AROS interfaces; they
+are original APL-licensed work.

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/aros_drm_vc4.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/aros_drm_vc4.c
@@ -1,0 +1,805 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    vc4 driver glue for the mesa3dgl-side gallium path: screen creation,
+    the display/present path (which dereferences vc4_resource / vc4_bo /
+    vc4_screen, so it must live here on the Mesa side, not in the
+    Mesa-type-free hidd), the zero-copy fullscreen scanout, and the
+    vc4/v3d linker stubs the statically linked Mesa driver references.
+
+    The generic POSIX/libdrm shims and the shared aros_drm_bridge pointer
+    live in aros_drm_shim.c. A future v3d driver gets aros_drm_v3d.c.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+/* aros/debug.h leaves DEBUG defined, which trips the `#if defined(DEBUG)`
+ * paths in Mesa's u_debug_refcnt.h / u_inlines.h — emitting refs to
+ * debug_refcnt_state etc. that only exist in mesa3dgl's copy of mesautil.
+ * NDEBUG keeps Mesa's assert() from referencing _debug_assert_fail
+ * directly (the driver archive's asserts go through the trampolines). */
+#undef DEBUG
+#define NDEBUG 1
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <dos/dosextens.h>
+#include <proto/oop.h>
+#include <proto/layers.h>
+#include <proto/alib.h>
+#include <proto/graphics.h>
+#include <proto/icon.h>
+#include <workbench/workbench.h>
+
+#include <string.h>
+
+#include <graphics/rastport.h>
+#include <graphics/clip.h>
+#include <graphics/layers.h>
+#include <hidd/gallium.h>
+#include <hidd/gfx.h>
+
+#include "pipe/p_state.h"
+#include "vc4_resource.h"
+#include "vc4_bufmgr.h"
+#include "vc4_screen.h"
+#include "renderonly/renderonly.h"
+
+#include "vc4_aros_bridge.h"
+#include "gallium_core_api.h"
+
+/* Shared dispatch handle, defined in aros_drm_shim.c. */
+extern struct vc4_aros_bridge *aros_drm_bridge;
+
+/* The Mesa vc4 driver's screen entry, statically linked into mesa3dgl. */
+struct renderonly;
+extern struct pipe_screen *vc4_screen_create(int fd, struct renderonly *ro);
+
+/* renderonly_* stubs to satisfy the linker (renderonly.c isn't in our
+ * linklib). Never called at runtime — we pass NULL renderonly to
+ * vc4_screen_create. The static-inline helpers in renderonly.h need no
+ * stub. */
+struct renderonly *renderonly_dup(const struct renderonly *ro)
+{
+    return NULL;
+}
+
+void renderonly_scanout_destroy(struct renderonly_scanout *scanout,
+                                struct renderonly *ro)
+{
+}
+
+struct renderonly_scanout *renderonly_create_gpu_import_for_resource(
+    struct pipe_resource *rsc, struct renderonly *ro,
+    struct winsys_handle *out_handle)
+{
+    return NULL;
+}
+
+/*
+ * V3D CL dump / debug stubs. Used by vc4_cl_dump.c for debug output;
+ * always no-ops in release builds.
+ */
+void *clif_dump_init(unsigned int devinfo, void *out, int v3d_ver)
+{
+    return (void *)0;
+}
+
+void clif_dump_destroy(void *clif)
+{
+}
+
+void *v3d_spec_load(void *devinfo)
+{
+    return (void *)0;
+}
+
+void *v3d_spec_find_instruction(void *spec, const void *p, const char *name)
+{
+    return (void *)0;
+}
+
+unsigned int v3d_group_get_length(void *group)
+{
+    return 0;
+}
+
+const char *v3d_group_get_name(void *group)
+{
+    return "";
+}
+
+void v3d_print_group(void *clif, void *group, int offset,
+                     const void *p, const char *name)
+{
+}
+
+/*
+ * Zero-copy fullscreen scanout state. When the GL surface covers the
+ * whole flippable framebuffer, the render resource's BO is rebound to
+ * the back page: the GPU renders straight into scanout and presenting
+ * is a page flip, not a 5-8 MB DMA copy (~37 MB/s through the uncached
+ * alias, which dominated frame time). Single context, like the bridge.
+ */
+static struct {
+    struct pipe_resource *rsc;      /* resource bound to a page (identity only) */
+    uint32_t        page_handle;    /* hidd BO handle of the bound page */
+    uint32_t        name[2];        /* page GEM names (phys addrs) */
+} aros_scanout;
+
+static void aros_scanout_forget(void)
+{
+    aros_scanout.rsc = NULL;
+    aros_scanout.page_handle = 0;
+    aros_scanout.name[0] = aros_scanout.name[1] = 0;
+}
+
+/* Bind the current back page's BO into the render resource, so the next
+ * frame is rendered directly into it. Returns TRUE on success. */
+static BOOL aros_scanout_bind_back(struct vc4_resource *rsc,
+                                   OOP_Object *bm_obj)
+{
+    struct vc4_aros_scanout so;
+    struct vc4_screen *vscreen = vc4_screen(rsc->base.screen);
+    struct vc4_bo *nb;
+
+    if (aros_drm_bridge->get_scanout(aros_drm_bridge->ctx, bm_obj, &so) != 0)
+        return FALSE;
+
+    nb = vc4_bo_open_name(vscreen, so.name[so.back]);
+    if (!nb)
+        return FALSE;
+
+    vc4_bo_unreference(&rsc->bo);
+    rsc->bo = nb;
+    rsc->slices[0].offset = 0;
+
+    aros_scanout.rsc = &rsc->base;
+    aros_scanout.page_handle = nb->handle;
+    aros_scanout.name[0] = so.name[0];
+    aros_scanout.name[1] = so.name[1];
+    return TRUE;
+}
+
+/* Detach from the page: give the resource a private BO again so windowed
+ * rendering can't scribble into the framebuffer pages. */
+static void aros_scanout_unbind(struct vc4_resource *rsc)
+{
+    struct vc4_screen *vscreen = vc4_screen(rsc->base.screen);
+    struct vc4_bo *nb;
+
+    nb = vc4_bo_alloc(vscreen, rsc->slices[0].size, "scanout-exit");
+    if (nb)
+    {
+        vc4_bo_unreference(&rsc->bo);
+        rsc->bo = nb;
+        rsc->slices[0].offset = 0;
+    }
+    aros_scanout_forget();
+}
+
+/*
+ * Zero-copy windowed present state: when the GL window is a single
+ * unobscured cliprect, the rendered BO is shown as an HVS overlay
+ * plane — the windowed analogue of the fullscreen scanout path above.
+ *
+ * The present is PIPELINED over a ring of three private pages: each
+ * present displays the frame rendered the present BEFORE (whose jobs
+ * finished while this frame was being built, so the seqno wait is
+ * normally instant) and queues the just-rendered frame for the next
+ * present. Rotation: render target -> queued -> on plane -> render
+ * target. This overlaps CPU emit with GPU render — frame time becomes
+ * max(CPU, GPU) instead of CPU + GPU (the hidd's set_overlay used to
+ * wait for full GPU idle, which cost tens of ms per frame in a
+ * GPU-bound scene) — at the cost of one frame of display latency.
+ */
+static struct {
+    struct pipe_resource *rsc;
+    uint32_t        page_handle;    /* BO bound in rsc (render target) */
+    struct vc4_bo  *queued;         /* last-rendered frame; shown next present */
+    uint32_t        queued_seqno;   /* submit seqno covering `queued` */
+    struct vc4_bo  *onplane;        /* page the overlay currently scans */
+    struct vc4_bo  *freep;          /* 3rd page, parked until the ring fills */
+    BOOL            shown;          /* plane currently on scanout */
+    struct pipe_resource *refused;  /* set_overlay said no for this
+                                     * resource (e.g. scaled desktop):
+                                     * don't retry every present */
+} aros_ovl;
+
+/* Hide the plane but KEEP the page pair: obscure/reveal cycles (another
+ * window dragged across, menus opening over the GL window) must not
+ * allocate or free BOs — a bo_alloc during the menu-close transition
+ * deadlocked against Intuition's own bitmap traffic while we held
+ * LockLayerRom. Resuming is just the steady-state present succeeding
+ * again. */
+/* Render-scale divisor from ENV:VC4_RENDER_SCALE / icon tooltype: the
+ * drawable renders at 1/N and presents show it N x through the HVS
+ * scaler. dest = src * N stays within the window because the drawable
+ * was computed as floor(window/N). This module reads the same sources on
+ * the same process as mesa3dgl_support.c does when sizing the drawable,
+ * so the two module-local values always agree. */
+static ULONG mesa3dgl_render_scale = 1;
+
+/* Per-program override: VC4_RENDER_SCALE tooltype in the program's icon.
+ * Mirror of MESA3DGLReadScaleToolType (mesa3dgl_support.c) — the value
+ * must be read on both sides of the module split. */
+static BOOL vc4_read_scale_tooltype(ULONG *scale)
+{
+    struct Library *IconBase;
+    struct Process *me = (struct Process *)FindTask(NULL);
+    struct DiskObject *dob;
+    BPTR progdir, olddir;
+    TEXT name[108];
+    STRPTR val;
+    BOOL found = FALSE;
+
+    if (me->pr_Task.tc_Node.ln_Type != NT_PROCESS)
+        return FALSE;
+
+    progdir = GetProgramDir();
+    if (progdir == BNULL)
+        return FALSE;
+
+    if (GetProgramName(name, sizeof(name)) == DOSFALSE || name[0] == '\0')
+    {
+        /* WB-launched: no CLI name set, the process carries the tool name */
+        name[sizeof(name) - 1] = '\0';
+        strncpy(name, me->pr_Task.tc_Node.ln_Name, sizeof(name) - 1);
+    }
+
+    IconBase = OpenLibrary((STRPTR)"icon.library", 0);
+    if (!IconBase)
+        return FALSE;
+
+    olddir = CurrentDir(progdir);
+    dob = GetDiskObject(FilePart(name));
+    if (dob)
+    {
+        val = FindToolType(dob->do_ToolTypes, "VC4_RENDER_SCALE");
+        if (val && val[0] >= '1' && val[0] <= '4' && val[1] == '\0')
+        {
+            *scale = val[0] - '0';
+            found = TRUE;
+        }
+        FreeDiskObject(dob);
+    }
+    CurrentDir(olddir);
+    CloseLibrary(IconBase);
+
+    return found;
+}
+
+static void vc4_read_render_scale(void)
+{
+    TEXT buf[8];
+
+    mesa3dgl_render_scale = 1;
+
+    if (GetVar((STRPTR)"VC4_RENDER_SCALE", buf, sizeof(buf), 0) > 0
+        && buf[0] >= '1' && buf[0] <= '4')
+        mesa3dgl_render_scale = buf[0] - '0';
+
+    /* Icon tooltype (per program) overrides the env variable (global) */
+    vc4_read_scale_tooltype(&mesa3dgl_render_scale);
+}
+
+static void aros_ovl_suspend(void)
+{
+    if (aros_drm_bridge && aros_ovl.shown)
+        aros_drm_bridge->clear_overlay(aros_drm_bridge->ctx, NULL);
+    aros_ovl.shown = FALSE;
+}
+
+/* Full teardown: resource changed or the screen is going away. */
+static void aros_ovl_exit(void)
+{
+    aros_ovl_suspend();
+    if (aros_ovl.queued)
+        vc4_bo_unreference(&aros_ovl.queued);
+    if (aros_ovl.onplane)
+        vc4_bo_unreference(&aros_ovl.onplane);
+    if (aros_ovl.freep)
+        vc4_bo_unreference(&aros_ovl.freep);
+    aros_ovl.queued_seqno = 0;
+    aros_ovl.rsc = NULL;
+    aros_ovl.page_handle = 0;
+}
+
+/*
+ * Display a rendered pipe_resource to a RastPort via the bridge,
+ * replacing the gallium.library BltPipeResourceRastPort path for vc4.
+ * The pipe_resource is dereferenced here (mesa3dgl-side, where Mesa
+ * types live) into BO handle/stride/offset/cpp; bridge->display_blit
+ * does the per-cliprect blit hidd-side. Fullscreen surfaces use the
+ * zero-copy path above (steady-state presents are a page flip).
+ */
+BOOL aros_drm_blit_resource(struct pipe_resource *src_pres,
+                            LONG xSrc, LONG ySrc,
+                            struct RastPort *destRP,
+                            LONG xDest, LONG yDest,
+                            LONG xSize, LONG ySize)
+{
+    struct vc4_resource *rsc;
+    struct Layer *L;
+    struct Rectangle renderableLayerRect, result;
+    struct ClipRect *CR;
+    BOOL copied = FALSE;
+    BOOL fullscreen, bound, enter_scanout = FALSE, detach_after_blit = FALSE;
+    OOP_Object *scr_bm_obj;
+    ULONG bo_handle, stride, offset, cpp;
+
+    /* No vc4 bridge (e.g. softpipe in QEMU — no V3D, so no vc4 screen was
+     * created): decline so the caller falls back to BltPipeResourceRastPort.
+     * Must come before the vc4_resource cast: src_pres is a softpipe_resource
+     * here, not ours. */
+    if (!aros_drm_bridge)
+        return FALSE;
+    if (!src_pres || !destRP)
+        return TRUE;
+
+    rsc = (struct vc4_resource *)src_pres;
+    if (!rsc->bo)
+        return TRUE;
+
+    bo_handle = rsc->bo->handle;
+    stride    = rsc->slices[0].stride;
+    offset    = rsc->slices[0].offset;
+    cpp       = rsc->cpp;
+
+    /* Clamp the blit to the resource's actual allocation. During a window
+     * resize glASwapBuffers passes the new framebuffer size while
+     * render_resource is still last frame's allocation (the state tracker
+     * recreates it on the next draw) — unclamped, the hidd rejects the
+     * whole blit as out of range. req_w/req_h keep the caller's original
+     * request for the flip-geometry check below. */
+    LONG req_w = xSize, req_h = ySize;
+    if (xSrc >= (LONG)src_pres->width0 || ySrc >= (LONG)src_pres->height0)
+        return TRUE;
+    if (xSize > (LONG)src_pres->width0 - xSrc)
+        xSize = (LONG)src_pres->width0 - xSrc;
+    if (ySize > (LONG)src_pres->height0 - ySrc)
+        ySize = (LONG)src_pres->height0 - ySrc;
+
+    if (!(L = destRP->Layer))
+        return TRUE;
+    if (!IsLayerVisible(L))
+        return TRUE;
+
+    /* Drop stale scanout state if the bound resource went away (e.g.
+     * the framebuffer was resized and recreated). Pointer compare only;
+     * the page BO itself was released with the old resource. */
+    if (aros_scanout.rsc && aros_scanout.rsc != src_pres)
+        aros_scanout_forget();
+    if (aros_ovl.rsc && aros_ovl.rsc != src_pres)
+        aros_ovl_exit();
+    if (aros_ovl.refused && aros_ovl.refused != src_pres)
+        aros_ovl.refused = NULL;
+
+    LockLayerRom(L);
+
+    scr_bm_obj = HIDD_BM_OBJ(destRP->BitMap);
+
+    /* Fullscreen = a single unobscured cliprect, surface at 0,0, no
+     * source offset. Geometry against the framebuffer is checked by
+     * get_scanout below. */
+    fullscreen = (xSrc == 0 && ySrc == 0 && xDest == 0 && yDest == 0 &&
+                  L->bounds.MinX == 0 && L->bounds.MinY == 0 &&
+                  L->ClipRect && !L->ClipRect->Next && !L->ClipRect->lobs);
+
+    bound = (aros_scanout.rsc == src_pres &&
+             rsc->bo->handle == aros_scanout.page_handle);
+
+    if (fullscreen && cpp == 4 && offset == 0 &&
+        aros_drm_bridge->version >= 2)
+    {
+        struct vc4_aros_scanout so;
+
+        if (aros_drm_bridge->get_scanout(aros_drm_bridge->ctx,
+                                         scr_bm_obj, &so) == 0 &&
+            (ULONG)xSize == so.width && (ULONG)ySize == so.height &&
+            stride == so.pitch && (so.width & 15) == 0)
+        {
+            if (bound &&
+                so.name[0] == aros_scanout.name[0] &&
+                so.name[1] == aros_scanout.name[1])
+            {
+                /* Steady state: the frame is already in the back page.
+                 * Make it visible and aim the resource at the new back
+                 * page. No pixels move. */
+                if (aros_drm_bridge->flip_scanout(aros_drm_bridge->ctx,
+                                                  scr_bm_obj) == 0 &&
+                    aros_scanout_bind_back(rsc, scr_bm_obj))
+                {
+                    UnlockLayerRom(L);
+                    return TRUE;
+                }
+                /* Flip refused (e.g. flipping got disabled): this
+                 * frame's pixels live in the page rsc->bo still points
+                 * at, so blit them out below, then detach. */
+                aros_scanout_forget();
+                detach_after_blit = TRUE;
+            }
+            else
+            {
+                /* Enter scanout mode after this frame's blit+flip. */
+                enter_scanout = TRUE;
+            }
+        }
+        else if (bound)
+        {
+            /* Geometry changed under us — blit this frame from its
+             * page, then detach. */
+            detach_after_blit = TRUE;
+        }
+    }
+    else if (bound)
+    {
+        /* No longer fullscreen (window mode, obscured, moved): blit this
+         * frame from the page it was rendered into, then detach so the
+         * next frame uses a private BO. */
+        detach_after_blit = TRUE;
+    }
+
+    /* Zero-copy windowed present: a fully visible window (single
+     * unobscured cliprect) shows the rendered BO as an HVS overlay
+     * plane. Falls back to the blit below whenever the conditions
+     * lapse (obscured, resized, scaled desktop, no takeover). With a
+     * render-scale divisor active, fullscreen surfaces also present
+     * through the (scaled) overlay — the drawable no longer matches
+     * the framebuffer pages, so the flip path can't serve them. */
+    if ((!fullscreen || mesa3dgl_render_scale > 1) && cpp == 4 && offset == 0
+        && aros_drm_bridge->version >= 5)
+    {
+        BOOL windowed = (xSrc == 0 && ySrc == 0 &&
+                         xSize == (LONG)src_pres->width0 &&
+                         ySize == (LONG)src_pres->height0 &&
+                         req_w == xSize && req_h == ySize &&
+                         L->ClipRect && !L->ClipRect->Next &&
+                         !L->ClipRect->lobs);
+        LONG absX = L->bounds.MinX + xDest;
+        LONG absY = L->bounds.MinY + yDest;
+
+        if (aros_ovl.rsc == src_pres)
+        {
+            if (windowed && rsc->bo->handle == aros_ovl.page_handle)
+            {
+                struct vc4_screen *vscreen = vc4_screen(rsc->base.screen);
+
+                if (!aros_ovl.queued)
+                {
+                    /* Ring not full yet (2nd present after entry): keep
+                     * showing the entry frame, queue this one, render
+                     * the next into the parked page. */
+                    aros_ovl.queued = rsc->bo;
+                    aros_ovl.queued_seqno =
+                        aros_drm_bridge->get_seqno(aros_drm_bridge->ctx);
+                    rsc->bo = aros_ovl.freep;
+                    aros_ovl.freep = NULL;
+                    rsc->slices[0].offset = 0;
+                    aros_ovl.page_handle = rsc->bo->handle;
+                    UnlockLayerRom(L);
+                    return TRUE;
+                }
+
+                /* Display the PREVIOUS frame; its jobs ran while this
+                 * frame was being built, so this wait is normally a
+                 * no-op. The just-rendered frame goes into the queue. */
+                vc4_wait_seqno(vscreen, aros_ovl.queued_seqno,
+                               PIPE_TIMEOUT_INFINITE, "ovl-present");
+
+                if (aros_drm_bridge->set_overlay(aros_drm_bridge->ctx,
+                        scr_bm_obj, aros_ovl.queued->handle, stride,
+                        absX, absY, xSize, ySize,
+                        xSize * mesa3dgl_render_scale,
+                        ySize * mesa3dgl_render_scale) == 0)
+                {
+                    /* Rotate: queued -> on plane; the page leaving the
+                     * plane becomes the next render target (the GPU
+                     * won't write it before the next submit, long after
+                     * the vblank latch). */
+                    struct vc4_bo *freed = aros_ovl.onplane;
+
+                    aros_ovl.shown = TRUE;
+                    aros_ovl.onplane = aros_ovl.queued;
+                    aros_ovl.queued = rsc->bo;
+                    aros_ovl.queued_seqno =
+                        aros_drm_bridge->get_seqno(aros_drm_bridge->ctx);
+                    rsc->bo = freed;
+                    rsc->slices[0].offset = 0;
+                    aros_ovl.page_handle = rsc->bo->handle;
+                    UnlockLayerRom(L);
+                    return TRUE;
+                }
+                /* The hidd refused a present that was fine before
+                 * (e.g. mode changed under us): tear down and don't
+                 * retry for this resource. */
+                aros_ovl_exit();
+                aros_ovl.refused = src_pres;
+            }
+            else if (!windowed)
+            {
+                /* Obscured/partially hidden: hide the plane but keep
+                 * the page pair — the steady-state branch resumes
+                 * without any allocation when the window is free
+                 * again. Blit the frame below. */
+                aros_ovl_suspend();
+            }
+            else
+            {
+                /* Mesa replaced the resource's BO under us — our page
+                 * bookkeeping is void. */
+                aros_ovl_exit();
+            }
+        }
+        else if (windowed && !aros_ovl.rsc && rsc->slices[0].size
+                 && aros_ovl.refused != src_pres)
+        {
+            struct vc4_screen *vscreen = vc4_screen(rsc->base.screen);
+            struct vc4_bo *nb1, *nb2 = NULL;
+            int oret = -1;
+
+            D(bug("[vc4ovl] enter: bo=%lu %ldx%ld at %ld,%ld stride=%lu\n",
+                (unsigned long)rsc->bo->handle, xSize, ySize,
+                absX, absY, (unsigned long)stride));
+            nb1 = vc4_bo_alloc(vscreen, rsc->slices[0].size, "overlay-page");
+            if (nb1)
+                nb2 = vc4_bo_alloc(vscreen, rsc->slices[0].size,
+                                   "overlay-page");
+            D(bug("[vc4ovl] page alloc: %s\n", nb2 ? "ok" : "FAILED"));
+
+            if (nb2)
+            {
+                /* The entry present shows the frame just rendered, so
+                 * it must wait for it — the only full wait left on this
+                 * path (steady state waits on the previous frame). */
+                vc4_wait_seqno(vscreen,
+                    aros_drm_bridge->get_seqno(aros_drm_bridge->ctx),
+                    PIPE_TIMEOUT_INFINITE, "ovl-enter");
+                oret = aros_drm_bridge->set_overlay(aros_drm_bridge->ctx,
+                    scr_bm_obj, rsc->bo->handle, stride,
+                    absX, absY, xSize, ySize,
+                    xSize * mesa3dgl_render_scale,
+                    ySize * mesa3dgl_render_scale);
+            }
+            D(bug("[vc4ovl] set_overlay=%d\n", oret));
+
+            if (nb2 && oret == 0)
+            {
+                aros_ovl.rsc = src_pres;
+                aros_ovl.shown = TRUE;
+                aros_ovl.onplane = rsc->bo;    /* now on the overlay */
+                aros_ovl.queued = NULL;
+                aros_ovl.queued_seqno = 0;
+                aros_ovl.freep = nb2;
+                rsc->bo = nb1;
+                rsc->slices[0].offset = 0;
+                aros_ovl.page_handle = nb1->handle;
+                UnlockLayerRom(L);
+                return TRUE;
+            }
+            if (nb1)
+                vc4_bo_unreference(&nb1);
+            if (nb2)
+                vc4_bo_unreference(&nb2);
+            /* Refused (scaled desktop / no takeover): remember and stop
+             * paying an alloc+refusal on every present. Cleared when
+             * the resource changes (resize/mode switch). */
+            aros_ovl.refused = src_pres;
+        }
+    }
+
+    renderableLayerRect.MinX = L->bounds.MinX + xDest;
+    renderableLayerRect.MaxX = L->bounds.MinX + xDest + xSize - 1;
+    renderableLayerRect.MinY = L->bounds.MinY + yDest;
+    renderableLayerRect.MaxY = L->bounds.MinY + yDest + ySize - 1;
+    if (renderableLayerRect.MinX < L->bounds.MinX) renderableLayerRect.MinX = L->bounds.MinX;
+    if (renderableLayerRect.MaxX > L->bounds.MaxX) renderableLayerRect.MaxX = L->bounds.MaxX;
+    if (renderableLayerRect.MinY < L->bounds.MinY) renderableLayerRect.MinY = L->bounds.MinY;
+    if (renderableLayerRect.MaxY > L->bounds.MaxY) renderableLayerRect.MaxY = L->bounds.MaxY;
+
+    CR = L->ClipRect;
+    for (; CR; CR = CR->Next)
+    {
+        if (CR->lobs)
+            continue;
+
+        if (AndRectRect(&renderableLayerRect, &CR->bounds, &result))
+        {
+            LONG cr_srcx = xSrc + result.MinX - L->bounds.MinX - xDest;
+            LONG cr_srcy = ySrc + result.MinY - L->bounds.MinY - yDest;
+            ULONG cr_w   = result.MaxX - result.MinX + 1;
+            ULONG cr_h   = result.MaxY - result.MinY + 1;
+            ULONG cr_off = offset + cr_srcy * stride + cr_srcx * cpp;
+            OOP_Object *bm_obj = HIDD_BM_OBJ(destRP->BitMap);
+
+            aros_drm_bridge->display_blit(aros_drm_bridge->ctx,
+                bo_handle, stride, cr_off, cpp,
+                bm_obj,
+                result.MinX, result.MinY,
+                cr_w, cr_h);
+
+            copied = TRUE;
+        }
+    }
+
+    if (copied)
+    {
+        /* Notify the bitmap about the damage. */
+        struct pHidd_BitMap_UpdateRect urmsg = {
+            .mID    = OOP_GetMethodID(IID_Hidd_BitMap, moHidd_BitMap_UpdateRect),
+            .x      = renderableLayerRect.MinX,
+            .y      = renderableLayerRect.MinY,
+            .width  = renderableLayerRect.MaxX - renderableLayerRect.MinX + 1,
+            .height = renderableLayerRect.MaxY - renderableLayerRect.MinY + 1,
+        };
+        OOP_DoMethod(HIDD_BM_OBJ(destRP->BitMap), (OOP_Msg)&urmsg);
+    }
+
+    /* The full-frame blit above also flipped (inside the hidd), so the
+     * back page reported by get_scanout is now the page to render the
+     * next frame into. */
+    if (enter_scanout)
+        aros_scanout_bind_back(rsc, scr_bm_obj);
+    else if (detach_after_blit)
+        aros_scanout_unbind(rsc);
+
+    UnlockLayerRom(L);
+    return TRUE;
+}
+
+/*
+ * Create a pipe_screen. Called from the hidd's CreatePipeScreen method
+ * with the module-internal bridge and mesa3dgl's GalliumCoreAPI table
+ * (from aHidd_Gallium_CoreAPI). Returns NULL when the table is missing
+ * or from a different Mesa generation; the GL context creation then
+ * fails cleanly instead of corrupting.
+ * Single screen at a time, matching the in-hidd single-fd model.
+ */
+/* Private util_cpu_caps copy (u_cpu_detect.o is linked into this module;
+ * the provider's caps live in mesa3dgl and are a different object). */
+extern void util_cpu_detect(void);
+
+/* Live screens created through the bridge. An app toggling between
+ * fullscreen and windowed mode may create the new context before
+ * destroying the old one; dropping the bridge pointer on the first
+ * destroy would kill presents for the survivor. */
+static LONG aros_drm_screens;
+
+struct pipe_screen *vc4_aros_create_screen(struct vc4_aros_bridge *bridge,
+                                           APTR coreapi)
+{
+    struct pipe_screen *pscreen = NULL;
+
+    if (!bridge)
+        return NULL;
+
+    /* Bind the driver's Mesa-core trampolines to mesa3dgl's
+     * GalliumCoreAPI table before any driver code runs. Idempotent;
+     * refusing on version/hash/name mismatch is what makes a driver from
+     * a different Mesa generation fail cleanly instead of corrupting. */
+    {
+        int bres = gca_bind((const struct GalliumCoreAPI *)coreapi);
+        if (bres > 0)
+        {
+            bug("[aros_drm_vc4] GalliumCoreAPI bind refused: slot %d is not"
+                " '%s' — rebuild mesa3dgl-library and this hidd together\n",
+                bres - 1, gca_slot_name((uint32_t)(bres - 1)));
+            return NULL;
+        }
+        if (bres < 0)
+        {
+            bug("[aros_drm_vc4] GalliumCoreAPI bind refused (code %d:"
+                " -1 version, -2 size, -3 hash, -4 count) — rebuild"
+                " mesa3dgl-library and this hidd together\n", bres);
+            return NULL;
+        }
+    }
+
+    /* Fill this module's private util_cpu_caps (has_neon selects the
+     * tiling path) — the trampolined core never touches our copy. */
+    util_cpu_detect();
+
+    /* Same env/tooltype read mesa3dgl does when sizing the drawable;
+     * runs on the app's process, so the values agree. */
+    vc4_read_render_scale();
+
+    aros_drm_bridge = bridge;
+
+    /* New-app reclaim: an application may exit via exit() without any GL
+     * teardown, so glADestroyContext (aros_drm_release_bridge) never runs
+     * and the driver-internal pages (overlay/scanout/pools) leak VideoCore
+     * memory until the firmware OOMs after a few runs. The aros_drm_screens
+     * counter is unreliable for detecting this (it only decrements on clean
+     * teardown, so it grows without bound across dirty-exit runs). Instead
+     * key on the owning task: a different task means the PREVIOUS app is
+     * dead and its leftover BOs are safe to sweep. The same task (one app
+     * creating several contexts) does NOT sweep — which also means
+     * successive Shell commands, that RunCommand() runs on one task, are
+     * not told apart here. */
+    {
+        struct Task *me = FindTask(NULL);
+        static struct Task *aros_bo_owner_task;
+        static BOOL aros_bo_owner_valid;
+
+        if (aros_bo_owner_valid && me != aros_bo_owner_task)
+        {
+            D(bug("[aros_drm_vc4] new run (task %p -> task %p):"
+                " reclaiming leaked BOs\n", aros_bo_owner_task, me));
+            if (bridge->release_all_bos)
+                bridge->release_all_bos(bridge->ctx);
+            aros_drm_screens = 0;   /* stale counter from dirty-exit runs */
+        }
+        aros_bo_owner_task = me;
+        aros_bo_owner_valid = TRUE;
+    }
+
+    /* Dispatch on driver_id (one mesa3dgl can carry several drivers, one
+     * per Pi GPU gen). Only VC4 today; V3D slots into the commented case.
+     * fd is any positive value (dispatch goes through the bridge, not fd
+     * lookup); NULL renderonly since we own the display path. */
+    switch (bridge->driver_id)
+    {
+    case AROS_GALLIUM_DRIVER_VC4:
+        pscreen = vc4_screen_create(1, NULL);
+        if (!pscreen)
+            bug("[aros_drm_vc4] vc4_screen_create FAILED (bridge ok, falling back)\n");
+        break;
+
+    /* case AROS_GALLIUM_DRIVER_V3D:
+     *     pscreen = v3d_screen_create(1, NULL);
+     *     break; */
+
+    default:
+        bug("[aros_drm_vc4] unsupported gallium driver_id %u\n",
+            (unsigned int)bridge->driver_id);
+        return NULL;
+    }
+
+    if (pscreen)
+        aros_drm_screens++;
+    return pscreen;
+}
+
+/* Mesa-typed shim for the hidd's DisplayResourceRP method, so the OOP
+ * class file stays free of pipe_resource. TRUE = presented; FALSE = the
+ * caller falls back to the per-cliprect DisplayResource loop. */
+IPTR vc4_aros_display_rp(APTR resource, LONG srcx, LONG srcy,
+                         struct RastPort *rp, LONG dstx, LONG dsty,
+                         LONG width, LONG height)
+{
+    return aros_drm_blit_resource((struct pipe_resource *)resource,
+                                  srcx, srcy, rp, dstx, dsty,
+                                  width, height) ? TRUE : FALSE;
+}
+
+/* Per-screen teardown bookkeeping, called from DestroyPipeScreen after
+ * the screen itself is gone. Returns TRUE when this was the LAST live
+ * screen, which is the caller's cue to put the hardware back in its
+ * idle, empty state. An app may hold two screens at once - a toolkit
+ * probing GL capabilities keeps its probe context while building the
+ * real one, and switching to fullscreen typically creates the new
+ * context before dropping the old - so that reset must not run on the
+ * first of them: it would free the survivor's BOs and clear V3D state
+ * mid-render. */
+BOOL aros_drm_release_bridge(void)
+{
+    /* Just drop our in-lib bookkeeping pointers — the underlying firmware
+     * BOs are freed by the hidd sweep below, not here (unreferencing the
+     * vc4_bo structs would touch the just-freed in-lib screen). */
+    aros_ovl.queued = NULL;
+    aros_ovl.onplane = NULL;
+    aros_ovl.freep = NULL;
+    aros_ovl.queued_seqno = 0;
+    aros_ovl.shown = FALSE;
+    aros_ovl.rsc = NULL;
+    aros_ovl.page_handle = 0;
+
+    if (aros_drm_screens > 0 && --aros_drm_screens > 0)
+        return FALSE;
+
+    /* Last screen gone. The BO sweep itself is the caller's job (it owns
+     * the bo_table); here we only drop the pointers into it. */
+    aros_scanout_forget();
+    aros_drm_bridge = NULL;
+    return TRUE;
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/err.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/err.h
@@ -1,0 +1,8 @@
+/*
+    AROS stub for err.h
+    Included by vc4_bufmgr.c / vc4_context.c but not used.
+*/
+#ifndef _ERR_H_AROS_
+#define _ERR_H_AROS_
+
+#endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/libsync.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/libsync.h
@@ -1,0 +1,26 @@
+/*
+    AROS stub for libsync.h
+    Sync file fence operations — we don't support native fences,
+    so these are stubs that fail gracefully.
+*/
+#ifndef _LIBSYNC_H_AROS_
+#define _LIBSYNC_H_AROS_
+
+/* sync_wait: wait for sync file fd. Returns 0 on success, -1 on failure. */
+static inline int sync_wait(int fd, int timeout)
+{
+    (void)fd;
+    (void)timeout;
+    return -1;
+}
+
+/* sync_accumulate: merge sync fd into *fd_out. */
+static inline int sync_accumulate(const char *name, int *fd_out, int fd)
+{
+    (void)name;
+    (void)fd_out;
+    (void)fd;
+    return -1;
+}
+
+#endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/sys/ioccom.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/sys/ioccom.h
@@ -1,0 +1,11 @@
+/*
+    AROS shim: sys/ioccom.h -> sys/ioctl.h
+    drm.h on non-Linux includes sys/ioccom.h for _IOWR etc.
+    AROS provides these in sys/ioctl.h.
+*/
+#ifndef _SYS_IOCCOM_H_AROS_
+#define _SYS_IOCCOM_H_AROS_
+
+#include <sys/ioctl.h>
+
+#endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/sys/mman.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/sys/mman.h
@@ -1,0 +1,18 @@
+/*
+    AROS stub for sys/mman.h
+    mmap/munmap are implemented in mesa3dgl-side aros_drm_shim.c.
+*/
+#ifndef _SYS_MMAN_H_AROS_
+#define _SYS_MMAN_H_AROS_
+
+#include <stddef.h>
+
+#define PROT_READ   0x1
+#define PROT_WRITE  0x2
+#define MAP_SHARED  0x01
+#define MAP_FAILED  ((void *)-1)
+
+void *mmap(void *addr, unsigned long length, int prot, int flags, int fd, long offset);
+int munmap(void *addr, unsigned long length);
+
+#endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/xf86drm.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/xf86drm.h
@@ -1,0 +1,46 @@
+/*
+    AROS stub for xf86drm.h
+
+    Provides function declarations for DRM functions that Mesa's VC4
+    driver uses. Implementations are in mesa3dgl's aros_drm_shim.c
+    (the Mesa vc4 driver now lives in mesa3dgl.library; vc4gallium.hidd
+    services the DRM ioctls via the bridge ABI).
+*/
+
+#ifndef _XF86DRM_H_AROS_
+#define _XF86DRM_H_AROS_
+
+#include <stdint.h>
+
+/* DRM_COMMAND_BASE is defined in drm-uapi/drm.h but we need it here too */
+#ifndef DRM_COMMAND_BASE
+#define DRM_COMMAND_BASE 0x40
+#endif
+
+/* DRM capability constants */
+#define DRM_CAP_SYNCOBJ 0x13
+
+/* Syncobj creation flags */
+#define DRM_SYNCOBJ_CREATE_SIGNALED (1 << 0)
+
+/*
+ * Implementations are in mesa3dgl-side aros_drm_shim.c. drmIoctl
+ * forwards to vc4gallium via the bridge; the rest are no-op stubs.
+ */
+int drmIoctl(int fd, unsigned long request, void *arg);
+int drmPrimeFDToHandle(int fd, int prime_fd, unsigned int *handle);
+int drmPrimeHandleToFD(int fd, unsigned int handle, unsigned int flags, int *prime_fd);
+int drmSyncobjCreate(int fd, unsigned int flags, unsigned int *handle);
+int drmSyncobjDestroy(int fd, unsigned int handle);
+int drmSyncobjImportSyncFile(int fd, unsigned int handle, int sync_file_fd);
+int drmSyncobjExportSyncFile(int fd, unsigned int handle, int *sync_file_fd);
+
+/* drmGetCap — report no capabilities on AROS */
+static inline int drmGetCap(int fd, uint64_t capability, uint64_t *value)
+{
+    if (value)
+        *value = 0;
+    return -1;
+}
+
+#endif /* _XF86DRM_H_AROS_ */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/xf86drmMode.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/drm_compat/xf86drmMode.h
@@ -1,0 +1,11 @@
+/*
+    AROS stub for xf86drmMode.h
+    Included by vc4_bufmgr.c but no functions are actually used.
+*/
+
+#ifndef _XF86DRMMODE_H_AROS_
+#define _XF86DRMMODE_H_AROS_
+
+/* Empty — no KMS/modesetting functions needed */
+
+#endif /* _XF86DRMMODE_H_AROS_ */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/mmakefile.src
@@ -1,0 +1,242 @@
+
+include $(SRCDIR)/config/aros.cfg
+include $(SRCDIR)/workbench/libs/mesa/mesa.cfg
+
+CUR_MESADIR = src/gallium
+CUR_GALLIUMDIR = drivers/vc4
+GALLIUM_PATH = $(top_srcdir)/$(CUR_MESADIR)
+
+#
+# Only build for ARM targets
+#
+#MM- workbench-hidds : hidd-vc4gallium-$(AROS_TARGET_CPU)
+#MM- hidd-vc4gallium-arm : hidd-vc4gallium
+#MM- hidd-vc4gallium-aarch64 : hidd-vc4gallium
+
+#MM hidd-vc4gallium : includes hidd-gallium mesa3dgl-linklibs linklibs-libatomic linklibs-gallium_vc4 linklibs-gallium_vc4-gca kernel-mbox-bcm2708-includes kernel-dma-bcm2708-includes
+#MM linklibs-gallium_vc4 : mesa3dgl-linklibs linklibs-gallium_vc4-gen-cle
+#MM linklibs-gallium_vc4-gca : linklibs-gallium_vc4 mesa3dgl-linklibs
+#MM linklibs-galliumcoreapi : linklibs-gallium_vc4-gca
+
+#
+# VC4 Gallium driver sources from Mesa
+#
+
+include $(GALLIUM_PATH)/$(CUR_GALLIUMDIR)/Makefile.sources
+
+# Mesa VC4 driver C sources (filter .c files, exclude .h files)
+MESA3D_VC4_C_SOURCES := $(filter %.c, $(C_SOURCES))
+
+# Remove simulator and kernel files (guarded by USE_VC4_SIMULATOR)
+MESA3D_VC4_C_SOURCES := $(filter-out vc4_simulator.c, $(MESA3D_VC4_C_SOURCES))
+MESA3D_VC4_C_SOURCES := $(filter-out kernel/%, $(MESA3D_VC4_C_SOURCES))
+
+# NEON tiling variant (upstream meson builds this; the target is compiled
+# -mfpu=neon-vfpv4 so __ARM_NEON is already defined and the runtime
+# has_neon check passes)
+MESA3D_VC4_C_SOURCES += vc4_tiling_lt_neon.c
+
+# Full paths for linklib build
+VC4_DRIVER_SOURCES := \
+    $(addprefix $(GALLIUM_PATH)/drivers/vc4/, $(MESA3D_VC4_C_SOURCES:.c=))
+
+#
+# AROS-specific HIDD sources. Since the runtime-binding rework the hidd
+# also carries the winsys/present half (aros_drm_vc4.c) and the driver's
+# libc environment: the POSIX/libdrm shims and the malloc->AllocMem
+# override, both shared with mesa3dgl (compiled once per module).
+#
+VC4GALLIUM_HIDD_SOURCES := \
+    vc4_galliumclass \
+    vc4_init \
+    vc4_v3d \
+    vc4_aros_bridge \
+    vc4_drm_aros \
+    $(SRCDIR)/workbench/libs/mesa/aros_drm_shim \
+    $(SRCDIR)/workbench/libs/mesa/emul_arosc
+
+#
+# Include paths
+#
+# drm_compat/ must come FIRST to override system xf86drm.h, sys/mman.h, etc.
+#
+USER_INCLUDES := \
+    $(USER_INCLUDES) \
+    -I$(SRCDIR)/$(CURDIR)/drm_compat \
+    -I$(SRCDIR)/$(CURDIR) \
+    -I$(top_builddir)/galliumglue \
+    -iquote $(GALLIUM_PATH)/drivers \
+    -iquote $(GALLIUM_PATH)/drivers/vc4 \
+    -iquote $(GALLIUM_PATH)/include \
+    -iquote $(GALLIUM_PATH)/auxiliary \
+    -iquote $(top_srcdir)/src \
+    -iquote $(top_builddir)/src \
+    -iquote $(top_srcdir)/src/broadcom \
+    -iquote $(top_builddir)/src/broadcom \
+    -iquote $(top_srcdir)/src/compiler/nir \
+    -iquote $(top_builddir)/src/compiler/nir \
+    -I$(SRCDIR)/arch/arm-native/soc/broadcom/2708/include
+
+#
+# Compiler flags
+#
+NOWARN_FLAGS := $(NOWARN_UNINITIALIZED) $(NOWARN_STRICT_ALIASING) $(NOWARN_MAYBE_UNINITIALIZED)
+USER_CFLAGS += $(NOWARN_FLAGS) -std=gnu99
+
+USER_CPPFLAGS += \
+    -DGALLIUM_VC4 \
+    -DHAVE_STRUCT_TIMESPEC \
+    -DUSE_ARM_ASM \
+    -DGCA_CONSUMER_MODULE
+
+#
+# Link flags. Mesa linklibs moved to mesa3dgl; vc4gallium has no Mesa
+# code, only the AROS HW bridge. Keep the C runtime for stdcio.
+#
+USER_LDFLAGS := -L$(top_libdir) -lstdcio -lstdc
+
+#
+# Generate broadcom CLE pack headers from XML definitions
+# (Mesa's meson build does this via custom_target; we do it manually here)
+#
+CLE_SRCDIR := $(top_srcdir)/src/broadcom/cle
+CLE_GENDIR := $(top_builddir)/src/broadcom/cle
+CLE_GENSCRIPT := $(CLE_SRCDIR)/gen_pack_header.py
+
+$(CLE_GENDIR)/v3d_packet_v21_pack.h: $(CLE_GENSCRIPT) $(CLE_SRCDIR)/v3d_packet_v21.xml
+	%mkdir_q dir="$(CLE_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 21 > $@
+
+$(CLE_GENDIR)/v3d_packet_v33_pack.h: $(CLE_GENSCRIPT) $(CLE_SRCDIR)/v3d_packet_v33.xml
+	%mkdir_q dir="$(CLE_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 33 > $@
+
+$(CLE_GENDIR)/v3d_packet_v41_pack.h: $(CLE_GENSCRIPT) $(CLE_SRCDIR)/v3d_packet_v33.xml
+	%mkdir_q dir="$(CLE_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 41 > $@
+
+$(CLE_GENDIR)/v3d_packet_v42_pack.h: $(CLE_GENSCRIPT) $(CLE_SRCDIR)/v3d_packet_v33.xml
+	%mkdir_q dir="$(CLE_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 42 > $@
+
+CLE_GEN_HEADERS := \
+    $(CLE_GENDIR)/v3d_packet_v21_pack.h \
+    $(CLE_GENDIR)/v3d_packet_v33_pack.h \
+    $(CLE_GENDIR)/v3d_packet_v41_pack.h \
+    $(CLE_GENDIR)/v3d_packet_v42_pack.h
+
+#MM
+linklibs-gallium_vc4-gen-cle : $(CLE_GEN_HEADERS)
+
+#
+# Build the VC4 driver linklib from Mesa sources
+#
+%build_linklib mmake=linklibs-gallium_vc4 libname=gallium_vc4 \
+    libdir=$(top_libdir) objdir=$(top_builddir)/$(CUR_MESADIR)/$(CUR_GALLIUMDIR) \
+    files="$(VC4_DRIVER_SOURCES)"
+
+#
+# GalliumCoreAPI glue (runtime pipe-driver binding).
+#
+# galliumglue.py computes the driver's Mesa-core import set (nm of
+# libgallium_vc4.a intersected with the mesa3dgl core linklibs) and
+# generates a versioned function-pointer table plus ARM trampolines and
+# an objcopy rename map. The driver archive is rewritten so every
+# imported core function call routes through __gca_local[], bound by
+# gca_bind() at CreatePipeScreen. Two artefacts come out:
+#   libgallium_vc4_gca.a  - consumer: rewritten driver + bind + glue +
+#                           private data objects; linked into THIS hidd
+#   libgalliumcoreapi.a   - provider: the populated table; linked into
+#                           mesa3dgl.library
+#
+GCA_GENDIR   := $(top_builddir)/galliumglue
+GCA_TOOL     := $(SRCDIR)/workbench/libs/mesa/galliumglue.py
+GCA_NM       := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-nm
+GCA_OBJCOPY  := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-objcopy
+GCA_AR       := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-ar
+GCA_CORELIBS := $(addprefix $(top_libdir)/lib, \
+    compiler.a galliumauxiliary.a mesautil.a mesa.a glapi.a mesadevutil.a)
+GCA_GENFILES := gallium_core_api.h gca_table.c gca_bind.c gca_glue.S \
+    gca_redefs.txt gca_private.list
+
+# NOTE: a regenerated table only reaches applications when BOTH modules
+# are redeployed — a new hidd against an old mesa3dgl (or vice versa)
+# refuses to bind at CreatePipeScreen (clean GL failure, serial log says
+# why). After driver or Mesa changes rebuild mesa3dgl-library AND
+# hidd-vc4gallium.
+GCA_ABI_FLAGS := $(TARGET_ISA_CFLAGS) $(USER_CPPFLAGS)
+
+$(GCA_GENDIR)/.gca.stamp : $(top_libdir)/libgallium_vc4.a $(GCA_CORELIBS) $(GCA_TOOL)
+	%mkdir_q dir="$(GCA_GENDIR)"
+	$(Q)$(ECHO) "Generating GalliumCoreAPI glue"
+	$(Q)$(PYTHON) $(GCA_TOOL) --nm $(GCA_NM) --ar $(GCA_AR) \
+		--consumer $(top_libdir)/libgallium_vc4.a \
+		--providers $(GCA_CORELIBS) \
+		--private-data nir_intrinsic_infos nir_op_infos util_cpu_caps \
+		--mesa-version $(MESAGLVERSION) --arch $(AROS_TARGET_CPU) \
+		--abi-flags "$(strip $(GCA_ABI_FLAGS))" \
+		--abi-files $(SRCDIR)/workbench/libs/mesa/mesa-$(MESAGLVERSION)-aros.diff \
+		--outdir $(GCA_GENDIR)
+	$(Q)touch $@
+
+$(addprefix $(GCA_GENDIR)/, $(GCA_GENFILES)) : $(GCA_GENDIR)/.gca.stamp
+
+$(GCA_GENDIR)/gca_table.o : $(GCA_GENDIR)/gca_table.c $(GCA_GENDIR)/gallium_core_api.h
+	%compile_q
+
+$(GCA_GENDIR)/gca_bind.o : $(GCA_GENDIR)/gca_bind.c $(GCA_GENDIR)/gallium_core_api.h
+	%compile_q
+
+$(GCA_GENDIR)/gca_glue.o : $(GCA_GENDIR)/gca_glue.S $(GCA_GENDIR)/.gca.stamp
+	%compile_q
+
+# The winsys/present half dereferences Mesa vc4 types via inline headers
+# (vc4_bo_unreference -> util_hash_table_remove etc.), so its core calls
+# must route through the trampolines exactly like the driver archive's:
+# compile with the driver's flags, then apply the same symbol rewrite.
+# Hand-rolled rule = no Makedepend; list the local headers explicitly so
+# editing them rebuilds this object instead of leaving it silently stale.
+$(GCA_GENDIR)/aros_drm_vc4_raw.o : $(SRCDIR)/$(CURDIR)/aros_drm_vc4.c \
+        $(GCA_GENDIR)/.gca.stamp \
+        $(SRCDIR)/$(CURDIR)/vc4_aros_bridge.h \
+        $(SRCDIR)/$(CURDIR)/vc4gallium_intern.h
+	%compile_q opt="$(strip $(CFLAGS) $(USER_CFLAGS) $(CPPFLAGS) $(USER_CPPFLAGS) $(USER_INCLUDES))"
+
+$(GCA_GENDIR)/aros_drm_vc4.o : $(GCA_GENDIR)/aros_drm_vc4_raw.o $(GCA_GENDIR)/gca_redefs.txt
+	$(Q)$(GCA_OBJCOPY) --redefine-syms=$(GCA_GENDIR)/gca_redefs.txt $< $@
+
+$(top_libdir)/libgallium_vc4_gca.a : $(top_libdir)/libgallium_vc4.a \
+        $(GCA_GENDIR)/gca_redefs.txt $(GCA_GENDIR)/gca_bind.o \
+        $(GCA_GENDIR)/gca_glue.o $(GCA_GENDIR)/aros_drm_vc4.o
+	$(Q)$(ECHO) "Rewriting gallium_vc4 through the GalliumCoreAPI table"
+	$(Q)$(GCA_OBJCOPY) --redefine-syms=$(GCA_GENDIR)/gca_redefs.txt \
+		$(top_libdir)/libgallium_vc4.a $@
+	$(Q)$(GCA_AR) rs $@ $(GCA_GENDIR)/gca_bind.o $(GCA_GENDIR)/gca_glue.o \
+		$(GCA_GENDIR)/aros_drm_vc4.o
+	$(Q)cat $(GCA_GENDIR)/gca_private.list | xargs $(GCA_AR) rs $@
+
+$(top_libdir)/libgalliumcoreapi.a : $(GCA_GENDIR)/gca_table.o
+	$(Q)$(ECHO) "Creating GalliumCoreAPI provider table linklib"
+	$(Q)$(GCA_AR) rcs $@ $(GCA_GENDIR)/gca_table.o
+
+#MM
+linklibs-gallium_vc4-gca : $(top_libdir)/libgallium_vc4_gca.a
+
+#MM
+linklibs-galliumcoreapi : $(top_libdir)/libgalliumcoreapi.a
+
+#
+# Build the HIDD module. gallium_vc4_gca is the rewritten pipe driver
+# (all Mesa-core calls through the GalliumCoreAPI trampolines); pthread
+# covers the driver's mutex/once usage.
+#
+%build_module mmake=hidd-vc4gallium modname=vc4gallium modtype=hidd \
+    files="$(VC4GALLIUM_HIDD_SOURCES)" alwayscxxlink=yes \
+    uselibs="gallium_vc4_gca pthread" \
+    objdir="$(OBJDIR)/$(MESAGLVERSION)"
+
+%common

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_aros_bridge.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_aros_bridge.c
@@ -1,0 +1,155 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D - Bridge implementation.
+
+    Populates struct vc4_aros_bridge with thin wrappers forwarding into
+    the fd-based vc4_drm_aros.c / vc4_galliumclass.c helpers. The bridge
+    takes an opaque ctx; we synthesise a stack-local vc4_aros_fd per call
+    to reuse the existing fd-based handlers untouched.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include "vc4gallium_intern.h"
+#include "vc4_drm_aros.h"
+#include "vc4_aros_bridge.h"
+
+/* Stack-local fake fd wrapping the ctx (the hidd's staticdata). Valid
+ * only for the helper call — no helper stores it past return. */
+#define BRIDGE_FD(ctx)                                              \
+    struct vc4_aros_fd _bfd = { VC4_AROS_FD_MAGIC,                  \
+                                (struct vc4galliumstaticdata *)(ctx) }; \
+    int _fd = (int)(IPTR)&_bfd
+
+static int bridge_ioctl(void *ctx, unsigned long request, void *arg)
+{
+    BRIDGE_FD(ctx);
+    return vc4_aros_ioctl(_fd, request, arg);
+}
+
+static void *bridge_mmap(void *ctx, ULONG handle)
+{
+    BRIDGE_FD(ctx);
+    return vc4_aros_mmap(_fd, handle);
+}
+
+static int bridge_munmap(void *ctx, void *addr, unsigned long length)
+{
+    /* Identity mapping (CPU == physical) and BO lifetime is governed by
+     * GEM_CLOSE, so munmap is a no-op. */
+    (void)ctx;
+    (void)addr;
+    (void)length;
+    return 0;
+}
+
+static int bridge_close(void *ctx)
+{
+    /* Per-fd state is only the stack-local fake fd; nothing to release.
+     * Hidd teardown happens via release_all_bos + ExpungeLib. */
+    (void)ctx;
+    return 0;
+}
+
+static void bridge_release_all_bos(void *ctx)
+{
+    vc4_aros_release_all_bos((struct vc4galliumstaticdata *)ctx);
+}
+
+/* Implemented in vc4_galliumclass.c — resolved fields only, no Mesa
+ * types cross the API boundary. */
+extern void vc4_aros_display_blit(struct vc4galliumstaticdata *sd,
+                                  ULONG src_bo_handle,
+                                  ULONG src_stride,
+                                  ULONG src_offset,
+                                  ULONG cpp,
+                                  OOP_Object *bm_obj,
+                                  LONG dst_x, LONG dst_y,
+                                  ULONG width, ULONG height);
+extern void vc4_aros_wait_idle(struct vc4galliumstaticdata *sd);
+extern int vc4_aros_get_scanout(struct vc4galliumstaticdata *sd,
+                                OOP_Object *bm_obj,
+                                struct vc4_aros_scanout *out);
+extern int vc4_aros_flip_scanout(struct vc4galliumstaticdata *sd,
+                                 OOP_Object *bm_obj);
+extern int vc4_aros_set_overlay(struct vc4galliumstaticdata *sd,
+                                OOP_Object *bm_obj,
+                                ULONG src_bo_handle, ULONG src_stride,
+                                LONG x, LONG y, ULONG w, ULONG h,
+                                ULONG dest_w, ULONG dest_h);
+extern void vc4_aros_clear_overlay(struct vc4galliumstaticdata *sd,
+                                   OOP_Object *bm_obj);
+
+static void bridge_display_blit(void *ctx,
+    ULONG src_bo_handle, ULONG src_stride, ULONG src_offset, ULONG cpp,
+    OOP_Object *dest_bitmap,
+    LONG dst_x, LONG dst_y,
+    ULONG width, ULONG height)
+{
+    vc4_aros_display_blit((struct vc4galliumstaticdata *)ctx,
+                          src_bo_handle, src_stride, src_offset, cpp,
+                          dest_bitmap, dst_x, dst_y, width, height);
+}
+
+static void bridge_wait_idle(void *ctx)
+{
+    vc4_aros_wait_idle((struct vc4galliumstaticdata *)ctx);
+}
+
+static int bridge_get_scanout(void *ctx, OOP_Object *dest_bitmap,
+                              struct vc4_aros_scanout *out)
+{
+    return vc4_aros_get_scanout((struct vc4galliumstaticdata *)ctx,
+                                dest_bitmap, out);
+}
+
+static int bridge_flip_scanout(void *ctx, OOP_Object *dest_bitmap)
+{
+    return vc4_aros_flip_scanout((struct vc4galliumstaticdata *)ctx,
+                                 dest_bitmap);
+}
+
+static int bridge_set_overlay(void *ctx, OOP_Object *dest_bitmap,
+                              ULONG src_bo_handle, ULONG src_stride,
+                              LONG x, LONG y, ULONG w, ULONG h,
+                              ULONG dest_w, ULONG dest_h)
+{
+    return vc4_aros_set_overlay((struct vc4galliumstaticdata *)ctx,
+                                dest_bitmap, src_bo_handle, src_stride,
+                                x, y, w, h, dest_w, dest_h);
+}
+
+static void bridge_clear_overlay(void *ctx, OOP_Object *dest_bitmap)
+{
+    vc4_aros_clear_overlay((struct vc4galliumstaticdata *)ctx, dest_bitmap);
+}
+
+static ULONG bridge_get_seqno(void *ctx)
+{
+    /* Aligned ULONG read — no lock needed for a monotonic snapshot. */
+    return ((struct vc4galliumstaticdata *)ctx)->v3d.seqno;
+}
+
+/* Populate a bridge struct for the given hidd staticdata. The struct
+ * lives in caller storage (typically mesa3dgl's screen->priv slot). */
+void vc4_aros_bridge_init(struct vc4_aros_bridge *bridge,
+                          struct vc4galliumstaticdata *sd)
+{
+    bridge->version         = VC4_AROS_BRIDGE_VERSION;
+    bridge->driver_id       = AROS_GALLIUM_DRIVER_VC4;
+    bridge->ctx             = sd;
+    bridge->ioctl           = bridge_ioctl;
+    bridge->mmap            = bridge_mmap;
+    bridge->munmap          = bridge_munmap;
+    bridge->close           = bridge_close;
+    bridge->display_blit    = bridge_display_blit;
+    bridge->wait_idle       = bridge_wait_idle;
+    bridge->release_all_bos = bridge_release_all_bos;
+    bridge->get_scanout     = bridge_get_scanout;
+    bridge->flip_scanout    = bridge_flip_scanout;
+    bridge->set_overlay     = bridge_set_overlay;
+    bridge->clear_overlay   = bridge_clear_overlay;
+    bridge->get_seqno       = bridge_get_seqno;
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_aros_bridge.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_aros_bridge.h
@@ -1,0 +1,136 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D - Bridge ABI between mesa3dgl.library and vc4gallium.hidd.
+
+    mesa3dgl statically links the Mesa VC4 driver; vc4gallium.hidd owns the
+    hardware (V3D registers, mailbox, BO table, DMA channel). This header is
+    the only ABI surface between them. It carries no Mesa types — only AROS
+    primitives and DRM UAPI handle ids — so it stays stable across Mesa
+    upgrades.
+
+    Lifecycle: vc4gallium.hidd::CreatePipeScreen builds and populates a
+    vc4_aros_bridge, passes it to mesa3dgl's vc4_screen_create(), which
+    stores it in pipe_screen->priv. Mesa-side drmIoctl(fd, …) calls become
+    bridge->ioctl(bridge->ctx, …).
+*/
+
+#ifndef _VC4_AROS_BRIDGE_H
+#define _VC4_AROS_BRIDGE_H
+
+#include <exec/types.h>
+#include <oop/oop.h>
+
+/* ABI version. Bump on any field add/remove/reorder. mesa3dgl checks it
+ * at screen-create and refuses an incompatible bridge. */
+#define VC4_AROS_BRIDGE_VERSION   5
+
+/* Which gallium driver this bridge fronts. mesa3dgl dispatches
+ * screen-create on driver_id, so one mesa3dgl can carry several drivers
+ * (vc4 for Pi 0-3, v3d for Pi 4) and pick by the instantiated hidd. */
+#define AROS_GALLIUM_DRIVER_VC4   0
+//#define AROS_GALLIUM_DRIVER_V3D   1
+
+/* Scanout page description for zero-copy fullscreen GL (v2). The vc4gfx
+ * framebuffer has two flip pages; Mesa renders into the back page and
+ * presents via flip_scanout instead of copying. name[] are GEM_OPEN names
+ * (page physical addresses), stable across flips; `back` indexes the page
+ * not currently shown. */
+struct vc4_aros_scanout
+{
+    ULONG   name[2];
+    ULONG   pitch;
+    ULONG   width;
+    ULONG   height;
+    ULONG   back;
+};
+
+struct vc4_aros_bridge
+{
+    ULONG   version;        /* Must equal VC4_AROS_BRIDGE_VERSION */
+    ULONG   driver_id;      /* AROS_GALLIUM_DRIVER_* — picks *_screen_create */
+
+    /* Opaque per-hidd context. mesa3dgl never dereferences it, just
+     * passes it back; the hidd resolves it to its staticdata. */
+    void   *ctx;
+
+    /* DRM ioctl entry. request is a DRM_VC4_* command (DRM_COMMAND_BASE +
+     * cmd) or plain DRM_GEM_CLOSE etc; arg is the matching drm_vc4_*
+     * struct. Returns 0 / negative errno. */
+    int    (*ioctl)(void *ctx, unsigned long request, void *arg);
+
+    /* Map a BO (handle from DRM_VC4_CREATE_BO) and return a CPU pointer,
+     * NULL on failure. Mapping is identity (CPU == physical) on AROS, so
+     * this is just a handle→pointer lookup. */
+    void  *(*mmap)(void *ctx, ULONG handle);
+
+    /* Reverse of mmap. Safe to call with NULL/zero. */
+    int    (*munmap)(void *ctx, void *addr, unsigned long length);
+
+    /* Close the fake DRM fd (per-fd state only). Bridge ctx stays alive
+     * until the hidd expunges. */
+    int    (*close)(void *ctx);
+
+    /* DMA a rendered BO into an AROS bitmap. src_bo_handle is a CREATE_BO
+     * handle (hidd looks up the vaddr); dest_bitmap is a Hidd_BitMap whose
+     * framebuffer address the hidd resolves via aHidd_ChunkyBM_Buffer.
+     * No pipe_resource crosses the boundary — mesa3dgl resolves it to
+     * {handle, stride, offset, cpp} first. */
+    void   (*display_blit)(void *ctx,
+                           ULONG src_bo_handle,
+                           ULONG src_stride,
+                           ULONG src_offset,
+                           ULONG cpp,
+                           OOP_Object *dest_bitmap,
+                           LONG dst_x, LONG dst_y,
+                           ULONG width, ULONG height);
+
+    /* Wait for outstanding GPU work; mesa3dgl calls this before reading a
+     * BO's CPU mapping. Optional — no-op if the bridge syncs per submit. */
+    void   (*wait_idle)(void *ctx);
+
+    /* Release every outstanding BO back to the firmware. Called by
+     * mesa3dgl from screen destroy. */
+    void   (*release_all_bos)(void *ctx);
+
+    /* v2: query the framebuffer's flip pages (publishing them as GEM_OPEN
+     * names). Returns 0 for a flippable vc4gfx framebuffer, -1 otherwise. */
+    int    (*get_scanout)(void *ctx, OOP_Object *dest_bitmap,
+                          struct vc4_aros_scanout *out);
+
+    /* v2: make the back page visible (waits for GPU + DMA first). Returns
+     * 0 on success; get_scanout then reports the new back index. */
+    int    (*flip_scanout)(void *ctx, OOP_Object *dest_bitmap);
+
+    /* v3: zero-copy windowed present. Show src_bo_handle as an opaque
+     * HVS overlay plane at (x,y) (fb coordinates), source size w*h,
+     * shown at dest_w*dest_h (v4; 0 = unscaled, larger = HVS PPF
+     * upscale) on the screen's framebuffer bitmap. Waits for GPU idle
+     * first, pins the BO while shown, and returns 0 on success (-1 =
+     * unavailable: firmware owns the display / scaled desktop /
+     * downscale — caller blits instead). Repeated calls retarget/move
+     * the plane; the update latches at vblank with flip pacing. */
+    int    (*set_overlay)(void *ctx, OOP_Object *dest_bitmap,
+                          ULONG src_bo_handle, ULONG src_stride,
+                          LONG x, LONG y, ULONG w, ULONG h,
+                          ULONG dest_w, ULONG dest_h);
+
+    /* v3: remove the overlay plane and unpin its BO. Safe to call when
+     * none is shown; dest_bitmap may be NULL (uses the bitmap of the
+     * last set_overlay). */
+    void   (*clear_overlay)(void *ctx, OOP_Object *dest_bitmap);
+
+    /* v5: latest SUBMITTED job seqno (same domain as DRM_VC4_WAIT_SEQNO
+     * and drm_vc4_submit_cl.seqno). Snapshotted at present time so the
+     * pipelined overlay path can wait for exactly the frame it is about
+     * to display instead of full GPU idle. */
+    ULONG  (*get_seqno)(void *ctx);
+};
+
+/* Populate `bridge` with function pointers forwarding to `sd`'s state.
+ * Implemented in the hidd; mesa3dgl only ever sees the bridge struct. */
+struct vc4galliumstaticdata;
+void vc4_aros_bridge_init(struct vc4_aros_bridge *bridge,
+                          struct vc4galliumstaticdata *sd);
+
+#endif /* _VC4_AROS_BRIDGE_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_drm_aros.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_drm_aros.c
@@ -1,0 +1,2961 @@
+/*
+    Copyright 2025, The AROS Development Team. All rights reserved.
+
+    Portions of this file (the V3D packet definitions, command-list
+    processing, shader-record relocation and render-control-list
+    generation) are derived from Mesa's MIT-licensed VC4 Gallium driver
+    kernel-validation sources, src/gallium/drivers/vc4/kernel/
+    (vc4_packet.h, vc4_validate.c, vc4_render_cl.c):
+
+      Copyright (C) 2014-2015 Broadcom
+
+      Permission is hereby granted, free of charge, to any person obtaining a
+      copy of this software and associated documentation files (the "Software"),
+      to deal in the Software without restriction, including without limitation
+      the rights to use, copy, modify, merge, publish, distribute, sublicense,
+      and/or sell copies of the Software, and to permit persons to whom the
+      Software is furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice (including the next
+      paragraph) shall be included in all copies or substantial portions of the
+      Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+      THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+      IN THE SOFTWARE.
+
+    VC4 Gallium 3D HIDD - DRM compatibility layer implementation
+
+    Replaces the DRM ioctl interface with direct AROS hardware access.
+    Mesa's VC4 Gallium driver calls vc4_ioctl() which wraps drmIoctl().
+    We intercept at the drmIoctl level and dispatch to our handlers.
+
+    This file implements:
+    - BO (Buffer Object) management via mailbox GPU memory allocation
+    - Bin CL processing: strip GEM_HANDLES, patch addresses
+    - Shader record relocation: resolve BO handle indices to GPU bus addresses
+    - RCL (Render Control List) generation from surface configuration
+    - V3D job submission (binning + rendering)
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/mbox.h>
+#include <proto/kernel.h>
+
+#include <hardware/videocore.h>
+#include <errno.h>
+
+/* stdc's errno.h has no ETIME; the value must match posixc's (what the
+ * Mesa side is built against) — vc4_bufmgr.c tests ret == -ETIME to
+ * classify a timeout_ns=0 wait as "busy" instead of an error. */
+#ifndef ETIME
+#define ETIME 92
+#endif
+
+#include "vc4gallium_intern.h"
+#include "vc4_drm_aros.h"
+#include "vc4_v3d.h"
+
+/* vc4_v3d.h provides ARM_PERIIOBASE; bcm2708.h gives us the 1 MHz
+ * system timer used by the hybrid GPU wait below. */
+#include <hardware/bcm2708.h>
+
+static inline ULONG v3d_now_us(void)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)SYSTIMER_CLO);
+}
+
+/* Base-free memset. This hidd is kickstart-resident; the stdc memset
+ * stub caches the FIRST caller task's per-task StdCBase in our globals
+ * and calls through that dead base from every later process (2nd-GL-app
+ * crash). A local strong definition also catches clang's implicit
+ * struct-init memset calls.
+ *
+ * gcc's -ftree-loop-distribute-patterns (on at -O2) recognizes the byte
+ * loop as the memset idiom and replaces it with a call to memset — this
+ * very function, which then spins forever. clang deliberately skips
+ * idiom recognition inside functions named after the idiom. Turn the
+ * pass off here, the way libcs building their own string routines do. */
+#if defined(__GNUC__) && !defined(__clang__)
+__attribute__((optimize("no-tree-loop-distribute-patterns")))
+#endif
+void *memset(void *dst, int c, __SIZE_TYPE__ n)
+{
+    UBYTE *d = dst;
+    while (n--)
+        *d++ = (UBYTE)c;
+    return dst;
+}
+
+/* Base-free "%02x " formatter for the diagnostic hexdumps (replaces the
+ * stdc snprintf stub for the same reason as memset above). Returns the
+ * 3 bytes written; caller guarantees space. */
+static ULONG vc4_hexbyte(char *dst, UBYTE b)
+{
+    static const char hex[] = "0123456789abcdef";
+    dst[0] = hex[b >> 4];
+    dst[1] = hex[b & 0xf];
+    dst[2] = ' ';
+    dst[3] = '\0';
+    return 3;
+}
+
+/* Mailbox property channel */
+#define VCMB_PROPCHAN   8
+
+#ifdef MBoxBase
+#undef MBoxBase
+#endif
+#define MBoxBase    sd->MBoxBase
+
+/* ---- V3D Packet Constants (from Mesa's MIT-licensed
+ *      src/gallium/drivers/vc4/kernel/vc4_packet.h) ---- */
+
+/* Packet opcodes */
+#define VC4_PACKET_HALT                         0
+#define VC4_PACKET_NOP                          1
+#define VC4_PACKET_FLUSH                        4
+#define VC4_PACKET_FLUSH_ALL                    5
+#define VC4_PACKET_START_TILE_BINNING           6
+#define VC4_PACKET_INCREMENT_SEMAPHORE          7
+#define VC4_PACKET_WAIT_ON_SEMAPHORE            8
+#define VC4_PACKET_BRANCH                       16
+#define VC4_PACKET_BRANCH_TO_SUB_LIST           17
+#define VC4_PACKET_STORE_MS_TILE_BUFFER         24
+#define VC4_PACKET_STORE_MS_TILE_BUFFER_AND_EOF 25
+#define VC4_PACKET_STORE_FULL_RES_TILE_BUFFER   26
+#define VC4_PACKET_LOAD_FULL_RES_TILE_BUFFER    27
+#define VC4_PACKET_STORE_TILE_BUFFER_GENERAL    28
+#define VC4_PACKET_LOAD_TILE_BUFFER_GENERAL     29
+#define VC4_PACKET_GL_INDEXED_PRIMITIVE         32
+#define VC4_PACKET_GL_ARRAY_PRIMITIVE           33
+#define VC4_PACKET_PRIMITIVE_LIST_FORMAT        56
+#define VC4_PACKET_GL_SHADER_STATE              64
+#define VC4_PACKET_NV_SHADER_STATE              65
+#define VC4_PACKET_CONFIGURATION_BITS           96
+#define VC4_PACKET_FLAT_SHADE_FLAGS             97
+#define VC4_PACKET_POINT_SIZE                   98
+#define VC4_PACKET_LINE_WIDTH                   99
+#define VC4_PACKET_RHT_X_BOUNDARY              100
+#define VC4_PACKET_DEPTH_OFFSET                101
+#define VC4_PACKET_CLIP_WINDOW                 102
+#define VC4_PACKET_VIEWPORT_OFFSET             103
+#define VC4_PACKET_Z_CLIPPING                  104
+#define VC4_PACKET_CLIPPER_XY_SCALING          105
+#define VC4_PACKET_CLIPPER_Z_SCALING           106
+#define VC4_PACKET_TILE_BINNING_MODE_CONFIG    112
+#define VC4_PACKET_TILE_RENDERING_MODE_CONFIG  113
+#define VC4_PACKET_CLEAR_COLORS                114
+#define VC4_PACKET_TILE_COORDINATES            115
+#define VC4_PACKET_GEM_HANDLES                 254
+
+/* Packet sizes (including opcode byte) */
+static const UBYTE vc4_packet_sizes[256] = {
+    [VC4_PACKET_HALT]                       = 1,
+    [VC4_PACKET_NOP]                        = 1,
+    [VC4_PACKET_FLUSH]                      = 1,
+    [VC4_PACKET_FLUSH_ALL]                  = 1,
+    [VC4_PACKET_START_TILE_BINNING]         = 1,
+    [VC4_PACKET_INCREMENT_SEMAPHORE]        = 1,
+    [VC4_PACKET_WAIT_ON_SEMAPHORE]          = 1,
+    [VC4_PACKET_BRANCH]                     = 5,
+    [VC4_PACKET_BRANCH_TO_SUB_LIST]         = 5,
+    [VC4_PACKET_STORE_MS_TILE_BUFFER]       = 1,
+    [VC4_PACKET_STORE_MS_TILE_BUFFER_AND_EOF] = 1,
+    [VC4_PACKET_STORE_FULL_RES_TILE_BUFFER] = 5,
+    [VC4_PACKET_LOAD_FULL_RES_TILE_BUFFER]  = 5,
+    [VC4_PACKET_STORE_TILE_BUFFER_GENERAL]  = 7,
+    [VC4_PACKET_LOAD_TILE_BUFFER_GENERAL]   = 7,
+    [VC4_PACKET_GL_INDEXED_PRIMITIVE]       = 14,
+    [VC4_PACKET_GL_ARRAY_PRIMITIVE]         = 10,
+    [48]                                    = 1,  /* COMPRESSED_PRIMITIVE */
+    [49]                                    = 1,  /* CLIPPED_COMPRESSED_PRIMITIVE */
+    [VC4_PACKET_PRIMITIVE_LIST_FORMAT]      = 2,
+    [VC4_PACKET_GL_SHADER_STATE]            = 5,
+    [VC4_PACKET_NV_SHADER_STATE]            = 5,
+    [66]                                    = 5,  /* VG_SHADER_STATE */
+    [VC4_PACKET_CONFIGURATION_BITS]         = 4,
+    [VC4_PACKET_FLAT_SHADE_FLAGS]           = 5,
+    [VC4_PACKET_POINT_SIZE]                 = 5,
+    [VC4_PACKET_LINE_WIDTH]                 = 5,
+    [VC4_PACKET_RHT_X_BOUNDARY]            = 3,
+    [VC4_PACKET_DEPTH_OFFSET]              = 5,
+    [VC4_PACKET_CLIP_WINDOW]               = 9,
+    [VC4_PACKET_VIEWPORT_OFFSET]           = 5,
+    [VC4_PACKET_Z_CLIPPING]                = 9,
+    [VC4_PACKET_CLIPPER_XY_SCALING]        = 9,
+    [VC4_PACKET_CLIPPER_Z_SCALING]         = 9,
+    [VC4_PACKET_TILE_BINNING_MODE_CONFIG]  = 16,
+    [VC4_PACKET_TILE_RENDERING_MODE_CONFIG]= 11,
+    [VC4_PACKET_CLEAR_COLORS]              = 14,
+    [VC4_PACKET_TILE_COORDINATES]          = 3,
+    [VC4_PACKET_GEM_HANDLES]               = 9,
+};
+
+/* Tile buffer constants */
+#define VC4_TILE_BUFFER_SIZE    (64 * 64 * 4)
+
+/* Load/Store tile buffer bits */
+#define VC4_LOADSTORE_TILE_BUFFER_NONE                  0
+#define VC4_STORE_TILE_BUFFER_DISABLE_VG_MASK_CLEAR     (1 << 15)
+#define VC4_STORE_TILE_BUFFER_DISABLE_ZS_CLEAR          (1 << 14)
+#define VC4_STORE_TILE_BUFFER_DISABLE_COLOR_CLEAR       (1 << 13)
+#define VC4_LOADSTORE_TILE_BUFFER_EOF                   (1 << 3)
+#define VC4_LOADSTORE_FULL_RES_EOF                      (1 << 3)
+#define VC4_LOADSTORE_FULL_RES_DISABLE_CLEAR_ALL        (1 << 2)
+#define VC4_LOADSTORE_FULL_RES_DISABLE_ZS               (1 << 1)
+#define VC4_LOADSTORE_FULL_RES_DISABLE_COLOR            (1 << 0)
+
+/* RCL surface flag */
+#define VC4_SUBMIT_RCL_SURFACE_READ_IS_FULL_RES         (1 << 0)
+
+/* Binning config flags */
+#define VC4_BIN_CONFIG_AUTO_INIT_TSDA                   (1 << 2)
+#define VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_MASK            (3 << 5)
+#define VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_128             (2 << 5)
+#define VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_MASK       (3 << 3)
+#define VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_32         (0 << 3)
+
+/* roundup helper */
+#define ROUNDUP(x, y) (((x) + (y) - 1) & ~((y) - 1))
+#define DIV_ROUND_UP(x, y) (((x) + (y) - 1) / (y))
+
+static struct vc4galliumstaticdata *fd_to_sd(int fd)
+{
+    struct vc4_aros_fd *afd = (struct vc4_aros_fd *)(IPTR)fd;
+    if (afd && afd->magic == VC4_AROS_FD_MAGIC)
+        return afd->sd;
+    bug("[VC4Gallium] BUG: invalid fd 0x%08x\n", fd);
+    return NULL;
+}
+
+/* ---- Buffer Object Management ---- */
+
+static ULONG bo_alloc_handle(struct vc4galliumstaticdata *sd)
+{
+    ULONG i;
+    for (i = 1; i < VC4_MAX_BOS; i++)
+    {
+        ULONG h = (sd->bo_next_handle + i) % VC4_MAX_BOS;
+        if (h == 0) continue;
+        if (sd->bo_table[h].refcount == 0)
+        {
+            sd->bo_next_handle = h;
+            return h;
+        }
+    }
+    return 0;
+}
+
+/* Allocate GPU memory via mailbox; returns physical address (0x3fffffff masked). */
+static APTR gpu_mem_alloc(struct vc4galliumstaticdata *sd, ULONG size, ULONG align, ULONG flags, ULONG *out_handle)
+{
+    APTR phys = NULL;
+    ULONG gpu_handle;
+
+    ObtainSemaphore(&sd->mbox_lock);
+
+    D(bug("[VC4Gallium] gpu_mem_alloc: requesting %d bytes align=%d flags=0x%x mbox_msg=0x%08x\n",
+        size, align, flags, (ULONG)(IPTR)sd->mbox_msg));
+
+    /* Allocate memory.
+     * Mailbox property tag layout:
+     *   [0] total size  [1] VCTAG_REQ  [2] tag_id
+     *   [3] value_buf_size  [4] request_indicator  [5..] values
+     *   [...] end_tag(0)
+     * msg[4] = request value length in bytes (bit 31 clear).
+     * Response overwrites msg[4] with 0x80000000|resp_len.
+     */
+    sd->mbox_msg[0] = AROS_LE2LONG(10 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(VCTAG_ALLOCMEM);
+    sd->mbox_msg[3] = AROS_LE2LONG(4 * 3);        /* value buffer size = 12 */
+    sd->mbox_msg[4] = AROS_LE2LONG(4 * 3);         /* request indicator = 12 */
+    sd->mbox_msg[5] = AROS_LE2LONG(size);           /* value[0] = size */
+    sd->mbox_msg[6] = AROS_LE2LONG(align);          /* value[1] = alignment */
+    sd->mbox_msg[7] = AROS_LE2LONG(flags);          /* value[2] = flags */
+    sd->mbox_msg[8] = 0;                            /* end tag */
+    sd->mbox_msg[9] = 0;
+
+    /* MBoxCall (not MBoxWrite + MBoxRead) so the request/response pair is
+     * atomic under the resource's own mbox_Sem. A separate write+read drops
+     * that lock between the two, letting another mailbox user (e.g. vc4gfx's
+     * cursor/mode MBoxCall) inject a request and consume our reply. */
+    if (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg)
+        == (volatile unsigned int *)-1)
+    {
+        bug("[VC4Gallium] gpu_mem_alloc: ALLOCMEM MBoxCall failed\n");
+        ReleaseSemaphore(&sd->mbox_lock);
+        return NULL;
+    }
+
+    D(bug("[VC4Gallium] gpu_mem_alloc: ALLOCMEM response: msg[1]=0x%08x msg[4]=0x%08x msg[5]=0x%08x\n",
+        AROS_LE2LONG(sd->mbox_msg[1]), AROS_LE2LONG(sd->mbox_msg[4]),
+        AROS_LE2LONG(sd->mbox_msg[5])));
+
+    gpu_handle = AROS_LE2LONG(sd->mbox_msg[5]);
+    if (gpu_handle == 0)
+    {
+        bug("[VC4Gallium] gpu_mem_alloc: firmware returned handle=0 for %d bytes (OOM?)\n", size);
+        ReleaseSemaphore(&sd->mbox_lock);
+        return NULL;
+    }
+
+    /* Lock memory to get physical address */
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(VCTAG_LOCKMEM);
+    sd->mbox_msg[3] = AROS_LE2LONG(4);             /* value buffer size = 4 */
+    sd->mbox_msg[4] = AROS_LE2LONG(4);              /* request indicator = 4 */
+    sd->mbox_msg[5] = AROS_LE2LONG(gpu_handle);     /* value[0] = handle */
+    sd->mbox_msg[6] = 0;                            /* end tag */
+    sd->mbox_msg[7] = 0;
+
+    if (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg)
+        == (volatile unsigned int *)-1)
+    {
+        bug("[VC4Gallium] gpu_mem_alloc: LOCKMEM MBoxCall failed\n");
+        ReleaseSemaphore(&sd->mbox_lock);
+        return NULL;
+    }
+
+    phys = (APTR)(AROS_LE2LONG(sd->mbox_msg[5]) & 0x3fffffff);
+
+    D(bug("[VC4Gallium] gpu_mem_alloc: LOCKMEM response: msg[4]=0x%08x msg[5]=0x%08x -> phys=0x%08x\n",
+        AROS_LE2LONG(sd->mbox_msg[4]), AROS_LE2LONG(sd->mbox_msg[5]), (ULONG)phys));
+
+    ReleaseSemaphore(&sd->mbox_lock);
+
+    if (out_handle)
+        *out_handle = gpu_handle;
+
+    D(bug("[VC4Gallium] gpu_mem_alloc: %d bytes -> phys=0x%08x gpu_handle=0x%08x\n",
+        size, (ULONG)phys, gpu_handle));
+
+    return phys;
+}
+
+static void gpu_mem_free(struct vc4galliumstaticdata *sd, ULONG gpu_handle)
+{
+    D(bug("[VC4Gallium] gpu_mem_free: gpu_handle=0x%08x\n", gpu_handle));
+
+    ObtainSemaphore(&sd->mbox_lock);
+
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(VCTAG_UNLOCKMEM);
+    sd->mbox_msg[3] = AROS_LE2LONG(4);             /* value buffer size */
+    sd->mbox_msg[4] = AROS_LE2LONG(4);              /* request indicator */
+    sd->mbox_msg[5] = AROS_LE2LONG(gpu_handle);     /* value[0] = handle */
+    sd->mbox_msg[6] = 0;                            /* end tag */
+    sd->mbox_msg[7] = 0;
+
+    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg);
+
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(VCTAG_FREEMEM);
+    sd->mbox_msg[3] = AROS_LE2LONG(4);             /* value buffer size */
+    sd->mbox_msg[4] = AROS_LE2LONG(4);              /* request indicator */
+    sd->mbox_msg[5] = AROS_LE2LONG(gpu_handle);     /* value[0] = handle */
+    sd->mbox_msg[6] = 0;                            /* end tag */
+    sd->mbox_msg[7] = 0;
+
+    MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg);
+
+    ReleaseSemaphore(&sd->mbox_lock);
+}
+
+static int v3d_wait_seqno(struct vc4galliumstaticdata *sd, ULONG seqno, ULONG timeout_loops);
+
+/*
+ * Reclaim GPU memory by waiting for all in-flight jobs and freeing
+ * the pooled frame BOs. Called when gpu_mem_alloc fails as a last
+ * resort before reporting OOM to Mesa.
+ */
+static void gpu_mem_reclaim(struct vc4galliumstaticdata *sd)
+{
+    struct vc4_v3d_state *v3d = &sd->v3d;
+    int i;
+
+    D(bug("[VC4Gallium] gpu_mem_reclaim: attempting to free pool BOs\n"));
+
+    if (v3d->finished_seqno < v3d->seqno)
+        v3d_wait_seqno(sd, v3d->seqno, 50000000);
+
+    for (i = 0; i < VC4_NUM_POOL_SETS; i++)
+    {
+        struct vc4_frame_bo *pools[] = {
+            &sd->pool[i].tile,
+            &sd->pool[i].exec,
+            &sd->pool[i].rcl,
+            &sd->pool[i].binoverflow
+        };
+        int p;
+        for (p = 0; p < 4; p++)
+        {
+            if (pools[p]->vaddr)
+            {
+                D(bug("[VC4Gallium] gpu_mem_reclaim: freeing pool[%d].%s (%d bytes)\n",
+                    i, (p == 0) ? "tile" : (p == 1) ? "exec" :
+                       (p == 2) ? "rcl" : "binoverflow",
+                    pools[p]->size));
+                gpu_mem_free(sd, pools[p]->gpu_handle);
+                pools[p]->vaddr = NULL;
+                pools[p]->bus_addr = 0;
+                pools[p]->gpu_handle = 0;
+                pools[p]->size = 0;
+            }
+        }
+        sd->pool[i].seqno = 0;
+    }
+}
+
+/* ---- Helper: resolve BO handle to bus address ---- */
+
+static ULONG bo_bus_addr(struct vc4galliumstaticdata *sd,
+                         ULONG *bo_handles, ULONG bo_handle_count,
+                         ULONG hindex)
+{
+    ULONG handle;
+    if (hindex >= bo_handle_count)
+    {
+        bug("[VC4Gallium] bo_bus_addr: hindex %d >= count %d\n",
+            hindex, bo_handle_count);
+        return 0;
+    }
+    handle = bo_handles[hindex];
+    if (handle == 0 || handle >= VC4_MAX_BOS || sd->bo_table[handle].refcount == 0)
+    {
+        bug("[VC4Gallium] bo_bus_addr: invalid handle %d at hindex %d\n",
+            handle, hindex);
+        return 0;
+    }
+    return sd->bo_table[handle].bus_addr;
+}
+
+/* ---- QPU Shader Instruction Scanner ----
+ *
+ * Scan QPU instructions to extract uniform-relocation metadata, mirroring
+ * Mesa's MIT-licensed kernel/vc4_validate_shaders.c. Extracts:
+ * - uniforms_size: total bytes of uniform data the shader reads
+ * - num_texture_samples: number of TMU submissions
+ * - texture_samples[]: per-sample p_offset[0..3] into the uniform stream
+ * - uniform_addr_offsets[]: indices of UNIFORMS_ADDRESS uniform words
+ *
+ * Mesa's submitted uniform stream is, per shader:
+ *   [tex_handle_0..N-1] [uniform_data_0..M-1]
+ * N = num_texture_samples, M = uniforms_size/4 reads; tex handles first.
+ */
+
+/* QPU instruction field extraction. Bit positions and signal/waddr enum
+ * values mirror Mesa's vc4_qpu_defines.h (see the kernel/Mesa-shipped
+ * mesa-21.0.2/src/gallium/drivers/vc4/vc4_qpu_defines.h). */
+#define QPU_GET_FIELD(inst, shift, nbits) \
+    (((inst) >> (shift)) & ((1ULL << (nbits)) - 1))
+#define QPU_SIG(inst)       QPU_GET_FIELD(inst, 60, 4)
+#define QPU_RADDR_A(inst)   QPU_GET_FIELD(inst, 18, 6)
+#define QPU_RADDR_B(inst)   QPU_GET_FIELD(inst, 12, 6)
+#define QPU_WADDR_ADD(inst) QPU_GET_FIELD(inst, 38, 6)
+#define QPU_WADDR_MUL(inst) QPU_GET_FIELD(inst, 32, 6)
+#define QPU_OP_ADD(inst)    QPU_GET_FIELD(inst, 24, 5)
+#define QPU_ADD_B(inst)     QPU_GET_FIELD(inst, 9, 3)
+#define QPU_BRANCH_REL_BIT  ((UQUAD)1 << 51)
+#define QPU_BRANCH_REG_BIT  ((UQUAD)1 << 50)
+#define QPU_BRANCH_TARGET(inst) ((LONG)((ULONG)((inst) & 0xffffffffULL)))
+
+#define QPU_R_UNIF          32
+#define QPU_MUX_A           6
+#define QPU_MUX_B           7
+
+/* Signal field values. Note: these are enum-position values matching
+ * Mesa's `enum qpu_sig_bits` — QPU_SIG_NONE is 1, not 0. */
+#define QPU_SIG_SW_BREAKPOINT        0
+#define QPU_SIG_NONE                 1
+#define QPU_SIG_THREAD_SWITCH        2
+#define QPU_SIG_PROG_END             3
+#define QPU_SIG_WAIT_FOR_SCOREBOARD  4
+#define QPU_SIG_SCOREBOARD_UNLOCK    5
+#define QPU_SIG_LAST_THREAD_SWITCH   6
+#define QPU_SIG_COVERAGE_LOAD        7
+#define QPU_SIG_COLOR_LOAD           8
+#define QPU_SIG_COLOR_LOAD_END       9
+#define QPU_SIG_LOAD_TMU0           10
+#define QPU_SIG_LOAD_TMU1           11
+#define QPU_SIG_ALPHA_MASK_LOAD     12
+#define QPU_SIG_SMALL_IMM           13
+#define QPU_SIG_LOAD_IMM            14
+#define QPU_SIG_BRANCH              15
+
+#define QPU_A_ADD            0
+
+/* TMU write addresses: S triggers submission, T/R/B are parameter writes */
+#define QPU_W_TMU0_S        56
+#define QPU_W_TMU0_T        57
+#define QPU_W_TMU0_R        58
+#define QPU_W_TMU0_B        59
+#define QPU_W_TMU1_S        60
+#define QPU_W_TMU1_T        61
+#define QPU_W_TMU1_R        62
+#define QPU_W_TMU1_B        63
+
+/* Other write addresses used by the validator */
+#define QPU_W_TMU_NOSWAP        36
+#define QPU_W_HOST_INT          38
+#define QPU_W_NOP               39
+#define QPU_W_UNIFORMS_ADDRESS  40
+#define QPU_W_TLB_STENCIL_SETUP 43
+#define QPU_W_TLB_Z             44
+#define QPU_W_TLB_COLOR_MS      45
+#define QPU_W_TLB_COLOR_ALL     46
+#define QPU_W_TLB_ALPHA_MASK    47
+#define QPU_W_VPM               48
+#define QPU_W_VPMVCD_SETUP      49
+#define QPU_W_VPM_ADDR          50
+#define QPU_W_MUTEX_RELEASE     51
+
+static inline BOOL is_tmu_write(ULONG waddr)
+{
+    return (waddr >= QPU_W_TMU0_S && waddr <= QPU_W_TMU1_B);
+}
+
+static inline BOOL is_tmu_submit(ULONG waddr)
+{
+    return (waddr == QPU_W_TMU0_S || waddr == QPU_W_TMU1_S);
+}
+
+static void scan_shader_qpu(APTR shader_data, ULONG shader_size,
+                             struct vc4_bo_entry *bo)
+{
+    UQUAD *inst = (UQUAD *)shader_data;
+    ULONG num_inst = shader_size / 8;
+    ULONG uniforms_size = 0;
+    ULONG tex_samples = 0;
+    ULONG num_uniform_addr = 0;
+    ULONG i, j;
+
+    /* Per-TMU state: track parameter writes until submit */
+    struct {
+        ULONG p_offset[4];
+        ULONG write_count;
+        BOOL  is_direct;
+    } tmu_setup[2];
+
+    for (j = 0; j < 2; j++)
+    {
+        tmu_setup[j].write_count = 0;
+        tmu_setup[j].is_direct = FALSE;
+        for (i = 0; i < 4; i++)
+            tmu_setup[j].p_offset[i] = ~0UL;
+    }
+
+    for (i = 0; i < num_inst; i++)
+    {
+        UQUAD instr = inst[i];
+        ULONG sig = QPU_SIG(instr);
+
+        /* Branches have no uniform/TMU side effects (the branch-address
+         * uniform scheme is not used by Mesa's vc4 compiler). */
+        if (sig == QPU_SIG_BRANCH)
+            continue;
+
+        ULONG raddr_a = QPU_RADDR_A(instr);
+        ULONG raddr_b = QPU_RADDR_B(instr);
+        ULONG waddr_add = QPU_WADDR_ADD(instr);
+        ULONG waddr_mul = QPU_WADDR_MUL(instr);
+
+        /* Writes: add ALU and mul ALU independently (LOAD_IMM writes too) */
+        ULONG tmu_waddrs[2] = { waddr_add, waddr_mul };
+        ULONG w;
+        for (w = 0; w < 2; w++)
+        {
+            ULONG waddr = tmu_waddrs[w];
+
+            if (waddr == QPU_W_UNIFORMS_ADDRESS)
+            {
+                /* Uniform stream reset (add unif_addr, imm, unif). The
+                 * uniform operand — counted by the read accounting below —
+                 * is the slot the kernel patches with the stream's GPU
+                 * address. Mirrors require_uniform_address_uniform(). */
+                if (num_uniform_addr < VC4_MAX_UNIFORM_ADDR)
+                    bo->uniform_addr_offsets[num_uniform_addr++] =
+                        uniforms_size / 4;
+                continue;
+            }
+
+            if (!is_tmu_write(waddr))
+                continue;
+
+            int tmu = (waddr > QPU_W_TMU0_B) ? 1 : 0;
+            BOOL submit = is_tmu_submit(waddr);
+            /* A submit with no prior T/R/B parameter writes is a direct
+             * (UBO) memory read: its address uniform arrives via raddr and
+             * is counted by the read accounting below. */
+            BOOL is_direct = submit && tmu_setup[tmu].write_count == 0;
+
+            if (tmu_setup[tmu].write_count < 4)
+            {
+                tmu_setup[tmu].p_offset[tmu_setup[tmu].write_count] =
+                    uniforms_size;
+            }
+            tmu_setup[tmu].write_count++;
+
+            /* Every non-direct TMU parameter write implicitly pops one
+             * word (P0/P1 config) from the uniform FIFO — there is no
+             * raddr read for it. */
+            if (is_direct)
+                tmu_setup[tmu].is_direct = TRUE;
+            else
+                uniforms_size += 4;
+
+            if (submit)
+            {
+                /* Record this texture sample. Cap the count at the array
+                 * size — silently dropping samples would inflate
+                 * num_texture_samples past VC4_MAX_TEX_SAMPLES and let
+                 * later consumers read past texture_samples[]. */
+                if (tex_samples < VC4_MAX_TEX_SAMPLES)
+                {
+                    struct vc4_texture_sample_info *s =
+                        &bo->texture_samples[tex_samples];
+                    s->is_direct = tmu_setup[tmu].is_direct;
+                    for (j = 0; j < 4; j++)
+                        s->p_offset[j] = tmu_setup[tmu].p_offset[j];
+                    tex_samples++;
+                }
+                else
+                {
+                    bug("[VC4Gallium] scan_shader: texture sample limit "
+                        "(%d) reached, dropping subsequent samples\n",
+                        (ULONG)VC4_MAX_TEX_SAMPLES);
+                }
+
+                /* Reset TMU state for next sample */
+                tmu_setup[tmu].write_count = 0;
+                tmu_setup[tmu].is_direct = FALSE;
+                for (j = 0; j < 4; j++)
+                    tmu_setup[tmu].p_offset[j] = ~0UL;
+            }
+        }
+
+        /* Uniform FIFO reads: at most ONE word per instruction no matter
+         * how many ports reference UNIF — both ports deliver the same
+         * word. LOAD_IMM instructions have no register reads. */
+        if (sig != QPU_SIG_LOAD_IMM &&
+            (raddr_a == QPU_R_UNIF ||
+             (raddr_b == QPU_R_UNIF && sig != QPU_SIG_SMALL_IMM)))
+            uniforms_size += 4;
+    }
+
+    bo->uniforms_size = uniforms_size;
+    bo->num_texture_samples = tex_samples;
+    bo->num_uniform_addr_offsets = num_uniform_addr;
+
+}
+
+/* ---- IOCTL Handlers ---- */
+
+static int ioctl_get_param(struct vc4galliumstaticdata *sd, struct drm_vc4_get_param *args)
+{
+    struct vc4_v3d_state *v3d = &sd->v3d;
+
+    if (!v3d->v3d_available)
+        return -1;
+
+    switch (args->param)
+    {
+    case DRM_VC4_PARAM_V3D_IDENT0:
+        args->value = v3d->ident0;
+        break;
+    case DRM_VC4_PARAM_V3D_IDENT1:
+        args->value = v3d->ident1;
+        break;
+    case DRM_VC4_PARAM_V3D_IDENT2:
+        args->value = v3d->ident2;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_BRANCHES:
+        args->value = 1;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_ETC1:
+        args->value = 1;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_THREADED_FS:
+        args->value = 1;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_FIXED_RCL_ORDER:
+        args->value = 1;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_MADVISE:
+        args->value = 0;
+        break;
+    case DRM_VC4_PARAM_SUPPORTS_PERFMON:
+        args->value = 0;
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
+}
+
+static int ioctl_create_bo(struct vc4galliumstaticdata *sd, struct drm_vc4_create_bo *args)
+{
+    ULONG handle;
+    APTR vaddr;
+    ULONG gpu_handle;
+
+    ObtainSemaphore(&sd->bo_lock);
+    handle = bo_alloc_handle(sd);
+    if (handle == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        bug("[VC4Gallium] create_bo: out of handles\n");
+        return -1;
+    }
+
+    vaddr = gpu_mem_alloc(sd, args->size, 4096,
+                          VCMEM_L1NONALLOCATING | VCMEM_ZERO,
+                          &gpu_handle);
+    if (!vaddr)
+    {
+        /* Retry after reclaiming pool memory */
+        ReleaseSemaphore(&sd->bo_lock);
+        gpu_mem_reclaim(sd);
+        ObtainSemaphore(&sd->bo_lock);
+
+        vaddr = gpu_mem_alloc(sd, args->size, 4096,
+                              VCMEM_L1NONALLOCATING | VCMEM_ZERO,
+                              &gpu_handle);
+        if (!vaddr)
+        {
+            ReleaseSemaphore(&sd->bo_lock);
+            bug("[VC4Gallium] create_bo: allocation failed for %d bytes (even after reclaim)\n", args->size);
+            return -1;
+        }
+    }
+
+    sd->bo_table[handle].vaddr = vaddr;
+    sd->bo_table[handle].bus_addr = GPU_BUS_ADDR(vaddr);
+    sd->bo_table[handle].gpu_handle = gpu_handle;
+    sd->bo_table[handle].size = args->size;
+    sd->bo_table[handle].refcount = 1;
+    sd->bo_table[handle].is_shader = FALSE;
+    sd->bo_table[handle].cpu_mapped = FALSE;
+    sd->bo_table[handle].tiling_modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
+
+    ReleaseSemaphore(&sd->bo_lock);
+
+    args->handle = handle;
+
+    D(bug("[VC4Gallium] create_bo: handle=%d size=%d vaddr=0x%08x bus=0x%08x gpu_h=0x%08x\n",
+        handle, args->size, (ULONG)vaddr, GPU_BUS_ADDR(vaddr), gpu_handle));
+
+    return 0;
+}
+
+static int ioctl_create_shader_bo(struct vc4galliumstaticdata *sd, struct drm_vc4_create_shader_bo *args)
+{
+    ULONG handle;
+    APTR vaddr;
+    ULONG gpu_handle;
+
+    ObtainSemaphore(&sd->bo_lock);
+    handle = bo_alloc_handle(sd);
+    if (handle == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+
+    vaddr = gpu_mem_alloc(sd, args->size, 4096,
+                          VCMEM_L1NONALLOCATING,
+                          &gpu_handle);
+    if (!vaddr)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        gpu_mem_reclaim(sd);
+        ObtainSemaphore(&sd->bo_lock);
+
+        vaddr = gpu_mem_alloc(sd, args->size, 4096,
+                              VCMEM_L1NONALLOCATING,
+                              &gpu_handle);
+        if (!vaddr)
+        {
+            ReleaseSemaphore(&sd->bo_lock);
+            bug("[VC4Gallium] create_shader_bo: allocation failed for %d bytes (even after reclaim)\n", args->size);
+            return -1;
+        }
+    }
+
+    CopyMem((APTR)(IPTR)args->data, vaddr, args->size);
+
+    /* Flush CPU-written QPU instructions to RAM. V3D fetches shader code
+     * through the uncached 0xC0000000 alias and would otherwise miss dirty
+     * ARM L1 lines, stalling the render thread on FS code fetch. */
+    CacheClearE(vaddr, args->size, CACRF_ClearD);
+    asm volatile("dsb sy" ::: "memory");
+
+    sd->bo_table[handle].vaddr = vaddr;
+    sd->bo_table[handle].bus_addr = GPU_BUS_ADDR(vaddr);
+    sd->bo_table[handle].gpu_handle = gpu_handle;
+    sd->bo_table[handle].size = args->size;
+    sd->bo_table[handle].refcount = 1;
+    sd->bo_table[handle].is_shader = TRUE;
+    sd->bo_table[handle].cpu_mapped = FALSE;
+    sd->bo_table[handle].tiling_modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
+
+    scan_shader_qpu(vaddr, args->size, &sd->bo_table[handle]);
+
+    ReleaseSemaphore(&sd->bo_lock);
+
+    args->handle = handle;
+
+    D(bug("[VC4Gallium] create_shader_bo: handle=%d size=%d uniforms=%d tex=%d\n",
+        handle, args->size,
+        sd->bo_table[handle].uniforms_size,
+        sd->bo_table[handle].num_texture_samples));
+
+    return 0;
+}
+
+static int ioctl_mmap_bo(struct vc4galliumstaticdata *sd, struct drm_vc4_mmap_bo *args)
+{
+    ObtainSemaphore(&sd->bo_lock);
+
+    if (args->handle == 0 || args->handle >= VC4_MAX_BOS ||
+        sd->bo_table[args->handle].refcount == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+
+    args->offset = (UQUAD)(IPTR)sd->bo_table[args->handle].vaddr;
+
+    /* The CPU now has a (cached) pointer to this BO and may dirty its
+     * lines — submit_cl's flush loop must include it from here on. */
+    sd->bo_table[args->handle].cpu_mapped = TRUE;
+
+    ReleaseSemaphore(&sd->bo_lock);
+
+    return 0;
+}
+
+void vc4_aros_bo_unref_locked(struct vc4galliumstaticdata *sd, ULONG handle)
+{
+    if (handle == 0 || handle >= VC4_MAX_BOS)
+        return;
+    if (sd->bo_table[handle].refcount == 0)
+        return;
+
+    sd->bo_table[handle].refcount--;
+
+    if (sd->bo_table[handle].refcount == 0)
+    {
+        if (sd->bo_table[handle].gpu_handle)
+            gpu_mem_free(sd, sd->bo_table[handle].gpu_handle);
+        sd->bo_table[handle].vaddr = NULL;
+        sd->bo_table[handle].bus_addr = 0;
+        sd->bo_table[handle].gpu_handle = 0;
+        sd->bo_table[handle].size = 0;
+        sd->bo_table[handle].tiling_modifier = 0;
+        sd->bo_table[handle].is_shader = FALSE;
+        sd->bo_table[handle].external = FALSE;
+        sd->bo_table[handle].cpu_mapped = FALSE;
+        sd->bo_table[handle].uniforms_size = 0;
+        sd->bo_table[handle].num_texture_samples = 0;
+        sd->bo_table[handle].num_uniform_addr_offsets = 0;
+        D(bug("[VC4Gallium] bo_unref: freed handle=%d\n", handle));
+    }
+}
+
+/*
+ * GEM_OPEN: wrap a scanout page as an external BO. `name` is the page's
+ * physical address, as announced by the bridge's get_scanout entry —
+ * arbitrary names are refused. The entry carries no gpu_handle, so the
+ * normal refcount/GEM_CLOSE machinery drops the table slot without
+ * touching firmware memory (the page belongs to the framebuffer).
+ */
+static int ioctl_gem_open(struct vc4galliumstaticdata *sd, struct drm_gem_open *args)
+{
+    ULONG handle;
+
+    if (args->name == 0 || sd->scanout_size == 0 ||
+        (args->name != sd->scanout_phys[0] && args->name != sd->scanout_phys[1]))
+        return -1;
+
+    ObtainSemaphore(&sd->bo_lock);
+
+    /* Already wrapped? Just take another reference. */
+    for (handle = 1; handle < VC4_MAX_BOS; handle++)
+    {
+        if (sd->bo_table[handle].refcount > 0 &&
+            sd->bo_table[handle].external &&
+            (ULONG)(IPTR)sd->bo_table[handle].vaddr == args->name)
+        {
+            sd->bo_table[handle].refcount++;
+            ReleaseSemaphore(&sd->bo_lock);
+            args->handle = handle;
+            args->size = sd->bo_table[handle].size;
+            return 0;
+        }
+    }
+
+    handle = bo_alloc_handle(sd);
+    if (handle == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+
+    sd->bo_table[handle].vaddr = (APTR)(IPTR)args->name;
+    sd->bo_table[handle].bus_addr = GPU_BUS_ADDR(args->name);
+    sd->bo_table[handle].gpu_handle = 0;
+    sd->bo_table[handle].size = sd->scanout_size;
+    sd->bo_table[handle].refcount = 1;
+    sd->bo_table[handle].is_shader = FALSE;
+    sd->bo_table[handle].external = TRUE;
+    sd->bo_table[handle].cpu_mapped = FALSE;
+    sd->bo_table[handle].tiling_modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
+
+    ReleaseSemaphore(&sd->bo_lock);
+
+    args->handle = handle;
+    args->size = sd->scanout_size;
+
+    D(bug("[VC4Gallium] gem_open: scanout page 0x%08x -> handle=%d size=%d\n",
+        args->name, handle, (ULONG)args->size));
+
+    return 0;
+}
+
+static int ioctl_gem_close(struct vc4galliumstaticdata *sd, struct drm_gem_close *args)
+{
+    ObtainSemaphore(&sd->bo_lock);
+
+    if (args->handle == 0 || args->handle >= VC4_MAX_BOS ||
+        sd->bo_table[args->handle].refcount == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+
+    vc4_aros_bo_unref_locked(sd, args->handle);
+
+    ReleaseSemaphore(&sd->bo_lock);
+    return 0;
+}
+
+/* Forensics: snapshot of the most recent submission, dumped by the
+ * v3d_wait_seqno timeout path so a hang can be diagnosed post-mortem. */
+static struct
+{
+    ULONG seqno;
+    ULONG rcl_bus, rcl_size, bin_size;
+    UWORD width, height;
+    UBYTE min_x, min_y, max_x, max_y;
+    ULONG cw_hindex, zsw_hindex;
+    const volatile UBYTE *rcl_vaddr;
+    const volatile UBYTE *tile_alloc_vaddr; /* first per-tile sublist */
+} vc4_last_submit;
+
+void v3d_dump_last_submit(void)
+{
+    bug("[VC4Gallium]   last submit: seqno=%d rcl=0x%08x+%d bin=%d "
+        "%dx%d tiles x=%d..%d y=%d..%d cw=%d zsw=%d\n",
+        vc4_last_submit.seqno, vc4_last_submit.rcl_bus,
+        vc4_last_submit.rcl_size, vc4_last_submit.bin_size,
+        (ULONG)vc4_last_submit.width, (ULONG)vc4_last_submit.height,
+        (ULONG)vc4_last_submit.min_x, (ULONG)vc4_last_submit.max_x,
+        (ULONG)vc4_last_submit.min_y, (ULONG)vc4_last_submit.max_y,
+        vc4_last_submit.cw_hindex, vc4_last_submit.zsw_hindex);
+
+    if (vc4_last_submit.rcl_vaddr && vc4_last_submit.rcl_size)
+    {
+        const volatile UBYTE *rb = vc4_last_submit.rcl_vaddr;
+        ULONG size = vc4_last_submit.rcl_size;
+        ULONG head = size < 96 ? size : 96;
+        ULONG tail_start = (size > head + 32) ? size - 32 : head;
+        ULONG i;
+
+        for (i = 0; i < head; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < head; j++)
+                p += vc4_hexbyte(line + p, rb[i + j]);
+            bug("[VC4Gallium]   rcl[%04d]: %s\n", i, line);
+        }
+        for (i = tail_start; i < size; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < size; j++)
+                p += vc4_hexbyte(line + p, rb[i + j]);
+            bug("[VC4Gallium]   rcl[%04d]: %s\n", i, line);
+        }
+    }
+
+    /* First per-tile sublist as written by the binner: all zeros here means
+     * the binner never produced tile lists for this job. */
+    if (vc4_last_submit.tile_alloc_vaddr)
+    {
+        const volatile UBYTE *tb = vc4_last_submit.tile_alloc_vaddr;
+        ULONG i;
+        for (i = 0; i < 32; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16; j++)
+                p += vc4_hexbyte(line + p, tb[i + j]);
+            bug("[VC4Gallium]   tile0[%02d]: %s\n", i, line);
+        }
+    }
+}
+
+/*
+ * Sample BFC/RFC and advance v3d->bfc_completed / rfc_completed
+ * by the (mod-256) delta since the last sample.
+ */
+static void v3d_advance_counters(struct vc4_v3d_state *v3d)
+{
+    ULONG bfc = V3D_READ(v3d, V3D_BFC) & 0xff;
+    ULONG rfc = V3D_READ(v3d, V3D_RFC) & 0xff;
+    ULONG bdelta = (bfc - v3d->last_bfc) & 0xff;
+    ULONG rdelta = (rfc - v3d->last_rfc) & 0xff;
+    v3d->last_bfc = bfc;
+    v3d->last_rfc = rfc;
+    v3d->bfc_completed += bdelta;
+    v3d->rfc_completed += rdelta;
+
+    if (v3d->pending_render && v3d->bfc_completed >= v3d->seqno)
+        vc4_v3d_kick_pending_render(v3d, "BFC");
+
+    ULONG done = v3d->rfc_completed;
+    if (done > v3d->seqno)
+        done = v3d->seqno;
+    v3d->finished_seqno = done;
+}
+
+/*
+ * Poll V3D until the given seqno has completed.
+ * Drives v3d->finished_seqno from the V3D_RFC hardware counter.
+ * timeout_loops: max poll iterations (0 = no limit).
+ * Returns 0 on success, -1 on timeout.
+ */
+static int v3d_wait_seqno(struct vc4galliumstaticdata *sd, ULONG seqno, ULONG timeout_loops)
+{
+    struct vc4_v3d_state *v3d = &sd->v3d;
+    /* Serialize against submit_cl and other waiters touching V3D state.
+     * Nestable — submit_cl already holds render_lock when it calls us to
+     * wait for a pool set to free up. */
+    ObtainSemaphore(&sd->render_lock);
+    /* Tiered wait (see VC4_GPUWAIT_* in vc4gallium_intern.h): tight spin
+     * for µs precision, then ~1 ms timer naps that keep the CPU free for
+     * input handling, then vblank blocking for long waits with the
+     * existing timeout accounting. Blocking from the start quantized
+     * every wait to ~20 ms; pure spinning starves the mouse. */
+    BYTE wsig = vc4_wait_enter(sd);
+    ULONG ticks = 0;
+    ULONG budget = (wsig >= 0) ? (timeout_loops / 70000 + 4) : timeout_loops;
+    ULONG spin_start = v3d_now_us();
+
+    while (v3d->finished_seqno < seqno)
+    {
+        vc4_v3d_service_interrupts(v3d);
+        v3d_advance_counters(v3d);
+        if (v3d->finished_seqno >= seqno)
+            break;
+
+        /* Binner out-of-memory (both the INTCTL latch and the PCS.BMOOM
+         * level condition) is handled inside vc4_v3d_service_interrupts,
+         * which feeds the overspill BO. Don't ack OUTOMEM here — a blind
+         * W1C would eat the edge-triggered latch before the feed runs. */
+
+        {
+            ULONG waited = v3d_now_us() - spin_start;
+            if (waited < VC4_GPUWAIT_SPIN_US)
+                continue;
+            if (waited < VC4_GPUWAIT_NAP_WINDOW)
+            {
+                vc4_gpu_nap(sd, VC4_GPUWAIT_NAP_US);
+                continue;
+            }
+        }
+
+        if (budget > 0 && ++ticks >= budget)
+        {
+            /* Timeout: GPU is stuck. Reset both control threads so the
+             * next submission can actually take effect (writing CT1CA
+             * while CTRUN is asserted does not reload the renderer
+             * PC). Bump finished_seqno so subsequent waits don't keep
+             * timing out trying to catch up to a render that never
+             * completed, and re-snapshot BFC/RFC so the delta tracking
+             * in v3d_advance_counters doesn't double-count the post-
+             * reset jumps. */
+            bug("[VC4Gallium] v3d_wait_seqno TIMEOUT: want seqno=%d fin=%d "
+                "— resetting CT0/CT1 and aborting\n",
+                seqno, v3d->finished_seqno);
+            bug("[VC4Gallium]   PCS=0x%08x CT0: CS=0x%08x CA=0x%08x EA=0x%08x\n",
+                V3D_READ(v3d, V3D_PCS), V3D_READ(v3d, V3D_CT0CS),
+                V3D_READ(v3d, V3D_CT0CA), V3D_READ(v3d, V3D_CT0EA));
+            bug("[VC4Gallium]   CT1: CS=0x%08x CA=0x%08x EA=0x%08x pending_render=%d\n",
+                V3D_READ(v3d, V3D_CT1CS), V3D_READ(v3d, V3D_CT1CA),
+                V3D_READ(v3d, V3D_CT1EA), (LONG)v3d->pending_render);
+            bug("[VC4Gallium]   BFC=%d RFC=%d INTCTL=0x%08x ERRSTAT=0x%08x SRQCS=0x%08x\n",
+                V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff,
+                V3D_READ(v3d, V3D_INTCTL), V3D_READ(v3d, V3D_ERRSTAT),
+                V3D_READ(v3d, V3D_SRQCS));
+            bug("[VC4Gallium]   BPCA=0x%08x BPCS=0x%08x BPOA=0x%08x BPOS=0x%08x "
+                "handed=%d cnt: oom=%d fl=%d fr=%d\n",
+                V3D_READ(v3d, V3D_BPCA), V3D_READ(v3d, V3D_BPCS),
+                V3D_READ(v3d, V3D_BPOA), V3D_READ(v3d, V3D_BPOS),
+                v3d->overflow_handed, v3d->int_outomem, v3d->int_fldone,
+                v3d->int_frdone);
+            v3d_dump_last_submit();
+            V3D_WRITE(v3d, V3D_CT0CS, V3D_CTCS_CTRSTA);
+            V3D_WRITE(v3d, V3D_CT1CS, V3D_CTCS_CTRSTA);
+            /* The reset killed EVERY in-flight job, not just the one we
+             * waited for (a pool-reuse wait targets an older seqno), so
+             * catch the bookkeeping up to the newest submission — else the
+             * next wait times out a second time chasing a job that can no
+             * longer complete. Drop any pending CT1 handoff too: kicking
+             * it now would re-run a dead job's RCL. */
+            v3d->pending_render = FALSE;
+            v3d->finished_seqno = v3d->seqno;
+            v3d->last_bfc = V3D_READ(v3d, V3D_BFC) & 0xff;
+            v3d->last_rfc = V3D_READ(v3d, V3D_RFC) & 0xff;
+            v3d->bfc_completed = v3d->seqno;
+            v3d->rfc_completed = v3d->seqno;
+            vc4_wait_leave(sd, wsig);
+            ReleaseSemaphore(&sd->render_lock);
+            return -1;
+        }
+
+        /* Block until the next vblank (~20 ms, CPU-free) on the registered
+         * path; spin otherwise (no free signal — rare). */
+        if (wsig >= 0)
+            Wait(1UL << wsig);
+    }
+
+    vc4_wait_leave(sd, wsig);
+    ReleaseSemaphore(&sd->render_lock);
+    return 0;
+}
+
+static int ioctl_wait_seqno(struct vc4galliumstaticdata *sd, struct drm_vc4_wait_seqno *args)
+{
+    if (sd->v3d.finished_seqno >= args->seqno)
+        return 0;
+
+    /* timeout_ns == 0 is Mesa's non-blocking busy probe (PIPE_TRANSFER_
+     * DONTBLOCK and friends). Poll once — the V3D IRQ is masked, so
+     * nothing advances the counters unless polled — then report busy via
+     * ETIME instead of blocking out the full budget. */
+    if (args->timeout_ns == 0)
+    {
+        ObtainSemaphore(&sd->render_lock);
+        vc4_v3d_service_interrupts(&sd->v3d);
+        v3d_advance_counters(&sd->v3d);
+        ReleaseSemaphore(&sd->render_lock);
+
+        if (sd->v3d.finished_seqno >= args->seqno)
+            return 0;
+        /* Negative errno crosses the bridge (the mesa3dgl-side shim
+         * decodes it into Mesa's errno); a bare -1 reads as EINVAL
+         * there and vc4_bo_wait() abort()s on anything but ETIME. */
+        return -ETIME;
+    }
+
+    /* ~1 second budget at ~3.5M iters/sec. Longer than a real frame, short
+     * enough to fail fast when the GPU is wedged. Report a timeout as
+     * ETIME, which Mesa's vc4_bo_wait() treats as
+     * "still busy" and carries on, but abort()s the process on ANY
+     * other errno — a slow frame must not be fatal (returning any other
+     * error killed the client via __stdc_jmp2exit). */
+    if (v3d_wait_seqno(sd, args->seqno, 3500000) != 0)
+        return -ETIME;
+    return 0;
+}
+
+static int ioctl_wait_bo(struct vc4galliumstaticdata *sd, struct drm_vc4_wait_bo *args)
+{
+    struct drm_vc4_wait_seqno wait;
+    wait.seqno = sd->v3d.seqno;
+    wait.timeout_ns = args->timeout_ns;
+    return ioctl_wait_seqno(sd, &wait);
+}
+
+/* ---- Pooled frame BO allocation ----
+ *
+ * Reuse GPU BOs across frames. Only reallocate if the requested size
+ * exceeds the current allocation. This avoids 12 mailbox round-trips
+ * per frame (2 per alloc + 2 per free, times 3 BOs).
+ */
+static APTR pool_bo_get(struct vc4galliumstaticdata *sd,
+                         struct vc4_frame_bo *pool,
+                         ULONG size, ULONG align, ULONG flags)
+{
+    if (pool->size >= size && pool->vaddr)
+        return pool->vaddr;
+
+    if (pool->vaddr)
+    {
+        gpu_mem_free(sd, pool->gpu_handle);
+        pool->vaddr = NULL;
+        pool->size = 0;
+    }
+
+    /* Round up to avoid frequent reallocs */
+    ULONG alloc_size = ROUNDUP(size + size / 4, 4096);
+
+    pool->vaddr = gpu_mem_alloc(sd, alloc_size, align, flags, &pool->gpu_handle);
+    if (!pool->vaddr)
+    {
+        /* Try without the 25% headroom */
+        alloc_size = ROUNDUP(size, 4096);
+        pool->vaddr = gpu_mem_alloc(sd, alloc_size, align, flags, &pool->gpu_handle);
+        if (!pool->vaddr)
+            return NULL;
+    }
+
+    pool->bus_addr = GPU_BUS_ADDR(pool->vaddr);
+    pool->size = alloc_size;
+
+    D(bug("[VC4Gallium] pool_bo_get: grew to %d bytes (requested %d)\n",
+        alloc_size, size));
+
+    return pool->vaddr;
+}
+
+/* ---- Unaligned memory access helpers ----
+ *
+ * GPU memory on RPi is mapped Device/Strongly-Ordered.  On ARMv7
+ * that means *any* word access to an unaligned address aborts,
+ * regardless of SCTLR.A — unaligned-access support only applies to
+ * Normal memory.  CL packets are byte-packed, so addresses within
+ * packets sit at arbitrary byte offsets and must be issued as
+ * separate byte transactions.
+ *
+ * Neither a plain byte sequence (gcc -O2 store-merges back to STR)
+ * nor a __packed struct (still emits one STR — fine on Normal,
+ * fatal on Device) is safe.  Volatile byte stores are the only
+ * portable way to guarantee STRB/LDRB: the compiler may not coalesce
+ * or reorder volatile accesses.
+ */
+static inline ULONG get_u32_unaligned(const UBYTE *p)
+{
+    const volatile UBYTE *vp = (const volatile UBYTE *)p;
+    return (ULONG)vp[0] | ((ULONG)vp[1] << 8) |
+           ((ULONG)vp[2] << 16) | ((ULONG)vp[3] << 24);
+}
+
+static inline void put_u32_unaligned(UBYTE *p, ULONG val)
+{
+    volatile UBYTE *vp = (volatile UBYTE *)p;
+    vp[0] = (UBYTE)(val & 0xFF);
+    vp[1] = (UBYTE)((val >> 8) & 0xFF);
+    vp[2] = (UBYTE)((val >> 16) & 0xFF);
+    vp[3] = (UBYTE)(val >> 24);
+}
+
+/* ---- Bin CL Processing ----
+ *
+ * Walk the user-submitted bin CL, stripping GEM_HANDLES packets and
+ * patching addresses:
+ * - TILE_BINNING_MODE_CONFIG: replace tile alloc/state addresses
+ * - GL_SHADER_STATE: replace shader record offset with GPU address
+ * - GL_INDEXED_PRIMITIVE: replace index buffer offset with GPU address
+ *
+ * GEM_HANDLES sets the "current BO" for subsequent packets.
+ * Returns the output CL size, or 0 on error.
+ */
+struct exec_state {
+    struct vc4galliumstaticdata *sd;
+    ULONG *bo_handles;
+    ULONG bo_handle_count;
+    ULONG current_bo[2];        /* Current BO bus addresses set by GEM_HANDLES */
+    /* Tile alloc BO */
+    ULONG tile_alloc_bus;
+    ULONG tile_state_bus;
+    ULONG tile_alloc_offset;    /* Offset of tile alloc within tile BO */
+    ULONG tile_alloc_size;      /* Size of that region (what the BO holds) */
+    ULONG bin_tiles_x;
+    ULONG bin_tiles_y;
+    /* Shader rec info: flags collected from each GL_SHADER_STATE packet,
+     * in CL order (relocate_shader_recs walks the shader_rec buffer using
+     * them). Points at sd->shader_state_scratch, sized shader_state_max. */
+    ULONG *shader_state_addrs;      /* Low bits from GL_SHADER_STATE */
+    ULONG shader_state_max;         /* Capacity of shader_state_addrs */
+    ULONG shader_state_count;
+    /* Shader rec validated bus address base */
+    ULONG shader_rec_bus;
+    /* Validated uniforms bus address base */
+    ULONG uniforms_bus;
+};
+
+static ULONG process_bin_cl(struct exec_state *exec,
+                            UBYTE *src, ULONG src_size,
+                            UBYTE *dst, ULONG dst_max)
+{
+    ULONG src_off = 0;
+    ULONG dst_off = 0;
+    ULONG shader_rec_p = exec->shader_rec_bus;
+
+    /* RCL-only submissions: Mesa's vc4_tile_blit (glReadPixels staging
+     * copies, texture updates of busy resources, u_blitter surface copies)
+     * legitimately carries NO bin CL. Rather than special-casing the whole
+     * pipeline, synthesize a minimal draw-less bin CL: the binner auto-inits
+     * tile state, the FLUSH emits empty per-tile lists (as for any geometry-
+     * free tile), INCREMENT pairs with the RCL's WAIT_ON_SEMAPHORE, FLDONE
+     * fires, and BFC keeps tracking seqno 1:1. Rejecting these (the old
+     * behaviour) silently broke every internal Mesa blit. */
+    if (src_size == 0)
+    {
+        if (dst_max < 19)
+            return 0;
+
+        dst[0] = VC4_PACKET_TILE_BINNING_MODE_CONFIG;
+        put_u32_unaligned(dst + 1, exec->tile_alloc_bus);
+        put_u32_unaligned(dst + 5, exec->tile_alloc_size);
+        put_u32_unaligned(dst + 9, exec->tile_state_bus);
+        dst[13] = exec->bin_tiles_x;
+        dst[14] = exec->bin_tiles_y;
+        dst[15] = VC4_BIN_CONFIG_AUTO_INIT_TSDA |
+                  VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_32 |
+                  VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_128;
+        dst[16] = VC4_PACKET_START_TILE_BINNING;
+        dst[17] = VC4_PACKET_INCREMENT_SEMAPHORE;
+        dst[18] = VC4_PACKET_FLUSH;
+        return 19;
+    }
+
+    while (src_off < src_size)
+    {
+        UBYTE cmd = src[src_off];
+        ULONG pkt_size = vc4_packet_sizes[cmd];
+
+        if (pkt_size == 0)
+        {
+            bug("[VC4Gallium] process_bin_cl: unknown packet 0x%02x at offset %d\n",
+                cmd, src_off);
+            return 0;
+        }
+
+        if (src_off + pkt_size > src_size)
+        {
+            bug("[VC4Gallium] process_bin_cl: packet 0x%02x overflows CL (%d + %d > %d)\n",
+                cmd, src_off, pkt_size, src_size);
+            return 0;
+        }
+
+        switch (cmd)
+        {
+        case VC4_PACKET_GEM_HANDLES:
+        {
+            /* 1 byte cmd + handle0 (4) + handle1 (4) = 9 bytes */
+            ULONG hindex0 = get_u32_unaligned(src + src_off + 1);
+            ULONG hindex1 = get_u32_unaligned(src + src_off + 5);
+
+            exec->current_bo[0] = bo_bus_addr(exec->sd, exec->bo_handles,
+                                               exec->bo_handle_count, hindex0);
+            if (hindex1 != 0)
+                exec->current_bo[1] = bo_bus_addr(exec->sd, exec->bo_handles,
+                                                   exec->bo_handle_count, hindex1);
+
+            /* Don't copy GEM_HANDLES to output — it's not a real HW packet */
+            src_off += pkt_size;
+            continue;
+        }
+
+        case VC4_PACKET_GL_SHADER_STATE:
+        {
+            /* GL_SHADER_STATE: 1 byte cmd + 4 byte address.
+             * Low 4 bits are flags (nr_attributes + extended bit).
+             * The address field is the offset into the shader_rec buffer.
+             * We replace it with the GPU bus address of the validated
+             * shader record.
+             */
+            ULONG addr = get_u32_unaligned(src + src_off + 1);
+            ULONG low_bits = addr & 0xf;
+
+            /* Record this shader state's flags for shader rec relocation.
+             * Fail the submission when the table is full — truncating
+             * would leave later GL_SHADER_STATE packets pointing at
+             * records relocate_shader_recs never wrote. */
+            if (exec->shader_state_count >= exec->shader_state_max)
+            {
+                bug("[VC4Gallium] process_bin_cl: more than %lu "
+                    "GL_SHADER_STATE packets in one CL\n",
+                    (unsigned long)exec->shader_state_max);
+                return 0;
+            }
+            exec->shader_state_addrs[exec->shader_state_count++] = low_bits;
+
+            /* Compute shader record packet size for advancing shader_rec_p */
+            ULONG nr_attr = low_bits & 0x7;
+            if (nr_attr == 0) nr_attr = 8;
+            ULONG rec_size = (low_bits & 0x8) ? (100 + nr_attr * 4) : (36 + nr_attr * 8);
+
+            /* Copy packet to output, patch address */
+            if (dst_off + pkt_size > dst_max) return 0;
+            dst[dst_off] = cmd;
+            put_u32_unaligned(dst + dst_off + 1, (shader_rec_p | low_bits));
+
+            shader_rec_p += ROUNDUP(rec_size, 16);
+
+            dst_off += pkt_size;
+            src_off += pkt_size;
+            continue;
+        }
+
+        case VC4_PACKET_GL_INDEXED_PRIMITIVE:
+        {
+            /* GL_INDEXED_PRIMITIVE: 1 byte cmd + 1 byte mode + 4 byte count +
+             * 4 byte index_offset + 4 byte max_index = 14 bytes.
+             * The index_offset (at byte 6) needs BO address relocation.
+             */
+            if (dst_off + pkt_size > dst_max) return 0;
+            CopyMem(src + src_off, dst + dst_off, pkt_size);
+
+            /* Patch index buffer address: offset is at byte 6 (after cmd+mode+count) */
+            ULONG ib_offset = get_u32_unaligned(src + src_off + 6);
+            put_u32_unaligned(dst + dst_off + 6, exec->current_bo[0] + ib_offset);
+
+            dst_off += pkt_size;
+            src_off += pkt_size;
+            continue;
+        }
+
+        case VC4_PACKET_TILE_BINNING_MODE_CONFIG:
+        {
+            /* TILE_BINNING_MODE_CONFIG: 16 bytes.
+             * bytes 1-4:  tile alloc address -> our tile_alloc_bus
+             * bytes 5-8:  tile alloc size
+             * bytes 9-12: tile state address -> our tile_state_bus
+             * byte 13:    tiles_x
+             * byte 14:    tiles_y
+             * byte 15:    flags
+             */
+            if (dst_off + pkt_size > dst_max) return 0;
+            CopyMem(src + src_off, dst + dst_off, pkt_size);
+
+            exec->bin_tiles_x = src[src_off + 13];
+            exec->bin_tiles_y = src[src_off + 14];
+
+            /* Patch tile alloc address, size, and tile state address. The
+             * size must be what the tile BO actually holds — recomputing it
+             * from the packet's tile counts could claim more than the BO
+             * was sized for. */
+            put_u32_unaligned(dst + dst_off + 1, exec->tile_alloc_bus);
+            put_u32_unaligned(dst + dst_off + 5, exec->tile_alloc_size);
+            put_u32_unaligned(dst + dst_off + 9, exec->tile_state_bus);
+
+            /* Patch flags: set auto-init TSDA, block sizes */
+            UBYTE flags = dst[dst_off + 15];
+            flags &= ~(VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_MASK |
+                        VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_MASK);
+            flags |= VC4_BIN_CONFIG_AUTO_INIT_TSDA |
+                     VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_32 |
+                     VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_128;
+            dst[dst_off + 15] = flags;
+
+            dst_off += pkt_size;
+            src_off += pkt_size;
+            continue;
+        }
+
+        default:
+            if (dst_off + pkt_size > dst_max) return 0;
+            CopyMem(src + src_off, dst + dst_off, pkt_size);
+            dst_off += pkt_size;
+            src_off += pkt_size;
+            continue;
+        }
+    }
+
+    return dst_off;
+}
+
+/* ---- Shader Record Relocation ----
+ *
+ * Mesa's shader_rec buffer contains, for each shader record:
+ *   [handle0][handle1]...[handleN]   (N = 3 + nr_attributes) uint32 each
+ *   [shader_record_packet_data]      (variable size)
+ *
+ * The handle indices reference entries in the bo_handles array.
+ * Shader record offsets that need patching:
+ *   offset 4:  FS code address        (handle[0])
+ *   offset 8:  FS uniform address     (set to validated uniforms position)
+ *   offset 16: VS code address        (handle[1])
+ *   offset 20: VS uniform address     (set to validated uniforms position)
+ *   offset 28: CS code address        (handle[2])
+ *   offset 32: CS uniform address     (set to validated uniforms position)
+ *   offset 36 + i*8: VBO i base addr  (handle[3+i])
+ *
+ * Uniform stream layout per shader (in Mesa's uniform buffer):
+ *   [tex_handle_0..N-1]  N = num_texture_samples, each is a BO handle index
+ *   [uniform_data_0..M]  remaining uniform values (plain data or need reloc)
+ * Total uniform reads = uniforms_size/4 (from QPU scan).
+ * The first N reads are texture p0 addresses.
+ */
+
+/* Uniform offsets in shader record: FS=8, VS=20, CS=32 */
+static const ULONG shader_code_offsets[]    = { 4, 16, 28 };
+static const ULONG shader_uniform_offsets[] = { 8, 20, 32 };
+
+static int relocate_shader_recs(struct exec_state *exec,
+                                UBYTE *shader_rec_data,
+                                ULONG shader_rec_size,
+                                UBYTE *out_rec_data,
+                                ULONG *uniforms_src,
+                                ULONG uniforms_src_count,
+                                ULONG *uniforms_dst,
+                                ULONG uniforms_dst_max,
+                                ULONG *out_uniforms_count)
+{
+    ULONG src_off = 0;
+    ULONG dst_off = 0;
+    ULONG uni_src_idx = 0;    /* Current position in source uniform stream */
+    ULONG uni_dst_idx = 0;    /* Current position in output uniform stream */
+    ULONG i, rec;
+
+    for (rec = 0; rec < exec->shader_state_count; rec++)
+    {
+        ULONG low_bits = exec->shader_state_addrs[rec];
+        ULONG nr_attributes = low_bits & 0x7;
+        ULONG extended = low_bits & 0x8;
+        ULONG nr_relocs, packet_size;
+
+        if (nr_attributes == 0)
+            nr_attributes = 8;
+
+        nr_relocs = 3 + nr_attributes;
+        packet_size = extended ? (100 + nr_attributes * 4) : (36 + nr_attributes * 8);
+
+        /* Validate source data bounds */
+        if (src_off + nr_relocs * 4 + packet_size > shader_rec_size)
+        {
+            bug("[VC4Gallium] relocate_shader_recs: overflow at rec %d "
+                "(off %d + %d handles + %d data > %d)\n",
+                rec, src_off, nr_relocs * 4, packet_size, shader_rec_size);
+            return -1;
+        }
+
+        ULONG *handles = (ULONG *)(shader_rec_data + src_off);
+        UBYTE *pkt_src = shader_rec_data + src_off + nr_relocs * 4;
+        UBYTE *pkt_dst = out_rec_data + dst_off;
+
+        CopyMem(pkt_src, pkt_dst, packet_size);
+
+        /* Process each shader stage: FS(0), VS(1), CS(2) */
+        for (i = 0; i < 3; i++)
+        {
+            ULONG code_off = shader_code_offsets[i];
+            ULONG uni_off  = shader_uniform_offsets[i];
+
+            /* Patch shader code address */
+            ULONG src_offset = get_u32_unaligned(pkt_src + code_off);
+            ULONG code_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                           exec->bo_handle_count, handles[i]);
+            put_u32_unaligned(pkt_dst + code_off, code_addr + src_offset);
+
+            /* Look up shader BO to get uniform metadata. Bounds-check
+             * the same way bo_bus_addr() does — handles[i] is the hindex
+             * into bo_handles[], whose value is the bo_table[] handle. */
+            if (handles[i] >= exec->bo_handle_count)
+            {
+                bug("[VC4Gallium] relocate_shader_recs: rec %d stage %d "
+                    "hindex %d >= bo_handle_count %d\n",
+                    rec, i, handles[i], exec->bo_handle_count);
+                return -1;
+            }
+            ULONG shader_handle = exec->bo_handles[handles[i]];
+            if (shader_handle == 0 || shader_handle >= VC4_MAX_BOS ||
+                exec->sd->bo_table[shader_handle].refcount == 0)
+            {
+                bug("[VC4Gallium] relocate_shader_recs: rec %d stage %d "
+                    "invalid shader handle %d\n", rec, i, shader_handle);
+                return -1;
+            }
+            struct vc4_bo_entry *shader_bo = &exec->sd->bo_table[shader_handle];
+            ULONG num_tex = shader_bo->num_texture_samples;
+            ULONG num_uniforms = shader_bo->uniforms_size / 4;  /* Data words the QPU reads */
+            ULONG src_total = num_tex + num_uniforms;  /* Total words in source per shader */
+
+            /* Set uniform address to current position in validated uniform output */
+            put_u32_unaligned(pkt_dst + uni_off, exec->uniforms_bus + uni_dst_idx * 4);
+
+            D(bug("[VC4Gallium]   shader[%d] rec %d: code=0x%08x, %d uniforms (%d tex)\n",
+                i, rec, get_u32_unaligned(pkt_dst + code_off), num_uniforms, num_tex));
+
+            /* Source per shader (Mesa's cl_start_shader_reloc): N tex-handle
+             * words then M data words (N+M total). Output is the M data words;
+             * texture p0 words within them are patched below using p_offset
+             * from shader validation. */
+            if (uni_src_idx + src_total > uniforms_src_count)
+            {
+                bug("[VC4Gallium] relocate_shader_recs: uniform overflow at rec %d "
+                    "shader %d (idx %d + %d > %d)\n",
+                    rec, i, uni_src_idx, src_total, uniforms_src_count);
+                return -1;
+            }
+            if (uni_dst_idx + num_uniforms > uniforms_dst_max)
+            {
+                bug("[VC4Gallium] relocate_shader_recs: uniform dst overflow\n");
+                return -1;
+            }
+
+            {
+                /* Tex-handle indices first, then the actual uniform data */
+                ULONG *tex_handles_u = &uniforms_src[uni_src_idx];
+                ULONG *uniform_data = &uniforms_src[uni_src_idx + num_tex];
+                ULONG *uniforms_out = &uniforms_dst[uni_dst_idx];
+                ULONG uni_start_p = exec->uniforms_bus + uni_dst_idx * 4;
+                ULONG d, t, u;
+
+                for (d = 0; d < num_uniforms; d++)
+                    uniforms_out[d] = uniform_data[d];
+
+                /* Texture P0 relocation: for each texture sample, patch
+                 * the P0 word in the output uniforms with the texture
+                 * BO's bus address + the P0 offset field. */
+                for (t = 0; t < num_tex; t++)
+                {
+                    if (t >= VC4_MAX_TEX_SAMPLES)
+                        break;
+
+                    struct vc4_texture_sample_info *sample =
+                        &shader_bo->texture_samples[t];
+                    ULONG p0_word_idx = sample->p_offset[0] / 4;
+
+                    if (sample->p_offset[0] == ~0UL || p0_word_idx >= num_uniforms)
+                        continue;
+
+                    /* Get texture BO bus address from handle index */
+                    ULONG tex_bus = bo_bus_addr(exec->sd, exec->bo_handles,
+                                                exec->bo_handle_count,
+                                                tex_handles_u[t]);
+                    if (tex_bus == 0)
+                        continue;
+
+                    /* P0 format: bits [31:12] = level-0 offset, bits [11:0]
+                     * = config (TYPE[7:4], MIPLVLS[3:0], FLIPY, CMMODE,
+                     * CSWIZ). ADD the whole word:
+                     * the BO base is 4K-aligned, so the add applies the
+                     * offset and keeps the config bits. Masking the low
+                     * bits off forced type=RGBA8888 on every texture,
+                     * which scrambled all 8-bit and 565 sampling. The
+                     * same formula covers is_direct (P0 = plain address). */
+                    ULONG p0_val = uniforms_out[p0_word_idx];
+                    uniforms_out[p0_word_idx] = tex_bus + p0_val;
+
+                    D(bug("[VC4Gallium]   tex[%d]: p0_idx=%d p0=0x%08x -> 0x%08x\n",
+                        t, p0_word_idx, p0_val, uniforms_out[p0_word_idx]));
+                }
+
+                /* Fill in UNIFORMS_ADDRESS slots: the kernel uses
+                 * uniform_addr_offsets[] to find which uniform words
+                 * need the shader's uniform stream GPU address. */
+                for (u = 0; u < shader_bo->num_uniform_addr_offsets; u++)
+                {
+                    ULONG o = shader_bo->uniform_addr_offsets[u];
+                    if (o < num_uniforms)
+                        uniforms_out[o] = uni_start_p;
+                }
+            }
+
+            uni_src_idx += src_total;
+            uni_dst_idx += num_uniforms;
+        }
+
+        /* Patch VBO attribute base addresses (at offset 36 + i*8) */
+        for (i = 0; i < nr_attributes; i++)
+        {
+            ULONG o = 36 + i * 8;
+            ULONG vbo_offset = get_u32_unaligned(pkt_src + o);
+            ULONG addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                      exec->bo_handle_count, handles[3 + i]);
+            put_u32_unaligned(pkt_dst + o, addr + vbo_offset);
+        }
+
+        src_off += nr_relocs * 4 + packet_size;
+        dst_off += ROUNDUP(packet_size, 16);
+    }
+
+    *out_uniforms_count = uni_dst_idx;
+    return 0;
+}
+
+/* ---- RCL Generation ----
+ *
+ * Build the Render Control List. The RCL tells the GPU how to load,
+ * process, and store each tile's pixel data.
+ *
+ * Based on Mesa's MIT-licensed src/gallium/drivers/vc4/kernel/vc4_render_cl.c.
+ */
+
+/* RCL builder helpers */
+struct rcl_builder {
+    UBYTE *data;
+    ULONG offset;
+    ULONG max_size;
+};
+
+/* Volatile byte writes — see put_u32_unaligned above for the why
+ * (gcc -O2 store-merging vs Device-mapped RCL BO memory). */
+static inline void rcl_u8(struct rcl_builder *b, UBYTE val)
+{
+    if (b->offset < b->max_size)
+        ((volatile UBYTE *)b->data)[b->offset] = val;
+    b->offset++;
+}
+
+static inline void rcl_u16(struct rcl_builder *b, UWORD val)
+{
+    if (b->offset + 1 < b->max_size)
+    {
+        volatile UBYTE *vp = (volatile UBYTE *)b->data + b->offset;
+        vp[0] = (UBYTE)(val & 0xFF);
+        vp[1] = (UBYTE)(val >> 8);
+    }
+    b->offset += 2;
+}
+
+static inline void rcl_u32(struct rcl_builder *b, ULONG val)
+{
+    if (b->offset + 3 < b->max_size)
+    {
+        volatile UBYTE *vp = (volatile UBYTE *)b->data + b->offset;
+        vp[0] = (UBYTE)(val & 0xFF);
+        vp[1] = (UBYTE)((val >> 8) & 0xFF);
+        vp[2] = (UBYTE)((val >> 16) & 0xFF);
+        vp[3] = (UBYTE)(val >> 24);
+    }
+    b->offset += 4;
+}
+
+static void rcl_store_before_load(struct rcl_builder *b)
+{
+    rcl_u8(b, VC4_PACKET_STORE_TILE_BUFFER_GENERAL);
+    rcl_u16(b,
+        VC4_LOADSTORE_TILE_BUFFER_NONE |
+        VC4_STORE_TILE_BUFFER_DISABLE_COLOR_CLEAR |
+        VC4_STORE_TILE_BUFFER_DISABLE_ZS_CLEAR |
+        VC4_STORE_TILE_BUFFER_DISABLE_VG_MASK_CLEAR);
+    rcl_u32(b, 0);
+}
+
+static void rcl_tile_coords(struct rcl_builder *b, UBYTE x, UBYTE y)
+{
+    rcl_u8(b, VC4_PACKET_TILE_COORDINATES);
+    rcl_u8(b, x);
+    rcl_u8(b, y);
+}
+
+static ULONG rcl_full_res_offset(ULONG base_addr, ULONG surf_offset,
+                                  ULONG width, ULONG tile_width,
+                                  UBYTE x, UBYTE y)
+{
+    return base_addr + surf_offset +
+           VC4_TILE_BUFFER_SIZE * (DIV_ROUND_UP(width, tile_width) * y + x);
+}
+
+static int build_rcl(struct exec_state *exec,
+                     struct drm_vc4_submit_cl *args,
+                     UBYTE *rcl_data, ULONG rcl_max_size,
+                     ULONG *out_size)
+{
+    struct rcl_builder b = { rcl_data, 0, rcl_max_size };
+    UBYTE min_x = args->min_x_tile;
+    UBYTE min_y = args->min_y_tile;
+    UBYTE max_x = args->max_x_tile;
+    UBYTE max_y = args->max_y_tile;
+    UBYTE xtiles = max_x - min_x + 1;
+    UBYTE ytiles = max_y - min_y + 1;
+    UBYTE xi, yi;
+    /* Even RCL-only submissions (bin_cl_size == 0) get a synthesized bin
+     * CL from process_bin_cl, so the semaphore interlock and per-tile
+     * branch lists are always present. */
+    BOOL has_bin = TRUE;
+    BOOL positive_x = TRUE, positive_y = TRUE;
+
+    /* Resolve surface BO addresses */
+    ULONG color_write_addr = 0;
+    ULONG color_read_addr = 0;
+    ULONG zs_read_addr = 0;
+    ULONG zs_write_addr = 0;
+    ULONG msaa_color_write_addr = 0;
+    ULONG msaa_zs_write_addr = 0;
+    BOOL has_color_write = (args->color_write.hindex != (ULONG)~0);
+    BOOL has_color_read  = (args->color_read.hindex != (ULONG)~0);
+    BOOL has_zs_read     = (args->zs_read.hindex != (ULONG)~0);
+    BOOL has_zs_write    = (args->zs_write.hindex != (ULONG)~0);
+    BOOL has_msaa_color  = (args->msaa_color_write.hindex != (ULONG)~0);
+    BOOL has_msaa_zs     = (args->msaa_zs_write.hindex != (ULONG)~0);
+
+    if (has_color_write)
+        color_write_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                        exec->bo_handle_count,
+                                        args->color_write.hindex);
+    if (has_color_read)
+        color_read_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                       exec->bo_handle_count,
+                                       args->color_read.hindex);
+    if (has_zs_read)
+        zs_read_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                    exec->bo_handle_count,
+                                    args->zs_read.hindex);
+    if (has_zs_write)
+        zs_write_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                     exec->bo_handle_count,
+                                     args->zs_write.hindex);
+    if (has_msaa_color)
+        msaa_color_write_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                             exec->bo_handle_count,
+                                             args->msaa_color_write.hindex);
+    if (has_msaa_zs)
+        msaa_zs_write_addr = bo_bus_addr(exec->sd, exec->bo_handles,
+                                          exec->bo_handle_count,
+                                          args->msaa_zs_write.hindex);
+
+    /* Fixed RCL order */
+    if (args->flags & VC4_SUBMIT_CL_FIXED_RCL_ORDER)
+    {
+        if (!(args->flags & VC4_SUBMIT_CL_RCL_ORDER_INCREASING_X))
+            positive_x = FALSE;
+        if (!(args->flags & VC4_SUBMIT_CL_RCL_ORDER_INCREASING_Y))
+            positive_y = FALSE;
+    }
+
+    /* RCL header order matches Mesa's MIT-licensed vc4_render_cl.c:344-365 —
+     * emit CLEAR_COLORS + TILE_COORDINATES(0,0) + None-mode STORE first to
+     * latch the clear values into the tile buffer, THEN emit
+     * TILE_RENDERING_MODE_CONFIG. */
+
+    /* Clear colors (if requested) */
+    if (args->flags & VC4_SUBMIT_CL_USE_CLEAR_COLOR)
+    {
+        rcl_u8(&b, VC4_PACKET_CLEAR_COLORS);
+        rcl_u32(&b, args->clear_color[0]);
+        rcl_u32(&b, args->clear_color[1]);
+        rcl_u32(&b, args->clear_z);
+        rcl_u8(&b, args->clear_s);
+
+        rcl_tile_coords(&b, 0, 0);
+
+        /* Store in None mode to trigger tile buffer clear */
+        rcl_u8(&b, VC4_PACKET_STORE_TILE_BUFFER_GENERAL);
+        rcl_u16(&b, VC4_LOADSTORE_TILE_BUFFER_NONE);
+        rcl_u32(&b, 0);
+    }
+
+    /* Tile rendering mode config */
+    rcl_u8(&b, VC4_PACKET_TILE_RENDERING_MODE_CONFIG);
+    rcl_u32(&b, has_color_write ?
+            (color_write_addr + args->color_write.offset) : 0);
+    rcl_u16(&b, args->width);
+    rcl_u16(&b, args->height);
+    rcl_u16(&b, args->color_write.bits);
+
+    D(bug("[VC4Gallium] RCL render config: addr=0x%08x %dx%d color.bits=0x%04x zs.bits=0x%04x flags=0x%x clear=0x%08x,0x%08x z=0x%08x s=0x%02x\n",
+        has_color_write ? (color_write_addr + args->color_write.offset) : 0,
+        (ULONG)args->width, (ULONG)args->height,
+        (UWORD)args->color_write.bits, (UWORD)args->zs_write.bits,
+        (ULONG)args->flags,
+        (ULONG)args->clear_color[0], (ULONG)args->clear_color[1],
+        (ULONG)args->clear_z, (UBYTE)args->clear_s));
+
+    /* Diagnostics: which BO in the handle list is the color target?
+     * If color_write.hindex points to a different BO than what
+     * DisplayResource ends up reading from, we have a back/front
+     * mismatch in the state tracker layer. */
+    if (has_color_write && args->color_write.hindex < exec->bo_handle_count)
+    {
+        ULONG color_handle = exec->bo_handles[args->color_write.hindex];
+        D(bug("[VC4Gallium]   color_write hindex=%d -> handle=%d vaddr=0x%08x bus=0x%08x\n",
+            (ULONG)args->color_write.hindex, color_handle,
+            (ULONG)(IPTR)exec->sd->bo_table[color_handle].vaddr,
+            exec->sd->bo_table[color_handle].bus_addr));
+    }
+
+    for (yi = 0; yi < ytiles; yi++)
+    {
+        UBYTE y = positive_y ? (min_y + yi) : (max_y - yi);
+        for (xi = 0; xi < xtiles; xi++)
+        {
+            UBYTE x = positive_x ? (min_x + xi) : (max_x - xi);
+            BOOL first = (xi == 0 && yi == 0);
+            BOOL last  = (xi == xtiles - 1 && yi == ytiles - 1);
+
+            /* Load color buffer */
+            if (has_color_read)
+            {
+                if (args->color_read.flags & VC4_SUBMIT_RCL_SURFACE_READ_IS_FULL_RES)
+                {
+                    rcl_u8(&b, VC4_PACKET_LOAD_FULL_RES_TILE_BUFFER);
+                    rcl_u32(&b,
+                        rcl_full_res_offset(color_read_addr,
+                                            args->color_read.offset,
+                                            args->width, 64, x, y) |
+                        VC4_LOADSTORE_FULL_RES_DISABLE_ZS);
+                }
+                else
+                {
+                    rcl_u8(&b, VC4_PACKET_LOAD_TILE_BUFFER_GENERAL);
+                    rcl_u16(&b, args->color_read.bits);
+                    rcl_u32(&b, color_read_addr + args->color_read.offset);
+                }
+            }
+
+            /* Load Z/S buffer */
+            if (has_zs_read)
+            {
+                if (has_color_read)
+                {
+                    /* Execute previous load */
+                    rcl_tile_coords(&b, x, y);
+                    rcl_store_before_load(&b);
+                }
+
+                if (args->zs_read.flags & VC4_SUBMIT_RCL_SURFACE_READ_IS_FULL_RES)
+                {
+                    rcl_u8(&b, VC4_PACKET_LOAD_FULL_RES_TILE_BUFFER);
+                    rcl_u32(&b,
+                        rcl_full_res_offset(zs_read_addr,
+                                            args->zs_read.offset,
+                                            args->width, 64, x, y) |
+                        VC4_LOADSTORE_FULL_RES_DISABLE_COLOR);
+                }
+                else
+                {
+                    rcl_u8(&b, VC4_PACKET_LOAD_TILE_BUFFER_GENERAL);
+                    rcl_u16(&b, args->zs_read.bits);
+                    rcl_u32(&b, zs_read_addr + args->zs_read.offset);
+                }
+            }
+
+            /* Tile coordinates (needed for clipping and triggering loads) */
+            rcl_tile_coords(&b, x, y);
+
+            /* Wait for binner on first tile */
+            if (first && has_bin)
+                rcl_u8(&b, VC4_PACKET_WAIT_ON_SEMAPHORE);
+
+            /* Branch to per-tile bin list */
+            if (has_bin)
+            {
+                rcl_u8(&b, VC4_PACKET_BRANCH_TO_SUB_LIST);
+                rcl_u32(&b, exec->tile_alloc_bus +
+                        (y * exec->bin_tiles_x + x) * 32);
+            }
+
+            /* Store MSAA color */
+            if (has_msaa_color)
+            {
+                BOOL last_write = (!has_msaa_zs && !has_zs_write && !has_color_write);
+                ULONG bits = VC4_LOADSTORE_FULL_RES_DISABLE_ZS;
+                if (!last_write)
+                    bits |= VC4_LOADSTORE_FULL_RES_DISABLE_CLEAR_ALL;
+                else if (last)
+                    bits |= VC4_LOADSTORE_FULL_RES_EOF;
+                rcl_u8(&b, VC4_PACKET_STORE_FULL_RES_TILE_BUFFER);
+                rcl_u32(&b,
+                    rcl_full_res_offset(msaa_color_write_addr,
+                                        args->msaa_color_write.offset,
+                                        args->width, 64, x, y) | bits);
+            }
+
+            /* Store MSAA Z/S */
+            if (has_msaa_zs)
+            {
+                BOOL last_write = (!has_zs_write && !has_color_write);
+                ULONG bits = VC4_LOADSTORE_FULL_RES_DISABLE_COLOR;
+                if (has_msaa_color)
+                    rcl_tile_coords(&b, x, y);
+                if (!last_write)
+                    bits |= VC4_LOADSTORE_FULL_RES_DISABLE_CLEAR_ALL;
+                else if (last)
+                    bits |= VC4_LOADSTORE_FULL_RES_EOF;
+                rcl_u8(&b, VC4_PACKET_STORE_FULL_RES_TILE_BUFFER);
+                rcl_u32(&b,
+                    rcl_full_res_offset(msaa_zs_write_addr,
+                                        args->msaa_zs_write.offset,
+                                        args->width, 64, x, y) | bits);
+            }
+
+            /* Store Z/S buffer */
+            if (has_zs_write)
+            {
+                BOOL last_write = !has_color_write;
+                if (has_msaa_color || has_msaa_zs)
+                    rcl_tile_coords(&b, x, y);
+
+                rcl_u8(&b, VC4_PACKET_STORE_TILE_BUFFER_GENERAL);
+                rcl_u16(&b, args->zs_write.bits |
+                    (last_write ? 0 : VC4_STORE_TILE_BUFFER_DISABLE_COLOR_CLEAR));
+                rcl_u32(&b,
+                    (zs_write_addr + args->zs_write.offset) |
+                    ((last && last_write) ? VC4_LOADSTORE_TILE_BUFFER_EOF : 0));
+            }
+
+            /* Store color buffer (final store for this tile) */
+            if (has_color_write)
+            {
+                if (has_msaa_color || has_msaa_zs || has_zs_write)
+                    rcl_tile_coords(&b, x, y);
+
+                if (last)
+                    rcl_u8(&b, VC4_PACKET_STORE_MS_TILE_BUFFER_AND_EOF);
+                else
+                    rcl_u8(&b, VC4_PACKET_STORE_MS_TILE_BUFFER);
+            }
+        }
+    }
+
+    *out_size = b.offset;
+    if (b.offset > rcl_max_size)
+    {
+        bug("[VC4Gallium] build_rcl: RCL overflow (%d > %d)\n", b.offset, rcl_max_size);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * Submit a render job to V3D. From Mesa's bin_cl (GEM_HANDLES interleaved),
+ * shader records and uniforms, we:
+ * 1. Get pooled tile state + tile alloc memory (reused across frames)
+ * 2. Process bin CL: strip GEM_HANDLES, patch addresses
+ * 3. Relocate shader records: resolve handle indices to GPU bus addrs
+ * 4. Copy uniforms (as-is for now — no texture relocation yet)
+ * 5. Build the RCL from surface config
+ * 6. Submit binning CL (CT0) + render CL (CT1) concurrently, return seqno
+ */
+static int do_submit_cl(struct vc4galliumstaticdata *sd, struct drm_vc4_submit_cl *args)
+{
+    struct vc4_v3d_state *v3d = &sd->v3d;
+    ULONG *bo_handles;
+    ULONG tiles_x, tiles_y, tile_count;
+    ULONG tile_state_size, tile_alloc_size, tile_bo_size;
+    APTR tile_vaddr;
+    ULONG exec_size, bin_cl_max;
+    APTR exec_vaddr;
+    ULONG exec_bus;
+    ULONG bin_cl_offset, shader_rec_offset, uniforms_offset;
+    ULONG bin_cl_out_size;
+    ULONG rcl_max_size, rcl_size;
+    APTR rcl_vaddr;
+    ULONG rcl_bus;
+    ULONG seqno;
+    int ret;
+    struct exec_state exec;
+
+    if (!v3d->v3d_available)
+        return -1;
+
+    ULONG _t_entry = VC4G_NOW_US();
+
+    bo_handles = (ULONG *)(IPTR)args->bo_handles;
+
+    tiles_x = args->max_x_tile - args->min_x_tile + 1;
+    tiles_y = args->max_y_tile - args->min_y_tile + 1;
+
+    /* Tile counts for sizing the tile state/alloc BO. These must match the
+     * BINNER's view, i.e. the tile counts in the TILE_BINNING_MODE_CONFIG
+     * packet (always the full framebuffer), NOT the draw-bounds max_*_tile
+     * from the submit args: tile state is indexed by global tile coordinate
+     * with the packet's row width, so when a frame's draws don't reach the
+     * right/bottom edge the packet counts exceed the draw-bounds counts and
+     * a BO sized from the latter lets the binner write tile state past its
+     * area into the sublists. Prescan the packet for the real tile
+     * counts; keep the draw-bounds counts as the floor (they are what
+     * the synthesized RCL-only bin CL uses). */
+    {
+        ULONG bin_tiles_x = args->max_x_tile + 1;
+        ULONG bin_tiles_y = args->max_y_tile + 1;
+        UBYTE *src = (UBYTE *)(IPTR)args->bin_cl;
+        ULONG off = 0;
+
+        while (off < args->bin_cl_size)
+        {
+            UBYTE cmd = src[off];
+            ULONG pkt_size = vc4_packet_sizes[cmd];
+
+            if (pkt_size == 0 || off + pkt_size > args->bin_cl_size)
+                break;      /* malformed CL — process_bin_cl rejects it */
+            if (cmd == VC4_PACKET_TILE_BINNING_MODE_CONFIG)
+            {
+                if (src[off + 13] > bin_tiles_x)
+                    bin_tiles_x = src[off + 13];
+                if (src[off + 14] > bin_tiles_y)
+                    bin_tiles_y = src[off + 14];
+            }
+            off += pkt_size;
+        }
+
+        tile_count = bin_tiles_x * bin_tiles_y;
+    }
+
+    D(bug("[VC4Gallium] submit_cl: %dx%d tiles (%dx%d), bin_cl=%d shader_rec=%d uniforms=%d bo_count=%d\n",
+        tiles_x, tiles_y, args->width, args->height,
+        args->bin_cl_size, args->shader_rec_size,
+        args->uniforms_size, args->bo_handle_count));
+
+    /* ---- Step 0: Select pool set and wait if it's still in flight ---- */
+    /*
+     * Double-buffered pools: alternate between two sets so the CPU can
+     * prepare frame N+1 while the GPU renders frame N using the other set.
+     * We only block if the pool set we want to use hasn't finished yet.
+     */
+    {
+        ULONG pi = sd->pool_idx;
+        if (sd->pool[pi].seqno > v3d->finished_seqno)
+        {
+            /* This pool set is still in use by the GPU — wait for it */
+            v3d_wait_seqno(sd, sd->pool[pi].seqno, 10000000);
+        }
+    }
+    ULONG pi = sd->pool_idx;
+
+    /* ---- Step 1: Get pooled tile state + alloc memory ---- */
+    tile_state_size = 48 * tile_count;
+    ULONG tile_alloc_offset = ROUNDUP(tile_state_size, 4096);
+    tile_alloc_size = ROUNDUP(32 * tile_count, 256) + 1024 * 1024;  /* + 1MB overflow */
+    tile_bo_size = tile_alloc_offset + tile_alloc_size;
+
+    tile_vaddr = pool_bo_get(sd, &sd->pool[pi].tile, tile_bo_size, 4096,
+                              VCMEM_L1NONALLOCATING | VCMEM_ZERO);
+    if (!tile_vaddr)
+    {
+        bug("[VC4Gallium] submit_cl: failed to alloc tile BO (%d bytes)\n", tile_bo_size);
+        return -1;
+    }
+
+    /* Zero the tile state area — binning needs clean state each frame.
+     * When pool_bo_get reuses an existing BO, old tile state must be cleared. */
+    {
+        ULONG *p = (ULONG *)tile_vaddr;
+        ULONG n = tile_state_size / 4;
+        ULONG i;
+        for (i = 0; i < n; i++)
+            p[i] = 0;
+    }
+
+    /* ---- Step 2: Get pooled exec BO for validated bin CL + shader recs + uniforms ---- */
+    bin_cl_max = args->bin_cl_size + 256;
+    /* Match the per-section ROUNDUP(16) below so the BO is large enough
+     * to hold all three sections after alignment padding. */
+    exec_size = ROUNDUP(bin_cl_max, 16) +
+                ROUNDUP(args->shader_rec_size, 16) +
+                args->uniforms_size +
+                32; /* extra slack for trailing alignment */
+    exec_size = ROUNDUP(exec_size, 4096);
+
+    exec_vaddr = pool_bo_get(sd, &sd->pool[pi].exec, exec_size, 4096,
+                              VCMEM_L1NONALLOCATING | VCMEM_ZERO);
+    if (!exec_vaddr)
+    {
+        bug("[VC4Gallium] submit_cl: failed to alloc exec BO (%d bytes)\n", exec_size);
+        return -1;
+    }
+    exec_bus = sd->pool[pi].exec.bus_addr;
+
+    ULONG _t_after_pools = VC4G_NOW_US();
+
+    /* Section offsets are referenced as ULONG arrays later (handles,
+     * uniforms) — keep them 16-byte aligned so the loads/stores hit
+     * naturally aligned addresses on Device memory. */
+    bin_cl_offset = 0;
+    shader_rec_offset = ROUNDUP(bin_cl_max, 16);
+    uniforms_offset = ROUNDUP(shader_rec_offset + args->shader_rec_size, 16);
+
+    /* ---- Step 3: Set up exec state and process bin CL ---- */
+    exec.sd = sd;
+    exec.bo_handles = bo_handles;
+    exec.bo_handle_count = args->bo_handle_count;
+    exec.current_bo[0] = 0;
+    exec.current_bo[1] = 0;
+    exec.tile_alloc_bus = sd->pool[pi].tile.bus_addr + tile_alloc_offset;
+    exec.tile_state_bus = sd->pool[pi].tile.bus_addr;
+    exec.tile_alloc_offset = tile_alloc_offset;
+    exec.tile_alloc_size = tile_alloc_size;
+    exec.bin_tiles_x = args->max_x_tile + 1;  /* Will be overwritten by bin config */
+    exec.bin_tiles_y = args->max_y_tile + 1;
+    exec.shader_state_count = 0;
+    exec.shader_rec_bus = exec_bus + shader_rec_offset;
+    exec.uniforms_bus = exec_bus + uniforms_offset;
+
+    /* Grow the persistent GL_SHADER_STATE scratch to cover this CL. A CL
+     * can hold at most bin_cl_size/5 shader-state packets (5 bytes each);
+     * that bound scales with the scene, and a complex one overflows any
+     * fixed guess. Serialized under render_lock, so no locking here. */
+    {
+        ULONG need = args->bin_cl_size / 5 + 1;
+
+        if (sd->shader_state_scratch_max < need)
+        {
+            if (sd->shader_state_scratch)
+                FreeVec(sd->shader_state_scratch);
+            sd->shader_state_scratch = AllocVec(need * sizeof(ULONG), MEMF_ANY);
+            sd->shader_state_scratch_max =
+                sd->shader_state_scratch ? need : 0;
+        }
+        if (!sd->shader_state_scratch)
+        {
+            bug("[VC4Gallium] submit_cl: no memory for %lu shader-state slots\n",
+                (unsigned long)need);
+            return -1;
+        }
+        exec.shader_state_addrs = sd->shader_state_scratch;
+        exec.shader_state_max = sd->shader_state_scratch_max;
+    }
+
+    bin_cl_out_size = process_bin_cl(&exec,
+                                      (UBYTE *)(IPTR)args->bin_cl, args->bin_cl_size,
+                                      (UBYTE *)exec_vaddr + bin_cl_offset, bin_cl_max);
+    if (bin_cl_out_size == 0)
+    {
+        bug("[VC4Gallium] submit_cl: bin CL processing failed\n");
+        return -1;
+    }
+
+    D(bug("[VC4Gallium] submit_cl: bin CL %d -> %d bytes, %d shader recs\n",
+        args->bin_cl_size, bin_cl_out_size, exec.shader_state_count));
+
+    ULONG _t_after_bin = VC4G_NOW_US();
+
+    /* ---- Step 4: Relocate shader records + process uniforms ---- */
+    {
+        ULONG uniforms_out_count = 0;
+        ret = relocate_shader_recs(&exec,
+                                    (UBYTE *)(IPTR)args->shader_rec, args->shader_rec_size,
+                                    (UBYTE *)exec_vaddr + shader_rec_offset,
+                                    (ULONG *)(IPTR)args->uniforms,
+                                    args->uniforms_size / 4,
+                                    (ULONG *)((UBYTE *)exec_vaddr + uniforms_offset),
+                                    args->uniforms_size / 4,
+                                    &uniforms_out_count);
+        if (ret != 0)
+        {
+            bug("[VC4Gallium] submit_cl: shader rec + uniform relocation failed\n");
+            return -1;
+        }
+        D(bug("[VC4Gallium] submit_cl: relocated %d uniform words\n", uniforms_out_count));
+    }
+
+    ULONG _t_after_shader = VC4G_NOW_US();
+
+    /* ---- Step 6: Build RCL ---- */
+    /* Estimate RCL size: generous upper bound */
+    rcl_max_size = 11 +     /* TILE_RENDERING_MODE_CONFIG */
+                   14 + 3 + 7 +  /* CLEAR_COLORS + TILE_COORDS + STORE_GENERAL */
+                   tiles_x * tiles_y * (
+                       7 +  /* LOAD_TILE_BUFFER_GENERAL (color) */
+                       3 + 7 +  /* TILE_COORDS + STORE (for Z/S load) */
+                       7 +  /* LOAD_TILE_BUFFER_GENERAL (Z/S) */
+                       3 +  /* TILE_COORDINATES */
+                       1 +  /* WAIT_ON_SEMAPHORE */
+                       5 +  /* BRANCH_TO_SUB_LIST */
+                       5 +  /* STORE_FULL_RES (MSAA color) */
+                       3 +  /* TILE_COORDINATES */
+                       5 +  /* STORE_FULL_RES (MSAA zs) */
+                       3 +  /* TILE_COORDINATES */
+                       7 +  /* STORE_TILE_BUFFER_GENERAL (zs) */
+                       3 +  /* TILE_COORDINATES */
+                       1    /* STORE_MS_TILE_BUFFER */
+                   ) + 64;  /* safety margin */
+
+    rcl_vaddr = pool_bo_get(sd, &sd->pool[pi].rcl, ROUNDUP(rcl_max_size, 4096), 4096,
+                             VCMEM_L1NONALLOCATING | VCMEM_ZERO);
+    if (!rcl_vaddr)
+    {
+        bug("[VC4Gallium] submit_cl: failed to alloc RCL BO\n");
+        return -1;
+    }
+    rcl_bus = sd->pool[pi].rcl.bus_addr;
+
+    ret = build_rcl(&exec, args, (UBYTE *)rcl_vaddr, rcl_max_size, &rcl_size);
+    if (ret != 0)
+        return -1;
+
+    D(bug("[VC4Gallium] submit_cl: RCL %d bytes, tile_alloc=0x%08x tile_state=0x%08x\n",
+        rcl_size, exec.tile_alloc_bus, exec.tile_state_bus));
+
+    /* Forensics snapshot for the timeout dump in v3d_wait_seqno. */
+    vc4_last_submit.seqno     = v3d->seqno + 1;
+    vc4_last_submit.rcl_bus   = rcl_bus;
+    vc4_last_submit.rcl_size  = rcl_size;
+    vc4_last_submit.bin_size  = args->bin_cl_size;
+    vc4_last_submit.width     = args->width;
+    vc4_last_submit.height    = args->height;
+    vc4_last_submit.min_x     = args->min_x_tile;
+    vc4_last_submit.min_y     = args->min_y_tile;
+    vc4_last_submit.max_x     = args->max_x_tile;
+    vc4_last_submit.max_y     = args->max_y_tile;
+    vc4_last_submit.cw_hindex = args->color_write.hindex;
+    vc4_last_submit.zsw_hindex = args->zs_write.hindex;
+    vc4_last_submit.rcl_vaddr = (const volatile UBYTE *)rcl_vaddr;
+    vc4_last_submit.tile_alloc_vaddr =
+        (const volatile UBYTE *)tile_vaddr + tile_alloc_offset;
+
+    ULONG _t_after_rcl = VC4G_NOW_US();
+
+    /* ---- Step 7: Submit to V3D ---- */
+    /*
+     * V3D supports pipelined binning + rendering: Thread 0 (binner) and
+     * Thread 1 (renderer) run concurrently. The RCL uses WAIT_ON_SEMAPHORE
+     * on the first tile, and the bin CL ends with INCREMENT_SEMAPHORE +
+     * FLUSH, so the hardware interlock is already in place. Submit both
+     * threads before waiting — renderer will stall on semaphore until
+     * each tile's bin data is ready.
+     */
+
+    /*
+     * Make the CPU-written CL/shader/uniform/RCL bytes visible to V3D, which
+     * fetches through the uncached 0xC0000000 alias. Every buffer here — the
+     * exec/rcl/tile pools AND every referenced BO — comes from gpu_mem_alloc,
+     * i.e. VideoCore GPU-pool memory that is mapped UNCACHED on the ARM. So
+     * there are NO dirty ARM cache lines to clean: a dsb that drains the CPU
+     * write buffer (the volatile byte stores from process_bin_cl /
+     * relocate_shader_recs / build_rcl and the tile_state zeroing) to RAM is
+     * all the GPU needs.
+     *
+     * The per-frame CacheClearE walks that used to live here (exec/rcl/tile +
+     * every cpu_mapped BO) cleaned nothing yet DOMINATED submit time: the
+     * arm-native c7,c14 loop (syscall.c:118) issues one op per cache line over
+     * the whole BO size whether or not a line is present, measured at ~1.6 ms
+     * on a 300x300 window. cpu_mapped BOs are gpu_mem_alloc'd too (MMAP_BO
+     * hands back the identity vaddr), so they were as pointless to walk as the
+     * GPU-only buffers the walk already skipped.
+     */
+    asm volatile("dsb sy" ::: "memory");
+
+    {
+        volatile UBYTE *rb = (volatile UBYTE *)rcl_vaddr;
+        D(bug("[VC4Gallium] DIAG RCL[0..31]: %02x %02x %02x %02x %02x %02x %02x %02x  %02x %02x %02x %02x %02x %02x %02x %02x  %02x %02x %02x %02x %02x %02x %02x %02x  %02x %02x %02x %02x %02x %02x %02x %02x\n",
+            rb[0],rb[1],rb[2],rb[3],rb[4],rb[5],rb[6],rb[7],
+            rb[8],rb[9],rb[10],rb[11],rb[12],rb[13],rb[14],rb[15],
+            rb[16],rb[17],rb[18],rb[19],rb[20],rb[21],rb[22],rb[23],
+            rb[24],rb[25],rb[26],rb[27],rb[28],rb[29],rb[30],rb[31]));
+    }
+
+#if DEBUG
+    /* DIAG: dump entire validated bin CL and RCL in 16-byte chunks
+     * so we can verify opcode placement (0x07 INCREMENT_SEMAPHORE,
+     * 0x08 WAIT_ON_SEMAPHORE, 0x11 BRANCH_TO_SUB_LIST etc). */
+    {
+        volatile UBYTE *bb = (volatile UBYTE *)((UBYTE *)exec_vaddr + bin_cl_offset);
+        ULONG i;
+        D(bug("[VC4Gallium] DIAG bin_cl full (size=%d):\n", bin_cl_out_size));
+        for (i = 0; i < bin_cl_out_size; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < bin_cl_out_size; j++)
+                p += vc4_hexbyte(line + p, bb[i + j]);
+            D(bug("[VC4Gallium]   bin[%03d]: %s\n", i, line));
+        }
+    }
+    {
+        volatile UBYTE *rb = (volatile UBYTE *)rcl_vaddr;
+        ULONG i;
+        D(bug("[VC4Gallium] DIAG rcl full (size=%d):\n", rcl_size));
+        for (i = 0; i < rcl_size; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < rcl_size; j++)
+                p += vc4_hexbyte(line + p, rb[i + j]);
+            D(bug("[VC4Gallium]   rcl[%03d]: %s\n", i, line));
+        }
+    }
+#endif
+
+    /* Binner overspill pool. The VC4 binner draws its tile-list blocks from
+     * the overspill pool (BPOA/BPOS); leaving it 0 makes the binner OOM on
+     * the very first block (PCS=BMOOM, CT0CA=0). We start each frame with
+     * BPOA/BPOS = 0 and feed a dedicated BO on-demand from the OUTOMEM IRQ
+     * (vc4_v3d_service_interrupts). It's a separate BO from tile_alloc —
+     * pointing BPOA at tile_alloc would let the binner overwrite the sublists
+     * it just emitted — and one per pool set, so frame N+1's binner can't
+     * clobber frame N's lists while CT1 still reads them. overflow_handed = 0
+     * is reset per frame for the (currently disabled) OUTOMEM handler;
+     * OUTOMEM stays masked because asserting the V3D IRQ wedges the firmware
+     * mailbox (see vc4_v3d_init). Note: ERRSTAT bit 12 (0x00001000) is
+     * latched on every submission even when nothing is wrong — don't
+     * treat it as a fault. */
+    if (!pool_bo_get(sd, &sd->pool[pi].binoverflow, VC4_BIN_OVERFLOW_SIZE, 4096,
+                     VCMEM_L1NONALLOCATING | VCMEM_ZERO))
+    {
+        bug("[VC4Gallium] submit_cl: failed to alloc binner overflow BO\n");
+        return -1;
+    }
+    v3d->overflow_bus = sd->pool[pi].binoverflow.bus_addr;
+    v3d->overflow_size = sd->pool[pi].binoverflow.size;
+    v3d->overflow_handed = 0;
+    V3D_WRITE(v3d, V3D_BPOA, 0);
+    V3D_WRITE(v3d, V3D_BPOS, 0);
+
+    /* Clear caches: flush both L2 and the per-slice caches before every bin
+     * job — without the slice flush, V3D reads stale QPU instructions,
+     * uniforms or texture data from the per-slice caches even after we've
+     * patched RAM. L2CCLR auto-clears; we don't need to write L2CENA because
+     * L2 is enabled by default after reset. */
+    V3D_WRITE(v3d, V3D_L2CACTL, V3D_L2CACTL_L2CCLR);
+    V3D_WRITE(v3d, V3D_SLCACTL, V3D_SLCACTL_ALL);
+
+    /* Drain the pipeline state left by the PREVIOUS submission before
+     * touching CT0 or pending_ct1*. Two submissions can arrive
+     * back-to-back (Mesa flushes mid-frame on shader/state changes, no
+     * wait in between): the previous bin may still be running, and its
+     * FLDONE→CT1 handoff may not have been serviced yet. The old code
+     * blindly W1C-cleared INTCTL here, eating that FLDONE — the previous
+     * frame's render was then silently dropped and the seqno bookkeeping
+     * ran one behind forever, hanging the client. Consume events properly
+     * and let the handoff complete instead. */
+    {
+        ULONG spins = 0;
+        while ((V3D_READ(v3d, V3D_CT0CS) & V3D_CTCS_CTRUN) ||
+               v3d->pending_render)
+        {
+            vc4_v3d_service_interrupts(v3d);
+            v3d_advance_counters(v3d);
+            if (++spins > 100000000)
+            {
+                bug("[VC4Gallium] submit_cl: drain timeout (CT0CS=0x%08x "
+                    "pending=%d) — proceeding\n",
+                    V3D_READ(v3d, V3D_CT0CS), (LONG)v3d->pending_render);
+                break;
+            }
+        }
+    }
+
+    /* Clear latched ERRSTAT bits (W1C) so the post-kick read reflects only
+     * this submission. Without this, sticky bits (e.g. VPAERGL from a
+     * previous CS allocation) make it impossible to tell when in the
+     * binner/render timeline the error actually fired. */
+    V3D_WRITE(v3d, V3D_ERRSTAT, 0xffffffff);
+
+    /* DIAG: state immediately before kick */
+    D(bug("[VC4Gallium] DIAG V3D pre-kick: CT0CS=0x%08x CT1CS=0x%08x PCS=0x%08x BFC=0x%02x RFC=0x%02x VPMBASE=0x%08x VPACNTL=0x%08x\n",
+        V3D_READ(v3d, V3D_CT0CS), V3D_READ(v3d, V3D_CT1CS),
+        V3D_READ(v3d, V3D_PCS),
+        V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff,
+        V3D_READ(v3d, V3D_VPMBASE), V3D_READ(v3d, V3D_VPACNTL)));
+
+#if DEBUG
+    /* DIAG: dump validated shader_rec section + uniform section. Layout
+     * per v3d_packet_v21.xml "Shader Record": byte 0 = flags
+     * (single-threaded / point-size / clipping), byte 3 = FS num_varyings,
+     * bytes 4-11 = FS code+uniforms; byte 14 = VS attribute_array_select_bits,
+     * byte 15 = VS total_attributes_size, bytes 16-23 = VS code+uniforms;
+     * byte 26/27 = CS select_bits / total_size, bytes 28-35 = CS code+uniforms;
+     * attribute records (8 bytes each) start at offset 36. */
+    {
+        volatile UBYTE *sb = (volatile UBYTE *)((UBYTE *)exec_vaddr + shader_rec_offset);
+        ULONG i;
+        D(bug("[VC4Gallium] DIAG shader_rec full (size=%d, at exec+0x%x -> bus 0x%08x):\n",
+            args->shader_rec_size, shader_rec_offset, exec_bus + shader_rec_offset));
+        for (i = 0; i < args->shader_rec_size; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < args->shader_rec_size; j++)
+                p += vc4_hexbyte(line + p, sb[i + j]);
+            D(bug("[VC4Gallium]   srec[%03d]: %s\n", i, line));
+        }
+    }
+    {
+        volatile UBYTE *ub = (volatile UBYTE *)((UBYTE *)exec_vaddr + uniforms_offset);
+        ULONG i;
+        D(bug("[VC4Gallium] DIAG uniforms full (size=%d):\n", args->uniforms_size));
+        for (i = 0; i < args->uniforms_size; i += 16)
+        {
+            ULONG j;
+            char line[16*3 + 8];
+            ULONG p = 0;
+            for (j = 0; j < 16 && (i + j) < args->uniforms_size; j++)
+                p += vc4_hexbyte(line + p, ub[i + j]);
+            D(bug("[VC4Gallium]   uni[%03d]: %s\n", i, line));
+        }
+    }
+
+    /* DIAG: dump first 64 bytes of every non-shader, non-color-target BO
+     * referenced by this submission. For typical draws that's the VBO(s)
+     * — if Mesa never actually uploaded vertex data, this region will be
+     * all zeros (or whatever the firmware initialized the BO to) and we
+     * know the GPU is binning a degenerate primitive. Skip shader code
+     * BOs (already validated) and the color target (just receives writes,
+     * no useful pre-kick content). */
+    {
+        ULONG bi;
+        for (bi = 0; bi < args->bo_handle_count; bi++)
+        {
+            ULONG bh = bo_handles[bi];
+            struct vc4_bo_entry *be;
+
+            if (!bh || bh >= VC4_MAX_BOS)
+                continue;
+            be = &sd->bo_table[bh];
+            if (!be->vaddr || be->size == 0 || be->is_shader)
+                continue;
+            if (args->color_write.hindex != (ULONG)~0 &&
+                bi == args->color_write.hindex)
+                continue;
+            if (args->zs_write.hindex != (ULONG)~0 &&
+                bi == args->zs_write.hindex)
+                continue;
+            {
+                volatile UBYTE *vb = (volatile UBYTE *)be->vaddr;
+                ULONG dump_len = be->size < 64 ? be->size : 64;
+                ULONG i;
+                D(bug("[VC4Gallium] DIAG BO[hindex=%d handle=%d bus=0x%08x size=%d]:\n",
+                    bi, bh, be->bus_addr, be->size));
+                for (i = 0; i < dump_len; i += 16)
+                {
+                    ULONG j;
+                    char line[16*3 + 8];
+                    ULONG p = 0;
+                    for (j = 0; j < 16 && (i + j) < dump_len; j++)
+                        p += vc4_hexbyte(line + p, vb[i + j]);
+                    D(bug("[VC4Gallium]   bo[%03d]: %s\n", i, line));
+                }
+            }
+        }
+    }
+#endif
+
+    /* Submit binning CL (Thread 0). The FLDONE IRQ handler will kick CT1
+     * with the RCL addresses stashed below. Deferring the render kick to
+     * the bin-done interrupt guarantees the binner's FLUSH has committed
+     * per-tile sublist writes to memory before the renderer fetches them.
+     *
+     * Stash CT1 addresses BEFORE writing CT0EA — writing CT0EA is what
+     * starts the binner, and FLDONE can fire as soon as a small bin CL
+     * completes, racing with our stash if we did it afterward. */
+    v3d->pending_ct1ca = rcl_bus;
+    v3d->pending_ct1ea = rcl_bus + rcl_size;
+    v3d->pending_render = TRUE;
+    asm volatile("dsb sy" ::: "memory");
+
+    V3D_WRITE(v3d, V3D_CT0CA, exec_bus + bin_cl_offset);
+    V3D_WRITE(v3d, V3D_CT0EA, exec_bus + bin_cl_offset + bin_cl_out_size);
+
+    vc4_v3d_service_interrupts(v3d);
+
+    /* DIAG: did the V3D accept the new CL addresses? */
+    D(bug("[VC4Gallium] DIAG V3D post-kick: CT0CS=0x%08x CT0CA=0x%08x CT0EA=0x%08x CT1CS=0x%08x CT1CA=0x%08x CT1EA=0x%08x PCS=0x%08x ERRSTAT=0x%08x\n",
+        V3D_READ(v3d, V3D_CT0CS), V3D_READ(v3d, V3D_CT0CA), V3D_READ(v3d, V3D_CT0EA),
+        V3D_READ(v3d, V3D_CT1CS), V3D_READ(v3d, V3D_CT1CA), V3D_READ(v3d, V3D_CT1EA),
+        V3D_READ(v3d, V3D_PCS), V3D_READ(v3d, V3D_ERRSTAT)));
+
+    /* Assign seqno and return immediately — don't wait for GPU.
+     * Mesa will call WAIT_SEQNO or WAIT_BO when it actually needs
+     * the result. The next submit_cl will only block if it needs
+     * to reuse this pool set (which won't happen until 2 frames later
+     * due to double-buffering). */
+    seqno = ++v3d->seqno;
+    args->seqno = seqno;
+
+    /* Tag this pool set with the seqno so we know when it's safe to reuse */
+    sd->pool[pi].seqno = seqno;
+
+    sd->pool_idx = (pi + 1) % VC4_NUM_POOL_SETS;
+
+    D(bug("[VC4Gallium] submit_cl: submitted seqno=%d on pool %d\n", seqno, pi));
+
+    {
+
+        ULONG _t_done = VC4G_NOW_US();
+        VC4G_PROFF("[VC4Prof] submit_cl: pools=%ld bin=%ld shader=%ld rcl=%ld kick=%ld total=%ld "
+                  "bin_in=%ld bin_out=%ld rec=%ld unif=%ld tiles=%ldx%ld\n",
+            _t_after_pools - _t_entry,
+            _t_after_bin - _t_after_pools,
+            _t_after_shader - _t_after_bin,
+            _t_after_rcl - _t_after_shader,
+            _t_done - _t_after_rcl,
+            _t_done - _t_entry,
+            args->bin_cl_size, bin_cl_out_size,
+            args->shader_rec_size, args->uniforms_size,
+            tiles_x, tiles_y);
+    }
+
+    return 0;
+}
+
+/* Public submit entry. Serialize the whole submission against the wait /
+ * display-blit paths (render_lock) so the V3D registers, the job seqno, the
+ * pool ping-pong and the pending FLDONE->CT1 handoff are never touched
+ * concurrently. do_submit_cl's internal pool-reuse wait re-enters
+ * v3d_wait_seqno, which obtains render_lock again — safe, it nests. */
+static int ioctl_submit_cl(struct vc4galliumstaticdata *sd, struct drm_vc4_submit_cl *args)
+{
+    int ret;
+
+    ObtainSemaphore(&sd->render_lock);
+    ret = do_submit_cl(sd, args);
+    ReleaseSemaphore(&sd->render_lock);
+
+    return ret;
+}
+
+static int ioctl_set_tiling(struct vc4galliumstaticdata *sd, struct drm_vc4_set_tiling *args)
+{
+    if (args->handle == 0 || args->handle >= VC4_MAX_BOS ||
+        sd->bo_table[args->handle].refcount == 0)
+    {
+        errno = ENOENT;
+        return -1;
+    }
+    sd->bo_table[args->handle].tiling_modifier = args->modifier;
+    return 0;
+}
+
+static int ioctl_get_tiling(struct vc4galliumstaticdata *sd, struct drm_vc4_get_tiling *args)
+{
+    if (args->handle == 0 || args->handle >= VC4_MAX_BOS ||
+        sd->bo_table[args->handle].refcount == 0)
+    {
+        errno = ENOENT;
+        return -1;
+    }
+    args->modifier = sd->bo_table[args->handle].tiling_modifier;
+    return 0;
+}
+
+static int ioctl_label_bo(struct vc4galliumstaticdata *sd, struct drm_vc4_label_bo *args)
+{
+    return 0;
+}
+
+static int ioctl_gem_madvise(struct vc4galliumstaticdata *sd, struct drm_vc4_gem_madvise *args)
+{
+    args->retained = 1;
+    return 0;
+}
+
+/* ---- Main ioctl dispatcher ---- */
+
+static int vc4_aros_ioctl_dispatch(struct vc4galliumstaticdata *sd,
+                                   unsigned long cmd, void *arg)
+{
+    switch (cmd)
+    {
+    case DRM_VC4_GET_PARAM:
+        return ioctl_get_param(sd, (struct drm_vc4_get_param *)arg);
+
+    case DRM_VC4_CREATE_BO:
+        return ioctl_create_bo(sd, (struct drm_vc4_create_bo *)arg);
+
+    case DRM_VC4_CREATE_SHADER_BO:
+        return ioctl_create_shader_bo(sd, (struct drm_vc4_create_shader_bo *)arg);
+
+    case DRM_VC4_MMAP_BO:
+        return ioctl_mmap_bo(sd, (struct drm_vc4_mmap_bo *)arg);
+
+    case DRM_VC4_WAIT_SEQNO:
+        return ioctl_wait_seqno(sd, (struct drm_vc4_wait_seqno *)arg);
+
+    case DRM_VC4_WAIT_BO:
+        return ioctl_wait_bo(sd, (struct drm_vc4_wait_bo *)arg);
+
+    case DRM_VC4_SUBMIT_CL:
+        return ioctl_submit_cl(sd, (struct drm_vc4_submit_cl *)arg);
+
+    case DRM_VC4_SET_TILING:
+        return ioctl_set_tiling(sd, (struct drm_vc4_set_tiling *)arg);
+
+    case DRM_VC4_GET_TILING:
+        return ioctl_get_tiling(sd, (struct drm_vc4_get_tiling *)arg);
+
+    case DRM_VC4_LABEL_BO:
+        return ioctl_label_bo(sd, (struct drm_vc4_label_bo *)arg);
+
+    case DRM_VC4_GEM_MADVISE:
+        return ioctl_gem_madvise(sd, (struct drm_vc4_gem_madvise *)arg);
+
+    case DRM_GEM_CLOSE:
+        return ioctl_gem_close(sd, (struct drm_gem_close *)arg);
+
+    case DRM_GEM_OPEN:
+        return ioctl_gem_open(sd, (struct drm_gem_open *)arg);
+
+    default:
+        bug("[VC4Gallium] unhandled ioctl 0x%lx\n", cmd);
+        return -1;
+    }
+}
+
+#if VC4G_PROFILE
+/*
+ * Classify the observed whole-CPU slowdown once per profile period:
+ * pure ALU (core clock), cached-memory writes (TLB/cache health),
+ * uncached BO writes (VC-region/write-buffer health), plus the
+ * firmware's ARM clock and throttle flags. ~1.5 ms per 120 frames.
+ */
+static void vc4_prof_bench(struct vc4galliumstaticdata *sd)
+{
+    static UBYTE cached_buf[65536];
+    static APTR nc_buf;
+    static ULONG nc_handle;
+    volatile ULONG acc = 0;
+    ULONG t0, t1, us_alu, us_cached, us_nc = 0;
+    ULONG arm_hz = 0, arm_meas_hz = 0, throttled = 0;
+    ULONG sctlr = 0, actlr = 0;
+    ULONG i;
+
+    t0 = VC4G_NOW_US();
+    for (i = 0; i < 100000; i++)
+        acc += i ^ (acc << 1);
+    t1 = VC4G_NOW_US();
+    us_alu = t1 - t0;
+
+    t0 = t1;
+    for (i = 0; i < sizeof(cached_buf); i += 4)
+        *(volatile ULONG *)&cached_buf[i] = i;
+    t1 = VC4G_NOW_US();
+    us_cached = t1 - t0;
+
+    if (!nc_buf)
+        nc_buf = gpu_mem_alloc(sd, 65536, 4096,
+                               VCMEM_L1NONALLOCATING, &nc_handle);
+    if (nc_buf)
+    {
+        t0 = VC4G_NOW_US();
+        for (i = 0; i < 65536; i += 4)
+            *(volatile ULONG *)((UBYTE *)nc_buf + i) = i;
+        asm volatile("dsb sy" ::: "memory");
+        t1 = VC4G_NOW_US();
+        us_nc = t1 - t0;
+    }
+
+    /* Cache/branch-predictor/MMU control bits — a mid-run change here
+     * (I-bit 12, Z-bit 11, C-bit 2) would explain a global slowdown. */
+    {
+        APTR ss = SuperState();
+        asm volatile("mrc p15, 0, %0, c1, c0, 0" : "=r"(sctlr));
+        asm volatile("mrc p15, 0, %0, c1, c0, 1" : "=r"(actlr));
+        UserState(ss);
+    }
+
+    ObtainSemaphore(&sd->mbox_lock);
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(VCTAG_GETCLKRATE);
+    sd->mbox_msg[3] = AROS_LE2LONG(8);
+    sd->mbox_msg[4] = AROS_LE2LONG(4);
+    sd->mbox_msg[5] = AROS_LE2LONG(3);      /* clock id 3 = ARM */
+    sd->mbox_msg[6] = 0;
+    sd->mbox_msg[7] = 0;
+    if (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg)
+        != (volatile unsigned int *)-1)
+        arm_hz = AROS_LE2LONG(sd->mbox_msg[6]);
+
+    /* Measured (actual PLL) rate — 0x00030047. The plain GETCLKRATE above
+     * reports the *configured* rate and can miss a real divider change.
+     * Old firmware may not know the tag; 0 then. */
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(0x00030047);
+    sd->mbox_msg[3] = AROS_LE2LONG(8);
+    sd->mbox_msg[4] = AROS_LE2LONG(4);
+    sd->mbox_msg[5] = AROS_LE2LONG(3);      /* clock id 3 = ARM */
+    sd->mbox_msg[6] = 0;
+    sd->mbox_msg[7] = 0;
+    if (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg)
+        != (volatile unsigned int *)-1)
+        arm_meas_hz = AROS_LE2LONG(sd->mbox_msg[6]);
+
+    sd->mbox_msg[0] = AROS_LE2LONG(8 * 4);
+    sd->mbox_msg[1] = AROS_LE2LONG(VCTAG_REQ);
+    sd->mbox_msg[2] = AROS_LE2LONG(0x00030046);  /* GET_THROTTLED */
+    sd->mbox_msg[3] = AROS_LE2LONG(4);
+    sd->mbox_msg[4] = AROS_LE2LONG(4);
+    sd->mbox_msg[5] = 0;
+    sd->mbox_msg[6] = 0;
+    sd->mbox_msg[7] = 0;
+    if (MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)sd->mbox_msg)
+        != (volatile unsigned int *)-1)
+        throttled = AROS_LE2LONG(sd->mbox_msg[5]);
+    ReleaseSemaphore(&sd->mbox_lock);
+
+    bug("[VC4Prof] bench: alu=%lu us cached=%lu us nc=%lu us "
+        "arm=%lu/%lu Hz throttled=0x%lx sctlr=0x%08lx actlr=0x%08lx\n",
+        us_alu, us_cached, us_nc, arm_hz, arm_meas_hz, throttled,
+        sctlr, actlr);
+}
+#endif
+
+#if VC4G_PROFILE
+/* Frame-budget accumulators: mesa_gap = time between ioctls (Mesa + app
+ * CPU), ioctl = time inside the hidd. Reset every 120 submits. */
+static ULONG fp_t0, fp_last_exit, fp_mesa, fp_ioctl;
+static ULONG fp_prev_submit, fp_period, fp_frames;
+#endif
+
+int vc4_aros_ioctl(int fd, unsigned long request, void *arg)
+{
+    struct vc4galliumstaticdata *sd = fd_to_sd(fd);
+    int ret;
+    if (!sd)
+        return -1;
+
+    D(bug("[VC4Gallium] ioctl cmd=0x%02lx\n", request));
+
+#if VC4G_PROFILE
+    fp_t0 = VC4G_NOW_US();
+    if (fp_last_exit)
+        fp_mesa += fp_t0 - fp_last_exit;
+#endif
+
+    ret = vc4_aros_ioctl_dispatch(sd, request, arg);
+
+#if VC4G_PROFILE
+    {
+        ULONG fp_t1 = VC4G_NOW_US();
+        fp_ioctl += fp_t1 - fp_t0;
+        fp_last_exit = fp_t1;
+        if (request == DRM_VC4_SUBMIT_CL)
+        {
+            if (fp_prev_submit)
+                fp_period += fp_t1 - fp_prev_submit;
+            fp_prev_submit = fp_t1;
+            if (++fp_frames >= 120)
+            {
+                VC4G_PROF("[VC4Prof] %lu frames: frame=%lu us (%lu fps) "
+                          "mesa_gap=%lu us/f ioctl=%lu us/f\n",
+                    fp_frames,
+                    fp_period / fp_frames,
+                    fp_period ? 1000000UL * fp_frames / fp_period : 0,
+                    fp_mesa / fp_frames,
+                    fp_ioctl / fp_frames);
+                fp_mesa = 0; fp_ioctl = 0; fp_period = 0; fp_frames = 0;
+
+                vc4_prof_bench(sd);
+            }
+        }
+    }
+#endif
+
+    return ret;
+}
+
+/*
+ * mmap replacement, called after MMAP_BO. RPi memory is directly
+ * accessible, so just return the vaddr.
+ */
+void *vc4_aros_mmap(int fd, ULONG handle)
+{
+    struct vc4galliumstaticdata *sd = fd_to_sd(fd);
+
+    if (!sd || handle == 0 || handle >= VC4_MAX_BOS)
+        return NULL;
+
+    D(bug("[VC4Gallium] mmap: handle=%d -> vaddr=0x%08x size=%d\n",
+        handle, (ULONG)sd->bo_table[handle].vaddr, sd->bo_table[handle].size));
+
+    return sd->bo_table[handle].vaddr;
+}
+
+/*
+ * Free every outstanding BO and pool-set BO back to the firmware.
+ * Called from DestroyPipeScreen (end of each GL session, so leftovers
+ * can't poison the next one) and from Expunge so we don't leak
+ * GPU-locked SDRAM until reboot if the module unloads while Mesa
+ * still holds resources.
+ */
+void vc4_aros_release_all_bos(struct vc4galliumstaticdata *sd)
+{
+    ULONG i;
+
+    D({
+        ULONG freed_n = 0, freed_bytes = 0, live_n = 0;
+        for (i = 1; i < VC4_MAX_BOS; i++)
+            if (sd->bo_table[i].refcount > 0)
+            {
+                live_n++;
+                freed_bytes += sd->bo_table[i].size;
+                if (sd->bo_table[i].gpu_handle)
+                    freed_n++;
+            }
+        bug("[VC4Gallium] release_all_bos: %u live BOs (%u gpu, %u KB "
+            "firmware)\n", live_n, freed_n, freed_bytes / 1024);
+    })
+
+    /* Remove a live overlay plane first — it scans one of the BOs
+     * about to be freed. */
+    {
+        extern void vc4_aros_clear_overlay(struct vc4galliumstaticdata *,
+                                           OOP_Object *);
+        vc4_aros_clear_overlay(sd, NULL);
+    }
+
+    /* Drain any async display-blit DMA so we don't free its source BO
+     * while the channel is still reading it. */
+    vc4_aros_dma_wait_idle(sd);
+    sd->dma_pinned_handle = 0;
+
+    /* Clear external (scanout-wrap) entries too — they carry no
+     * gpu_handle but would otherwise hold their slots forever. */
+    for (i = 1; i < VC4_MAX_BOS; i++)
+    {
+        if (sd->bo_table[i].refcount > 0)
+        {
+            if (sd->bo_table[i].gpu_handle)
+                gpu_mem_free(sd, sd->bo_table[i].gpu_handle);
+            sd->bo_table[i].vaddr = NULL;
+            sd->bo_table[i].bus_addr = 0;
+            sd->bo_table[i].gpu_handle = 0;
+            sd->bo_table[i].size = 0;
+            sd->bo_table[i].refcount = 0;
+            sd->bo_table[i].tiling_modifier = 0;
+            sd->bo_table[i].is_shader = FALSE;
+            sd->bo_table[i].external = FALSE;
+            sd->bo_table[i].cpu_mapped = FALSE;
+        }
+    }
+
+    for (i = 0; i < VC4_NUM_POOL_SETS; i++)
+    {
+        struct vc4_frame_bo *pools[] = {
+            &sd->pool[i].tile,
+            &sd->pool[i].exec,
+            &sd->pool[i].rcl,
+            &sd->pool[i].binoverflow
+        };
+        int p;
+        for (p = 0; p < 4; p++)
+        {
+            if (pools[p]->vaddr && pools[p]->gpu_handle)
+            {
+                gpu_mem_free(sd, pools[p]->gpu_handle);
+                pools[p]->vaddr = NULL;
+                pools[p]->bus_addr = 0;
+                pools[p]->gpu_handle = 0;
+                pools[p]->size = 0;
+            }
+        }
+        sd->pool[i].seqno = 0;
+    }
+
+    if (sd->shader_state_scratch)
+    {
+        FreeVec(sd->shader_state_scratch);
+        sd->shader_state_scratch = NULL;
+        sd->shader_state_scratch_max = 0;
+    }
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_drm_aros.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_drm_aros.h
@@ -1,0 +1,237 @@
+/*
+    Copyright 2025, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D HIDD - DRM compatibility layer for AROS
+
+    This replaces the DRM ioctl interface with direct hardware
+    access. Mesa's VC4 Gallium driver calls drmIoctl() — we intercept
+    these and implement them using mailbox + V3D registers.
+*/
+
+#ifndef _VC4_DRM_AROS_H
+#define _VC4_DRM_AROS_H
+
+#include <exec/types.h>
+
+struct vc4galliumstaticdata;
+
+/*
+ * Fake file descriptor: Mesa stores screen->fd and passes it to all
+ * ioctls, so we stash our static-data pointer in place of a real fd.
+ */
+struct vc4_aros_fd
+{
+    ULONG                       magic;      /* VC4_AROS_FD_MAGIC */
+    struct vc4galliumstaticdata  *sd;
+};
+
+#define VC4_AROS_FD_MAGIC   0x56433444  /* "VC4D" */
+
+/* DRM ioctl encoding */
+#define DRM_COMMAND_BASE            0x40
+
+/* VC4-specific DRM ioctl numbers (at DRM_COMMAND_BASE offset) */
+#define DRM_VC4_SUBMIT_CL           (DRM_COMMAND_BASE + 0x00)
+#define DRM_VC4_WAIT_SEQNO          (DRM_COMMAND_BASE + 0x01)
+#define DRM_VC4_WAIT_BO             (DRM_COMMAND_BASE + 0x02)
+#define DRM_VC4_CREATE_BO           (DRM_COMMAND_BASE + 0x03)
+#define DRM_VC4_MMAP_BO             (DRM_COMMAND_BASE + 0x04)
+#define DRM_VC4_CREATE_SHADER_BO    (DRM_COMMAND_BASE + 0x05)
+#define DRM_VC4_GET_HANG_STATE      (DRM_COMMAND_BASE + 0x06)
+#define DRM_VC4_GET_PARAM           (DRM_COMMAND_BASE + 0x07)
+#define DRM_VC4_SET_TILING          (DRM_COMMAND_BASE + 0x08)
+#define DRM_VC4_GET_TILING          (DRM_COMMAND_BASE + 0x09)
+#define DRM_VC4_LABEL_BO            (DRM_COMMAND_BASE + 0x0a)
+#define DRM_VC4_GEM_MADVISE         (DRM_COMMAND_BASE + 0x0b)
+#define DRM_VC4_PERFMON_CREATE      (DRM_COMMAND_BASE + 0x0c)
+#define DRM_VC4_PERFMON_DESTROY     (DRM_COMMAND_BASE + 0x0d)
+#define DRM_VC4_PERFMON_GET_VALUES  (DRM_COMMAND_BASE + 0x0e)
+
+/* Standard DRM ioctls (below DRM_COMMAND_BASE) */
+#define DRM_GEM_CLOSE               0x09
+#define DRM_GEM_OPEN                0x0b
+
+/*
+ * DRM ioctl structures — mirroring the DRM UAPI exactly so Mesa's
+ * VC4 driver can use them unchanged.
+ */
+
+struct drm_vc4_submit_rcl_surface {
+    ULONG hindex;
+    ULONG offset;
+    UWORD bits;
+    UWORD flags;
+};
+
+struct drm_vc4_submit_cl {
+    UQUAD bin_cl;
+    UQUAD shader_rec;
+    UQUAD uniforms;
+    UQUAD bo_handles;
+
+    ULONG bin_cl_size;
+    ULONG shader_rec_size;
+    ULONG shader_rec_count;
+    ULONG uniforms_size;
+    ULONG bo_handle_count;
+
+    UWORD width;
+    UWORD height;
+    UBYTE min_x_tile;
+    UBYTE min_y_tile;
+    UBYTE max_x_tile;
+    UBYTE max_y_tile;
+
+    struct drm_vc4_submit_rcl_surface color_read;
+    struct drm_vc4_submit_rcl_surface color_write;
+    struct drm_vc4_submit_rcl_surface zs_read;
+    struct drm_vc4_submit_rcl_surface zs_write;
+    struct drm_vc4_submit_rcl_surface msaa_color_write;
+    struct drm_vc4_submit_rcl_surface msaa_zs_write;
+
+    ULONG clear_color[2];
+    ULONG clear_z;
+    UBYTE clear_s;
+
+    /*
+     * UAPI layout:
+     *   __u8  clear_s;
+     *   __u32 pad:24;
+     *   __u32 flags;
+     * clear_s + pad:24 share one 4-byte storage unit (clear_s in the low
+     * byte, 24 bits of padding above it). flags follows in the next
+     * 4-byte unit. Total from clear_s to end of flags = 8 bytes.
+     */
+    UBYTE _pad_cs[3];
+    ULONG flags;
+
+    UQUAD seqno;
+
+    ULONG perfmonid;
+    ULONG in_sync;
+    ULONG out_sync;
+    ULONG pad2;
+};
+
+struct drm_vc4_wait_seqno {
+    UQUAD seqno;
+    UQUAD timeout_ns;
+};
+
+struct drm_vc4_wait_bo {
+    ULONG handle;
+    ULONG pad;
+    UQUAD timeout_ns;
+};
+
+struct drm_vc4_create_bo {
+    ULONG size;
+    ULONG flags;
+    ULONG handle;
+    ULONG pad;
+};
+
+struct drm_vc4_mmap_bo {
+    ULONG handle;
+    ULONG flags;
+    UQUAD offset;
+};
+
+struct drm_vc4_create_shader_bo {
+    ULONG size;
+    ULONG flags;
+    UQUAD data;
+    ULONG handle;
+    ULONG pad;
+};
+
+struct drm_vc4_get_param {
+    ULONG param;
+    ULONG pad;
+    UQUAD value;
+};
+
+struct drm_vc4_set_tiling {
+    ULONG handle;
+    ULONG flags;
+    UQUAD modifier;
+};
+
+struct drm_vc4_get_tiling {
+    ULONG handle;
+    ULONG flags;
+    UQUAD modifier;
+};
+
+struct drm_vc4_label_bo {
+    ULONG handle;
+    ULONG len;
+    UQUAD name;
+};
+
+struct drm_vc4_gem_madvise {
+    ULONG handle;
+    ULONG madv;
+    ULONG retained;
+    ULONG pad;
+};
+
+struct drm_gem_close {
+    ULONG handle;
+    ULONG pad;
+};
+
+/* Layout matches struct drm_gem_open (u32 name/handle, u64 size).
+ * Used by Mesa's vc4_bo_open_name() to wrap the scanout pages announced
+ * by the bridge's get_scanout entry: `name` is the page's physical
+ * address. */
+struct drm_gem_open {
+    ULONG name;
+    ULONG handle;
+    UQUAD size;
+};
+
+/* Parameter IDs for GET_PARAM */
+#define DRM_VC4_PARAM_V3D_IDENT0                0
+#define DRM_VC4_PARAM_V3D_IDENT1                1
+#define DRM_VC4_PARAM_V3D_IDENT2                2
+#define DRM_VC4_PARAM_SUPPORTS_BRANCHES         3
+#define DRM_VC4_PARAM_SUPPORTS_ETC1             4
+#define DRM_VC4_PARAM_SUPPORTS_THREADED_FS      5
+#define DRM_VC4_PARAM_SUPPORTS_FIXED_RCL_ORDER  6
+#define DRM_VC4_PARAM_SUPPORTS_MADVISE          7
+#define DRM_VC4_PARAM_SUPPORTS_PERFMON          8
+
+/* Madvise values */
+#define VC4_MADV_WILLNEED       0
+#define VC4_MADV_DONTNEED       1
+
+/* Submit flags */
+#define VC4_SUBMIT_CL_USE_CLEAR_COLOR           (1 << 0)
+#define VC4_SUBMIT_CL_FIXED_RCL_ORDER           (1 << 1)
+#define VC4_SUBMIT_CL_RCL_ORDER_INCREASING_X    (1 << 2)
+#define VC4_SUBMIT_CL_RCL_ORDER_INCREASING_Y    (1 << 3)
+
+/* Replaces drmIoctl(). Called by the bridge wrappers (vc4_aros_bridge.c)
+ * which synthesise a stack-local fake fd whose sd matches the bridge ctx. */
+int vc4_aros_ioctl(int fd, unsigned long request, void *arg);
+
+/* mmap replacement — returns CPU pointer for a BO. */
+void *vc4_aros_mmap(int fd, ULONG handle);
+
+/*
+ * Drop one refcount on a BO handle. If this is the last reference,
+ * free the firmware allocation and reset the table slot — mirrors
+ * the GEM_CLOSE drop-to-zero path so a pin held by display_blit /
+ * async DMA can run the same cleanup once released. Caller must
+ * hold sd->bo_lock.
+ */
+void vc4_aros_bo_unref_locked(struct vc4galliumstaticdata *sd, ULONG handle);
+
+/*
+ * Release every outstanding BO and pool-set BO back to the firmware.
+ * Called from Expunge.
+ */
+void vc4_aros_release_all_bos(struct vc4galliumstaticdata *sd);
+
+#endif /* _VC4_DRM_AROS_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_galliumclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_galliumclass.c
@@ -1,0 +1,1040 @@
+/*
+    Copyright 2025, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D HIDD - Gallium pipe_screen interface
+
+    Implements the Hidd_Gallium interface for VideoCore IV.
+    Mesa3DGL.library creates this HIDD and calls CreatePipeScreen()
+    to get a Gallium pipe_screen. DisplayResource() blits rendered
+    frames to the AROS display.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/oop.h>
+#include <proto/utility.h>
+#include <proto/cybergraphics.h>
+#include <proto/graphics.h>
+#include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/dma.h>
+
+#include <cybergraphx/cybergraphics.h>
+#include <string.h>
+
+#include <hidd/gallium.h>
+#include <hidd/gfx.h>
+#include <gallium/gallium.h>
+
+#include <aros/macros.h>
+
+#include "pipe/p_state.h"
+#include "pipe/p_screen.h"
+
+#include "vc4gallium_intern.h"
+#include "vc4_drm_aros.h"
+#include "vc4_v3d.h"  /* provides ARM_PERIIOBASE, bcm2708.h, GPU_BUS_ADDR */
+
+/* vc4gfx bitmap attributes — must match the aoHidd_VideoCoreGfxBitMap_*
+ * enum in vc4gfx_bitmap.h */
+#define aoHidd_VideoCoreGfxBitMap_Drawable      0
+#define aoHidd_VideoCoreGfxBitMap_BackDrawable  1
+#define aoHidd_VideoCoreGfxBitMap_Flip          2
+#define aoHidd_VideoCoreGfxBitMap_Overlay       3
+
+/* Mirrored from vc4gfx_bitmap.h, like the attr indices above. */
+struct vc4gfx_overlay
+{
+    ULONG ovl_Phys;
+    ULONG ovl_Pitch;
+    ULONG ovl_Width, ovl_Height;
+    LONG  ovl_X, ovl_Y;
+    ULONG ovl_DestW, ovl_DestH;     /* 0/== source = unscaled */
+};
+
+#if (AROS_BIG_ENDIAN == 1)
+#define AROS_PIXFMT RECTFMT_RAW
+#else
+#define AROS_PIXFMT RECTFMT_BGRA32
+#endif
+
+#define UtilityBase (SD(cl)->UtilityBase)
+
+#undef HiddGalliumAttrBase
+#define HiddGalliumAttrBase (SD(cl)->hiddGalliumAB)
+
+#undef HiddBitMapAttrBase
+#define HiddBitMapAttrBase (SD(cl)->hiddBitMapAB)
+
+/* ---- DMA helpers ---- */
+
+static inline void __gallium_dsb(void) { asm volatile("dsb sy" ::: "memory"); }
+
+/* BCM system timer ticks at 1 MHz — use it for real microsecond budgets
+ * instead of CPU-clock-dependent spin counts. */
+static inline ULONG gallium_now_us(void)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)SYSTIMER_CLO);
+}
+
+static inline void gallium_udelay(ULONG usec)
+{
+    ULONG start = gallium_now_us();
+    while ((gallium_now_us() - start) < usec)
+        asm volatile("nop");
+}
+
+/*
+ * Scheduler-friendly microsleep for the GPU wait loops: a timer.device
+ * UNIT_MICROHZ request lets other tasks (input, mouse) run while we wait
+ * out a slice of the render. Falls back to busy-wait if the timer was
+ * unavailable at init. The pre-opened device/unit is cloned into a stack
+ * request so any task may call this.
+ */
+void vc4_gpu_nap(struct vc4galliumstaticdata *sd, ULONG us)
+{
+    struct MsgPort port;
+    struct timerequest tr;
+    BYTE sig;
+
+    if (!sd->gpu_timer_ok || (sig = AllocSignal(-1)) < 0)
+    {
+        gallium_udelay(us);
+        return;
+    }
+
+    /* Zero the whole port: on SMP-platform builds struct MsgPort carries
+     * a spinlock, and stack garbage in it reads as "locked" — the timer
+     * interrupt's ReplyMsg then spins forever in interrupt context,
+     * hanging the machine. Zero == unlocked. */
+    memset(&port, 0, sizeof(port));
+    port.mp_Node.ln_Type = NT_MSGPORT;
+    port.mp_Flags        = PA_SIGNAL;
+    port.mp_SigBit       = sig;
+    port.mp_SigTask      = FindTask(NULL);
+    NEWLIST(&port.mp_MsgList);
+
+    tr = sd->gpu_timer_template;
+    tr.tr_node.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+    tr.tr_node.io_Message.mn_ReplyPort = &port;
+    tr.tr_node.io_Message.mn_Length = sizeof(tr);
+    tr.tr_node.io_Command = TR_ADDREQUEST;
+    tr.tr_time.tv_secs  = 0;
+    tr.tr_time.tv_micro = us;
+
+    DoIO((struct IORequest *)&tr);
+
+    FreeSignal(sig);
+}
+
+/*
+ * Wait for any in-progress display-blit DMA via the dma.resource
+ * completion-IRQ wait (the CB sets DMA_TI_INTEN); the resource handles the
+ * wedge-safe timeout and channel reset. Non-static so the BO teardown path
+ * in vc4_drm_aros.c can drain DMA before releasing dma_pinned_handle.
+ */
+void vc4_aros_dma_wait_idle(struct vc4galliumstaticdata *sd)
+{
+    if (!sd->dmaBusy)
+        return;
+
+    if (DMAWaitChannel(sd->dmaChannel, 1000000) != 0)
+        bug("[VC4Gallium] DMA timeout!\n");
+
+    sd->dmaBusy = FALSE;
+}
+
+/*
+ * Direct 2D stride DMA blit from GPU BO to framebuffer.
+ * Uses a single control block in TDMODE — no staging buffer, no CPU copy.
+ * Both source and destination are physically addressable on RPi.
+ * Waits for completion before returning (synchronous for display).
+ */
+static BOOL gallium_dma_blit_direct(struct vc4galliumstaticdata *sd,
+                                     ULONG src_phys, ULONG src_pitch,
+                                     ULONG dst_phys, ULONG dst_pitch,
+                                     ULONG width_bytes, ULONG height)
+{
+    ULONG cb_needed = sizeof(struct BCM2708DMACB) + 31;
+    struct BCM2708DMACB *cb;
+    ULONG cb_bus;
+    volatile ULONG *dma_cs;
+    volatile ULONG *dma_cb_reg;
+
+    if (height == 0 || width_bytes == 0 || sd->dmaChannel < 0)
+        return FALSE;
+
+    vc4_aros_dma_wait_idle(sd);
+
+    /* Ensure CB buffer exists (one CB, allocated once) */
+    if (sd->dmaCBRawSize < cb_needed)
+    {
+        if (sd->dmaCBRaw)
+            FreeMem(sd->dmaCBRaw, sd->dmaCBRawSize);
+        sd->dmaCBRaw = AllocMem(cb_needed, MEMF_PUBLIC);
+        if (!sd->dmaCBRaw)
+        {
+            sd->dmaCBRawSize = 0;
+            return FALSE;
+        }
+        sd->dmaCBRawSize = cb_needed;
+    }
+
+    cb = (struct BCM2708DMACB *)(((IPTR)sd->dmaCBRaw + 31) & ~31);
+
+    /* 2D stride mode: single CB transfers the entire rectangle.
+     * txfr_len = YLENGTH(height) | XLENGTH(width_bytes)
+     * stride   = D_STRIDE | S_STRIDE (signed 16-bit each).
+     * BURST_LENGTH(8) + wide bursts (default, BO/FB are 16-byte aligned)
+     * are essential for throughput: without a burst length the engine
+     * issues one AXI beat at a time, and WAIT_RESP then stalls on each
+     * write response — measured at ~30 MB/s. WAIT_RESP is dropped; the
+     * DMA_CS_WAIT_FOR_WRITES bit in the kick already drains outstanding
+     * writes before the channel signals END, so completion is safe. */
+    cb->ti = AROS_LONG2LE(DMA_TI_INTEN |
+                           DMA_TI_SRC_INC | DMA_TI_DEST_INC |
+                           DMA_TI_BURST_LENGTH(8) | DMA_TI_TDMODE);
+    cb->source_ad = AROS_LONG2LE(GPU_BUS_ADDR(src_phys));
+    cb->dest_ad = AROS_LONG2LE(GPU_BUS_ADDR(dst_phys));
+    cb->txfr_len = AROS_LONG2LE(((height - 1) << 16) | width_bytes);
+    cb->stride = AROS_LONG2LE(
+        ((UWORD)(dst_pitch - width_bytes) << 16) |
+        (UWORD)(src_pitch - width_bytes));
+    cb->nextconbk = 0;
+    cb->reserved[0] = 0;
+    cb->reserved[1] = 0;
+
+    /* No source cache flush: the DMA reads the BO via the uncached 0xC alias,
+     * the GPU (not CPU) produced the pixels, and vc4_aros_wait_idle() already
+     * stored V3D's tiles to RAM. A previous per-row CacheClearE here (copied
+     * from a CPU-read path) dominated the blit: ~143ms/1280x1024 frame vs
+     * ~10ms for the transfer.
+     *
+     * Only the control block needs flushing — the CPU wrote it into cached
+     * AllocMem and the DMA fetches it via the uncached alias. */
+    CacheClearE(cb, sizeof(*cb), CACRF_ClearD);
+    __gallium_dsb();
+
+    /* CB lives in AllocMem memory — translate CPU VA to physical bus addr. */
+    cb_bus = GPU_BUS_ADDR((ULONG)(IPTR)KrnVirtualToPhysical(cb));
+
+    /* Start DMA. vc4_aros_dma_wait_idle() above left the channel idle; channel
+     * reset is only needed on the timeout recovery path, not every kick. */
+    dma_cs = (volatile ULONG *)DMA_CS(sd->dmaChannel);
+    dma_cb_reg = (volatile ULONG *)DMA_CONBLK_AD(sd->dmaChannel);
+
+    *dma_cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+    *dma_cb_reg = AROS_LONG2LE(cb_bus);
+    __gallium_dsb();
+    *dma_cs = AROS_LONG2LE(
+        DMA_CS_WAIT_FOR_WRITES |
+        DMA_CS_PANIC_PRI(15) |
+        DMA_CS_PRI(8) |
+        DMA_CS_ACTIVE);
+
+    sd->dmaBusy = TRUE;
+
+    /* DMA runs asynchronously — the next vc4_aros_dma_wait_idle() or
+     * gallium_dma_blit_direct() waits for completion. Lets the CPU start the
+     * next frame while the engine transfers pixels to the framebuffer. */
+
+    return TRUE;
+}
+
+/* ---- Gallium HIDD Methods ---- */
+
+OOP_Object *METHOD(HiddVC4Gallium, Root, New)
+{
+    IPTR interfaceVers;
+
+    D(bug("[VC4Gallium] %s()\n", __PRETTY_FUNCTION__));
+
+    interfaceVers = GetTagData(aHidd_Gallium_InterfaceVersion, -1, msg->attrList);
+    if (interfaceVers != GALLIUM_INTERFACE_VERSION)
+    {
+        bug("[VC4Gallium] Interface version mismatch: got %ld, expected %d\n",
+            interfaceVers, GALLIUM_INTERFACE_VERSION);
+        return NULL;
+    }
+
+    /* mesa3dgl's compiler-core table; one per system, so staticdata. The
+     * driver's trampolines bind to it at CreatePipeScreen (and refuse a
+     * table from a different Mesa generation there). */
+    SD(cl)->coreapi = (APTR)GetTagData(aHidd_Gallium_CoreAPI, 0, msg->attrList);
+
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    if (o)
+    {
+        struct HiddGalliumVC4Data *data = OOP_INST_DATA(cl, o);
+        data->vc4_obj = o;
+
+        if (!SD(cl)->v3d.v3d_available)
+        {
+            bug("[VC4Gallium] V3D hardware not available\n");
+            OOP_MethodID dispose_mid = OOP_GetMethodID(IID_Root, moRoot_Dispose);
+            OOP_CoerceMethod(cl, o, (OOP_Msg)&dispose_mid);
+            return NULL;
+        }
+    }
+
+    return o;
+}
+
+VOID METHOD(HiddVC4Gallium, Root, Dispose)
+{
+    D(bug("[VC4Gallium] %s()\n", __PRETTY_FUNCTION__));
+
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+VOID METHOD(HiddVC4Gallium, Root, Get)
+{
+    ULONG idx;
+
+    if (IS_GALLIUM_ATTR(msg->attrID, idx))
+    {
+        switch (idx)
+        {
+        case aoHidd_Gallium_InterfaceVersion:
+            *msg->storage = GALLIUM_INTERFACE_VERSION;
+            return;
+        }
+    }
+
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+APTR METHOD(HiddVC4Gallium, Hidd_Gallium, CreatePipeScreen)
+{
+    struct vc4galliumstaticdata *sd = SD(cl);
+
+    /* Diagnostic: has the firmware governor re-clocked anything since
+     * InitLib forced V3D to max? Logged once per GL context start. */
+    vc4_log_clocks(sd, "CreatePipeScreen");
+
+    if (!sd->coreapi)
+    {
+        bug("[VC4Gallium] no GalliumCoreAPI table (old mesa3dgl?)\n");
+        return NULL;
+    }
+
+    if (!sd->bridge_inited)
+    {
+        vc4_aros_bridge_init(&sd->bridge, sd);
+        sd->bridge_inited = TRUE;
+    }
+
+    return vc4_aros_create_screen(&sd->bridge, sd->coreapi);
+}
+
+IPTR METHOD(HiddVC4Gallium, Hidd_Gallium, DisplayResourceRP)
+{
+    return vc4_aros_display_rp(msg->resource, msg->srcx, msg->srcy,
+                               msg->rastport, msg->dstx, msg->dsty,
+                               msg->width, msg->height);
+}
+
+VOID METHOD(HiddVC4Gallium, Hidd_Gallium, DestroyPipeScreen)
+{
+    struct vc4galliumstaticdata *sd = SD(cl);
+    struct vc4_v3d_state *v3d = &sd->v3d;
+
+    /* The direct path builds the pipe_screen in mesa3dgl via
+     * vc4_screen_create(), so the base class's no-op DestroyPipeScreen
+     * would leak the Mesa screen, BO cache, and driver allocations.
+     * Dispatch into the screen's own destroy fn here. */
+    D(bug("[VC4Gallium] %s(screen=%p)\n", __PRETTY_FUNCTION__, msg->screen));
+
+    if (msg->screen)
+    {
+        struct pipe_screen *screen = (struct pipe_screen *)msg->screen;
+
+        /* Quiesce before the screen frees its BOs: context teardown can
+         * flush a trailing submission, and nothing polls after this call.
+         * Without the wait, screen->destroy GEM_CLOSEs memory the GPU is
+         * still rendering from, and a pending FLDONE->CT1 handoff would
+         * kick a stale RCL into the NEXT GL session's first frame. */
+        vc4_aros_wait_idle(sd);
+        vc4_aros_dma_wait_idle(sd);
+
+        screen->destroy(screen);
+    }
+
+    /* Drop the winsys bookkeeping for this screen. TRUE means it was the
+     * last one, so the hardware reset below is safe; with a second screen
+     * still live (a capability-probe context, or a fullscreen toggle
+     * building the new context before dropping the old) it would free the
+     * survivor's BOs and clear V3D state under its rendering. */
+    if (!aros_drm_release_bridge())
+        return;
+
+    /* Return the driver to a clean, idle, empty state for the next GL
+     * session: sweep whatever Mesa leaked (plus the async-DMA pin and the
+     * frame pools) and drop the per-session submission/scanout state. */
+    vc4_aros_release_all_bos(sd);
+
+    if (v3d->v3d_available)
+    {
+        v3d->pending_render = FALSE;
+        v3d->pending_ct1ca = 0;
+        v3d->pending_ct1ea = 0;
+        v3d->overflow_bus = 0;
+        v3d->overflow_size = 0;
+        v3d->overflow_handed = 0;
+        /* GPU is idle now — W1C any leftover event latches so the next
+         * session's first poll can't act on this session's events. */
+        V3D_WRITE(v3d, V3D_INTCTL,
+                  V3D_INT_FLDONE | V3D_INT_FRDONE | V3D_INT_OUTOMEM);
+    }
+
+    ObtainSemaphore(&sd->bo_lock);
+    sd->scanout_phys[0] = 0;
+    sd->scanout_phys[1] = 0;
+    sd->scanout_size = 0;
+    ReleaseSemaphore(&sd->bo_lock);
+}
+
+/*
+ * Wait for the V3D to finish all submitted work, then flush its L2
+ * cache so the rendered pixels are visible to subsequent DMA/CPU
+ * reads of the source BO.
+ *
+ * Called from the bridge's wait_idle entry (used by glReadPixels and
+ * any other CPU-read of a BO), and once internally from
+ * vc4_aros_display_blit before kicking the DMA.
+ */
+void vc4_aros_wait_idle(struct vc4galliumstaticdata *sd)
+{
+    struct vc4_v3d_state *v3d = &sd->v3d;
+#if VC4G_PROFILE
+    ULONG _w_t0 = VC4G_NOW_US();
+#endif
+    /* Serialize V3D access against submit_cl / v3d_wait_seqno (e.g. the
+     * display task waiting here while a render task is in submit_cl). */
+    ObtainSemaphore(&sd->render_lock);
+    /* Tiered wait (see VC4_GPUWAIT_* in vc4gallium_intern.h): tight spin for
+     * µs-precise completion of short jobs, then ~1 ms timer naps so input
+     * keeps running while the GPU renders. (Blocking on the vblank signal
+     * from the start quantized every wait to ~20 ms and phase-locked the
+     * zero-copy GL frame time to 40 ms; pure spinning starves the mouse.)
+     * Beyond the nap window, fall back to CPU-free vblank blocking. */
+    BYTE wsig = vc4_wait_enter(sd);
+    ULONG ticks = 0;
+    ULONG budget = (wsig >= 0) ? 60 : 3500000;
+    ULONG spin_start = gallium_now_us();
+
+    while (v3d->finished_seqno < v3d->seqno && ticks < budget)
+    {
+        ULONG bfc = V3D_READ(v3d, V3D_BFC) & 0xff;
+        ULONG rfc = V3D_READ(v3d, V3D_RFC) & 0xff;
+        ULONG bdelta = (bfc - v3d->last_bfc) & 0xff;
+        ULONG rdelta = (rfc - v3d->last_rfc) & 0xff;
+        v3d->last_bfc = bfc;
+        v3d->last_rfc = rfc;
+        v3d->bfc_completed += bdelta;
+        v3d->rfc_completed += rdelta;
+        if (v3d->pending_render && v3d->bfc_completed >= v3d->seqno)
+            vc4_v3d_kick_pending_render(v3d, "BFC");
+        {
+            ULONG done = v3d->rfc_completed;
+            if (done > v3d->seqno) done = v3d->seqno;
+            v3d->finished_seqno = done;
+        }
+        if (v3d->finished_seqno >= v3d->seqno)
+            break;
+
+        /* Poll-driven interrupt servicing: reads + W1C-clears INTCTL and does
+         * the FLDONE -> CT1 handoff and OUTOMEM handling. The V3D IRQ is masked
+         * (see vc4_v3d_init), so this poll is the only thing advancing the
+         * pipeline. */
+        vc4_v3d_service_interrupts(v3d);
+
+        /* OUTOMEM (latch and PCS.BMOOM level) is handled inside
+         * vc4_v3d_service_interrupts — a blind W1C here would eat the
+         * edge-triggered latch before the overspill feed runs. */
+
+        {
+            ULONG waited = gallium_now_us() - spin_start;
+            if (waited < VC4_GPUWAIT_SPIN_US)
+                continue;
+            if (waited < VC4_GPUWAIT_NAP_WINDOW)
+            {
+                vc4_gpu_nap(sd, VC4_GPUWAIT_NAP_US);
+                continue;
+            }
+
+            /* Live hang probe: state DURING the stall, not post-reset.
+             * Normal frames never wait this long, so these only fire on
+             * genuine hangs. */
+            {
+                static ULONG midlog = 0;
+                if (midlog < 6)
+                {
+                    midlog++;
+                    bug("[VC4Gallium] wait_idle probe @%dms: want=%d fin=%d "
+                        "CT1CS=0x%08x CT1CA=0x%08x BFC=%d RFC=%d "
+                        "pend=%d kicks=%d\n",
+                        waited / 1000, v3d->seqno, v3d->finished_seqno,
+                        V3D_READ(v3d, V3D_CT1CS), V3D_READ(v3d, V3D_CT1CA),
+                        V3D_READ(v3d, V3D_BFC) & 0xff,
+                        V3D_READ(v3d, V3D_RFC) & 0xff,
+                        (LONG)v3d->pending_render, v3d->kick_count);
+                }
+            }
+        }
+
+        ticks++;
+        /* Block until the next vblank (~20 ms, CPU-free) on the registered
+         * path; spin otherwise (no free signal — rare). */
+        if (wsig >= 0)
+            Wait(1UL << wsig);
+    }
+
+    vc4_wait_leave(sd, wsig);
+
+    /* Timeout recovery: reset the control lists (CTRSTA) and advance
+     * finished_seqno so the next submission isn't perpetually trying to
+     * "catch up" to a render that will never complete. */
+    if (v3d->finished_seqno < v3d->seqno)
+    {
+        ULONG ct0_before = V3D_READ(v3d, V3D_CT0CS);
+        ULONG ct1_before = V3D_READ(v3d, V3D_CT1CS);
+        ULONG ct0_after, ct1_after;
+
+        bug("[VC4Gallium] wait_idle TIMEOUT: want seqno=%d fin=%d "
+            "CT0CS=0x%08x CT1CS=0x%08x — writing CTRSTA\n",
+            v3d->seqno, v3d->finished_seqno, ct0_before, ct1_before);
+        bug("[VC4Gallium]   PCS=0x%08x CT0CA=0x%08x CT0EA=0x%08x "
+            "CT1CA=0x%08x CT1EA=0x%08x pending=%d\n",
+            V3D_READ(v3d, V3D_PCS),
+            V3D_READ(v3d, V3D_CT0CA), V3D_READ(v3d, V3D_CT0EA),
+            V3D_READ(v3d, V3D_CT1CA), V3D_READ(v3d, V3D_CT1EA),
+            (LONG)v3d->pending_render);
+        bug("[VC4Gallium]   BFC=%d RFC=%d INTCTL=0x%08x ERRSTAT=0x%08x "
+            "SRQCS=0x%08x BPCA=0x%08x BPCS=0x%08x BPOA=0x%08x handed=%d\n",
+            V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff,
+            V3D_READ(v3d, V3D_INTCTL), V3D_READ(v3d, V3D_ERRSTAT),
+            V3D_READ(v3d, V3D_SRQCS),
+            V3D_READ(v3d, V3D_BPCA), V3D_READ(v3d, V3D_BPCS),
+            V3D_READ(v3d, V3D_BPOA), v3d->overflow_handed);
+        bug("[VC4Gallium]   kicks=%d fl=%d fr=%d pend_ca=0x%08x "
+            "pend_ea=0x%08x\n",
+            v3d->kick_count, v3d->int_fldone, v3d->int_frdone,
+            v3d->pending_ct1ca, v3d->pending_ct1ea);
+        v3d_dump_last_submit();
+
+        V3D_WRITE(v3d, V3D_CT0CS, V3D_CTCS_CTRSTA);
+        V3D_WRITE(v3d, V3D_CT1CS, V3D_CTCS_CTRSTA);
+
+        ct0_after = V3D_READ(v3d, V3D_CT0CS);
+        ct1_after = V3D_READ(v3d, V3D_CT1CS);
+        bug("[VC4Gallium] wait_idle TIMEOUT: post-CTRSTA CT0CS=0x%08x "
+            "CT1CS=0x%08x — CT1 %s reset\n",
+            ct0_after, ct1_after,
+            (ct1_after & V3D_CTCS_CTRUN) ? "DID NOT" : "appears");
+
+        /* All in-flight jobs died with the reset — drop any pending CT1
+         * handoff so a later poll can't kick a dead job's RCL. */
+        v3d->pending_render = FALSE;
+        v3d->finished_seqno = v3d->seqno;
+        v3d->last_bfc = V3D_READ(v3d, V3D_BFC) & 0xff;
+        v3d->last_rfc = V3D_READ(v3d, V3D_RFC) & 0xff;
+        v3d->bfc_completed = v3d->seqno;
+        v3d->rfc_completed = v3d->seqno;
+    }
+
+    /* Flush V3D L2 cache — ensures GPU writes are in main memory */
+    V3D_WRITE(v3d, V3D_L2CACTL, V3D_L2CACTL_L2CCLR);
+
+    ReleaseSemaphore(&sd->render_lock);
+#if VC4G_PROFILE
+    {
+        static ULONG _w_acc, _w_calls, _w_max;
+        ULONG _w_d = VC4G_NOW_US() - _w_t0;
+        _w_acc += _w_d;
+        _w_calls++;
+        if (_w_d > _w_max)
+            _w_max = _w_d;
+        if (_w_calls >= 120)
+        {
+            VC4G_PROF("[VC4Prof] wait_idle: %lu calls, avg=%lu us, max=%lu us "
+                      "(per ~120 wait_idle calls)\n",
+                _w_calls, _w_acc / _w_calls, _w_max);
+            _w_acc = 0; _w_calls = 0; _w_max = 0;
+        }
+    }
+#endif
+}
+
+/*
+ * Scanout page query for zero-copy fullscreen GL. Resolves the vc4gfx
+ * framebuffer's two flip pages and announces them (via sd->scanout_*)
+ * as acceptable GEM_OPEN names, so the Mesa side can wrap them as BOs
+ * and render straight into the back page. Returns 0 on success, -1
+ * when the bitmap isn't a flippable vc4gfx framebuffer.
+ */
+int vc4_aros_get_scanout(struct vc4galliumstaticdata *sd, OOP_Object *bm_obj,
+                         struct vc4_aros_scanout *out)
+{
+    IPTR front = 0, back = 0, pitch = 0, width = 0, height = 0;
+
+    if (!bm_obj || !sd->hiddVC4GfxBMAB || !sd->hiddBitMapAB)
+        return -1;
+
+    OOP_GetAttr(bm_obj,
+        sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Drawable, &front);
+    OOP_GetAttr(bm_obj,
+        sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_BackDrawable, &back);
+    OOP_GetAttr(bm_obj, sd->hiddBitMapAB + aoHidd_BitMap_BytesPerRow, &pitch);
+    OOP_GetAttr(bm_obj, sd->hiddBitMapAB + aoHidd_BitMap_Width, &width);
+    OOP_GetAttr(bm_obj, sd->hiddBitMapAB + aoHidd_BitMap_Height, &height);
+
+    if (!front || !back || !pitch || !width || !height)
+        return -1;
+
+    /* Stable page identity regardless of which one is currently front. */
+    out->name[0] = (front < back) ? (ULONG)front : (ULONG)back;
+    out->name[1] = (front < back) ? (ULONG)back : (ULONG)front;
+    out->back    = ((ULONG)back == out->name[1]) ? 1 : 0;
+    out->pitch   = (ULONG)pitch;
+    out->width   = (ULONG)width;
+    out->height  = (ULONG)height;
+
+    /* Publish for GEM_OPEN. */
+    ObtainSemaphore(&sd->bo_lock);
+    sd->scanout_phys[0] = out->name[0];
+    sd->scanout_phys[1] = out->name[1];
+    sd->scanout_size = (ULONG)pitch * (ULONG)height;
+    ReleaseSemaphore(&sd->bo_lock);
+
+    return 0;
+}
+
+/*
+ * Flip the vc4gfx framebuffer pages after the GPU has rendered a full
+ * frame into the back page. Waits for the GPU (and any in-flight blit
+ * DMA) before the page becomes visible. Returns 0 on success.
+ */
+int vc4_aros_flip_scanout(struct vc4galliumstaticdata *sd, OOP_Object *bm_obj)
+{
+    struct TagItem fliptags[] =
+    {
+        { 0, TRUE },
+        { TAG_DONE, 0 }
+    };
+    IPTR back_before = 0, back_after = 0;
+
+    if (!bm_obj || !sd->hiddVC4GfxBMAB)
+        return -1;
+
+    OOP_GetAttr(bm_obj,
+        sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_BackDrawable, &back_before);
+    if (!back_before)
+        return -1;
+
+    vc4_aros_wait_idle(sd);
+    vc4_aros_dma_wait_idle(sd);
+
+    /* The entry frame's blit pinned its source BO until "the next blit";
+     * on the flip path there is no next blit, so release it here now
+     * that the DMA engine is idle. */
+    ObtainSemaphore(&sd->bo_lock);
+    if (sd->dma_pinned_handle)
+    {
+        vc4_aros_bo_unref_locked(sd, sd->dma_pinned_handle);
+        sd->dma_pinned_handle = 0;
+    }
+    ReleaseSemaphore(&sd->bo_lock);
+
+    fliptags[0].ti_Tag = sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Flip;
+    OOP_SetAttrs(bm_obj, fliptags);
+
+    OOP_GetAttr(bm_obj,
+        sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_BackDrawable, &back_after);
+
+    /* The flip succeeded iff the back page changed. */
+    return (back_after && back_after != back_before) ? 0 : -1;
+}
+
+/*
+ * Zero-copy windowed present: show a rendered BO as an HVS overlay
+ * plane at (x,y) on the screen's framebuffer bitmap. The BO stays
+ * pinned while on scanout; each call retargets the plane and unpins
+ * the previous buffer (the hidd's overlay path waits for the vblank
+ * latch before returning, so the old buffer is off-screen by then).
+ * Returns 0 on success, -1 when the overlay is unavailable (firmware
+ * owns the display / scaled desktop / bad handle) — caller blits.
+ */
+int vc4_aros_set_overlay(struct vc4galliumstaticdata *sd,
+                         OOP_Object *bm_obj,
+                         ULONG src_bo_handle, ULONG src_stride,
+                         LONG x, LONG y, ULONG w, ULONG h,
+                         ULONG dest_w, ULONG dest_h)
+{
+    struct vc4gfx_overlay desc;
+    struct TagItem ovltags[] =
+    {
+        { 0, (IPTR)&desc },
+        { TAG_DONE, 0 }
+    };
+    IPTR active = 0;
+    ULONG prev;
+
+    if (!bm_obj || !sd->hiddVC4GfxBMAB || !w || !h)
+        return -1;
+
+    ObtainSemaphore(&sd->bo_lock);
+    if (src_bo_handle >= VC4_MAX_BOS || !sd->bo_table[src_bo_handle].vaddr
+        || (ULONG)src_stride * h > sd->bo_table[src_bo_handle].size)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+    desc.ovl_Phys   = sd->bo_table[src_bo_handle].bus_addr & 0x3fffffff;
+    desc.ovl_Pitch  = src_stride;
+    desc.ovl_Width  = w;
+    desc.ovl_Height = h;
+    desc.ovl_X      = x;
+    desc.ovl_Y      = y;
+    desc.ovl_DestW  = dest_w;
+    desc.ovl_DestH  = dest_h;
+
+    /* Pin the new buffer before showing it; the previous pin is
+     * released only after the hidd confirms the switch latched. */
+    sd->bo_table[src_bo_handle].refcount++;
+    prev = sd->overlay_pinned_handle;
+    sd->overlay_pinned_handle = src_bo_handle;
+    sd->overlay_bm = bm_obj;
+    ReleaseSemaphore(&sd->bo_lock);
+
+    /* The frame must be complete before it becomes visible — but that is
+     * the CALLER's contract now (bridge v5): mesa3dgl waits on the seqno
+     * of the frame it displays (normally the previous frame, already
+     * finished) before calling here. Waiting for full GPU idle at this
+     * point serialized CPU and GPU (frame time = CPU + GPU), costing tens
+     * of ms per frame in a GPU-bound scene. */
+
+    ovltags[0].ti_Tag = sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Overlay;
+    OOP_SetAttrs(bm_obj, ovltags);
+    OOP_GetAttr(bm_obj,
+        sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Overlay, &active);
+
+    {
+        static ULONG _ovl_n = 0;
+
+        _ovl_n++;
+        if (_ovl_n <= 4 || (_ovl_n & 255) == 0)
+            bug("[VC4Gallium] set_overlay #%u: bo=%lu %lux%lu at %d,%d "
+                "active=%d\n", _ovl_n, (unsigned long)src_bo_handle,
+                (unsigned long)w, (unsigned long)h, x, y, (LONG)active);
+    }
+
+    ObtainSemaphore(&sd->bo_lock);
+    if (!active)
+    {
+        /* Rejected: nothing is on scanout — drop both pins. */
+        vc4_aros_bo_unref_locked(sd, src_bo_handle);
+        if (prev)
+            vc4_aros_bo_unref_locked(sd, prev);
+        sd->overlay_pinned_handle = 0;
+        sd->overlay_bm = NULL;
+        ReleaseSemaphore(&sd->bo_lock);
+        return -1;
+    }
+    if (prev && prev != src_bo_handle)
+        vc4_aros_bo_unref_locked(sd, prev);
+    ReleaseSemaphore(&sd->bo_lock);
+    return 0;
+}
+
+void vc4_aros_clear_overlay(struct vc4galliumstaticdata *sd,
+                            OOP_Object *bm_obj)
+{
+    struct TagItem ovltags[] =
+    {
+        { 0, 0 },       /* NULL descriptor = remove */
+        { TAG_DONE, 0 }
+    };
+    OOP_Object *target = bm_obj ? bm_obj : sd->overlay_bm;
+
+    if (target && sd->hiddVC4GfxBMAB)
+    {
+        ovltags[0].ti_Tag = sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Overlay;
+        OOP_SetAttrs(target, ovltags);
+    }
+
+    ObtainSemaphore(&sd->bo_lock);
+    if (sd->overlay_pinned_handle)
+    {
+        vc4_aros_bo_unref_locked(sd, sd->overlay_pinned_handle);
+        sd->overlay_pinned_handle = 0;
+    }
+    sd->overlay_bm = NULL;
+    ReleaseSemaphore(&sd->bo_lock);
+}
+
+/*
+ * Blit a rectangle from a BO to an AROS bitmap. Waits for GPU work
+ * to finish first; pins/unpins the BO around the access; tries DMA
+ * to the framebuffer phys address when the dest is a vc4gfx bitmap,
+ * falls back to WritePixelArray otherwise.
+ *
+ * Caller supplies resolved fields — no Mesa types cross the API.
+ */
+void vc4_aros_display_blit(struct vc4galliumstaticdata *sd,
+                           ULONG src_bo_handle,
+                           ULONG src_stride,
+                           ULONG src_offset,
+                           ULONG cpp,
+                           OOP_Object *bm_obj,
+                           LONG dst_x, LONG dst_y,
+                           ULONG width, ULONG height)
+{
+    UBYTE *src_addr;
+    ULONG width_bytes = width * cpp;
+    ULONG bo_size;
+    BOOL _used_dma = FALSE;
+    ULONG _t_entry = VC4G_NOW_US();
+    ULONG _t_after_validate, _t_after_v3d, _t_after_blit;
+
+    /* Validate handle and pin BO under bo_lock so a concurrent gem_close
+     * can't free it out from under us. */
+    ObtainSemaphore(&sd->bo_lock);
+    if (src_bo_handle == 0 || src_bo_handle >= VC4_MAX_BOS ||
+        sd->bo_table[src_bo_handle].refcount == 0)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        bug("[VC4Gallium] display_blit: invalid bo handle %d "
+            "(max=%d, refcount=%d)\n",
+            src_bo_handle, VC4_MAX_BOS,
+            (src_bo_handle < VC4_MAX_BOS)
+                ? sd->bo_table[src_bo_handle].refcount : 0);
+        return;
+    }
+
+    /* Bounds-check the source rectangle against the BO size. Bridge is
+     * an ABI boundary, so don't trust offset/stride/cpp/width/height —
+     * a malformed combination would otherwise DMA past the BO end. */
+    bo_size = sd->bo_table[src_bo_handle].size;
+    if (width == 0 || height == 0 || cpp == 0 ||
+        width_bytes / cpp != width ||
+        width_bytes > src_stride ||
+        src_offset > bo_size ||
+        (ULONG)(height - 1) > (bo_size - src_offset) / src_stride ||
+        (ULONG)(height - 1) * src_stride + width_bytes > bo_size - src_offset)
+    {
+        ReleaseSemaphore(&sd->bo_lock);
+        bug("[VC4Gallium] display_blit: rect out of range bo=%d size=%d "
+            "offset=%d stride=%d cpp=%d %dx%d\n",
+            src_bo_handle, bo_size, src_offset, src_stride, cpp,
+            width, height);
+        return;
+    }
+
+    src_addr = (UBYTE *)sd->bo_table[src_bo_handle].vaddr + src_offset;
+    sd->bo_table[src_bo_handle].refcount++;
+    ReleaseSemaphore(&sd->bo_lock);
+
+    D(bug("[VC4Gallium] display_blit: bo=%d %dx%d cpp=%d stride=%d "
+          "src=0x%08x -> bm=%p at %d,%d\n",
+        src_bo_handle, width, height, cpp, src_stride,
+        (ULONG)(IPTR)src_addr, bm_obj, dst_x, dst_y));
+
+    /* Unconditional, rate-limited: the geometry-gated logs below go
+     * silent when a later app reuses an earlier app's geometry, which
+     * makes "is present happening at all" undiagnosable from serial. */
+    {
+        static ULONG _present_n = 0;
+
+        _present_n++;
+        if (_present_n <= 8 || (_present_n & 255) == 0)
+            bug("[VC4Gallium] present blit #%u: %dx%d at %d,%d bm=%p\n",
+                _present_n, width, height, dst_x, dst_y, bm_obj);
+    }
+
+    _t_after_validate = VC4G_NOW_US();
+
+    /* GPU must be idle before we read the BO. */
+    vc4_aros_wait_idle(sd);
+
+    D({
+        volatile ULONG *p = (volatile ULONG *)src_addr;
+        ULONG row_words = src_stride / 4;
+        CacheClearE(src_addr, src_stride * height, CACRF_ClearD);
+        bug("[VC4Gallium] BO sniff: [0]=0x%08x [middle]=0x%08x [last]=0x%08x\n",
+            p[0],
+            p[(height / 2) * row_words + (width / 2)],
+            p[(height - 1) * row_words + (width - 1)]);
+    });
+
+    _t_after_v3d = VC4G_NOW_US();
+
+    /* Fast path: DMA into a vc4gfx framebuffer phys address. */
+    {
+        IPTR fb_addr = 0;
+        IPTR fb_bpr = 0;
+
+        if (bm_obj && sd->hiddVC4GfxBMAB)
+        {
+            OOP_GetAttr(bm_obj,
+                sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Drawable,
+                &fb_addr);
+            OOP_GetAttr(bm_obj,
+                sd->hiddBitMapAB + aoHidd_BitMap_BytesPerRow,
+                &fb_bpr);
+        }
+
+        if (fb_addr && fb_bpr)
+        {
+            BOOL flip = FALSE;
+
+            /* Full-frame blit with a flippable framebuffer: blit into
+             * the back page and flip — tear-free, and the DMA never
+             * writes to live scanout. */
+            if (dst_x == 0 && dst_y == 0)
+            {
+                IPTR back = 0, bm_w = 0, bm_h = 0;
+
+                OOP_GetAttr(bm_obj,
+                    sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_BackDrawable,
+                    &back);
+                if (back)
+                {
+                    OOP_GetAttr(bm_obj,
+                        sd->hiddBitMapAB + aoHidd_BitMap_Width, &bm_w);
+                    OOP_GetAttr(bm_obj,
+                        sd->hiddBitMapAB + aoHidd_BitMap_Height, &bm_h);
+                    if (width == (ULONG)bm_w && height == (ULONG)bm_h)
+                    {
+                        fb_addr = back;
+                        flip = TRUE;
+                    }
+                }
+            }
+
+            {
+                /* Log on geometry change; ignore fb_addr (it alternates
+                 * between the two flip pages every frame). */
+                static struct {
+                    ULONG w, h, bpr;
+                    LONG x, y, flip;
+                    ULONG count;
+                } dlast = { 0, 0, 0, -1, -1, -1, 0 };
+
+                if (dlast.count < 100 &&
+                    (width != dlast.w || height != dlast.h ||
+                     (ULONG)fb_bpr != dlast.bpr || dst_x != dlast.x ||
+                     dst_y != dlast.y || (LONG)flip != dlast.flip))
+                {
+                    dlast.count++;
+                    dlast.w = width; dlast.h = height;
+                    dlast.bpr = (ULONG)fb_bpr;
+                    dlast.x = dst_x; dlast.y = dst_y;
+                    dlast.flip = flip;
+                    bug("[VC4Gallium] display_blit: DMA %dx%d cpp=%d to "
+                        "fb=0x%08x bpr=%d at %d,%d flip=%d\n",
+                        width, height, cpp, (ULONG)fb_addr, (ULONG)fb_bpr,
+                        dst_x, dst_y, (LONG)flip);
+                }
+            }
+
+            _used_dma = gallium_dma_blit_direct(sd,
+                (ULONG)(IPTR)src_addr, src_stride,
+                (ULONG)fb_addr + dst_y * (ULONG)fb_bpr + dst_x * cpp,
+                (ULONG)fb_bpr,
+                width_bytes, height);
+
+            /* On DMA failure (no TDMODE channel, CB alloc failure) fall
+             * through to the CPU path below, and skip the flip — the back
+             * page never received the frame. */
+            if (_used_dma && flip)
+            {
+                /* The blit runs asynchronously — the page must be
+                 * complete before it becomes visible. */
+                struct TagItem fliptags[] =
+                {
+                    { sd->hiddVC4GfxBMAB + aoHidd_VideoCoreGfxBitMap_Flip, TRUE },
+                    { TAG_DONE, 0 }
+                };
+
+                vc4_aros_dma_wait_idle(sd);
+                OOP_SetAttrs(bm_obj, fliptags);
+            }
+        }
+
+        if (!_used_dma)
+        {
+            static struct {
+                ULONG w, h;
+                LONG x, y;
+                APTR bm;
+                ULONG count;
+            } clast = { 0, 0, -1, -1, NULL, 0 };
+
+            if (clast.count < 100 &&
+                (width != clast.w || height != clast.h ||
+                 dst_x != clast.x || dst_y != clast.y || (APTR)bm_obj != clast.bm))
+            {
+                clast.count++;
+                clast.w = width; clast.h = height;
+                clast.x = dst_x; clast.y = dst_y;
+                clast.bm = (APTR)bm_obj;
+                bug("[VC4Gallium] display_blit: CPU path (no fb addr / DMA failed) "
+                    "%dx%d at %d,%d bm=%p\n",
+                    width, height, dst_x, dst_y, bm_obj);
+            }
+
+            /* Fallback for non-vc4gfx bitmaps — CPU reads BO data,
+             * so we must flush ARM D-cache to see fresh GPU output. */
+            CacheClearE(src_addr, src_stride * height, CACRF_ClearD);
+
+            struct RastPort *rp = CreateRastPort();
+            if (rp)
+            {
+                /* WritePixelArray needs a struct BitMap *, not the OOP
+                 * object. Resolve via aHidd_BitMap_BMStruct. */
+                IPTR struct_bm = 0;
+                OOP_GetAttr(bm_obj,
+                    sd->hiddBitMapAB + aoHidd_BitMap_BMStruct,
+                    &struct_bm);
+                if (struct_bm)
+                {
+                    rp->BitMap = (struct BitMap *)struct_bm;
+                    WritePixelArray(src_addr, 0, 0, src_stride,
+                                    rp, dst_x, dst_y,
+                                    width, height, AROS_PIXFMT);
+                }
+                FreeRastPort(rp);
+            }
+        }
+    }
+
+    _t_after_blit = VC4G_NOW_US();
+
+    /* Drop the pin. DMA path: the previous frame's DMA already finished
+     * inside gallium_dma_blit_direct, so release its pin and hand our own to
+     * the new DMA — keeps the BO alive even if Mesa runs GEM_CLOSE before the
+     * next swap. CPU path: BO consumed synchronously, release immediately. */
+    ObtainSemaphore(&sd->bo_lock);
+    if (_used_dma)
+    {
+        ULONG prev = sd->dma_pinned_handle;
+        sd->dma_pinned_handle = src_bo_handle;
+        if (prev)
+            vc4_aros_bo_unref_locked(sd, prev);
+    }
+    else
+    {
+        vc4_aros_bo_unref_locked(sd, src_bo_handle);
+    }
+    ReleaseSemaphore(&sd->bo_lock);
+
+    VC4G_PROFF("[VC4Prof] display_blit: validate=%ld v3d_wait=%ld blit=%ld total=%ld path=%s %ldx%ld\n",
+        _t_after_validate - _t_entry,
+        _t_after_v3d - _t_after_validate,
+        _t_after_blit - _t_after_v3d,
+        _t_after_blit - _t_entry,
+        _used_dma ? "DMA" : "CPU",
+        width, height);
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_init.c
@@ -1,0 +1,417 @@
+/*
+    Copyright 2025, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D HIDD - Module initialization
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <aros/symbolsets.h>
+#include <hidd/gallium.h>
+#include <hidd/gfx.h>
+#include <proto/oop.h>
+#include <proto/exec.h>
+#include <proto/mbox.h>
+#include <proto/dma.h>
+#include <proto/kernel.h>
+
+#include <hardware/videocore.h>
+
+#include <aros/asmcall.h>
+#include <exec/interrupts.h>
+#include <hardware/intbits.h>
+
+/* Peripheral base address — initialized at module load */
+IPTR __arm_periiobase __attribute__((used)) = 0;
+
+/* Module-global kernel.resource base — referenced implicitly by the
+ * Krn* macros from <proto/kernel.h>. */
+APTR KernelBase __attribute__((used)) = NULL;
+
+/* dma.resource base for channel allocation. */
+APTR DMABase = NULL;
+
+#include "vc4gallium_intern.h"
+#include "vc4_drm_aros.h"
+#include "vc4_v3d.h"
+
+/* IID for vc4gfx bitmap — matches vc4gfx_bitmap.h */
+#define IID_Hidd_BitMap_VideoCore4  "hidd.bitmap.bcmvc4"
+
+/*
+ * INTB_VERTB server: runs each vblank (~50 Hz, the BCM2708 scheduling
+ * heartbeat). It only signals the one registered GPU waiter — a lockless read
+ * plus Signal(), nothing that can block or deadlock against the heartbeat IRQ.
+ */
+AROS_INTH1(vc4_vblank_server, struct vc4galliumstaticdata *, sd)
+{
+    AROS_INTFUNC_INIT
+
+    struct Task *t = sd->vblank_waiter;
+    if (t)
+        Signal(t, 1UL << sd->vblank_waiter_sig);
+
+    return 0;   /* let other VBlank servers run */
+
+    AROS_INTFUNC_EXIT
+}
+
+/*
+ * Claim the single vblank-waiter slot for the calling task. Serialized by
+ * wait_gate (a second waiter blocks here, CPU-free, until the first leaves).
+ * Returns the allocated signal bit, or -1 if none free (caller then falls
+ * back to a bounded busy-poll). The gate is held until vc4_wait_leave().
+ */
+BYTE vc4_wait_enter(struct vc4galliumstaticdata *sd)
+{
+    BYTE sig;
+
+    ObtainSemaphore(&sd->wait_gate);
+
+    sig = AllocSignal(-1);
+    if (sig >= 0)
+    {
+        sd->vblank_waiter_sig = sig;
+        /* Publish the sig before the task pointer the IRQ server tests. */
+        __asm__ __volatile__("dmb sy" ::: "memory");
+        sd->vblank_waiter = FindTask(NULL);
+    }
+
+    return sig;
+}
+
+void vc4_wait_leave(struct vc4galliumstaticdata *sd, BYTE sig)
+{
+    if (sig >= 0)
+    {
+        sd->vblank_waiter = NULL;
+        __asm__ __volatile__("dmb sy" ::: "memory");
+        FreeSignal(sig);
+    }
+    ReleaseSemaphore(&sd->wait_gate);
+}
+
+/*
+ * Diagnostic: log the current ARM/core/V3D firmware clocks. InitLib forces
+ * V3D to max only once at boot; if the firmware governor later re-idle-clocks
+ * it behind our back, this (called from CreatePipeScreen, i.e. every GL
+ * context start) makes that visible in the serial log.
+ */
+void vc4_log_clocks(struct vc4galliumstaticdata *sd, const char *when)
+{
+#define MBoxBase sd->MBoxBase
+#define VCMB_PROPCHAN 8
+    D({
+    static const ULONG clkid[3] = { 3 /* arm */, 4 /* core */, 5 /* v3d */ };
+    volatile ULONG *msg = sd->mbox_msg;
+    ULONG rate[3];
+    int i;
+
+    ObtainSemaphore(&sd->mbox_lock);
+    for (i = 0; i < 3; i++)
+    {
+        msg[0] = AROS_LE2LONG(8 * 4);
+        msg[1] = AROS_LE2LONG(VCTAG_REQ);
+        msg[2] = AROS_LE2LONG(VCTAG_GETCLKRATE);
+        msg[3] = AROS_LE2LONG(8);
+        msg[4] = AROS_LE2LONG(4);
+        msg[5] = AROS_LE2LONG(clkid[i]);
+        msg[6] = 0;
+        msg[7] = 0;
+        MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)msg);
+        rate[i] = AROS_LE2LONG(msg[6]);
+    }
+    ReleaseSemaphore(&sd->mbox_lock);
+
+    bug("[VC4Gallium] clocks (%s): arm=%u core=%u v3d=%u Hz\n",
+        when, rate[0], rate[1], rate[2]);
+    });
+#undef VCMB_PROPCHAN
+#undef MBoxBase
+}
+
+static int HiddVC4Gallium_ExpungeLib(LIBBASETYPEPTR LIBBASE)
+{
+    D(bug("[VC4Gallium] ExpungeLib\n"));
+
+    /* Stop the vblank server before tearing anything down, so it can't fire
+     * into freed state. */
+    if (LIBBASE->sd.vblank_added)
+    {
+        RemIntServer(INTB_VERTB, &LIBBASE->sd.vblank_server);
+        LIBBASE->sd.vblank_added = FALSE;
+    }
+
+    /* Quiesce V3D interrupts and unhook our handler before tearing down
+     * the rest of the module, otherwise a late OUTOMEM IRQ would call into
+     * freed memory. */
+    if (LIBBASE->sd.v3d.v3d_available)
+    {
+        V3D_WRITE(&LIBBASE->sd.v3d, V3D_INTDIS,
+                  V3D_INT_FLDONE | V3D_INT_FRDONE | V3D_INT_OUTOMEM);
+        V3D_WRITE(&LIBBASE->sd.v3d, V3D_INTCTL,
+                  V3D_INT_FLDONE | V3D_INT_FRDONE | V3D_INT_OUTOMEM);
+    }
+    if (LIBBASE->sd.v3d.irq_handle)
+    {
+        KrnRemIRQHandler(LIBBASE->sd.v3d.irq_handle);
+        LIBBASE->sd.v3d.irq_handle = NULL;
+    }
+
+    /* Release any GPU memory still locked by Mesa or our pools, so the
+     * firmware can reclaim it instead of holding it until reboot. */
+    vc4_aros_release_all_bos(&LIBBASE->sd);
+
+    if (LIBBASE->sd.gpu_timer_ok)
+    {
+        CloseDevice((struct IORequest *)&LIBBASE->sd.gpu_timer_template);
+        LIBBASE->sd.gpu_timer_ok = FALSE;
+    }
+
+    if (LIBBASE->sd.dmaStaging)
+        FreeMem(LIBBASE->sd.dmaStaging, LIBBASE->sd.dmaStagingSize);
+    if (LIBBASE->sd.dmaCBRaw)
+        FreeMem(LIBBASE->sd.dmaCBRaw, LIBBASE->sd.dmaCBRawSize);
+    if ((DMABase) && (LIBBASE->sd.dmaChannel >= 0))
+    {
+        DMAFreeChannel(LIBBASE->sd.dmaChannel);
+        LIBBASE->sd.dmaChannel = -1;
+    }
+
+    if (LIBBASE->sd.mbox_msg_raw)
+    {
+        FreeMem(LIBBASE->sd.mbox_msg_raw, 256 + 16);
+        LIBBASE->sd.mbox_msg_raw = NULL;
+        LIBBASE->sd.mbox_msg = NULL;
+    }
+
+    if (LIBBASE->sd.UtilityBase)
+        CloseLibrary(LIBBASE->sd.UtilityBase);
+
+    if (LIBBASE->sd.hiddBitMapAB)
+        OOP_ReleaseAttrBase((STRPTR)IID_Hidd_BitMap);
+
+    if (LIBBASE->sd.hiddVC4GfxBMAB)
+        OOP_ReleaseAttrBase((STRPTR)IID_Hidd_BitMap_VideoCore4);
+
+    if (LIBBASE->sd.hiddGalliumAB)
+        OOP_ReleaseAttrBase((STRPTR)IID_Hidd_Gallium);
+
+    return TRUE;
+}
+
+static int HiddVC4Gallium_InitLib(LIBBASETYPEPTR LIBBASE)
+{
+    D(bug("[VC4Gallium] InitLib\n"));
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
+    D(bug("[VC4Gallium] Peripheral base: 0x%08lx\n", __arm_periiobase));
+
+    LIBBASE->sd.MBoxBase = OpenResource("mbox.resource");
+    if (!LIBBASE->sd.MBoxBase)
+    {
+        bug("[VC4Gallium] Failed to open mbox.resource\n");
+        return FALSE;
+    }
+
+    if (!(LIBBASE->sd.UtilityBase = OpenLibrary((STRPTR)"utility.library", 0)))
+    {
+        bug("[VC4Gallium] Failed to open utility.library\n");
+        return FALSE;
+    }
+
+    if (!(LIBBASE->sd.hiddGalliumAB = OOP_ObtainAttrBase((STRPTR)IID_Hidd_Gallium)))
+    {
+        bug("[VC4Gallium] Failed to obtain Gallium attr base\n");
+        CloseLibrary(LIBBASE->sd.UtilityBase);
+        return FALSE;
+    }
+
+    /* Allocate 16-byte aligned mailbox message buffer.
+     * MBoxWrite silently fails if the address isn't 16-byte aligned
+     * (lower 4 bits encode channel number). */
+    LIBBASE->sd.mbox_msg_raw = AllocMem(256 + 16, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!LIBBASE->sd.mbox_msg_raw)
+    {
+        bug("[VC4Gallium] Failed to alloc mailbox buffer\n");
+        OOP_ReleaseAttrBase((STRPTR)IID_Hidd_Gallium);
+        CloseLibrary(LIBBASE->sd.UtilityBase);
+        return FALSE;
+    }
+    LIBBASE->sd.mbox_msg = (volatile ULONG *)(((IPTR)LIBBASE->sd.mbox_msg_raw + 0xF) & ~0xF);
+
+    InitSemaphore(&LIBBASE->sd.bo_lock);
+    InitSemaphore(&LIBBASE->sd.mbox_lock);
+    InitSemaphore(&LIBBASE->sd.wait_gate);
+    InitSemaphore(&LIBBASE->sd.render_lock);
+
+    /* Install the vblank int server that wakes GPU waiters (~50 Hz). */
+    LIBBASE->sd.vblank_waiter = NULL;
+    LIBBASE->sd.vblank_added = FALSE;
+    LIBBASE->sd.vblank_server.is_Node.ln_Type = NT_INTERRUPT;
+    LIBBASE->sd.vblank_server.is_Node.ln_Pri  = 0;
+    LIBBASE->sd.vblank_server.is_Node.ln_Name = (STRPTR)"vc4gallium vblank";
+    LIBBASE->sd.vblank_server.is_Code = (APTR)vc4_vblank_server;
+    LIBBASE->sd.vblank_server.is_Data = &LIBBASE->sd;
+    AddIntServer(INTB_VERTB, &LIBBASE->sd.vblank_server);
+    LIBBASE->sd.vblank_added = TRUE;
+
+    /* timer.device (UNIT_MICROHZ) for the GPU wait loops' microsleeps.
+     * Only io_Device/io_Unit are kept — vc4_gpu_nap clones them into a
+     * stack request per use. Non-fatal: without it the waits degrade to
+     * busy-spinning inside the nap window. */
+    LIBBASE->sd.gpu_timer_ok = FALSE;
+    {
+        struct timerequest *tt = &LIBBASE->sd.gpu_timer_template;
+
+        tt->tr_node.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+        tt->tr_node.io_Message.mn_ReplyPort = NULL;
+        tt->tr_node.io_Message.mn_Length = sizeof(*tt);
+        if (OpenDevice("timer.device", UNIT_MICROHZ,
+                       (struct IORequest *)tt, 0) == 0)
+            LIBBASE->sd.gpu_timer_ok = TRUE;
+        else
+            bug("[VC4Gallium] timer.device unavailable — GPU waits will spin\n");
+    }
+
+    /* Initialize DMA state. The display blit needs a full DMA engine for
+     * 2D stride mode; without one we fall back to the CPU blit path. */
+    LIBBASE->sd.dmaChannel = -1;
+    if ((DMABase = OpenResource("dma.resource")) != NULL)
+        LIBBASE->sd.dmaChannel = DMAAllocChannel(DMACHF_TDMODE | DMACHF_IRQ);
+    if (LIBBASE->sd.dmaChannel < 0)
+        bug("[VC4Gallium] No 2D-capable DMA channel — using CPU display blit\n");
+    LIBBASE->sd.dmaBusy = FALSE;
+    LIBBASE->sd.dmaStaging = NULL;
+    LIBBASE->sd.dmaStagingSize = 0;
+    LIBBASE->sd.dmaCBRaw = NULL;
+    LIBBASE->sd.dmaCBRawSize = 0;
+
+    /* vc4gfx bitmap attr base is optional — without it we fall back to
+     * WritePixelArray for display. Not fatal. */
+    LIBBASE->sd.hiddVC4GfxBMAB = OOP_ObtainAttrBase((STRPTR)IID_Hidd_BitMap_VideoCore4);
+    if (!LIBBASE->sd.hiddVC4GfxBMAB)
+        D(bug("[VC4Gallium] vc4gfx bitmap attr base not available — will use CPU blit\n"));
+
+    /* Standard BitMap attribute base for BytesPerRow etc. */
+    LIBBASE->sd.hiddBitMapAB = OOP_ObtainAttrBase((STRPTR)IID_Hidd_BitMap);
+
+    /* Power on V3D domain via mailbox.
+     * BCM2835/2836 power domain ID 10 = V3D.
+     * Without this, V3D registers read as zero. */
+    {
+#define VCPOWER_V3D         10
+#define VCPOWER_STATE_ON    (1 << 0)
+#define VCPOWER_STATE_WAIT  (1 << 1)
+#define VCCLOCK_V3D         5       /* VideoCore clock id 5 = V3D */
+#define VCMB_PROPCHAN       8
+#ifdef MBoxBase
+#undef MBoxBase
+#endif
+#define MBoxBase LIBBASE->sd.MBoxBase
+
+        volatile ULONG *msg = LIBBASE->sd.mbox_msg;
+
+        ObtainSemaphore(&LIBBASE->sd.mbox_lock);
+
+        msg[0] = AROS_LE2LONG(8 * 4);
+        msg[1] = AROS_LE2LONG(VCTAG_REQ);
+        msg[2] = AROS_LE2LONG(VCTAG_SETPOWER);
+        msg[3] = AROS_LE2LONG(8);              /* value buffer size */
+        msg[4] = AROS_LE2LONG(8);              /* request size */
+        msg[5] = AROS_LE2LONG(VCPOWER_V3D);
+        msg[6] = AROS_LE2LONG(VCPOWER_STATE_ON | VCPOWER_STATE_WAIT);
+        msg[7] = 0;
+
+        MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)msg);
+
+        if (AROS_LE2LONG(msg[6]) & VCPOWER_STATE_ON)
+            D(bug("[VC4Gallium] V3D power domain enabled\n"));
+        else
+            bug("[VC4Gallium] V3D power-on failed (response: 0x%08x)\n",
+                AROS_LE2LONG(msg[6]));
+
+        /* Query and force the V3D core clock. We drive V3D bare-metal, so the
+         * firmware's on-demand governor never sees GPU load and idle-clocks
+         * V3D low — throttling GPU-bound frames. Log current/max, then lock to
+         * max. Logged unconditionally (once at init). */
+        {
+            ULONG v3d_cur, v3d_max;
+
+            msg[0] = AROS_LE2LONG(8 * 4);
+            msg[1] = AROS_LE2LONG(VCTAG_REQ);
+            msg[2] = AROS_LE2LONG(VCTAG_GETCLKRATE);
+            msg[3] = AROS_LE2LONG(8);
+            msg[4] = AROS_LE2LONG(4);
+            msg[5] = AROS_LE2LONG(VCCLOCK_V3D);
+            msg[6] = 0;
+            msg[7] = 0;
+            MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)msg);
+            v3d_cur = AROS_LE2LONG(msg[6]);
+
+            msg[0] = AROS_LE2LONG(8 * 4);
+            msg[1] = AROS_LE2LONG(VCTAG_REQ);
+            msg[2] = AROS_LE2LONG(VCTAG_GETCLKMAX);
+            msg[3] = AROS_LE2LONG(8);
+            msg[4] = AROS_LE2LONG(4);
+            msg[5] = AROS_LE2LONG(VCCLOCK_V3D);
+            msg[6] = 0;
+            msg[7] = 0;
+            MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)msg);
+            v3d_max = AROS_LE2LONG(msg[6]);
+
+            bug("[VC4Gallium] V3D clock: current=%u Hz max=%u Hz\n",
+                v3d_cur, v3d_max);
+
+            if (v3d_max && v3d_cur < v3d_max)
+            {
+                msg[0] = AROS_LE2LONG(9 * 4);
+                msg[1] = AROS_LE2LONG(VCTAG_REQ);
+                msg[2] = AROS_LE2LONG(VCTAG_SETCLKRATE);
+                msg[3] = AROS_LE2LONG(12);
+                msg[4] = AROS_LE2LONG(12);
+                msg[5] = AROS_LE2LONG(VCCLOCK_V3D);
+                msg[6] = AROS_LE2LONG(v3d_max);
+                msg[7] = 0;      /* skip_setting_turbo = 0 */
+                msg[8] = 0;
+                MBoxCall((void *)VCMB_BASE, VCMB_PROPCHAN, (APTR)msg);
+                bug("[VC4Gallium] V3D clock forced to %u Hz\n",
+                    AROS_LE2LONG(msg[6]));
+            }
+        }
+
+        /* The ARM core clock is raised to max in the bootstrap
+         * (arch/arm-raspi/boot/boot.c:setup_arm_clock) — system-wide
+         * concern, not the GPU driver's. */
+
+        /* NOTE: do NOT arm V3D interrupts (see VC4_V3D_IRQ_ENA in
+         * vc4_v3d.c) — and the ENABLE_QPU (0x00030012) handshake was
+         * tried and does not stop the firmware from wedging its
+         * mailbox task when the V3D line asserts. */
+
+        ReleaseSemaphore(&LIBBASE->sd.mbox_lock);
+
+#undef MBoxBase
+#undef VCMB_PROPCHAN
+    }
+
+    if (!vc4_v3d_init(&LIBBASE->sd.v3d))
+    {
+        bug("[VC4Gallium] V3D initialization failed — "
+            "GPU may be in use by firmware. Continuing without 3D.\n");
+        /* Don't fail init — the module loads, but CreatePipeScreen
+         * will return NULL if V3D isn't available. */
+    }
+
+    D(bug("[VC4Gallium] Module initialized successfully\n"));
+
+    return TRUE;
+}
+
+ADD2INITLIB(HiddVC4Gallium_InitLib, 0)
+ADD2EXPUNGELIB(HiddVC4Gallium_ExpungeLib, 0)
+
+ADD2LIBS((STRPTR)"gallium.hidd", 7, static struct Library *, GalliumHiddBase);

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_v3d.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_v3d.c
@@ -1,0 +1,300 @@
+/*
+    Copyright 2025, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D HIDD - V3D hardware initialization and control
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/kernel.h>
+
+#include <hardware/bcm2708.h>
+
+#include "vc4gallium_intern.h"
+#include "vc4_v3d.h"
+
+/* V3D interrupt sources delivered as real IRQs. Determined on
+ * hardware: arming ANY V3D interrupt kills the firmware property
+ * mailbox after the first frame's burst (ALLOCMEM MBoxCall timeouts
+ * from the second submit on), even though the ARM side services
+ * perfectly, and the ENABLE_QPU (0x00030012) "ARM owns V3D" handshake
+ * does NOT help. The firmware co-listens on the V3D interrupt line (it
+ * has its own V3D driver); the assertion or our INTCTL W1C wedges its
+ * mailbox task. Unlike the PV2 vsync line, which the firmware ignores.
+ * So: keep 0 — poll servicing in the wait paths (INTCTL latches status
+ * even while masked) is the permanent design as long as the firmware
+ * owns the mailbox/property services. */
+#define VC4_V3D_IRQ_ENA 0
+
+/* The interrupt handler and the (render_lock-serialized) task-side
+ * poll paths share the service state machine (pending_render,
+ * overflow_handed, CT1 kicks, W1C of INTCTL). This is a UP-exec build
+ * (__AROSEXEC_SMP__ unset), so Disable()/Enable() around the shared
+ * sections is complete protection. */
+
+void vc4_v3d_kick_pending_render(struct vc4_v3d_state *v3d, const char *reason)
+{
+    static ULONG kicklog = 0;
+
+    Disable();
+
+    if (!v3d->pending_render)
+    {
+        Enable();
+        return;
+    }
+
+    /* NEVER write CT1CA while the previous render is still running: the
+     * executor ignores CA writes while CTRUN is set, and since pool slots
+     * alternate, the new EA can equal the running job's EA — the frame is
+     * then silently dropped (renderer stops at CA==EA, the bin semaphore
+     * stays pending, RFC never advances). Defer: the poll paths call this
+     * again, and once the previous frame's FRDONE lands the kick goes
+     * through: the next render job is only ever submitted from the
+     * render-done path. */
+    if (V3D_READ(v3d, V3D_CT1CS) & V3D_CTCS_CTRUN)
+    {
+        static ULONG deferlog = 0;
+        if (deferlog < 8)
+        {
+            deferlog++;
+            bug("[VC4Gallium] kick deferred (%s): CT1 busy, CT1CA=0x%08x\n",
+                reason, V3D_READ(v3d, V3D_CT1CA));
+        }
+        Enable();
+        return;
+    }
+
+    /* Hang forensics: log the first kicks with full pre-kick state so the
+     * FLDONE-vs-BFC handoff timeline can be reconstructed from serial. */
+    if (kicklog < 16)
+    {
+        kicklog++;
+        bug("[VC4Gallium] kick CT1 (%s): CT1CS=0x%08x CA=0x%08x -> 0x%08x "
+            "EA -> 0x%08x BFC=%d RFC=%d INTCTL=0x%08x PCS=0x%08x\n",
+            reason, V3D_READ(v3d, V3D_CT1CS), V3D_READ(v3d, V3D_CT1CA),
+            v3d->pending_ct1ca, v3d->pending_ct1ea,
+            V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff,
+            V3D_READ(v3d, V3D_INTCTL), V3D_READ(v3d, V3D_PCS));
+    }
+
+    v3d->pending_render = FALSE;
+    v3d->kick_count++;
+    V3D_WRITE(v3d, V3D_CT1CA, v3d->pending_ct1ca);
+    V3D_WRITE(v3d, V3D_CT1EA, v3d->pending_ct1ea);
+
+    Enable();
+}
+
+/* Interrupt service helper. Three jobs:
+ *  - OUTOMEM: binner ran out of pool memory; we count + log and feed
+ *    the per-frame overspill BO.
+ *  - FLDONE: binner finished its FLUSH — trigger for kicking CT1 (the
+ *    renderer) with the RCL addresses submit_cl stashed in
+ *    pending_ct1{ca,ea}.
+ *  - FRDONE: renderer finished; we count, the wait loop picks up the RFC.
+ * Called from both the IRQ handler and the polling wait paths (IRQ_VC_3D
+ * isn't delivered reliably on all RPi setups yet). Must stay IRQ-safe: no
+ * allocations, no signals. */
+void vc4_v3d_service_interrupts(struct vc4_v3d_state *v3d)
+{
+    ULONG ints;
+
+    Disable();
+    ints = V3D_READ(v3d, V3D_INTCTL);
+
+    /* Check the level condition (PCS.BMOOM) as well as the INTCTL latch:
+     * the latch is edge-triggered and may already have been W1C-cleared
+     * while the binner is still stalled waiting for memory. */
+    if ((ints & V3D_INT_OUTOMEM) || (V3D_READ(v3d, V3D_PCS) & V3D_PCS_BMOOM))
+    {
+        v3d->int_outomem++;
+        /* Feed the binner the per-frame overspill BO (BPOA/BPOS).
+         * Once per submission: if the binner
+         * exhausts the overspill too, let it stall — v3d_wait_seqno times
+         * out, dumps the hang state and recovers. */
+        if (v3d->overflow_handed == 0 && v3d->overflow_bus != 0)
+        {
+            v3d->overflow_handed = 1;
+            V3D_WRITE(v3d, V3D_BPOA, v3d->overflow_bus);
+            V3D_WRITE(v3d, V3D_BPOS, v3d->overflow_size);
+            if (v3d->int_outomem <= 8)
+                bug("[VC4Gallium] OUTOMEM: fed overspill BO (0x%08x, %dKB) PCS=0x%08x "
+                    "INTCTL=0x%08x CT0CA=0x%08x BFC=%d RFC=%d\n",
+                    v3d->overflow_bus, v3d->overflow_size >> 10,
+                    V3D_READ(v3d, V3D_PCS), ints, V3D_READ(v3d, V3D_CT0CA),
+                    V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff);
+        }
+        else if (v3d->overflow_handed == 1)
+        {
+            v3d->overflow_handed = 2;
+            bug("[VC4Gallium] OUTOMEM: overspill exhausted (PCS=0x%08x) — binner stalls\n",
+                V3D_READ(v3d, V3D_PCS));
+        }
+    }
+    if (ints & V3D_INT_FLDONE)
+    {
+        v3d->int_fldone++;
+        if (v3d->int_fldone <= 8)
+            bug("[VC4Gallium] FLDONE seen: BFC=%d RFC=%d PCS=0x%08x\n",
+                V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff,
+                V3D_READ(v3d, V3D_PCS));
+        vc4_v3d_kick_pending_render(v3d, "FLDONE");
+    }
+    if (ints & V3D_INT_FRDONE)
+    {
+        v3d->int_frdone++;
+        if (v3d->int_frdone <= 8)
+            bug("[VC4Gallium] FRDONE seen: BFC=%d RFC=%d\n",
+                V3D_READ(v3d, V3D_BFC) & 0xff, V3D_READ(v3d, V3D_RFC) & 0xff);
+    }
+
+    /* W1C: writing 1 to a bit in INTCTL clears that pending interrupt. */
+    if (ints)
+        V3D_WRITE(v3d, V3D_INTCTL, ints);
+
+    Enable();
+}
+
+static void v3d_irq_handler(struct vc4_v3d_state *v3d, struct ExecBase *sysBase)
+{
+    /* Record what reached the ARM via a real interrupt BEFORE
+     * service_interrupts() W1C-clears INTCTL. Bumped only here (never the
+     * poll path), so if they climb the IRQ genuinely fires. No printing —
+     * IRQ context. */
+    ULONG ints = V3D_READ(v3d, V3D_INTCTL);
+    v3d->irq_calls++;
+    if (ints & V3D_INT_FLDONE)  v3d->irq_fldone++;
+    if (ints & V3D_INT_FRDONE)  v3d->irq_frdone++;
+    if (ints & V3D_INT_OUTOMEM) v3d->irq_outomem++;
+
+    vc4_v3d_service_interrupts(v3d);
+}
+
+BOOL vc4_v3d_init(struct vc4_v3d_state *v3d)
+{
+    /* Peripheral regs are identity-mapped at ARM_PERIIOBASE on RPi, so
+     * V3D_BASE is directly accessible. */
+    v3d->v3d_regs = (volatile ULONG *)V3D_BASE;
+
+    v3d->ident0 = V3D_READ(v3d, V3D_IDENT0);
+    v3d->ident1 = V3D_READ(v3d, V3D_IDENT1);
+    v3d->ident2 = V3D_READ(v3d, V3D_IDENT2);
+
+    /* IDENT0 magic: a valid V3D block returns 0x02443356 ("V3D" + version 2),
+     * top byte is the version. */
+    v3d->v3d_ver = (v3d->ident0 >> V3D_IDENT0_VER_SHIFT) & 0xFF;
+
+    if (v3d->ident0 == 0 || v3d->ident0 == 0xFFFFFFFF)
+    {
+        bug("[VC4Gallium] V3D not found (IDENT0=0x%08x)\n", v3d->ident0);
+        v3d->v3d_available = FALSE;
+        return FALSE;
+    }
+
+    /* Check that this is V3D version 2.x (VideoCore IV) */
+    if (v3d->v3d_ver < 1 || v3d->v3d_ver > 3)
+    {
+        bug("[VC4Gallium] Unexpected V3D version %d (IDENT0=0x%08x)\n",
+            v3d->v3d_ver, v3d->ident0);
+        v3d->v3d_available = FALSE;
+        return FALSE;
+    }
+
+    v3d->seqno = 0;
+    v3d->finished_seqno = 0;
+    v3d->v3d_available = TRUE;
+
+    D(bug("[VC4Gallium] driver build " __DATE__ " " __TIME__ "\n"));
+
+    D(bug("[VC4Gallium] V3D version %d detected\n", v3d->v3d_ver));
+    D(bug("[VC4Gallium]   IDENT0=0x%08x IDENT1=0x%08x IDENT2=0x%08x\n",
+        v3d->ident0, v3d->ident1, v3d->ident2));
+
+    V3D_WRITE(v3d, V3D_L2CACTL, V3D_L2CACTL_L2CENA);
+
+    /* Reset both control list executors FIRST, to clear any stale binner state
+     * (notably a BMOOM left in PCS by the firmware/boot) before we enable any
+     * interrupt. Without this, enabling OUTOMEM fires instantly on the stale
+     * condition, and the firmware — which co-owns the V3D IRQ in this
+     * firmware-framebuffer setup — chokes on the shared, never-cleared
+     * condition and stops servicing the property mailbox. */
+    V3D_WRITE(v3d, V3D_CT0CS, V3D_CTCS_CTRSTA);
+    V3D_WRITE(v3d, V3D_CT1CS, V3D_CTCS_CTRSTA);
+
+    /* Clear any pending interrupts */
+    V3D_WRITE(v3d, V3D_INTCTL, V3D_INT_FLDONE | V3D_INT_FRDONE | V3D_INT_OUTOMEM);
+
+    /* Install the IRQ handler (always) and reset the service state:
+     *  - FLDONE: binner finished its FLUSH. Service kicks CT1 with the
+     *    pending_ct1{ca,ea} that submit_cl stashed.
+     *  - FRDONE: render frame done; counted, waits poll RFC.
+     *  - OUTOMEM: binner out of pool memory; service feeds the
+     *    per-frame overspill BO (BPOA/BPOS). */
+    v3d->int_outomem = 0;
+    v3d->int_fldone  = 0;
+    v3d->int_frdone  = 0;
+    v3d->irq_calls   = 0;
+    v3d->kick_count  = 0;
+    v3d->irq_fldone  = 0;
+    v3d->irq_frdone  = 0;
+    v3d->irq_outomem = 0;
+    v3d->pending_render = FALSE;
+    v3d->pending_ct1ca = 0;
+    v3d->pending_ct1ea = 0;
+    v3d->overflow_bus = 0;
+    v3d->overflow_size = 0;
+    v3d->overflow_handed = 0;
+    v3d->irq_handle = KrnAddIRQHandler(IRQ_VC_3D, v3d_irq_handler, v3d, SysBase);
+    if (!v3d->irq_handle)
+        bug("[VC4Gallium] Failed to install V3D IRQ handler\n");
+    /* Mask everything, then arm the bring-up set (see VC4_V3D_IRQ_ENA).
+     * The wait paths keep polling V3D_INTCTL as fallback; the IRQ path
+     * merely services the same state machine sooner (immediate
+     * FLDONE->CT1 kick instead of waiting for the next poll). */
+    V3D_WRITE(v3d, V3D_INTDIS, V3D_INT_OUTOMEM | V3D_INT_FLDONE | V3D_INT_FRDONE);
+    if (VC4_V3D_IRQ_ENA && v3d->irq_handle)
+    {
+        V3D_WRITE(v3d, V3D_INTENA, VC4_V3D_IRQ_ENA);
+        bug("[VC4Gallium] V3D IRQs armed: 0x%02x (OUTOMEM %s, poll fallback on)\n",
+            (ULONG)VC4_V3D_IRQ_ENA,
+            (VC4_V3D_IRQ_ENA & V3D_INT_OUTOMEM) ? "irq" : "poll-fed");
+    }
+    else
+        bug("[VC4Gallium] V3D IRQs masked, poll-only\n");
+
+    /* VPM allocator state. Hardware init only needs VPMBASE written;
+     * VPACNTL must be left at its reset value — the HW reset defaults for
+     * the per-thread row counts (VPMURS_VS/CS/US in VPACNTL) are non-zero.
+     * Writing VPACNTL=0 zeros those counts and turns every subsequent
+     * VS/CS VPM allocation into a VPAERGL (ERRSTAT bit 12) error. Log the
+     * reset value for the record but leave the register alone. */
+    V3D_WRITE(v3d, V3D_VPMBASE, 0);
+    D(bug("[VC4Gallium] V3D VPACNTL reset default = 0x%08x\n",
+        V3D_READ(v3d, V3D_VPACNTL)));
+
+    /* QPU scheduler reservation. SQRSV0/SQRSV1 hold a 4-bit-per-QPU field
+     * for which workloads (user program / FS / VS / CS) each QPU may run.
+     * The Pi firmware can leave stale bits set: if QPUs end up reserved for
+     * the user-program queue only, the renderer stalls at the first
+     * primitive (no QPU free for FS/VS/CS). Clear so all QPUs run anything. */
+    D(bug("[VC4Gallium] V3D SQRSV0/SQRSV1/SQCNTL reset = 0x%08x 0x%08x 0x%08x\n",
+        V3D_READ(v3d, V3D_SQRSV0),
+        V3D_READ(v3d, V3D_SQRSV1),
+        V3D_READ(v3d, V3D_SQCNTL)));
+    V3D_WRITE(v3d, V3D_SQRSV0, 0);
+    V3D_WRITE(v3d, V3D_SQRSV1, 0);
+
+    /* Clear any latched error bits (W1C). */
+    V3D_WRITE(v3d, V3D_ERRSTAT, 0xffffffff);
+
+    /* Snapshot frame counters so future progress is relative. */
+    v3d->last_bfc = V3D_READ(v3d, V3D_BFC) & 0xff;
+    v3d->last_rfc = V3D_READ(v3d, V3D_RFC) & 0xff;
+    v3d->bfc_completed = 0;
+    v3d->rfc_completed = 0;
+
+    return TRUE;
+}

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_v3d.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_v3d.h
@@ -1,0 +1,135 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    VideoCore IV V3D register definitions
+    Reference: BCM2835 ARM Peripherals + VideoCoreIV-AG100-R
+*/
+
+#ifndef _VC4_V3D_H
+#define _VC4_V3D_H
+
+#include <exec/types.h>
+
+extern IPTR __arm_periiobase;
+#define ARM_PERIIOBASE __arm_periiobase
+#include <hardware/bcm2708.h>
+
+/* V3D register offsets from V3D_BASE */
+#define V3D_IDENT0      0x000   /* V3D Identification 0 (V3D block identity) */
+#define V3D_IDENT1      0x004   /* V3D Identification 1 (V3D configuration A) */
+#define V3D_IDENT2      0x008   /* V3D Identification 2 (V3D configuration B) */
+#define V3D_SCRATCH     0x010   /* Scratch register */
+
+/* Binning/Rendering pipeline control */
+#define V3D_CT0CS       0x100   /* Control List Executor Thread 0 Control and Status */
+#define V3D_CT1CS       0x104   /* Control List Executor Thread 1 Control and Status */
+#define V3D_CT0EA       0x108   /* Control List Executor Thread 0 End Address */
+#define V3D_CT1EA       0x10c   /* Control List Executor Thread 1 End Address */
+#define V3D_CT0CA       0x110   /* Control List Executor Thread 0 Current Address */
+#define V3D_CT1CA       0x114   /* Control List Executor Thread 1 Current Address */
+#define V3D_CT00RA0     0x118   /* Control List Executor Thread 0 Return Address */
+#define V3D_CT01RA0     0x11c   /* Control List Executor Thread 1 Return Address */
+#define V3D_CT0LC       0x120   /* Control List Executor Thread 0 List Counter */
+#define V3D_CT1LC       0x124   /* Control List Executor Thread 1 List Counter */
+#define V3D_CT0PC       0x128   /* Control List Executor Thread 0 Primitive List Counter */
+#define V3D_CT1PC       0x12c   /* Control List Executor Thread 1 Primitive List Counter */
+
+/* V3D Pipeline state */
+#define V3D_PCS         0x130   /* V3D Pipeline Control and Status */
+#define V3D_BFC         0x134   /* Binning Mode Flush Count */
+#define V3D_RFC         0x138   /* Rendering Mode Frame Count */
+
+/* Binning Memory Pool */
+#define V3D_BPCA        0x300   /* Current Pool Address */
+#define V3D_BPCS        0x304   /* Current Pool Size */
+#define V3D_BPOA        0x308   /* Overspill Pool Address */
+#define V3D_BPOS        0x30c   /* Overspill Pool Size */
+
+/* L2 Cache Control */
+#define V3D_L2CACTL     0x020   /* L2 Cache Control */
+/* Slice cache control. Independent 4-bit fields, one bit per slice; writing
+ * 0xf in a field invalidates that cache across all 4 slices. */
+#define V3D_SLCACTL     0x024   /* Slice Cache Control */
+#define V3D_SLCACTL_ICC_SHIFT   0   /* QPU instruction cache */
+#define V3D_SLCACTL_UCC_SHIFT   8   /* Uniforms cache */
+#define V3D_SLCACTL_T0CC_SHIFT  16  /* Texture 0 cache */
+#define V3D_SLCACTL_T1CC_SHIFT  24  /* Texture 1 cache */
+#define V3D_SLCACTL_ALL         0x0f0f0f0f  /* Clear all four slice caches */
+
+/* Slices / QPU Scheduler */
+#define V3D_SQRSV0      0x410   /* Reserve QPUs 0-7 */
+#define V3D_SQRSV1      0x414   /* Reserve QPUs 8-15 */
+#define V3D_SQCNTL      0x418   /* QPU Scheduler Control */
+#define V3D_SRQPC       0x430   /* QPU User Program Request Queue Program Counter */
+#define V3D_SRQUA       0x434   /* QPU User Program Request Queue Uniforms Address */
+#define V3D_SRQUL       0x438   /* QPU User Program Request Queue Uniforms Length */
+#define V3D_SRQCS       0x43c   /* QPU User Program Request Queue Control and Status */
+
+/* VPM (Vertex Pipe Memory) */
+#define V3D_VPACNTL     0x500   /* VPM Allocator Control */
+#define V3D_VPMBASE     0x504   /* VPM Base (User) Memory Reservation */
+
+/* Performance Counters */
+#define V3D_PCTRC       0x670   /* Performance Counter Clear */
+#define V3D_PCTRE       0x674   /* Performance Counter Enable */
+#define V3D_PCTR(n)     (0x680 + (n) * 0x08)   /* Performance Counter Count n */
+#define V3D_PCTRS(n)    (0x684 + (n) * 0x08)   /* Performance Counter Mapping n */
+
+/* Interrupt Control. */
+#define V3D_INTCTL      0x030   /* Interrupt Control / Status (W1C) */
+#define V3D_INTENA      0x034   /* Interrupt Enable Set */
+#define V3D_INTDIS      0x038   /* Interrupt Enable Clear */
+
+/* Error / Debug */
+#define V3D_ERRSTAT     0xf20   /* Miscellaneous Error Signals (active bits) */
+#define V3D_DBGE        0xf00   /* PSE Error Signals */
+#define V3D_FDBGO       0xf04   /* FEP Overrun Error Signals */
+#define V3D_FDBGB       0xf08   /* FEP Interface Ready and Stall Signals, FEP Busy Signals */
+#define V3D_FDBGR       0xf0c   /* FEP Internal Ready Signals */
+#define V3D_FDBGS       0xf10   /* FEP Internal Stall Input Signals */
+
+/* V3D_CTnCS bits */
+#define V3D_CTCS_CTRSTA    (1 << 15)  /* Reset bit, write 1 to force thread to stop */
+#define V3D_CTCS_CTSEMA    (1 << 12)  /* Control Thread interacted with semaphore */
+#define V3D_CTCS_CTRTSD    (1 << 8)   /* Control Thread Return-To-Subroutine-Delay */
+#define V3D_CTCS_CTRUN     (1 << 5)   /* Control Thread is running */
+#define V3D_CTCS_CTSUBS    (1 << 4)   /* Control Thread executing subroutine */
+#define V3D_CTCS_CTERR     (1 << 3)   /* Control Thread had error (read-only) */
+#define V3D_CTCS_CTMODE    (1 << 0)   /* Control Thread mode bit */
+
+/* V3D_INTCTL / V3D_INTENA / V3D_INTDIS bits */
+#define V3D_INT_FLDONE     (1 << 1)   /* Binning Mode Flush Done */
+#define V3D_INT_FRDONE     (1 << 0)   /* Rendering Mode Frame Done */
+#define V3D_INT_OUTOMEM    (1 << 2)   /* Binner Ran Out of Memory */
+
+/* V3D_L2CACTL bits */
+#define V3D_L2CACTL_L2CENA (1 << 0)   /* L2 Cache Enable */
+#define V3D_L2CACTL_L2CCLR (1 << 2)   /* L2 Cache Clear */
+
+/* V3D_PCS bits */
+#define V3D_PCS_BMACTIVE   (1 << 0)   /* Binning mode active */
+#define V3D_PCS_BMBUSY     (1 << 1)   /* Binning mode busy */
+#define V3D_PCS_RMACTIVE   (1 << 2)   /* Rendering mode active */
+#define V3D_PCS_RMBUSY     (1 << 3)   /* Rendering mode busy */
+#define V3D_PCS_BMOOM      (1 << 8)   /* Binning mode out of memory */
+
+/* IDENT0 fields */
+#define V3D_IDENT0_VER_SHIFT    24
+#define V3D_IDENT0_VER_MASK     0xFF000000
+
+#define V3D_READ(state, reg)        ((state)->v3d_regs[(reg) / 4])
+#define V3D_WRITE(state, reg, val)  ((state)->v3d_regs[(reg) / 4] = (val))
+
+/* CPU address of a VideoCore buffer -> the GPU's uncached bus alias.
+ * The VC region is identity-mapped below 1GB by the raspi bootstrap (arm
+ * and aarch64 alike), so the low 32 bits are the physical address; the
+ * IPTR step is what keeps 64-bit builds from warning about the narrowing
+ * that is intended here. VideoCore itself is 32-bit whatever the CPU
+ * mode, so bus addresses stay ULONG. */
+#define GPU_BUS_ADDR(x) (0xC0000000 | (ULONG)(IPTR)(x))
+
+BOOL vc4_v3d_init(struct vc4_v3d_state *v3d);
+void vc4_v3d_service_interrupts(struct vc4_v3d_state *v3d);
+void vc4_v3d_kick_pending_render(struct vc4_v3d_state *v3d, const char *reason);
+
+#endif /* _VC4_V3D_H */

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4gallium.conf
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4gallium.conf
@@ -1,0 +1,26 @@
+##begin config
+basename        HiddVC4Gallium
+version         1.0
+residentpri     -1
+libbasetype     struct HiddVC4GalliumBase
+libbasetypeextern struct HiddVC4GalliumBase
+classid         CLID_Hidd_Gallium_VC4
+superclass      CLID_Hidd_Gallium
+classptr_field  sd.galliumclass
+classdatatype   struct HiddGalliumVC4Data
+##end config
+
+##begin cdefprivate
+#include "vc4gallium_intern.h"
+##end cdefprivate
+
+##begin methodlist
+.interface Root
+New
+Dispose
+Get
+.interface Hidd_Gallium
+CreatePipeScreen
+DestroyPipeScreen
+DisplayResourceRP
+##end methodlist

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4gallium_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4gallium_intern.h
@@ -1,0 +1,312 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    VC4 Gallium 3D HIDD - Internal definitions
+*/
+
+#ifndef _VC4GALLIUM_INTERN_H
+#define _VC4GALLIUM_INTERN_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <exec/types.h>
+#include <exec/libraries.h>
+#include <exec/semaphores.h>
+#include <exec/interrupts.h>
+#include <devices/timer.h>
+#include <oop/oop.h>
+#include <hidd/gallium.h>
+
+#include LC_LIBDEFS_FILE
+
+#include "vc4_aros_bridge.h"
+
+#define CLID_Hidd_Gallium_VC4   "hidd.gallium.vc4"
+
+struct HiddGalliumVC4Data
+{
+    OOP_Object              *vc4_obj;
+};
+
+/* Buffer Object handle tracking. Entries are ~760 bytes (shader metadata
+ * inline), so the table is ~760 KB of library-base memory at 1024. */
+#define VC4_MAX_BOS     1024
+
+/* Max texture samples and uniform address offsets per shader */
+#define VC4_MAX_TEX_SAMPLES     32
+#define VC4_MAX_UNIFORM_ADDR    16
+
+/* Per-texture-sample metadata from QPU shader scan.
+ * p_offset[i] is the byte offset into the uniform data stream where
+ * texture parameter i (P0/P1/P2/P3) is located. ~0 = unused. */
+struct vc4_texture_sample_info
+{
+    BOOL    is_direct;      /* UBO direct access mode */
+    ULONG   p_offset[4];   /* Offsets to P0, P1, P2, P3 in uniform stream */
+};
+
+struct vc4_bo_entry
+{
+    APTR    vaddr;          /* CPU virtual address (= physical on RPi) */
+    ULONG   bus_addr;       /* GPU bus address (0xC0000000 | phys) */
+    ULONG   gpu_handle;     /* Mailbox memory handle for free */
+    ULONG   size;
+    ULONG   refcount;
+    BOOL    is_shader;      /* Immutable shader BO */
+    BOOL    external;       /* Wraps memory we don't own (scanout page) */
+    BOOL    cpu_mapped;     /* MMAP_BO was called — CPU may hold dirty lines */
+    UQUAD   tiling_modifier;/* DRM_FORMAT_MOD_* — round-tripped via set/get_tiling */
+    /* Shader metadata (set by QPU scanner on CREATE_SHADER_BO) */
+    ULONG   uniforms_size;          /* Bytes of uniform data GPU reads */
+    ULONG   num_texture_samples;    /* Number of texture lookups */
+    struct vc4_texture_sample_info texture_samples[VC4_MAX_TEX_SAMPLES];
+    ULONG   num_uniform_addr_offsets;
+    ULONG   uniform_addr_offsets[VC4_MAX_UNIFORM_ADDR]; /* Indices into uniform words */
+};
+
+/* V3D hardware state */
+struct vc4_v3d_state
+{
+    volatile ULONG  *v3d_regs;      /* Mapped V3D register block */
+    ULONG           ident0;         /* V3D_IDENT0 value */
+    ULONG           ident1;         /* V3D_IDENT1 value */
+    ULONG           ident2;         /* V3D_IDENT2 value */
+    ULONG           v3d_ver;        /* V3D version from IDENT0 */
+    volatile ULONG  seqno;          /* Monotonically increasing job seqno */
+    volatile ULONG  finished_seqno; /* Last completed seqno */
+    /* Frame counter tracking. BFC/RFC are 8-bit wrapping counters in V3D;
+     * we accumulate the delta into 32-bit completed counts. finished_seqno
+     * is driven by rfc_completed (render frame done = job done). */
+    volatile ULONG  last_bfc;       /* Last raw BFC sample (low 8 bits) */
+    volatile ULONG  last_rfc;       /* Last raw RFC sample (low 8 bits) */
+    volatile ULONG  bfc_completed;  /* Bin frames completed since init */
+    volatile ULONG  rfc_completed;  /* Render frames completed since init */
+    BOOL            v3d_available;  /* TRUE if V3D block responds */
+    /* IRQ diagnostics + handoff state. FLDONE handler kicks CT1 with the
+     * addresses submit_cl stashed in pending_ct1{ca,ea}. */
+    APTR            irq_handle;
+    volatile ULONG  int_outomem;    /* Binner OUT_OF_MEMORY count */
+    volatile ULONG  int_fldone;     /* Bin flush done count (for diff vs BFC) */
+    volatile ULONG  int_frdone;     /* Render frame done count (for diff vs RFC) */
+    /* IRQ-only counters (incremented solely in the ARM IRQ handler, never the
+     * poll path) - lets us tell whether IRQ_VC_3D actually reaches the ARM. */
+    volatile ULONG  irq_calls;      /* v3d_irq_handler entries                 */
+    volatile ULONG  irq_fldone;     /* FLDONE seen at IRQ entry                */
+    volatile ULONG  irq_frdone;     /* FRDONE seen at IRQ entry                */
+    volatile ULONG  irq_outomem;    /* OUTOMEM seen at IRQ entry               */
+    volatile ULONG  pending_ct1ca;  /* RCL start address, latched by submit_cl */
+    volatile ULONG  pending_ct1ea;  /* RCL end address */
+    volatile BOOL   pending_render; /* TRUE while waiting for FLDONE to kick CT1 */
+    volatile ULONG  kick_count;     /* Total CT1 kicks actually written */
+    /* Binner overspill pool, fed on-demand from the OUTOMEM IRQ. submit_cl
+     * pre-allocates the BO (no alloc in IRQ context), stashes its bus addr/size
+     * here and resets overflow_handed; the handler writes BPOA/BPOS once. */
+    volatile ULONG  overflow_bus;   /* Bus addr of binner overspill BO */
+    volatile ULONG  overflow_size;  /* Size of that BO */
+    volatile ULONG  overflow_handed;/* Times handed this submission (storm guard) */
+};
+
+/* Per-pool-set binner overspill BO. 512 KB covers worst-case tile-state +
+ * tile-alloc (~320 KB at 4096 tiles) plus per-bin 32 B CL overflow, keeping
+ * the VideoCore footprint small (2 sets = 1 MB). */
+#define VC4_BIN_OVERFLOW_SIZE   (512 * 1024)
+
+/* DMA channel for the display blit is allocated from dma.resource with
+ * DMACHF_TDMODE (2D stride mode needs a full engine). The shared control
+ * block layout and bus-alias macro come from the same header. */
+#include <hardware/bcm2708_dma.h>
+
+/* Reusable per-frame GPU BO — grows but never shrinks */
+struct vc4_frame_bo
+{
+    APTR    vaddr;
+    ULONG   gpu_handle;
+    ULONG   bus_addr;
+    ULONG   size;           /* Current allocated size (0 = not allocated) */
+};
+
+/* Static data for the module */
+struct vc4galliumstaticdata
+{
+    OOP_Class           *galliumclass;
+    OOP_AttrBase        hiddGalliumAB;
+    struct Library      *UtilityBase;
+    struct Library      *MBoxBase;
+
+    struct vc4_v3d_state    v3d;
+
+    /* Serializes all GPU submission/completion waits (submit_cl / wait_seqno
+     * / wait_idle) so V3D regs, job seqno, pool ping-pong and FLDONE->CT1
+     * handoff state are never touched by two tasks at once. Nestable:
+     * submit_cl holds it across its internal pool-reuse wait. */
+    struct SignalSemaphore  render_lock;
+
+    /* BO handle table */
+    struct vc4_bo_entry     bo_table[VC4_MAX_BOS];
+    ULONG                   bo_next_handle;
+    struct SignalSemaphore  bo_lock;
+
+    /* Mailbox message buffer (16-byte aligned) */
+    APTR                    mbox_msg_raw;   /* Raw allocation for FreeMem */
+    volatile ULONG          *mbox_msg;      /* 16-byte aligned pointer */
+    struct SignalSemaphore  mbox_lock;
+
+    /* Vblank-driven GPU wait. An INTB_VERTB server signals the one registered
+     * waiter each vblank (~50 Hz) so the wait paths block instead of spinning,
+     * freeing the CPU between vblanks. wait_gate serializes waiters (one slot
+     * suffices); the server only does a lockless Signal() in IRQ context. */
+    struct Interrupt        vblank_server;
+    struct Task             *vblank_waiter;
+    BYTE                    vblank_waiter_sig;
+    BOOL                    vblank_added;
+    struct SignalSemaphore  wait_gate;
+
+    /* vc4gfx bitmap detection */
+    OOP_AttrBase            hiddVC4GfxBMAB;     /* VideoCoreGfxBitMap attr base */
+    OOP_AttrBase            hiddBitMapAB;       /* standard BitMap attr base */
+
+    /* Rotating BO pools — three sets so the CPU can prepare frame N+1
+     * while the GPU renders frame N and frame N-1's set drains. With
+     * only two sets the submit of N blocked until N-2's render was done,
+     * which re-serialized the pipelined present path. */
+#define VC4_NUM_POOL_SETS   3
+    struct {
+        struct vc4_frame_bo tile;
+        struct vc4_frame_bo exec;
+        struct vc4_frame_bo rcl;
+        struct vc4_frame_bo binoverflow;    /* Binner overspill pool (BPOA/BPOS) */
+        ULONG               seqno;  /* Seqno of last job using this set (0 = idle) */
+    } pool[VC4_NUM_POOL_SETS];
+    ULONG                   pool_idx;   /* Current set index */
+
+    /* Scratch for process_bin_cl's per-GL_SHADER_STATE flag list. Grown
+     * on demand to bin_cl_size/5 (the max shader-state packets a CL can
+     * hold); persistent because submit_cl is serialized under render_lock,
+     * so a stack array would either overflow (up to ~7920 draws/job) or
+     * a per-submit alloc would leak on submit_cl's many early returns. */
+    ULONG                   *shader_state_scratch;
+    ULONG                   shader_state_scratch_max;
+
+    /* Scanout pages announced via the bridge's get_scanout entry. GEM_OPEN
+     * consults this to wrap a page as an external BO (the only names it
+     * accepts). Written under bo_lock. */
+    ULONG                   scanout_phys[2];
+    ULONG                   scanout_size;
+
+    /* Pre-opened timer.device (UNIT_MICROHZ) for GPU-wait microsleeps —
+     * io_Device/io_Unit are cloned into a stack request per use, so any
+     * task can sleep on it. */
+    struct timerequest      gpu_timer_template;
+    BOOL                    gpu_timer_ok;
+    /* DMA blit state */
+    LONG                    dmaChannel;         /* From dma.resource, -1 = none */
+    BOOL                    dmaBusy;
+    APTR                    dmaStaging;         /* Staging buffer (grows) */
+    ULONG                   dmaStagingSize;
+    APTR                    dmaCBRaw;           /* CB chain raw alloc */
+    ULONG                   dmaCBRawSize;
+    /* BO handle whose pin is currently owned by the in-flight async DMA.
+     * Released through vc4_aros_bo_unref_locked once vc4_aros_dma_wait_idle
+     * observes completion — keeps the firmware allocation alive across
+     * a Mesa-side GEM_CLOSE racing the display swap. 0 = none. */
+    ULONG                   dma_pinned_handle;
+
+    /* BO currently scanned out as the HVS overlay plane (windowed
+     * zero-copy GL), pinned until replaced or cleared; the bitmap it
+     * was shown on, for clear_overlay(NULL) at context teardown. */
+    ULONG                   overlay_pinned_handle;
+    OOP_Object             *overlay_bm;
+
+    /* Module-internal dispatch struct; the driver's winsys shims
+     * (aros_drm_shim.c) route drmIoctl/mmap through it. */
+    struct vc4_aros_bridge  bridge;
+    BOOL                    bridge_inited;
+
+    /* mesa3dgl's GalliumCoreAPI table (aHidd_Gallium_CoreAPI attr at New).
+     * The driver's Mesa-core trampolines bind to it at CreatePipeScreen. */
+    APTR                    coreapi;
+};
+
+LIBBASETYPE
+{
+    struct Library              LibNode;
+    struct vc4galliumstaticdata sd;
+};
+
+/* Per-frame timing. Flip to 0 to silence. Reads SYSTIMER_CLO (1 MHz).
+ * Output format is one bug() line per measured stage, so a single grep
+ * '[VC4Prof]' over a serial log gives a CSV of the bottleneck. */
+#define VC4G_PROFILE 0          /* periodic frame-budget summary (1 line / 120 frames) */
+#define VC4G_PROFILE_FRAME 0    /* per-frame submit_cl/display_blit dumps (serial-heavy) */
+
+#if VC4G_PROFILE || VC4G_PROFILE_FRAME
+#include <hardware/bcm2708.h>
+#define VC4G_NOW_US() ((ULONG)AROS_LE2LONG(*(volatile ULONG *)SYSTIMER_CLO))
+#else
+#define VC4G_NOW_US() 0
+#endif
+
+#if VC4G_PROFILE
+#define VC4G_PROF(...) bug(__VA_ARGS__)
+#else
+#define VC4G_PROF(...) do { } while (0)
+#endif
+
+#if VC4G_PROFILE_FRAME
+#define VC4G_PROFF(...) bug(__VA_ARGS__)
+#else
+#define VC4G_PROFF(...) do { } while (0)
+#endif
+
+/* Driver entry points in aros_drm_vc4.c (the winsys/present half). */
+struct pipe_screen;
+struct RastPort;
+struct pipe_screen *vc4_aros_create_screen(struct vc4_aros_bridge *bridge,
+                                           APTR coreapi);
+IPTR vc4_aros_display_rp(APTR resource, LONG srcx, LONG srcy,
+                         struct RastPort *rp, LONG dstx, LONG dsty,
+                         LONG width, LONG height);
+BOOL aros_drm_release_bridge(void);
+
+/* Drain any in-flight display-blit DMA. Defined in vc4_galliumclass.c. */
+void vc4_aros_dma_wait_idle(struct vc4galliumstaticdata *sd);
+
+/* Wait for all submitted V3D work and flush its L2. Defined in
+ * vc4_galliumclass.c. */
+void vc4_aros_wait_idle(struct vc4galliumstaticdata *sd);
+
+/* Hang forensics (vc4_drm_aros.c): dump the most recent submission's
+ * geometry + RCL head/tail + first binner sublist. */
+void v3d_dump_last_submit(void);
+
+/* GPU wait tiers, shared by v3d_wait_seqno and vc4_aros_wait_idle.
+ * Tight spin gives µs-precise completion for short jobs; the nap window
+ * polls on a ~1 ms grid while the CPU sleeps via timer.device (keeps
+ * input/mouse responsive during the GPU render); anything longer falls
+ * back to vblank blocking. */
+#define VC4_GPUWAIT_SPIN_US     2000
+#define VC4_GPUWAIT_NAP_US      1000
+#define VC4_GPUWAIT_NAP_WINDOW  20000
+
+/* ~1 ms scheduler-friendly sleep. Defined in vc4_galliumclass.c. */
+void vc4_gpu_nap(struct vc4galliumstaticdata *sd, ULONG us);
+
+
+/* GPU-wait blocking helpers (defined in vc4_init.c). vc4_wait_enter claims the
+ * single vblank-waiter slot and returns an allocated signal bit (-1 if none/no
+ * slot); the wait loops then block on Wait(1<<sig), woken each vblank by the
+ * INTB_VERTB server. vc4_wait_leave releases the slot. */
+BYTE vc4_wait_enter(struct vc4galliumstaticdata *sd);
+void vc4_wait_leave(struct vc4galliumstaticdata *sd, BYTE sig);
+
+/* Diagnostic clock logging (defined in vc4_init.c). */
+void vc4_log_clocks(struct vc4galliumstaticdata *sd, const char *when);
+
+#define METHOD(base, id, name) \
+    base ## __ ## id ## __ ## name (OOP_Class *cl, OOP_Object *o, struct p ## id ## _ ## name *msg)
+
+#define BASE(lib) ((LIBBASETYPEPTR)(lib))
+#define SD(cl) (&BASE(cl->UserData)->sd)
+
+#endif /* _VC4GALLIUM_INTERN_H */

--- a/arch/arm-raspi/boot/mmakefile.src
+++ b/arch/arm-raspi/boot/mmakefile.src
@@ -211,8 +211,11 @@ distfiles-raspi-armbe-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.im
 #MM
 distfiles-raspi-armle-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-raspi.img
 
+# gpu_mem: the vc4 GL stack needs headroom in VideoCore RAM (full-res
+# framebuffer + overlay page ring + BO pools); 64 (the firmware default)
+# runs out during a full-screen GL session. 128 is the working minimum.
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x10000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=0\nhdmi_drive=2\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x10000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=0\nhdmi_drive=2\ngpu_mem=128\n" > $@
 
 $(AROSDIR)/aros-armeb-raspi.img: $(TARGETDIR)/core-be.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o $(TARGETDIR)/$(f).d)
 	@$(ECHO) "Creating   $@"

--- a/developer/debug/test/gl/glclear.c
+++ b/developer/debug/test/gl/glclear.c
@@ -1,0 +1,120 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Minimal GL test: clear the back buffer to a known colour and swap.
+    Exercises the present path with no geometry or shaders.
+    Solid dark red = clear/swap pipeline works.
+*/
+
+#include <exec/types.h>
+#include <intuition/intuition.h>
+#include <proto/exec.h>
+#include <proto/intuition.h>
+
+#include <GL/gla.h>
+
+#include <stdio.h>
+
+#define VISIBLE_WIDTH  300
+#define VISIBLE_HEIGHT 300
+
+CONST_STRPTR version = "$VER: glclear 1.0 (18.05.2026) AROS";
+
+static GLAContext     glcont = NULL;
+static struct Window *win    = NULL;
+static BOOL           finished = FALSE;
+
+static void initgl(void)
+{
+    struct TagItem attributes[10];
+    int i = 0;
+
+    attributes[i].ti_Tag = GLA_Window;    attributes[i++].ti_Data = (IPTR)win;
+    attributes[i].ti_Tag = GLA_Left;      attributes[i++].ti_Data = win->BorderLeft;
+    attributes[i].ti_Tag = GLA_Top;       attributes[i++].ti_Data = win->BorderTop;
+    attributes[i].ti_Tag = GLA_Bottom;    attributes[i++].ti_Data = win->BorderBottom;
+    attributes[i].ti_Tag = GLA_Right;     attributes[i++].ti_Data = win->BorderRight;
+    attributes[i].ti_Tag = GLA_DoubleBuf; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_RGBMode;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoStencil; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoAccum;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = TAG_DONE;
+
+    glcont = glACreateContext(attributes);
+    if (glcont)
+    {
+        glAMakeCurrent(glcont);
+        glViewport(0, 0, VISIBLE_WIDTH, VISIBLE_HEIGHT);
+    }
+    else
+    {
+        finished = TRUE;
+    }
+}
+
+static void handle_messages(void)
+{
+    struct IntuiMessage *msg;
+    while ((msg = (struct IntuiMessage *)GetMsg(win->UserPort)))
+    {
+        switch (msg->Class)
+        {
+        case IDCMP_CLOSEWINDOW:
+            finished = TRUE;
+            break;
+        case IDCMP_VANILLAKEY:
+            if (msg->Code == 27)
+                finished = TRUE;
+            break;
+        }
+        ReplyMsg((struct Message *)msg);
+    }
+}
+
+int main(void)
+{
+    struct Screen *pubscreen;
+
+    if ((pubscreen = LockPubScreen(NULL)) == NULL)
+        return 1;
+
+    win = OpenWindowTags(0,
+        WA_Title,         (IPTR)"glclear",
+        WA_PubScreen,     pubscreen,
+        WA_CloseGadget,   TRUE,
+        WA_DragBar,       TRUE,
+        WA_DepthGadget,   TRUE,
+        WA_Left,          50,
+        WA_Top,           200,
+        WA_InnerWidth,    VISIBLE_WIDTH,
+        WA_InnerHeight,   VISIBLE_HEIGHT,
+        WA_Activate,      TRUE,
+        WA_RMBTrap,       TRUE,
+        WA_SimpleRefresh, TRUE,
+        WA_NoCareRefresh, TRUE,
+        WA_IDCMP,         IDCMP_VANILLAKEY | IDCMP_CLOSEWINDOW,
+        TAG_DONE);
+
+    UnlockPubScreen(NULL, pubscreen);
+
+    if (!win)
+        return 1;
+
+    initgl();
+
+    while (!finished)
+    {
+        glClearColor(0.5f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glASwapBuffers(glcont);
+
+        handle_messages();
+    }
+
+    if (glcont)
+        glADestroyContext(glcont);
+
+    CloseWindow(win);
+    return 0;
+}

--- a/developer/debug/test/gl/glcustomscreen.c
+++ b/developer/debug/test/gl/glcustomscreen.c
@@ -1,0 +1,158 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Isolation test for the vc4 VideoCore wedge seen when a scaled (non-native)
+    secondary custom screen is used with GL. Native display is e.g. 1280x1024;
+    opening a 640x480 custom screen makes the firmware upscale it (a scaled HVS
+    plane). Something in the scaled-secondary + GL path hard-wedges the
+    VideoCore (HDMI drops, machine dies).
+
+    Run with increasing STEP to find the exact step that wedges; each step logs
+    to the serial console, so the last [GLCS] line before death is the culprit:
+
+      glcustomscreen               (STEP 1) open scaled custom screen, hold, close
+      glcustomscreen STEP=2        + open a backdrop window on it
+      glcustomscreen STEP=3        + glACreateContext (vc4gallium init)
+      glcustomscreen STEP=4        + glAMakeCurrent + clear + swap (render)
+
+    W/H override the screen size (default 640x480), HOLD the per-step hold secs.
+*/
+
+#include <exec/types.h>
+#include <intuition/intuition.h>
+#include <intuition/screens.h>
+#include <dos/dos.h>
+#include <dos/rdargs.h>
+
+#include <proto/exec.h>
+#include <proto/intuition.h>
+#include <proto/dos.h>
+
+#include <aros/debug.h>
+
+#include <GL/gla.h>
+
+CONST_STRPTR version = "$VER: glcustomscreen 1.0 (19.07.2026) AROS";
+
+int main(void)
+{
+    IPTR args[4] = { 0, 0, 0, 0 };      /* STEP, W, H, HOLD */
+    struct RDArgs *rda;
+    LONG step = 1, w = 640, h = 480, hold = 3;
+    struct Screen *scr = NULL;
+    struct Window *win = NULL;
+    GLAContext ctx = NULL;
+    ULONG err = 0;
+
+    rda = ReadArgs("STEP/N,W/N,H/N,HOLD/N", args, NULL);
+    if (rda)
+    {
+        if (args[0]) step = *(LONG *)args[0];
+        if (args[1]) w    = *(LONG *)args[1];
+        if (args[2]) h    = *(LONG *)args[2];
+        if (args[3]) hold = *(LONG *)args[3];
+    }
+
+    bug("[GLCS] START step=%ld  %ldx%ld  hold=%lds\n",
+        (long)step, (long)w, (long)h, (long)hold);
+
+    /* ---- STEP 1: open a scaled (non-native) custom screen -------------- */
+    bug("[GLCS] step1: OpenScreenTags %ldx%ld depth 24...\n", (long)w, (long)h);
+    scr = OpenScreenTags(NULL,
+        SA_GammaControl, TRUE,
+        SA_Width,        w,
+        SA_Height,       h,
+        SA_Depth,        24,
+        SA_Quiet,        TRUE,
+        SA_ShowTitle,    FALSE,
+        SA_Title,        (IPTR)"GLCS",
+        SA_ErrorCode,    (IPTR)&err,
+        TAG_DONE);
+    bug("[GLCS] step1: screen=%p err=%lu\n", scr, (unsigned long)err);
+    if (!scr)
+        goto done;
+    bug("[GLCS] step1: opened %ldx%ld, holding...\n",
+        (long)scr->Width, (long)scr->Height);
+    Delay(hold * 50);
+    bug("[GLCS] step1: SURVIVED\n");
+    if (step < 2)
+        goto close_scr;
+
+    /* ---- STEP 2: open a backdrop window on the custom screen ----------- */
+    bug("[GLCS] step2: OpenWindowTags backdrop...\n");
+    win = OpenWindowTags(NULL,
+        WA_Left,         0,
+        WA_Top,          0,
+        WA_InnerWidth,   scr->Width,
+        WA_InnerHeight,  scr->Height,
+        WA_CustomScreen, (IPTR)scr,
+        WA_Flags,        WFLG_ACTIVATE | WFLG_BACKDROP | WFLG_BORDERLESS | WFLG_RMBTRAP,
+        WA_IDCMP,        IDCMP_VANILLAKEY,
+        TAG_DONE);
+    bug("[GLCS] step2: win=%p\n", win);
+    if (!win)
+        goto close_scr;
+    Delay(hold * 50);
+    bug("[GLCS] step2: SURVIVED\n");
+    if (step < 3)
+        goto close_win;
+
+    /* ---- STEP 3: create a GL context (triggers vc4gallium init) -------- */
+    {
+        struct TagItem attrs[8];
+        int i = 0;
+
+        attrs[i].ti_Tag = GLA_Window;    attrs[i++].ti_Data = (IPTR)win;
+        attrs[i].ti_Tag = GLA_DoubleBuf; attrs[i++].ti_Data = GL_TRUE;
+        attrs[i].ti_Tag = GLA_RGBMode;   attrs[i++].ti_Data = GL_TRUE;
+        attrs[i].ti_Tag = GLA_NoStencil; attrs[i++].ti_Data = GL_TRUE;
+        attrs[i].ti_Tag = GLA_NoAccum;   attrs[i++].ti_Data = GL_TRUE;
+        attrs[i].ti_Tag = TAG_DONE;
+
+        bug("[GLCS] step3: glACreateContext...\n");
+        ctx = glACreateContext(attrs);
+        bug("[GLCS] step3: ctx=%p\n", ctx);
+    }
+    if (!ctx)
+        goto close_win;
+    Delay(hold * 50);
+    bug("[GLCS] step3: SURVIVED\n");
+    if (step < 4)
+        goto destroy_ctx;
+
+    /* ---- STEP 4: make current, clear, swap ---------------------------- */
+    bug("[GLCS] step4: glAMakeCurrent + render...\n");
+    glAMakeCurrent(ctx);
+    glViewport(0, 0, scr->Width, scr->Height);
+    {
+        int f, frames = hold * 10;
+
+        for (f = 0; f < frames; f++)
+        {
+            glClearColor(0.2f, 0.0f, 0.3f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glASwapBuffers(ctx);
+            if ((f % 10) == 0)
+                bug("[GLCS] step4: frame %d\n", f);
+        }
+    }
+    bug("[GLCS] step4: SURVIVED\n");
+
+destroy_ctx:
+    bug("[GLCS] cleanup: glADestroyContext\n");
+    if (ctx)
+        glADestroyContext(ctx);
+close_win:
+    bug("[GLCS] cleanup: CloseWindow\n");
+    if (win)
+        CloseWindow(win);
+close_scr:
+    bug("[GLCS] cleanup: CloseScreen\n");
+    if (scr)
+        CloseScreen(scr);
+done:
+    if (rda)
+        FreeArgs(rda);
+    bug("[GLCS] DONE\n");
+    return 0;
+}

--- a/developer/debug/test/gl/glsimplerendering.c
+++ b/developer/debug/test/gl/glsimplerendering.c
@@ -21,6 +21,7 @@
 #include <GL/gla.h>
 
 #include <stdio.h>
+#include <string.h>
 
 #define SHOW_FPS
 
@@ -37,6 +38,11 @@ struct MsgPort      timeport;
 struct Library *    CyberGfxBase = NULL;
 BOOL                fullscreen = FALSE, trace = FALSE;
 #define DOTRACE(x)      ({ if (trace) { x } });
+
+/* Drawable size: VISIBLE_* in windowed mode, the screen size in
+ * fullscreen. Set up in main() before initgl(). */
+LONG                scrw = 0, scrh = 0;
+int                 fps_value = 0;
 GLuint              fragmentShader = 0;
 GLuint              vertexShader = 0;
 GLuint              shaderProgram = 0;
@@ -56,6 +62,14 @@ PFNGLDELETESHADERPROC       glDeleteShader          = NULL;
 PFNGLDELETEPROGRAMPROC      glDeleteProgram         = NULL;
 PFNGLUNIFORM1FPROC          glUniform1f             = NULL;
 PFNGLGETUNIFORMLOCATIONPROC glGetUniformLocation    = NULL;
+PFNGLGETSHADERIVPROC        glGetShaderiv           = NULL;
+
+#ifndef GL_COMPILE_STATUS
+#define GL_COMPILE_STATUS 0x8B81
+#endif
+#ifndef GL_SHADING_LANGUAGE_VERSION
+#define GL_SHADING_LANGUAGE_VERSION 0x8B8C
+#endif
 
 CONST_STRPTR version = "$VER: glsimplerendering 1.0 (28.04.2019) \xA9 2010-2019 The AROS Development Team";
 
@@ -95,7 +109,7 @@ void prepare_shader_program()
     glCompileShader(fragmentShader);
     glGetShaderInfoLog(fragmentShader, BUFFER_LEN, &len, buffer);
     printf("Fragment shader compile output: %s\n", buffer);
-    
+
     vertexShader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(vertexShader, 1, &vertexShaderSource, NULL);
     glCompileShader(vertexShader);
@@ -193,7 +207,7 @@ void render_cube()
 void render_triangle()
 {
     DOTRACE(bug("\n[GLSimpeRend] Render Triangle ...\n");)
-   
+
     glBegin(GL_TRIANGLES);
         glColor4f(1.0, 0.0, 0.0, 1.0);
         glVertex3f(-0.25, -0.25, 0.0);
@@ -205,6 +219,72 @@ void render_triangle()
 
     DOTRACE(bug("\n[GLSimpeRend] Render Triangle finished\n");)
 }
+
+#if defined(SHOW_FPS)
+/* Minimal 3x5 bitmap font (digits only); each row is 3 bits, MSB = leftmost
+ * column. Used for the on-screen FPS readout. */
+static const UBYTE fps_digits[10][5] =
+{
+    { 0x7,0x5,0x5,0x5,0x7 },  /* 0 */
+    { 0x2,0x6,0x2,0x2,0x7 },  /* 1 */
+    { 0x7,0x1,0x7,0x4,0x7 },  /* 2 */
+    { 0x7,0x1,0x7,0x1,0x7 },  /* 3 */
+    { 0x5,0x5,0x7,0x1,0x1 },  /* 4 */
+    { 0x7,0x4,0x7,0x1,0x7 },  /* 5 */
+    { 0x7,0x4,0x7,0x5,0x7 },  /* 6 */
+    { 0x7,0x1,0x1,0x1,0x1 },  /* 7 */
+    { 0x7,0x5,0x7,0x5,0x7 },  /* 8 */
+    { 0x7,0x5,0x7,0x1,0x7 },  /* 9 */
+};
+
+/* Draw fps_value as white pixel-quads in the top-left corner, in a screen-
+ * space orthographic overlay. */
+static void draw_fps_overlay(void)
+{
+    char buf[16];
+    int n, i, r, c;
+    const GLfloat px = 3.0f;        /* pixel cell size */
+    const GLfloat x = 8.0f, y = 8.0f;
+
+    snprintf(buf, sizeof(buf), "%d", fps_value);
+    n = strlen(buf);
+
+    glUseProgram(0);
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(0.0, (GLdouble)scrw, (GLdouble)scrh, 0.0, -1.0, 1.0);
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+    glBegin(GL_QUADS);
+    for (i = 0; i < n; i++)
+    {
+        const UBYTE *g = fps_digits[buf[i] - '0'];
+        GLfloat dx = x + i * 4 * px;    /* 3 columns + 1 gap */
+
+        for (r = 0; r < 5; r++)
+            for (c = 0; c < 3; c++)
+                if ((g[r] >> (2 - c)) & 1)
+                {
+                    GLfloat qx = dx + c * px, qy = y + r * px;
+                    glVertex2f(qx,      qy);
+                    glVertex2f(qx + px, qy);
+                    glVertex2f(qx + px, qy + px);
+                    glVertex2f(qx,      qy + px);
+                }
+    }
+    glEnd();
+
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+    glUseProgram(shaderProgram);
+}
+#endif
 
 void render()
 {
@@ -235,6 +315,10 @@ void render()
     glDisable(GL_BLEND);
     glDisable(GL_DEPTH_TEST);
 
+#if defined(SHOW_FPS)
+    draw_fps_overlay();
+#endif
+
     glASwapBuffers(glcont);
 
     DOTRACE(bug("\n[GLSimpeRend] Render finished\n");)
@@ -259,40 +343,79 @@ static void initextensions()
     glDeleteProgram         = (PFNGLDELETEPROGRAMPROC)glAGetProcAddress("glDeleteProgram");
     glUniform1f             = (PFNGLUNIFORM1FPROC)glAGetProcAddress("glUniform1f");
     glGetUniformLocation    = (PFNGLGETUNIFORMLOCATIONPROC)glAGetProcAddress("glGetUniformLocation");
+    glGetShaderiv           = (PFNGLGETSHADERIVPROC)glAGetProcAddress("glGetShaderiv");
+}
+
+/* Probe: does this driver's GLSL compiler accept a #version directive?
+ * eduke32/Polymost shaders failed to compile on AROS/VC4 with any #version
+ * line (identical shader without it compiled). This isolates that behaviour
+ * from SDL/eduke32. Prints compile status + info log for each variant. */
+static void probe_version_shaders(void)
+{
+    static const char * const probe_src[3] =
+    {
+        "#version 120\nvoid main(){ gl_Position = vec4(0.0); }",
+        "#version 110\nvoid main(){ gl_Position = vec4(0.0); }",
+        "void main(){ gl_Position = vec4(0.0); }",
+    };
+    static const char * const probe_name[3] =
+    {
+        "#version 120", "#version 110", "no #version",
+    };
+    int i;
+
+    printf("[GLVerProbe] GL_VERSION                 : %s\n", (const char *)glGetString(GL_VERSION));
+    printf("[GLVerProbe] GL_SHADING_LANGUAGE_VERSION: %s\n", (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION));
+    bug("[GLVerProbe] GLSL version: %s\n", (const char *)glGetString(GL_SHADING_LANGUAGE_VERSION));
+
+    for (i = 0; i < 3; i++)
+    {
+        char  log[512] = {0};
+        int   loglen = 0;
+        GLint status = 0;
+        GLuint s = glCreateShader(GL_VERTEX_SHADER);
+
+        glShaderSource(s, 1, &probe_src[i], NULL);
+        glCompileShader(s);
+        glGetShaderiv(s, GL_COMPILE_STATUS, &status);
+        glGetShaderInfoLog(s, sizeof(log), &loglen, log);
+
+        printf("[GLVerProbe] %-12s : compile status=%d  log=%s\n",
+               probe_name[i], (int)status, log);
+        bug("[GLVerProbe] %s: status=%d log=%s\n", probe_name[i], (int)status, log);
+
+        glDeleteShader(s);
+    }
 }
 
 void initgl()
 {
-    struct TagItem attributes [ 14 ]; /* 14 should be more than enough :) */
+    struct TagItem attributes [ 14 ];
     int i = 0;
     GLfloat h = 0.0f;
-    
+
     attributes[i].ti_Tag = GLA_Window;      attributes[i++].ti_Data = (IPTR)win;
     attributes[i].ti_Tag = GLA_Left;        attributes[i++].ti_Data = win->BorderLeft;
     attributes[i].ti_Tag = GLA_Top;         attributes[i++].ti_Data = win->BorderTop;
     attributes[i].ti_Tag = GLA_Bottom;      attributes[i++].ti_Data = win->BorderBottom;
     attributes[i].ti_Tag = GLA_Right;       attributes[i++].ti_Data = win->BorderRight;
 
-    // double buffer ?
     attributes[i].ti_Tag = GLA_DoubleBuf;   attributes[i++].ti_Data = GL_TRUE;
 
-    // RGB(A) Mode ?
     attributes[i].ti_Tag = GLA_RGBMode;     attributes[i++].ti_Data = GL_TRUE;
-    
-    /* Stencil/Accum */
+
     attributes[i].ti_Tag = GLA_NoStencil;   attributes[i++].ti_Data = GL_TRUE;
     attributes[i].ti_Tag = GLA_NoAccum;     attributes[i++].ti_Data = GL_TRUE;
-    
-    // done...
+
     attributes[i].ti_Tag    = TAG_DONE;
 
     glcont = glACreateContext(attributes);
     if (glcont)
     {
         glAMakeCurrent(glcont);
-        h = (GLfloat)VISIBLE_HEIGHT / (GLfloat)VISIBLE_WIDTH ;
+        h = (GLfloat)scrh / (GLfloat)scrw;
 
-        glViewport(0, 0, (GLint) VISIBLE_WIDTH, (GLint) VISIBLE_HEIGHT);
+        glViewport(0, 0, (GLint)scrw, (GLint)scrh);
 #if USE_PERSPECTIVE == 1
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
@@ -300,6 +423,7 @@ void initgl()
         glMatrixMode(GL_MODELVIEW);
 #endif
         initextensions();
+        probe_version_shaders();
         prepare_shader_program();
         glUseProgram(shaderProgram);
         angleLocation = glGetUniformLocation(shaderProgram, "angle");
@@ -401,9 +525,6 @@ void get_arguments(void)
     }
 }
 
-/*
-** Open a simple window using OpenWindowTagList()
-*/
 int main(void)
 {
     ULONG framecnt = 0;
@@ -412,16 +533,16 @@ int main(void)
     struct Screen * pubscreen = NULL;
     struct Screen * customscreen = NULL;
     LONG modeid;
-    
+
     struct timeval tv;
     UQUAD lastmicrosecs = 0L;
     UQUAD currmicrosecs = 0L;
     UQUAD fpsmicrosecs = 0L;
-    
+
     get_arguments();
-    
+
     init_timerbase();
-    
+
 #if defined(SHOW_FPS)
     GetSysTime(&tv);
     lastmicrosecs = tv.tv_secs * 1000000 + tv.tv_micro;
@@ -430,35 +551,62 @@ int main(void)
 
     if (fullscreen)
     {
+        LONG reqw, reqh;
+
         CyberGfxBase = OpenLibrary("cybergraphics.library", 0L);
-        
-        modeid = BestCModeIDTags(CYBRBIDTG_NominalWidth, VISIBLE_WIDTH,
-                                    CYBRBIDTG_NominalHeight, VISIBLE_HEIGHT,
+
+        /* Match the current desktop resolution so the GL surface is truly
+         * full-screen (and the native panel mode on the Pi). */
+        if ((pubscreen = LockPubScreen(NULL)) != NULL)
+        {
+            reqw = pubscreen->Width;
+            reqh = pubscreen->Height;
+            UnlockPubScreen(NULL, pubscreen);
+            pubscreen = NULL;
+        }
+        else
+        {
+            reqw = 640;
+            reqh = 480;
+        }
+
+        modeid = BestCModeIDTags(CYBRBIDTG_NominalWidth, reqw,
+                                    CYBRBIDTG_NominalHeight, reqh,
                                     TAG_DONE);
-        
+
         customscreen = OpenScreenTags(NULL,
                             SA_Type,        CUSTOMSCREEN,
-                            SA_DisplayID,   modeid,
-                            SA_Width,       VISIBLE_WIDTH,
-                            SA_Height,      VISIBLE_HEIGHT,
+                            modeid != INVALID_ID ? SA_DisplayID : TAG_IGNORE, modeid,
+                            SA_Width,       reqw,
+                            SA_Height,      reqh,
+                            SA_Depth,       24,
                             SA_ShowTitle,   FALSE,
                             SA_Quiet,       TRUE,
                             TAG_DONE);
 
-        win = OpenWindowTags(NULL,
-                WA_Left,            0,
-                WA_Top,             200,
-                WA_InnerWidth,      VISIBLE_WIDTH,
-                WA_InnerHeight,     VISIBLE_HEIGHT,
-                WA_CustomScreen,    (IPTR)customscreen,
-                WA_Flags,           WFLG_ACTIVATE | WFLG_BACKDROP | WFLG_BORDERLESS | WFLG_RMBTRAP,
-                WA_IDCMP,           IDCMP_VANILLAKEY,
-                TAG_DONE);
+        if (customscreen)
+        {
+            scrw = customscreen->Width;
+            scrh = customscreen->Height;
+
+            win = OpenWindowTags(NULL,
+                    WA_Left,            0,
+                    WA_Top,             0,
+                    WA_InnerWidth,      scrw,
+                    WA_InnerHeight,     scrh,
+                    WA_CustomScreen,    (IPTR)customscreen,
+                    WA_Flags,           WFLG_ACTIVATE | WFLG_BACKDROP | WFLG_BORDERLESS | WFLG_RMBTRAP,
+                    WA_IDCMP,           IDCMP_VANILLAKEY,
+                    TAG_DONE);
+        }
     }
     else
     {
         if ((pubscreen = LockPubScreen(NULL)) == NULL) return 1;
-        
+
+        scrw = VISIBLE_WIDTH;
+        scrh = VISIBLE_HEIGHT;
+
         win = OpenWindowTags(0,
                             WA_Title, (IPTR)"GLSimpleRendering",
                             WA_PubScreen, pubscreen,
@@ -475,10 +623,10 @@ int main(void)
                             WA_NoCareRefresh, TRUE,
                             WA_IDCMP, IDCMP_VANILLAKEY | IDCMP_CLOSEWINDOW,
                             TAG_DONE);
-        
+
         UnlockPubScreen(NULL, pubscreen);
     }
-                   
+
     initgl();
 //    finished = TRUE;
     while(!finished)
@@ -495,7 +643,8 @@ int main(void)
         if (currmicrosecs - fpsmicrosecs > 1000000)
         {
             /* FPS counting is naive! */
-            sprintf(title, "GLSimpleRendering, FPS: %d", (int)((framecnt * 1000000)/(currmicrosecs - fpsmicrosecs)));
+            fps_value = (int)((framecnt * 1000000)/(currmicrosecs - fpsmicrosecs));
+            sprintf(title, "GLSimpleRendering, FPS: %d", fps_value);
             fpsmicrosecs = currmicrosecs;
             framecnt = 0;
 
@@ -505,7 +654,7 @@ int main(void)
 
         angle_inc = ((double)(currmicrosecs - lastmicrosecs) / 1000000.0) * DEGREES_PER_SECOND;
         lastmicrosecs = currmicrosecs;
-        
+
         framecnt++;
 #endif
         render();
@@ -514,16 +663,16 @@ int main(void)
 //        Delay(10);
 //        if (exitcounter > 0) finished = TRUE;
     }
-    
+
     deinitgl();
-    
+
     deinit_timerbase();
-      
+
     CloseWindow(win);
-    
+
     if (customscreen) CloseScreen(customscreen);
-    
+
     if (CyberGfxBase) CloseLibrary(CyberGfxBase);
-    
+
     return 0;
 }

--- a/developer/debug/test/gl/gltexfbo.c
+++ b/developer/debug/test/gl/gltexfbo.c
@@ -1,0 +1,877 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    FBO/render-to-texture test for the vc4 T-format path.
+
+    Pass 1 renders a known quadrant pattern into a 320x200 RGBA texture
+    via an EXT_framebuffer_object FBO:
+        top half           = red
+        bottom-left        = green
+        bottom-right       = blue (clear colour)
+    Pass 2 draws that texture as a fullscreen quad in a 640x480 window.
+
+    Both passes are read back with glReadPixels and sample points are
+    printed. glReadPixels of the texture goes through Mesa's CPU-side
+    tiled->raster conversion, so it verifies the STORE side; the window
+    readback (and the visible result) verifies the SAMPLING side.
+*/
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+#include <exec/types.h>
+#include <intuition/intuition.h>
+#include <proto/exec.h>
+#include <proto/intuition.h>
+
+#include <GL/gla.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+#define WIN_W 640
+#define WIN_H 480
+#define FBO_W 320
+#define FBO_H 200
+
+CONST_STRPTR version = "$VER: gltexfbo 1.0 (04.07.2026) AROS";
+
+#ifndef GL_FRAMEBUFFER_EXT
+#define GL_FRAMEBUFFER_EXT          0x8D40
+#define GL_COLOR_ATTACHMENT0_EXT    0x8CE0
+#define GL_FRAMEBUFFER_COMPLETE_EXT 0x8CD5
+#endif
+#ifndef GL_CLAMP_TO_EDGE
+#define GL_CLAMP_TO_EDGE 0x812F
+#endif
+
+typedef void   (*PFN_GENFB)(GLsizei, GLuint *);
+typedef void   (*PFN_BINDFB)(GLenum, GLuint);
+typedef void   (*PFN_FBTEX2D)(GLenum, GLenum, GLenum, GLuint, GLint);
+typedef GLenum (*PFN_CHECKFB)(GLenum);
+
+static PFN_GENFB   pglGenFramebuffers;
+static PFN_BINDFB  pglBindFramebuffer;
+static PFN_FBTEX2D pglFramebufferTexture2D;
+static PFN_CHECKFB pglCheckFramebufferStatus;
+
+/* GL2 shader/attrib entry points for pass C (the scummvm-style path) */
+static PFNGLCREATESHADERPROC            pglCreateShader;
+static PFNGLSHADERSOURCEPROC            pglShaderSource;
+static PFNGLCOMPILESHADERPROC           pglCompileShader;
+static PFNGLGETSHADERIVPROC             pglGetShaderiv;
+static PFNGLCREATEPROGRAMPROC           pglCreateProgram;
+static PFNGLATTACHSHADERPROC            pglAttachShader;
+static PFNGLLINKPROGRAMPROC             pglLinkProgram;
+static PFNGLUSEPROGRAMPROC              pglUseProgram;
+static PFNGLBINDATTRIBLOCATIONPROC      pglBindAttribLocation;
+static PFNGLENABLEVERTEXATTRIBARRAYPROC pglEnableVertexAttribArray;
+static PFNGLDISABLEVERTEXATTRIBARRAYPROC pglDisableVertexAttribArray;
+static PFNGLVERTEXATTRIBPOINTERPROC     pglVertexAttribPointer;
+static PFNGLGETUNIFORMLOCATIONPROC      pglGetUniformLocation;
+static PFNGLUNIFORM1IPROC               pglUniform1i;
+
+#ifndef GL_COMPILE_STATUS
+#define GL_COMPILE_STATUS 0x8B81
+#endif
+#ifndef GL_FRAGMENT_SHADER
+#define GL_FRAGMENT_SHADER 0x8B30
+#define GL_VERTEX_SHADER   0x8B31
+#endif
+
+static const GLchar *vs_src =
+"attribute vec2 a_pos;"
+"attribute vec2 a_uv;"
+"varying vec2 v_uv;"
+"void main() { gl_Position = vec4(a_pos, 0.0, 1.0); v_uv = a_uv; }";
+
+static const GLchar *fs_src =
+"uniform sampler2D u_tex;"
+"varying vec2 v_uv;"
+"void main() { gl_FragColor = texture2D(u_tex, v_uv); }";
+
+static GLuint prg_global = 0;
+
+static GLAContext     glcont = NULL;
+static struct Window *win    = NULL;
+static BOOL           finished = FALSE;
+
+static void initgl(void)
+{
+    struct TagItem attributes[10];
+    int i = 0;
+
+    attributes[i].ti_Tag = GLA_Window;    attributes[i++].ti_Data = (IPTR)win;
+    attributes[i].ti_Tag = GLA_Left;      attributes[i++].ti_Data = win->BorderLeft;
+    attributes[i].ti_Tag = GLA_Top;       attributes[i++].ti_Data = win->BorderTop;
+    attributes[i].ti_Tag = GLA_Bottom;    attributes[i++].ti_Data = win->BorderBottom;
+    attributes[i].ti_Tag = GLA_Right;     attributes[i++].ti_Data = win->BorderRight;
+    attributes[i].ti_Tag = GLA_DoubleBuf; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_RGBMode;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoStencil; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoAccum;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = TAG_DONE;
+
+    glcont = glACreateContext(attributes);
+    if (glcont)
+        glAMakeCurrent(glcont);
+    else
+        finished = TRUE;
+}
+
+/* Print to both stdout and the serial log (driver lines live there). */
+static void out(const char *fmt, ...)
+{
+    char buf[256];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    printf("%s", buf);
+    bug("%s", buf);
+}
+
+static const char *classify(const GLubyte *px)
+{
+    if (px[0] > 128 && px[1] < 96 && px[2] < 96)   return "RED  ";
+    if (px[0] < 96 && px[1] > 128 && px[2] < 96)   return "GREEN";
+    if (px[0] < 96 && px[1] < 96 && px[2] > 128)   return "BLUE ";
+    if (px[0] < 32 && px[1] < 32 && px[2] < 32)    return "BLACK";
+    return "OTHER";
+}
+
+static void sample(const char *what, int x, int y, const char *expect)
+{
+    GLubyte px[4] = { 0, 0, 0, 0 };
+    glReadPixels(x, y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, px);
+    out("[gltexfbo] %s (%3d,%3d) = %02x%02x%02x%02x %s (expect %s)\n",
+        what, x, y, px[0], px[1], px[2], px[3], classify(px), expect);
+}
+
+static void handle_messages(void)
+{
+    struct IntuiMessage *msg;
+    while ((msg = (struct IntuiMessage *)GetMsg(win->UserPort)))
+    {
+        switch (msg->Class)
+        {
+        case IDCMP_CLOSEWINDOW:
+            finished = TRUE;
+            break;
+        case IDCMP_VANILLAKEY:
+            if (msg->Code == 27)
+                finished = TRUE;
+            break;
+        }
+        ReplyMsg((struct Message *)msg);
+    }
+}
+
+int main(void)
+{
+    struct Screen *pubscreen;
+    GLuint tex = 0, tex2 = 0, fbo = 0;
+    int round = 0;
+    static GLuint srcpix[640 * 480];
+
+    if ((pubscreen = LockPubScreen(NULL)) == NULL)
+        return 1;
+
+    win = OpenWindowTags(0,
+        WA_Title,         (IPTR)"gltexfbo",
+        WA_PubScreen,     pubscreen,
+        WA_CloseGadget,   TRUE,
+        WA_DragBar,       TRUE,
+        WA_DepthGadget,   TRUE,
+        WA_Left,          50,
+        WA_Top,           100,
+        WA_InnerWidth,    WIN_W,
+        WA_InnerHeight,   WIN_H,
+        WA_Activate,      TRUE,
+        WA_RMBTrap,       TRUE,
+        WA_SimpleRefresh, TRUE,
+        WA_NoCareRefresh, TRUE,
+        WA_IDCMP,         IDCMP_VANILLAKEY | IDCMP_CLOSEWINDOW,
+        TAG_DONE);
+
+    UnlockPubScreen(NULL, pubscreen);
+
+    if (!win)
+        return 1;
+
+    initgl();
+    if (finished)
+    {
+        CloseWindow(win);
+        return 1;
+    }
+
+    pglGenFramebuffers        = (PFN_GENFB)glAGetProcAddress("glGenFramebuffersEXT");
+    pglBindFramebuffer        = (PFN_BINDFB)glAGetProcAddress("glBindFramebufferEXT");
+    pglFramebufferTexture2D   = (PFN_FBTEX2D)glAGetProcAddress("glFramebufferTexture2DEXT");
+    pglCheckFramebufferStatus = (PFN_CHECKFB)glAGetProcAddress("glCheckFramebufferStatusEXT");
+
+    if (!pglGenFramebuffers || !pglBindFramebuffer ||
+        !pglFramebufferTexture2D || !pglCheckFramebufferStatus)
+    {
+        out("[gltexfbo] EXT_framebuffer_object entry points missing\n");
+        CloseWindow(win);
+        return 1;
+    }
+
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, FBO_W, FBO_H, 0,
+                 GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+
+    /* tex2: CPU-uploaded source texture (the scummvm game-screen role) */
+    glGenTextures(1, &tex2);
+    glBindTexture(GL_TEXTURE_2D, tex2);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    {
+        int x, y;
+        for (y = 0; y < 480; y++)
+            for (x = 0; x < 640; x++)          /* t=0 rows: YELLOW; t=1: CYAN */
+                srcpix[y * 640 + x] = (y < 240) ? 0xFF00FFFFUL : 0xFFFFFF00UL;
+    }
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 640, 480, 0,
+                 GL_RGBA, GL_UNSIGNED_BYTE, srcpix);
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    pglGenFramebuffers(1, &fbo);
+
+    while (!finished)
+    {
+        GLenum status;
+
+        /* ---- Pass 1: render pattern into the texture ---- */
+        pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+        pglFramebufferTexture2D(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT,
+                                GL_TEXTURE_2D, tex, 0);
+        status = pglCheckFramebufferStatus(GL_FRAMEBUFFER_EXT);
+        if (status != GL_FRAMEBUFFER_COMPLETE_EXT)
+        {
+            if (round == 0)
+                out("[gltexfbo] FBO incomplete: 0x%04x\n", (unsigned)status);
+            finished = TRUE;
+            break;
+        }
+
+        glViewport(0, 0, FBO_W, FBO_H);
+        glClearColor(0.0f, 0.0f, 1.0f, 1.0f);          /* blue */
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glDisable(GL_TEXTURE_2D);
+        glBegin(GL_QUADS);                              /* red: top half */
+        glColor3f(1.0f, 0.0f, 0.0f);
+        glVertex2f(-1.0f, 0.0f); glVertex2f(1.0f, 0.0f);
+        glVertex2f( 1.0f, 1.0f); glVertex2f(-1.0f, 1.0f);
+        glColor3f(0.0f, 1.0f, 0.0f);                    /* green: bottom-left */
+        glVertex2f(-1.0f, -1.0f); glVertex2f(0.0f, -1.0f);
+        glVertex2f( 0.0f,  0.0f); glVertex2f(-1.0f, 0.0f);
+        glEnd();
+
+        if (round == 0)
+        {
+            out("[gltexfbo] -- pass 1 readback (FBO, GL origin=bottom) --\n");
+            sample("fbo", 10, 10, "GREEN");
+            sample("fbo", 310, 10, "BLUE ");
+            sample("fbo", 10, 190, "RED  ");
+            sample("fbo", 310, 190, "RED  ");
+            sample("fbo", 160, 100, "RED  ");
+        }
+
+        /* ---- Pass 2: draw the texture as a fullscreen quad ---- */
+        pglBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+        glViewport(0, 0, WIN_W, WIN_H);
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glEnable(GL_TEXTURE_2D);
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glColor3f(1.0f, 1.0f, 1.0f);
+        glBegin(GL_QUADS);
+        glTexCoord2f(0.0f, 0.0f); glVertex2f(-1.0f, -1.0f);
+        glTexCoord2f(1.0f, 0.0f); glVertex2f( 1.0f, -1.0f);
+        glTexCoord2f(1.0f, 1.0f); glVertex2f( 1.0f,  1.0f);
+        glTexCoord2f(0.0f, 1.0f); glVertex2f(-1.0f,  1.0f);
+        glEnd();
+
+        if (round == 0)
+        {
+            int r;
+            out("[gltexfbo] -- pass 2 readback (window, GL origin=bottom) --\n");
+            sample("win", 20, 20, "GREEN");
+            sample("win", 620, 20, "BLUE ");
+            sample("win", 20, 460, "RED  ");
+            sample("win", 620, 460, "RED  ");
+            sample("win", 320, 240, "RED  ");
+            out("[gltexfbo] -- vertical map, x=320 --\n");
+            for (r = 10; r < WIN_H; r += 60)
+                sample("col", 320, r, r < WIN_H / 2 ? "GREEN/BLUE" : "RED  ");
+
+            /* ---- Pass B: client vertex arrays + GL_LINEAR ---- */
+            {
+                static const GLfloat vtx[] = {
+                    -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+                };
+                static const GLfloat uv[] = {
+                    0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+                };
+
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+                glClear(GL_COLOR_BUFFER_BIT);
+                glEnableClientState(GL_VERTEX_ARRAY);
+                glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+                glVertexPointer(2, GL_FLOAT, 0, vtx);
+                glTexCoordPointer(2, GL_FLOAT, 0, uv);
+                glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+                glDisableClientState(GL_VERTEX_ARRAY);
+                glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+
+                out("[gltexfbo] -- pass B (vertex arrays + LINEAR) --\n");
+                sample("pB ", 20, 20, "GREEN");
+                sample("pB ", 620, 20, "BLUE ");
+                sample("pB ", 20, 460, "RED  ");
+                sample("pB ", 320, 240, "RED  ");
+                for (r = 10; r < WIN_H; r += 120)
+                    sample("pBc", 320, r, r < WIN_H / 2 ? "GREEN/BLUE" : "RED  ");
+            }
+
+            /* ---- Pass C: GLSL shader + vertex attrib arrays ---- */
+            pglCreateShader   = (PFNGLCREATESHADERPROC)glAGetProcAddress("glCreateShader");
+            pglShaderSource   = (PFNGLSHADERSOURCEPROC)glAGetProcAddress("glShaderSource");
+            pglCompileShader  = (PFNGLCOMPILESHADERPROC)glAGetProcAddress("glCompileShader");
+            pglGetShaderiv    = (PFNGLGETSHADERIVPROC)glAGetProcAddress("glGetShaderiv");
+            pglCreateProgram  = (PFNGLCREATEPROGRAMPROC)glAGetProcAddress("glCreateProgram");
+            pglAttachShader   = (PFNGLATTACHSHADERPROC)glAGetProcAddress("glAttachShader");
+            pglLinkProgram    = (PFNGLLINKPROGRAMPROC)glAGetProcAddress("glLinkProgram");
+            pglUseProgram     = (PFNGLUSEPROGRAMPROC)glAGetProcAddress("glUseProgram");
+            pglBindAttribLocation = (PFNGLBINDATTRIBLOCATIONPROC)glAGetProcAddress("glBindAttribLocation");
+            pglEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)glAGetProcAddress("glEnableVertexAttribArray");
+            pglDisableVertexAttribArray = (PFNGLDISABLEVERTEXATTRIBARRAYPROC)glAGetProcAddress("glDisableVertexAttribArray");
+            pglVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)glAGetProcAddress("glVertexAttribPointer");
+            pglGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)glAGetProcAddress("glGetUniformLocation");
+            pglUniform1i      = (PFNGLUNIFORM1IPROC)glAGetProcAddress("glUniform1i");
+
+            if (pglCreateShader && pglVertexAttribPointer)
+            {
+                static const GLfloat vtx[] = {
+                    -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+                };
+                static const GLfloat uv[] = {
+                    0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+                };
+                GLuint vsh = pglCreateShader(GL_VERTEX_SHADER);
+                GLuint fsh = pglCreateShader(GL_FRAGMENT_SHADER);
+                GLuint prg = pglCreateProgram();
+                prg_global = prg;
+                GLint  ok1 = 0, ok2 = 0;
+
+                pglShaderSource(vsh, 1, &vs_src, NULL);
+                pglCompileShader(vsh);
+                pglGetShaderiv(vsh, GL_COMPILE_STATUS, &ok1);
+                pglShaderSource(fsh, 1, &fs_src, NULL);
+                pglCompileShader(fsh);
+                pglGetShaderiv(fsh, GL_COMPILE_STATUS, &ok2);
+
+                pglAttachShader(prg, vsh);
+                pglAttachShader(prg, fsh);
+                pglBindAttribLocation(prg, 0, "a_pos");
+                pglBindAttribLocation(prg, 1, "a_uv");
+                pglLinkProgram(prg);
+                pglUseProgram(prg);
+                pglUniform1i(pglGetUniformLocation(prg, "u_tex"), 0);
+
+                glClear(GL_COLOR_BUFFER_BIT);
+                pglEnableVertexAttribArray(0);
+                pglEnableVertexAttribArray(1);
+                pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+                pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+                glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+                pglDisableVertexAttribArray(0);
+                pglDisableVertexAttribArray(1);
+                pglUseProgram(0);
+
+                out("[gltexfbo] -- pass C (GLSL + attrib arrays) vs=%d fs=%d --\n",
+                       (int)ok1, (int)ok2);
+                sample("pC ", 20, 20, "GREEN");
+                sample("pC ", 620, 20, "BLUE ");
+                sample("pC ", 20, 460, "RED  ");
+                sample("pC ", 320, 240, "RED  ");
+                for (r = 10; r < WIN_H; r += 120)
+                    sample("pCc", 320, r, r < WIN_H / 2 ? "GREEN/BLUE" : "RED  ");
+            }
+            else
+                out("[gltexfbo] pass C skipped: no GL2 entry points\n");
+
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        }
+
+        /* ---- Rounds 2/3: scummvm-style flow. Round 2 draws the CPU-
+         * uploaded tex2 INTO the FBO (shader path, two draws = two shader
+         * recs), then FBO -> window. Round 3 first UPDATES tex2 while it
+         * is GPU-busy (glTexSubImage2D after sampling), then repeats —
+         * exercising Mesa's busy-resource upload path. ---- */
+        if ((round == 1 || round == 2) && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            static const GLfloat vtx2[] = {   /* small quad, bottom-left */
+                -1.0f, -1.0f,  -0.75f, -1.0f,  -0.75f, -0.75f,  -1.0f, -0.75f
+            };
+            const char *tag = (round == 1) ? "r2 " : "r3 ";
+            const char *topexp = (round == 1) ? "YELLOWISH" : "GREEN";
+            const char *botexp = (round == 1) ? "CYANISH" : "RED  ";
+            int r;
+
+            if (round == 2)
+            {
+                /* Update the (busy) source texture: swap the pattern to
+                 * GREEN top / RED bottom. */
+                int x, y;
+                for (y = 0; y < 480; y++)
+                    for (x = 0; x < 640; x++)
+                        srcpix[y * 640 + x] =
+                            (y < 240) ? 0xFF00FF00UL : 0xFF0000FFUL;
+                glBindTexture(GL_TEXTURE_2D, tex2);
+                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 640, 480,
+                                GL_RGBA, GL_UNSIGNED_BYTE, srcpix);
+            }
+
+            /* Pass 1': draw tex2 into the FBO via the GLSL path */
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            glViewport(0, 0, FBO_W, FBO_H);
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            pglUseProgram(prg_global);
+            glBindTexture(GL_TEXTURE_2D, tex2);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            /* second draw: small quad, second shader rec in the submit */
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx2);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+            out("[gltexfbo] -- %s FBO readback (tex2 -> fbo, GLSL) --\n", tag);
+            sample(tag, 160, 150, topexp);   /* top half of tex2 (t<0.5) */
+            sample(tag, 160, 50, botexp);    /* bottom half */
+
+            /* Pass 2': FBO texture -> window */
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+            glViewport(0, 0, WIN_W, WIN_H);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glBindTexture(GL_TEXTURE_2D, tex);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+
+            out("[gltexfbo] -- %s window readback --\n", tag);
+            sample(tag, 320, 360, topexp);
+            sample(tag, 320, 120, botexp);
+            for (r = 10; r < WIN_H; r += 120)
+                sample(tag, 320, r, "map  ");
+        }
+
+        /* ---- Round 4: the remaining scummvm particulars — PARTIAL
+         * glTexSubImage2D (dirty-rect with x/y offset), GL_LINEAR on the
+         * FBO texture, and a letterboxed sub-viewport in the FBO pass. */
+        if (round == 3 && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            static GLuint strip[400 * 20];
+            int i, r;
+
+            /* white dirty-rect at tex rows 100..119, x 50..449 */
+            for (i = 0; i < 400 * 20; i++)
+                strip[i] = 0xFFFFFFFFUL;
+            glBindTexture(GL_TEXTURE_2D, tex2);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 50, 100, 400, 20,
+                            GL_RGBA, GL_UNSIGNED_BYTE, strip);
+
+            /* FBO texture sampled with LINEAR from now on */
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+            /* Pass 1'': letterboxed viewport inside the FBO */
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            glViewport(0, 0, FBO_W, FBO_H);
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glViewport(0, 20, FBO_W, FBO_H - 40);   /* 20px letterbox */
+
+            pglUseProgram(prg_global);
+            glBindTexture(GL_TEXTURE_2D, tex2);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+            out("[gltexfbo] -- r4 FBO map x=160 (letterbox 0..19/180..199 BLACK, "
+                "white strip ~y=53..60) --\n");
+            for (r = 5; r < FBO_H; r += 13)
+                sample("r4f", 160, r, "map  ");
+
+            /* Pass 2'': FBO -> window (LINEAR) */
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+            glViewport(0, 0, WIN_W, WIN_H);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glBindTexture(GL_TEXTURE_2D, tex);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+
+            out("[gltexfbo] -- r4 window map x=320 (black<48, white ~127..145, "
+                "black>432) --\n");
+            for (r = 10; r < WIN_H; r += 30)
+                sample("r4w", 320, r, "map  ");
+        }
+
+        /* ---- Round 5: BLENDING + SCISSOR in the FBO pass (the last
+         * untested scummvm mechanics: alpha-blended cursor/overlay draws
+         * and scissored dirty-region rendering). */
+        if (round == 4 && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            int r;
+
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            glViewport(0, 0, FBO_W, FBO_H);
+            glClearColor(0.0f, 0.0f, 1.0f, 1.0f);      /* blue base */
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            /* scissored region: only rows 80..119 may be written */
+            glEnable(GL_SCISSOR_TEST);
+            glScissor(0, 80, FBO_W, 40);
+
+            /* blended full quad: tex2 at 50% alpha over blue */
+            glEnable(GL_BLEND);
+            glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
+            /* CONSTANT_ALPHA needs glBlendColor — fall back to additive
+             * which needs no extra entry points and still exercises the
+             * blend path: result = src + dst. */
+            glBlendFunc(GL_ONE, GL_ONE);
+
+            pglUseProgram(prg_global);
+            glBindTexture(GL_TEXTURE_2D, tex2);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+            glDisable(GL_BLEND);
+            glDisable(GL_SCISSOR_TEST);
+
+            /* Expected FBO content: pure blue everywhere EXCEPT rows
+             * 80..119: green+blue=cyan (rows 80..99 sample tex2 green
+             * region? tex2 t<0.5=GREEN rows -> fbo lower half) and
+             * red+blue=magenta above t=0.5. The white strip adds white. */
+            out("[gltexfbo] -- r5 FBO map x=160 (blend+scissor: blue outside "
+                "80..119, cyan/magenta inside) --\n");
+            for (r = 60; r < 140; r += 10)
+                sample("r5f", 160, r, "map  ");
+        }
+
+        /* ---- Round 6: the scummvm dirty-rect torture — many small
+         * position-coded glTexSubImage2D updates interleaved with draws
+         * (texture busy), with GL_UNPACK_ROW_LENGTH set. Each rect is
+         * filled with a colour encoding its index; the readback then
+         * shows exactly where each rect actually landed. */
+        if (round == 5 && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            static GLuint big[640 * 480];  /* ROW_LENGTH=640 source surface */
+            int i, x, y;
+
+            /* Base: mid-grey everywhere */
+            for (i = 0; i < 640 * 480; i++)
+                big[i] = 0xFF808080UL;
+            glBindTexture(GL_TEXTURE_2D, tex2);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 640, 480,
+                            GL_RGBA, GL_UNSIGNED_BYTE, big);
+
+            glEnableClientState(GL_VERTEX_ARRAY); /* keep attribs simple */
+            glDisableClientState(GL_VERTEX_ARRAY);
+
+            pglUseProgram(prg_global);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+
+            glPixelStorei(GL_UNPACK_ROW_LENGTH, 640);
+
+            /* 12 rects, 40x20 each, at spread positions; colour = index
+             * coded in the green channel (0x10 * (i+1)). Interleave each
+             * upload with a draw so the texture is busy. */
+            for (i = 0; i < 12; i++)
+            {
+                int rx = (i % 4) * 150 + 20;   /* 20,170,320,470 */
+                int ry = (i / 4) * 150 + 30;   /* 30,180,330 */
+                GLuint col = 0xFF000000UL | ((0x10UL * (i + 1)) << 8);
+
+                /* paint the rect region inside the big surface */
+                for (y = 0; y < 20; y++)
+                    for (x = 0; x < 40; x++)
+                        big[(ry + y) * 640 + (rx + x)] = col;
+
+                glTexSubImage2D(GL_TEXTURE_2D, 0, rx, ry, 40, 20,
+                                GL_RGBA, GL_UNSIGNED_BYTE,
+                                &big[ry * 640 + rx]);
+
+                /* draw into the FBO so the texture is busy for the next
+                 * upload */
+                pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+                glViewport(0, 0, FBO_W, FBO_H);
+                glBindTexture(GL_TEXTURE_2D, tex2);
+                glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            }
+            glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+            /* Final: FBO -> window, then verify every rect via the FBO
+             * coordinates (640x480 -> 320x200: x/2, y*200/480). */
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+            glViewport(0, 0, WIN_W, WIN_H);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glBindTexture(GL_TEXTURE_2D, tex);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+
+            out("[gltexfbo] -- r6 dirty-rect torture: each rect i should "
+                "read green=0x10*(i+1) --\n");
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            for (i = 0; i < 12; i++)
+            {
+                int rx = (i % 4) * 150 + 20 + 20;   /* rect centre */
+                int ry = (i / 4) * 150 + 30 + 10;
+                /* tex2 y -> fbo y: v = y/480; fbo row = v*200.
+                 * GL readback y = fbo row (same origin as render). */
+                int fx = rx / 2;
+                int fy = (int)((long)ry * 200 / 480);
+                char what[8];
+                snprintf(what, sizeof(what), "r6_%02d", i);
+                sample(what, fx, fy, "GREEN-coded");
+            }
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+        }
+
+        /* ---- Round 7: 8-bit (cpp=1) texture — the scummvm CLUT8/eduke32
+         * indexed path. GL_LUMINANCE 320x200 with position-coded content:
+         * horizontal bands of distinct grey levels (32*band) plus a white
+         * column at x=100..107. cpp=1 T-format uses 8x8 utiles — a layout
+         * never exercised by the cpp=4 rounds. */
+        if (round == 6 && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            static GLubyte lum[320 * 200];
+            GLuint tex3 = 0;
+            int x, y, r;
+
+            for (y = 0; y < 200; y++)
+                for (x = 0; x < 320; x++)
+                    lum[y * 320 + x] =
+                        (x >= 100 && x < 108) ? 0xFF
+                                              : (GLubyte)((y / 25) * 32 + 16);
+
+            glGenTextures(1, &tex3);
+            glBindTexture(GL_TEXTURE_2D, tex3);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 320, 200, 0,
+                         GL_LUMINANCE, GL_UNSIGNED_BYTE, lum);
+
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            glViewport(0, 0, FBO_W, FBO_H);
+            glClearColor(1.0f, 0.0f, 1.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            pglUseProgram(prg_global);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+
+            /* 1:1 mapping (320x200 tex -> 320x200 fbo, v flipped by uv).
+             * Band value at fbo row y = ((199-y)/25)*32+16.
+             * Expect x=50: band greys; x=103: white 0xFF. */
+            out("[gltexfbo] -- r7 8-bit LUMINANCE map (fbo row y: grey = "
+                "((199-y)/25)*32+16; x=103 white) --\n");
+            for (r = 12; r < FBO_H; r += 25)
+                sample("r7a", 50, r, "band ");
+            for (r = 12; r < FBO_H; r += 50)
+                sample("r7b", 103, r, "WHITE");
+        }
+
+        /* ---- Round 8: isolate the cpp=1 failure seen in round 7.
+         * r8a: pure CPU round-trip (glTexImage2D store -> glGetTexImage
+         * load) of a T-format 8-bit texture. The two directions use the
+         * same address math, so a mismatch means the CPU tiling code
+         * itself is broken; a clean pass means the layout is at least
+         * self-consistent and the TMU disagrees with it.
+         * r8b: 32-wide 8-bit texture = LT format (not T) drawn and read
+         * back, to tell whether LT cpp=1 works while T cpp=1 fails. */
+        if (round == 7 && pglCreateShader)
+        {
+            static const GLfloat vtx[] = {
+                -1.0f, -1.0f,  1.0f, -1.0f,  1.0f, 1.0f,  -1.0f, 1.0f
+            };
+            static const GLfloat uv[] = {
+                0.0f, 0.0f,  1.0f, 0.0f,  1.0f, 1.0f,  0.0f, 1.0f
+            };
+            static GLubyte lum[320 * 200], back[320 * 200];
+            static GLubyte lumlt[32 * 200];
+            GLuint t8 = 0, t8lt = 0;
+            int x, y, bad = 0, r;
+
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+            glPixelStorei(GL_PACK_ALIGNMENT, 1);
+
+            for (y = 0; y < 200; y++)
+                for (x = 0; x < 320; x++)
+                    lum[y * 320 + x] = (GLubyte)(x * 7 + y * 13);
+
+            glGenTextures(1, &t8);
+            glBindTexture(GL_TEXTURE_2D, t8);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 320, 200, 0,
+                         GL_LUMINANCE, GL_UNSIGNED_BYTE, lum);
+
+            memset(back, 0xAA, sizeof(back));
+            glGetTexImage(GL_TEXTURE_2D, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE,
+                          back);
+            for (y = 0; y < 200; y++)
+                for (x = 0; x < 320; x++)
+                    if (back[y * 320 + x] != lum[y * 320 + x])
+                    {
+                        if (bad < 4)
+                            out("[gltexfbo] r8a MISMATCH (%3d,%3d) "
+                                "got=%02x want=%02x\n", x, y,
+                                back[y * 320 + x], lum[y * 320 + x]);
+                        bad++;
+                    }
+            out("[gltexfbo] r8a T cpp=1 CPU round-trip: %d mismatches "
+                "of 64000\n", bad);
+
+            for (y = 0; y < 200; y++)
+                for (x = 0; x < 32; x++)
+                    lumlt[y * 32 + x] = (GLubyte)((y / 25) * 32 + 16);
+
+            glGenTextures(1, &t8lt);
+            glBindTexture(GL_TEXTURE_2D, t8lt);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 32, 200, 0,
+                         GL_LUMINANCE, GL_UNSIGNED_BYTE, lumlt);
+
+            memset(back, 0xAA, sizeof(back));
+            glGetTexImage(GL_TEXTURE_2D, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE,
+                          back);
+            bad = 0;
+            for (y = 0; y < 200; y++)
+                for (x = 0; x < 32; x++)
+                    if (back[y * 32 + x] != lumlt[y * 32 + x])
+                        bad++;
+            out("[gltexfbo] r8b LT cpp=1 CPU round-trip: %d mismatches "
+                "of 6400\n", bad);
+
+            pglBindFramebuffer(GL_FRAMEBUFFER_EXT, fbo);
+            glViewport(0, 0, FBO_W, FBO_H);
+            glClearColor(1.0f, 0.0f, 1.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            pglUseProgram(prg_global);
+            pglEnableVertexAttribArray(0);
+            pglEnableVertexAttribArray(1);
+            pglVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vtx);
+            pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, uv);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+            pglDisableVertexAttribArray(0);
+            pglDisableVertexAttribArray(1);
+            pglUseProgram(0);
+
+            out("[gltexfbo] -- r8c LT cpp=1 TMU sample (8 clean bands = "
+                "LT ok) --\n");
+            for (r = 12; r < FBO_H; r += 25)
+                sample("r8c", 50, r, "band ");
+        }
+
+        if (round < 8)
+            round++;
+
+        glASwapBuffers(glcont);
+        handle_messages();
+    }
+
+    if (fbo)
+    {
+        /* no delete fn fetched; process exit cleans up */
+    }
+    if (glcont)
+        glADestroyContext(glcont);
+
+    CloseWindow(win);
+    return 0;
+}

--- a/developer/debug/test/gl/gltri.c
+++ b/developer/debug/test/gl/gltri.c
@@ -1,0 +1,154 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Minimal GL test: clear + one immediate-mode triangle, fixed-function
+    pipeline (no glCreateShader/glUseProgram). Triangle over dark red =
+    basic rendering works, isolating any corruption to the user-shader path.
+*/
+#define DEBUG 1
+#include <aros/debug.h>
+
+#include <exec/types.h>
+#include <intuition/intuition.h>
+#include <proto/exec.h>
+#include <proto/intuition.h>
+
+#include <GL/gla.h>
+
+#include <stdio.h>
+
+#define VISIBLE_WIDTH  300
+#define VISIBLE_HEIGHT 300
+
+CONST_STRPTR version = "$VER: gltri 1.0 (18.05.2026) AROS";
+
+static GLAContext     glcont = NULL;
+static struct Window *win    = NULL;
+static BOOL           finished = FALSE;
+
+static void initgl(void)
+{
+    struct TagItem attributes[10];
+    int i = 0;
+
+    attributes[i].ti_Tag = GLA_Window;    attributes[i++].ti_Data = (IPTR)win;
+    attributes[i].ti_Tag = GLA_Left;      attributes[i++].ti_Data = win->BorderLeft;
+    attributes[i].ti_Tag = GLA_Top;       attributes[i++].ti_Data = win->BorderTop;
+    attributes[i].ti_Tag = GLA_Bottom;    attributes[i++].ti_Data = win->BorderBottom;
+    attributes[i].ti_Tag = GLA_Right;     attributes[i++].ti_Data = win->BorderRight;
+    attributes[i].ti_Tag = GLA_DoubleBuf; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_RGBMode;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoStencil; attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = GLA_NoAccum;   attributes[i++].ti_Data = GL_TRUE;
+    attributes[i].ti_Tag = TAG_DONE;
+
+    glcont = glACreateContext(attributes);
+    if (glcont)
+    {
+        bug("[gltri] before glAMakeCurrent\n");
+        glAMakeCurrent(glcont);
+        bug("[gltri] before glViewport\n");
+        glViewport(0, 0, VISIBLE_WIDTH, VISIBLE_HEIGHT);
+        bug("[gltri] before glMatrixMode(GL_PROJECTION)\n");
+        glMatrixMode(GL_PROJECTION);
+        bug("[gltri] before glLoadIdentity (1)\n");
+        glLoadIdentity();
+        bug("[gltri] before glMatrixMode(GL_MODELVIEW)\n");
+        glMatrixMode(GL_MODELVIEW);
+        bug("[gltri] before glLoadIdentity (2)\n");
+        glLoadIdentity();
+        bug("[gltri] initgl done\n");
+    }
+    else
+    {
+        finished = TRUE;
+    }
+}
+
+static void handle_messages(void)
+{
+    struct IntuiMessage *msg;
+    while ((msg = (struct IntuiMessage *)GetMsg(win->UserPort)))
+    {
+        switch (msg->Class)
+        {
+        case IDCMP_CLOSEWINDOW:
+            finished = TRUE;
+            break;
+        case IDCMP_VANILLAKEY:
+            if (msg->Code == 27)
+                finished = TRUE;
+            break;
+        }
+        ReplyMsg((struct Message *)msg);
+    }
+}
+
+int main(void)
+{
+    struct Screen *pubscreen;
+
+    if ((pubscreen = LockPubScreen(NULL)) == NULL)
+        return 1;
+
+    win = OpenWindowTags(0,
+        WA_Title,         (IPTR)"gltri",
+        WA_PubScreen,     pubscreen,
+        WA_CloseGadget,   TRUE,
+        WA_DragBar,       TRUE,
+        WA_DepthGadget,   TRUE,
+        WA_Left,          50,
+        WA_Top,           200,
+        WA_InnerWidth,    VISIBLE_WIDTH,
+        WA_InnerHeight,   VISIBLE_HEIGHT,
+        WA_Activate,      TRUE,
+        WA_RMBTrap,       TRUE,
+        WA_SimpleRefresh, TRUE,
+        WA_NoCareRefresh, TRUE,
+        WA_IDCMP,         IDCMP_VANILLAKEY | IDCMP_CLOSEWINDOW,
+        TAG_DONE);
+
+    UnlockPubScreen(NULL, pubscreen);
+
+    if (!win)
+        return 1;
+
+    initgl();
+
+    static int dbg_once = 0;
+    while (!finished)
+    {
+        glClearColor(0.5f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        if (!dbg_once) bug("[gltri] before glBegin\n");
+        glBegin(GL_TRIANGLES);
+        if (!dbg_once) bug("[gltri] before glColor3f #1\n");
+            glColor3f(1.0f, 0.0f, 0.0f);
+        if (!dbg_once) bug("[gltri] before glVertex2f #1\n");
+            glVertex2f(-0.5f, -0.5f);
+        if (!dbg_once) bug("[gltri] before glColor3f #2\n");
+            glColor3f(0.0f, 1.0f, 0.0f);
+        if (!dbg_once) bug("[gltri] before glVertex2f #2\n");
+            glVertex2f( 0.5f, -0.5f);
+        if (!dbg_once) bug("[gltri] before glColor3f #3\n");
+            glColor3f(0.0f, 0.0f, 1.0f);
+        if (!dbg_once) bug("[gltri] before glVertex2f #3\n");
+            glVertex2f( 0.0f,  0.5f);
+        if (!dbg_once) bug("[gltri] before glEnd\n");
+        glEnd();
+        if (!dbg_once) bug("[gltri] before glASwapBuffers\n");
+        glASwapBuffers(glcont);
+        if (!dbg_once) bug("[gltri] frame done\n");
+        dbg_once = 1;
+
+        handle_messages();
+    }
+
+
+    if (glcont)
+        glADestroyContext(glcont);
+
+    CloseWindow(win);
+    return 0;
+}

--- a/developer/debug/test/gl/mmakefile.src
+++ b/developer/debug/test/gl/mmakefile.src
@@ -4,7 +4,11 @@ include $(SRCDIR)/config/aros.cfg
 
 GLTESTFILES 	    := \
         glsimplerendering \
-        glgetprocaddress
+        glgetprocaddress \
+        glclear \
+        glcustomscreen \
+        gltri \
+        gltexfbo
 
 EXEDIR      := $(AROS_TESTS)/graphics/gl
 

--- a/workbench/hidds/gallium/gallium.conf
+++ b/workbench/hidds/gallium/gallium.conf
@@ -22,4 +22,5 @@ Get
 CreatePipeScreen
 DestroyPipeScreen
 DisplayResource
+DisplayResourceRP
 ##end methodlist

--- a/workbench/hidds/gallium/gallium_class.c
+++ b/workbench/hidds/gallium/gallium_class.c
@@ -51,7 +51,6 @@ VOID METHOD(HiddGallium, Root, Get)
         }
     }
 
-    /* Use parent class for all other properties */
     OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
 }
 
@@ -91,5 +90,13 @@ VOID METHOD(HiddGallium, Hidd_Gallium, DisplaySurface)
 VOID METHOD(HiddGallium, Hidd_Gallium, DisplayResource)
 {
     D(bug ("[Gallium] %s()\n", __func__));
+}
+
+IPTR METHOD(HiddGallium, Hidd_Gallium, DisplayResourceRP)
+{
+    /* Default: not handled. gallium.library falls back to the
+     * per-cliprect DisplayResource loop. */
+    D(bug ("[Gallium] %s()\n", __func__));
+    return FALSE;
 }
 

--- a/workbench/hidds/gallium/gallium_intern.h
+++ b/workbench/hidds/gallium/gallium_intern.h
@@ -10,7 +10,8 @@
 #include <stdbool.h>
 
 #include "pipe/p_shader_tokens.h"
-#if defined(TGSI_SEMANTIC_VIEWPORT_MASK)
+/* Mesa 21.0+ renamed state_tracker/ -> frontend/. */
+#if defined(__has_include) && __has_include("frontend/sw_winsys.h")
 #include "frontend/sw_winsys.h"
 #else
 #include "state_tracker/sw_winsys.h"
@@ -23,13 +24,13 @@ struct HiddGalliumData
     APTR  pad;
 };
 
-struct galliumstaticdata 
+struct galliumstaticdata
 {
     OOP_Class       *galliumclass;
     OOP_AttrBase    galliumAttrBase;
 };
 
-LIBBASETYPE 
+LIBBASETYPE
 {
     struct Library              LibNode;
     struct galliumstaticdata    sd;

--- a/workbench/hidds/gallium/include/gallium.h
+++ b/workbench/hidds/gallium/include/gallium.h
@@ -43,6 +43,7 @@ enum
     moHidd_Gallium_CreatePipeScreen = 0,
     moHidd_Gallium_DestroyPipeScreen,
     moHidd_Gallium_DisplayResource,
+    moHidd_Gallium_DisplayResourceRP,
 
     NUM_GALLIUM_METHODS
 };
@@ -50,11 +51,13 @@ enum
 enum
 {
     aoHidd_Gallium_InterfaceVersion = 0,
+    aoHidd_Gallium_CoreAPI,
 
     num_Hidd_Gallium_Attrs
 };
 
 #define aHidd_Gallium_InterfaceVersion  (HiddGalliumAttrBase + aoHidd_Gallium_InterfaceVersion)
+#define aHidd_Gallium_CoreAPI  (HiddGalliumAttrBase + aoHidd_Gallium_CoreAPI)
 #define aHidd_Gallium_WinSys  (HiddGalliumAttrBase + aoHidd_Gallium_WinSys)
 
 #define IS_GALLIUM_ATTR(attr, idx) \
@@ -83,6 +86,25 @@ struct pHidd_Gallium_DisplayResource
     STACKED ULONG                   dsty;
     STACKED ULONG                   width;
     STACKED ULONG                   height;
+};
+
+/* Whole-window present into a RastPort. A driver that can present the
+ * resource itself (zero-copy overlay, scanout flip, or its own DMA blit)
+ * overrides this and returns TRUE. The base class returns FALSE and the
+ * caller (gallium.library BltPipeResourceRastPort) falls back to the
+ * per-cliprect DisplayResource loop. */
+struct pHidd_Gallium_DisplayResourceRP
+{
+    STACKED OOP_MethodID            mID;
+    STACKED APTR                    resource; // struct pipe_resource
+    STACKED LONG                    srcx;
+    STACKED LONG                    srcy;
+
+    STACKED struct RastPort         *rastport;
+    STACKED LONG                    dstx;
+    STACKED LONG                    dsty;
+    STACKED LONG                    width;
+    STACKED LONG                    height;
 };
 
 #endif

--- a/workbench/libs/gallium/bltpiperesourcerastport.c
+++ b/workbench/libs/gallium/bltpiperesourcerastport.c
@@ -63,6 +63,26 @@
     if (!IsLayerVisible(L))
         return;
 
+    {
+        /* Whole-window present: a driver that can flip/overlay/blit the
+         * resource itself handles this and returns TRUE. FALSE falls
+         * through to the per-cliprect DisplayResource loop below. */
+        struct pHidd_Gallium_DisplayResourceRP rpmsg = {
+            .mID      = ((struct GalliumBase *)GalliumBase)->galliumMId_DisplayResourceRP,
+            .resource = srcPipeResource,
+            .srcx     = xSrc,
+            .srcy     = ySrc,
+            .rastport = destRP,
+            .dstx     = xDest,
+            .dsty     = yDest,
+            .width    = xSize,
+            .height   = ySize,
+        };
+
+        if (OOP_DoMethod((OOP_Object *)pipe, (OOP_Msg)&rpmsg))
+            return;
+    }
+
     struct Rectangle renderableLayerRect;
     struct pHidd_Gallium_DisplayResource drmsg = {
         .mID      = ((struct GalliumBase *)GalliumBase)->galliumMId_DisplayResource,

--- a/workbench/libs/gallium/createpipe.c
+++ b/workbench/libs/gallium/createpipe.c
@@ -9,12 +9,23 @@
 
 #include <hidd/gfx.h>
 
-#include <stdio.h>
-
 #include "gallium_intern.h"
 
 #undef HiddGalliumAttrBase
 #define HiddGalliumAttrBase GB(GalliumBase)->galliumAttrBase
+
+/* Base-free string join. This library is resident; going through the
+ * stdc sprintf stub would cache the FIRST caller task's per-task
+ * StdCBase in our globals and use that dead base from every later
+ * process (2nd-GL-app crash). */
+static void galliumstrjoin(char *dst, const char *a, const char *b)
+{
+    while (*a)
+        *dst++ = *a++;
+    while (*b)
+        *dst++ = *b++;
+    *dst = '\0';
+}
 
 /*****************************************************************************
 
@@ -59,6 +70,7 @@
     struct TagItem galliumTags[] =
     {
         { aHidd_Gallium_InterfaceVersion,       0 },
+        { aHidd_Gallium_CoreAPI,                0 },
         { TAG_DONE,                             0 }
     };
     OOP_Object                                  *_driver = NULL;
@@ -67,6 +79,7 @@
     struct Screen                               *pubscreen = NULL;
 
     galliumTags[0].ti_Data = GetTagData(CPS_GalliumInterfaceVersion, -1, tags);
+    galliumTags[1].ti_Data = GetTagData(CPS_GalliumCoreAPI, 0, tags);
     friendbm = (struct BitMap *)GetTagData(CPS_PipeFriendBitMap, 0, tags);
     driver = (OOP_Object **)GetTagData(CPS_PipeScreenDriver, (IPTR)&_driver, tags);
 
@@ -105,7 +118,7 @@
         char tmpname[128];
         if (!GB(GalliumBase)->fallbackmodule)
         {
-            sprintf(tmpname, "%s.hidd", GB(GalliumBase)->fallback);
+            galliumstrjoin(tmpname, GB(GalliumBase)->fallback, ".hidd");
 
             D(bug("[Gallium] %s: trying fallback '%s' ...\n", __PRETTY_FUNCTION__, tmpname));
 
@@ -116,7 +129,7 @@
 
         if (GB(GalliumBase)->fallbackmodule)
         {
-            sprintf(tmpname, "hidd.gallium.%s", GB(GalliumBase)->fallback);
+            galliumstrjoin(tmpname, "hidd.gallium.", GB(GalliumBase)->fallback);
 
             *driver = OOP_NewObject(NULL, tmpname, galliumTags);
 

--- a/workbench/libs/gallium/gallium_init.c
+++ b/workbench/libs/gallium/gallium_init.c
@@ -34,6 +34,7 @@ static int Init(LIBBASETYPEPTR LIBBASE)
     /* cache method id's that we use ..  */
     LIBBASE->galliumMId_UpdateRect = OOP_GetMethodID(IID_Hidd_BitMap, moHidd_BitMap_UpdateRect);
     LIBBASE->galliumMId_DisplayResource = OOP_GetMethodID(IID_Hidd_Gallium, moHidd_Gallium_DisplayResource);
+    LIBBASE->galliumMId_DisplayResourceRP = OOP_GetMethodID(IID_Hidd_Gallium, moHidd_Gallium_DisplayResourceRP);
 
     return TRUE;
 }

--- a/workbench/libs/gallium/gallium_intern.h
+++ b/workbench/libs/gallium/gallium_intern.h
@@ -52,6 +52,7 @@ struct GalliumBase
     /* methods we use .. */
     OOP_MethodID                galliumMId_UpdateRect;
     OOP_MethodID                galliumMId_DisplayResource;
+    OOP_MethodID                galliumMId_DisplayResourceRP;
 };
 
 #define GB(lb)  ((struct GalliumBase *)lb)

--- a/workbench/libs/gallium/include/gallium.h
+++ b/workbench/libs/gallium/include/gallium.h
@@ -12,6 +12,11 @@
 #define CPS_GalliumInterfaceVersion     (CPS_Dummy + 1)
 #define CPS_PipeFriendBitMap            (CPS_Dummy + 2)
 #define CPS_PipeScreenDriver            (CPS_Dummy + 3)
+/* mesa3dgl's GalliumCoreAPI table (struct GalliumCoreAPI *). Forwarded to
+ * the pipe hidd as aHidd_Gallium_CoreAPI so a runtime-bound pipe driver
+ * can call the one Mesa compiler core. 0 when the build carries no
+ * table; drivers that need it refuse CreatePipeScreen. */
+#define CPS_GalliumCoreAPI              (CPS_Dummy + 4)
 
 /* A special version of CreatePipe function with version embeded in call */
 #define CreatePipeV(tags)                                               \

--- a/workbench/libs/mesa/aros_drm_shim.c
+++ b/workbench/libs/mesa/aros_drm_shim.c
@@ -1,0 +1,305 @@
+/*
+    Copyright 2026, The AROS Development Team. All rights reserved.
+
+    Generic POSIX/libc and libdrm shims for the Mesa gallium drivers
+    statically linked into mesa3dgl.library. Mesa references a handful of
+    POSIX entry points (close/mmap/fcntl/sysconf/clock_gettime/getenv) and
+    the libdrm userland API (drmIoctl / drmPrime* / drmSyncobj*); AROS
+    provides none natively. These shims either no-op or route through the
+    AROS bridge (aros_drm_bridge), so they are driver-agnostic.
+
+    Per-driver glue — screen creation, the present/display path that
+    dereferences the driver's Mesa resource types, and the driver's own
+    linker stubs — lives in aros_drm_<driver>.c (e.g. aros_drm_vc4.c).
+
+    Only compiled in when MESA3DGL_GALLIUMCORE serves a DRM-needing driver
+    (currently gallium_vc4 on raspi); other builds keep arosc's libc.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+
+#include <aros/types/timespec_s.h>   /* struct timespec for clock_gettime() */
+
+#include <errno.h>
+#include <string.h>
+
+#include "vc4_aros_bridge.h"
+
+/* Per-process current bridge: the driver's screen-create glue sets it,
+ * the shims below dispatch through it. Single screen per process, same
+ * limit as the old in-hidd single fd_storage. */
+struct vc4_aros_bridge *aros_drm_bridge = NULL;
+
+/* Serial-log helper for instrumentation inside Mesa driver code (which
+ * can't easily include AROS debug headers). */
+#include <stdarg.h>
+#include <stdio.h>
+void vc4_aros_log(const char *fmt, ...)
+{
+    char lbuf[256];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(lbuf, sizeof(lbuf), fmt, ap);
+    va_end(ap);
+    bug("%s", lbuf);
+}
+
+/* Intercept Mesa's stderr diagnostics (Mesa is statically linked into
+ * mesa3dgl and calls fprintf/vfprintf/fputs for GL_INVALID_ENUM etc. that
+ * apps trigger by using GL features vc4's GL 2.1 lacks). Routed to the
+ * serial log rather than posixc stdio: a strong def here wins over the
+ * posixc linklib for Mesa's calls inside mesa3dgl, and going through
+ * posixc stdio from library context crashed (its per-task FILE state is
+ * unusable there).
+ *
+ * Always logged, never D()-gated: release Mesa only writes to stderr for
+ * things worth seeing - assertion failures, unreachable() and driver
+ * warnings. Swallowing them cost a long debugging session where an
+ * assertion fired, its message went nowhere, and the only evidence left
+ * was an illegal instruction (see the abort() note below). */
+int fprintf(FILE *stream, const char *fmt, ...)
+{
+    char lbuf[512];
+    va_list ap;
+
+    (void)stream;
+    va_start(ap, fmt);
+    vsnprintf(lbuf, sizeof(lbuf), fmt, ap);
+    va_end(ap);
+    bug("[mesa] %s", lbuf);
+    return 0;
+}
+
+int vfprintf(FILE *stream, const char *fmt, va_list ap)
+{
+    char lbuf[512];
+
+    (void)stream;
+    vsnprintf(lbuf, sizeof(lbuf), fmt, ap);
+    bug("[mesa] %s", lbuf);
+    return 0;
+}
+
+int fputs(const char *s, FILE *stream)
+{
+    (void)stream;
+    bug("[mesa] %s\n", s ? s : "(null)");
+    return 0;
+}
+
+/* Mesa calls abort() from assert() and unreachable(). stdc's abort()
+ * documents that it must not be used from a shared library: it longjmps
+ * to the exit point installed by a program's startup code, which does
+ * not exist in our context, so it RETURNS. The compiler treats abort()
+ * as noreturn and emits no return path, so control then falls out of the
+ * function into whatever follows it - a literal pool, in the case that
+ * sent us hunting an "Illegal instruction" at a float constant.
+ *
+ * Terminate the offending task instead, after saying so. RemTask(NULL)
+ * does not return and leaves the rest of the system alive, which beats
+ * both silently continuing and taking the machine down. */
+void abort(void)
+{
+    bug("[mesa] abort() called - killing task '%s'\n",
+        FindTask(NULL)->tc_Node.ln_Name ?
+            FindTask(NULL)->tc_Node.ln_Name : "?");
+
+    RemTask(NULL);
+
+    /* RemTask(NULL) never returns; keep the compiler's noreturn
+     * contract intact if it ever did. */
+    for (;;) ;
+}
+
+/*
+ * Per-task stdc base resolver, shadowing the linklib autoinit's version
+ * (a direct object wins over an archive member). stdc.library hands out
+ * PER-TASK bases, but the stock lazy autoinit caches the FIRST caller
+ * task's base in a resident global — after that process dies, Mesa's
+ * libc calls (fprintf(stderr) etc.) go through the dead base and crash
+ * the next GL app run. This version re-opens whenever the calling task
+ * changes. Opens are deliberately never closed: per-task bases must
+ * outlive process exit (the libc exit sequence itself still calls
+ * through them after the autoclose point).
+ */
+void *__aros_getbase_StdCBase(void)
+{
+    static void *stdcbase;
+    static struct Task *stdctask;
+    struct Task *me = FindTask(NULL);
+
+    if (!stdcbase || stdctask != me)
+    {
+        void *lb = OpenLibrary((STRPTR)"stdc.library", 0);
+        if (lb)
+        {
+            stdcbase = lb;
+            stdctask = me;
+        }
+    }
+    return stdcbase;
+}
+
+/* close() the fake DRM fd at teardown — no real fd, route to bridge. */
+int close(int fd)
+{
+    if (aros_drm_bridge)
+        aros_drm_bridge->close(aros_drm_bridge->ctx);
+    return 0;
+}
+
+/*
+ * getenv() override. Force NIR_VALIDATE=0: the 20.0.8 validator aborts
+ * on a benign GLSL type pointer mismatch (type singletons weren't shared
+ * across mesa3dgl/driver linklibs pre-refactor; kept as belt-and-braces).
+ * Unrecognised vars return NULL, which Mesa treats as "unset".
+ */
+char *getenv(const char *name)
+{
+    if (!name)
+        return (char *)0;
+
+    if (strcmp(name, "NIR_VALIDATE") == 0)
+        return (char *)"0";
+
+    return (char *)0;
+}
+
+/*
+ * drmIoctl() — route to the bridge so the hidd does the work (BO alloc,
+ * CL submit, etc.). The DRM ioctl encoding packs dir/size/type/nr into a
+ * u32; we pass just the nr (bits 0-7), which is what the hidd's
+ * vc4_aros_ioctl expects (raw DRM and DRM_VC4_* offset by COMMAND_BASE).
+ */
+int drmIoctl(int fd, unsigned long request, void *arg)
+{
+    unsigned long nr = request & 0xFF;
+    int ret;
+
+    if (!aros_drm_bridge)
+    {
+        errno = EBADF;
+        return -1;
+    }
+
+    /* The hidd returns 0, -1 (generic failure) or a NEGATIVE ERRNO for
+     * errors Mesa inspects — vc4_bo_wait()/vc4_wait_seqno() treat ETIME
+     * as "still busy" and carry on, but abort() the whole process on
+     * anything else, so a wait timeout MUST arrive as ETIME here.
+     * (errno set inside the hidd never reaches us: each side has its
+     * own stdc errno.) */
+    ret = aros_drm_bridge->ioctl(aros_drm_bridge->ctx, nr, arg);
+    if (ret != 0)
+    {
+        errno = (ret < -1) ? -ret : EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+/* drmPrime* — unused; fail. */
+int drmPrimeFDToHandle(int fd, int prime_fd, unsigned int *handle)
+{
+    return -1;
+}
+
+int drmPrimeHandleToFD(int fd, unsigned int handle, unsigned int flags, int *prime_fd)
+{
+    return -1;
+}
+
+/* Syncobj — has_syncobj=false, so Mesa uses seqno-based sync; fail. */
+int drmSyncobjCreate(int fd, unsigned int flags, unsigned int *handle)
+{
+    return -1;
+}
+
+int drmSyncobjDestroy(int fd, unsigned int handle)
+{
+    return -1;
+}
+
+int drmSyncobjImportSyncFile(int fd, unsigned int handle, int sync_file_fd)
+{
+    return -1;
+}
+
+int drmSyncobjExportSyncFile(int fd, unsigned int handle, int *sync_file_fd)
+{
+    return -1;
+}
+
+/*
+ * mmap() after MMAP_BO. On AROS the ioctl's "offset" is the BO's
+ * CPU-accessible vaddr (CPU == physical), so hand it back as the address.
+ */
+void *mmap(void *addr, unsigned long length, int prot, int flags, int fd, long offset)
+{
+    (void)addr; (void)length; (void)prot; (void)flags; (void)fd;
+    return (void *)(IPTR)offset;
+}
+
+int munmap(void *addr, unsigned long length)
+{
+    (void)addr; (void)length;
+    return 0;
+}
+
+/* fcntl() — Mesa dups the fd via F_DUPFD_CLOEXEC; return the same fake fd. */
+#ifndef F_DUPFD_CLOEXEC
+#define F_DUPFD_CLOEXEC 1030
+#endif
+
+int fcntl(int fd, int cmd, ...)
+{
+    if (cmd == F_DUPFD_CLOEXEC)
+        return fd;
+    return -1;
+}
+
+#ifndef _SC_PAGE_SIZE
+#define _SC_PAGE_SIZE 30
+#endif
+
+long sysconf(int name)
+{
+    if (name == _SC_PAGE_SIZE)
+        return 4096;
+    return -1;
+}
+
+/*
+ * clock_gettime() — used for BO cache timeout.
+ */
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+
+int clock_gettime(int clk_id, struct timespec *tp)
+{
+    if (tp)
+    {
+        struct DateStamp ds;
+        DateStamp(&ds);
+        tp->tv_sec = ds.ds_Days * 86400 + ds.ds_Minute * 60 + ds.ds_Tick / 50;
+        tp->tv_nsec = (ds.ds_Tick % 50) * 20000000;
+    }
+    return 0;
+}
+
+/* Link anchor for the GalliumCoreAPI table. mesa3dgl references
+ * gallium_core_get_api only weakly (glacreatecontext), and a weak
+ * reference won't pull gca_table.o out of libgalliumcoreapi.a. This file
+ * is always a direct object on raspi, so the strong reference here forces
+ * the table (and with it the exported compiler core) to be linked in.
+ * The consumer module (vc4gallium.hidd) compiles this file too but has
+ * no table — it must not take the reference. */
+#ifndef GCA_CONSUMER_MODULE
+extern const void *gallium_core_get_api(void);
+const void *(*const gallium_core_anchor)(void)
+    __attribute__((used)) = gallium_core_get_api;
+#endif

--- a/workbench/libs/mesa/emul_arosc.c
+++ b/workbench/libs/mesa/emul_arosc.c
@@ -5,12 +5,104 @@
 #include <aros/debug.h>
 
 #include <proto/dos.h>
+#include <proto/exec.h>
 #include <proto/timer.h>
 
+#include <errno.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #define IMPLEMENT()  bug("------IMPLEMENT(%s)\n", __func__)
+
+/*
+ * malloc/free/calloc/realloc overrides via Exec AllocMem/FreeMem.
+ *
+ * Each module has its own StdCBase mempool, so a ralloc object allocated
+ * in one module and freed in another corrupts the wrong pool's freelist.
+ * Going straight to AllocMem/FreeMem makes the allocator pool-independent;
+ * the magic cookie lets free() safely no-op a foreign pointer (e.g. one
+ * libc allocated before this override took effect).
+ *
+ * Since the vc4gallium refactor the vc4 driver lives in mesa3dgl.library,
+ * so this is only needed mesa-side; vc4gallium.hidd uses AllocMem directly.
+ */
+#define AROSC_MALLOC_MAGIC  0xCA113EDCu
+
+struct aros_malloc_hdr
+{
+    ULONG  magic;
+    ULONG  total;     /* allocation size including header */
+    size_t user_size; /* size requested by caller */
+};
+
+#define HDR_BYTES AROS_ALIGN(sizeof(struct aros_malloc_hdr))
+
+void *malloc(size_t size)
+{
+    ULONG total = HDR_BYTES + size;
+    UBYTE *raw = (UBYTE *)AllocMem(total, MEMF_ANY);
+    if (!raw)
+    {
+        errno = ENOMEM;
+        return NULL;
+    }
+    struct aros_malloc_hdr *h = (struct aros_malloc_hdr *)raw;
+    h->magic = AROSC_MALLOC_MAGIC;
+    h->total = total;
+    h->user_size = size;
+    return raw + HDR_BYTES;
+}
+
+void free(void *ptr)
+{
+    if (!ptr)
+        return;
+    struct aros_malloc_hdr *h = (struct aros_malloc_hdr *)((UBYTE *)ptr - HDR_BYTES);
+    if (h->magic != AROSC_MALLOC_MAGIC)
+        return;
+    h->magic = 0;
+    FreeMem((UBYTE *)h, h->total);
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+    size_t user = nmemb * size;
+    ULONG total = HDR_BYTES + user;
+    UBYTE *raw = (UBYTE *)AllocMem(total, MEMF_ANY | MEMF_CLEAR);
+    if (!raw)
+    {
+        errno = ENOMEM;
+        return NULL;
+    }
+    struct aros_malloc_hdr *h = (struct aros_malloc_hdr *)raw;
+    h->magic = AROSC_MALLOC_MAGIC;
+    h->total = total;
+    h->user_size = user;
+    return raw + HDR_BYTES;
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    if (!ptr)
+        return malloc(size);
+    if (size == 0)
+    {
+        free(ptr);
+        return NULL;
+    }
+    struct aros_malloc_hdr *h = (struct aros_malloc_hdr *)((UBYTE *)ptr - HDR_BYTES);
+    if (h->magic != AROSC_MALLOC_MAGIC)
+        return NULL;
+    size_t old = h->user_size;
+    void *np = malloc(size);
+    if (np)
+    {
+        memcpy(np, ptr, old < size ? old : size);
+        free(ptr);
+    }
+    return np;
+}
  
 /*
     The purpose of this file is to provide implementation for C functions part
@@ -52,24 +144,13 @@ int usleep (useconds_t usec)
 }
 
 /*
-    This implementation of atexit is different than the definition of atexit
-    function due to how libraries work in AROS.
-   
-    Under Linux, when an .so file is used by an application, the library's code
-    is being shared but the library's data (global, static variables) are COPIED for
-    each process. Then, an atexit call inside .so will only operate on COPY of data
-    and thus can for example free memory allocated by one process without
-    influencing other processes.
-   
-    Under AROS, when a .library file is used by an application, library code AND
-    library data is shared. This means, an atexit call inside .library which was
-    initially coded under Linux cannot be executed when process is finishing
-    (for example at CloseLibrary) because such call will most likely free shared
-    data which will make other processes crash. The best approximation of atexit
-    in case of .library is to call the atexit functions at library expunge/exit.
+    atexit differs from the standard definition because AROS .library code
+    AND data is shared across processes (unlike a shared object on a paging
+    OS, whose data is per-process). Running atexit handlers at CloseLibrary
+    would free shared data and crash other users, so we defer them to
+    library expunge/exit.
 
-    TODO: Check atexit() usage and determine best time to call atexit registered
-    functions.
+    TODO: Check atexit() usage and determine best time to call the handlers.
 */
 
 static struct exit_list {

--- a/workbench/libs/mesa/galliumglue.py
+++ b/workbench/libs/mesa/galliumglue.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright 2026, The AROS Development Team. All rights reserved.
+#
+# galliumglue.py - generate the GalliumCoreAPI function-pointer table and
+# the consumer-side trampoline glue that lets a gallium pipe driver (in
+# its own hidd module) call mesa3dgl's single Mesa compiler core (NIR,
+# ralloc, glsl_types, gallium auxiliary) through a versioned,
+# hash-checked table instead of linking its own copy.
+#
+# Provider side (compiled into mesa3dgl via libgalliumcoreapi.a):
+#   gallium_core_api.h   - slot enum, struct, GCA_VERSION, GCA_ABI_HASH
+#   gca_table.c          - the populated table + gallium_core_get_api()
+# Consumer side (compiled into the pipe driver hidd):
+#   gca_bind.c           - __gca_local[] + gca_bind() (version/hash check)
+#   gca_glue.S           - one ARM trampoline per imported function
+#   gca_redefs.txt       - objcopy --redefine-syms map (sym -> __gca_sym)
+#   private/             - extracted provider members whose DATA symbols
+#                          the driver references (const tables + the
+#                          util_cpu_caps write-once case). Linked
+#                          privately into the hidd; safe because they are
+#                          index-accessed metadata with no cross-module
+#                          pointer identity.
+#   gca_private.list     - the extracted objects, one path per line
+#
+# The import set is computed mechanically: undefined symbols of the
+# consumer archive plus the private members, minus their own definitions,
+# intersected with the provider archives. Function symbols are
+# trampolined. Data symbols must each be covered by --private-data;
+# anything else is a hard error (the class-4 guard rail).
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, check=True,
+                          **kw)
+
+
+def nm_lines(nm, path):
+    return run([nm, "-g", path]).stdout.splitlines()
+
+
+def collect_undefined(nm, paths):
+    syms = set()
+    for p in paths:
+        for line in nm_lines(nm, p):
+            parts = line.split()
+            if len(parts) == 2 and parts[0] == "U":
+                syms.add(parts[1])
+    return syms
+
+
+def collect_defined(nm, paths):
+    """symbol -> nm type letter (T/W/R/D/B/...)"""
+    syms = {}
+    for p in paths:
+        for line in run([nm, "-g", "--defined-only", p]).stdout.splitlines():
+            parts = line.split()
+            if len(parts) == 3:
+                if parts[2] not in syms or parts[1] in ("T", "D", "R", "B"):
+                    syms[parts[2]] = parts[1]
+    return syms
+
+
+def find_member(nm, archives, sym):
+    """(archive, member) defining sym."""
+    for a in archives:
+        member = None
+        for line in run([nm, "-g", "--defined-only", a]).stdout.splitlines():
+            if line.endswith(":"):
+                member = line[:-1]
+                continue
+            parts = line.split()
+            if len(parts) == 3 and parts[2] == sym:
+                return a, member
+    return None, None
+
+
+def fnv1a32(data):
+    h = 0x811c9dc5
+    for b in data.encode("utf-8"):
+        h = ((h ^ b) * 0x01000193) & 0xffffffff
+    return h
+
+
+def atomic_write(path, content):
+    d = os.path.dirname(path) or "."
+    data = content.encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=d)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    os.replace(tmp, path)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nm", required=True)
+    ap.add_argument("--ar", required=True)
+    ap.add_argument("--consumer", required=True,
+                    help="pipe driver archive (libgallium_vc4.a)")
+    ap.add_argument("--providers", required=True, nargs="+",
+                    help="mesa3dgl core archives")
+    ap.add_argument("--private-data", nargs="*", default=[],
+                    help="data symbols resolved by extracting the defining "
+                         "provider member into the consumer module")
+    ap.add_argument("--mesa-version", required=True)
+    ap.add_argument("--arch", default="arm", choices=("arm", "aarch64"),
+                    help="target CPU: picks the trampoline template")
+    ap.add_argument("--abi-flags", default="",
+                    help="ABI-relevant compile flags; part of the hash so "
+                         "layout-affecting flag changes refuse to bind")
+    ap.add_argument("--abi-files", nargs="*", default=[],
+                    help="files (e.g. the mesa aros diff) whose content is "
+                         "digested into the hash")
+    ap.add_argument("--outdir", required=True)
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+    privdir = os.path.join(args.outdir, "private")
+    os.makedirs(privdir, exist_ok=True)
+
+    # ---- extract private members ----
+    # Destination names carry the archive name: two archives may hold
+    # same-named members, and a bare-basename scheme would silently reuse
+    # the first extraction for both.
+    private_objs = []
+    for sym in args.private_data:
+        arch, member = find_member(args.nm, args.providers, sym)
+        if not member:
+            sys.exit("galliumglue: --private-data %s: no provider defines it"
+                     % sym)
+        libtag = os.path.splitext(os.path.basename(arch))[0]
+        dst = os.path.join(privdir, "%s__%s" % (libtag, member))
+        if not os.path.exists(dst):
+            run([args.ar, "x", os.path.abspath(arch), member], cwd=privdir)
+            os.replace(os.path.join(privdir, member), dst)
+        if dst not in private_objs:
+            private_objs.append(dst)
+
+    # ---- import set: driver + private members, minus own definitions ----
+    consumer_paths = [args.consumer] + private_objs
+    imports = collect_undefined(args.nm, consumer_paths)
+    own = collect_defined(args.nm, consumer_paths)
+    imports -= set(own)
+
+    provided = collect_defined(args.nm, args.providers)
+
+    funcs = sorted(s for s in imports if provided.get(s) in ("T", "W"))
+    data = sorted(s for s in imports if s in provided
+                  and provided[s] not in ("T", "W"))
+    residual = sorted(s for s in imports if s not in provided)
+
+    if not funcs:
+        sys.exit("galliumglue: empty function import set - wrong archives?")
+    if data:
+        # class-4 guard: every data import must be a --private-data decision
+        sys.exit("galliumglue: unhandled data imports (add to --private-data "
+                 "after auditing identity semantics): %s" % ", ".join(data))
+
+    # ABI hash: layout-compat scope ONLY — mesa version, ABI-relevant
+    # flags, and the content of layout-affecting inputs (the aros diff).
+    # Slot compatibility is deliberately NOT hashed: gca_bind verifies
+    # every slot by name, so appending slots keeps older consumers
+    # binding, and a slot mismatch is reported by index instead of as an
+    # opaque hash failure.
+    hashsrc = "mesa-%s|flags-%s" % (args.mesa_version, args.abi_flags.strip())
+    for f in args.abi_files:
+        with open(f, "rb") as fh:
+            hashsrc += "|%s-%08x" % (os.path.basename(f),
+                                     fnv1a32(fh.read().decode("utf-8",
+                                                              "replace")))
+    abihash = fnv1a32(hashsrc)
+
+    guardnote = ("/* Generated by galliumglue.py - DO NOT EDIT.\n"
+                 " * Consumer: %s\n * Mesa: %s, %d function slots, "
+                 "%d private data objects, %d residual libc/AROS refs.\n */\n"
+                 % (os.path.basename(args.consumer), args.mesa_version,
+                    len(funcs), len(private_objs), len(residual)))
+
+    # ---------- gallium_core_api.h ----------
+    h = [guardnote]
+    h.append("#ifndef GALLIUM_CORE_API_H\n#define GALLIUM_CORE_API_H\n")
+    h.append("#include <stdint.h>\n")
+    h.append("#define GCA_VERSION    1")
+    h.append("#define GCA_ABI_HASH   0x%08xu" % abihash)
+    h.append("#define GCA_FUNC_COUNT %d\n" % len(funcs))
+    h.append("struct GalliumCoreAPI\n{")
+    h.append("    uint32_t gca_Version;")
+    h.append("    uint32_t gca_Size;")
+    h.append("    uint32_t gca_ABIHash;")
+    h.append("    uint32_t gca_FuncCount;")
+    h.append("    void   *const *gca_Func;")
+    h.append("    const char *const *gca_Names;")
+    h.append("};\n")
+    h.append("enum\n{")
+    for s in funcs:
+        h.append("    GCA_%s," % s)
+    h.append("};\n")
+    h.append("/* Provider (mesa3dgl side). Validation is the consumer's "
+             "job (gca_bind). */")
+    h.append("const struct GalliumCoreAPI *gallium_core_get_api(void);\n")
+    h.append("/* Consumer (driver hidd side). 0 = bound. Negative = table")
+    h.append(" * rejected (-1 null/version, -2 size, -3 hash, -4 count);")
+    h.append(" * positive = name mismatch at slot (value - 1), see")
+    h.append(" * gca_slot_name() for what the consumer expected there. */")
+    h.append("int gca_bind(const struct GalliumCoreAPI *api);")
+    h.append("const char *gca_slot_name(uint32_t slot);\n")
+    h.append("#endif /* GALLIUM_CORE_API_H */")
+    atomic_write(os.path.join(args.outdir, "gallium_core_api.h"),
+                 "\n".join(h) + "\n")
+
+    # ---------- gca_table.c (provider) ----------
+    c = [guardnote]
+    c.append('#include "gallium_core_api.h"\n')
+    for s in funcs:
+        c.append("extern void %s(void);" % s)
+    c.append("\nstatic void *const gca_funcs[GCA_FUNC_COUNT] =\n{")
+    for s in funcs:
+        c.append("    (void *)%s," % s)
+    c.append("};\n")
+    c.append("static const char *const gca_names[GCA_FUNC_COUNT] =\n{")
+    for s in funcs:
+        c.append('    "%s",' % s)
+    c.append("};\n")
+    c.append("static const struct GalliumCoreAPI gca_table =\n{")
+    c.append("    GCA_VERSION,")
+    c.append("    sizeof(struct GalliumCoreAPI),")
+    c.append("    GCA_ABI_HASH,")
+    c.append("    GCA_FUNC_COUNT,")
+    c.append("    gca_funcs,")
+    c.append("    gca_names,")
+    c.append("};\n")
+    c.append("const struct GalliumCoreAPI *gallium_core_get_api(void)")
+    c.append("{")
+    c.append("    return &gca_table;")
+    c.append("}")
+    atomic_write(os.path.join(args.outdir, "gca_table.c"),
+                 "\n".join(c) + "\n")
+
+    # ---------- gca_bind.c (consumer) ----------
+    b = [guardnote]
+    b.append('#include "gallium_core_api.h"\n')
+    b.append("void *__gca_local[GCA_FUNC_COUNT];\n")
+    b.append("static int gca_streq(const char *a, const char *b)")
+    b.append("{")
+    b.append("    while (*a && *a == *b) { a++; b++; }")
+    b.append("    return *a == *b;")
+    b.append("}\n")
+    b.append("static const char *const gca_wanted[GCA_FUNC_COUNT] =")
+    b.append("{")
+    for s in funcs:
+        b.append('    "%s",' % s)
+    b.append("};\n")
+    b.append("const char *gca_slot_name(uint32_t slot)")
+    b.append("{")
+    b.append("    return (slot < GCA_FUNC_COUNT) ? gca_wanted[slot] : \"?\";")
+    b.append("}\n")
+    b.append("int gca_bind(const struct GalliumCoreAPI *api)")
+    b.append("{")
+    b.append("    uint32_t i;\n")
+    b.append("    if (!api || api->gca_Version != GCA_VERSION)")
+    b.append("        return -1;")
+    b.append("    if (api->gca_Size < sizeof(struct GalliumCoreAPI))")
+    b.append("        return -2;")
+    b.append("    if (api->gca_ABIHash != GCA_ABI_HASH)")
+    b.append("        return -3;")
+    b.append("    if (api->gca_FuncCount < GCA_FUNC_COUNT)")
+    b.append("        return -4;")
+    b.append("    /* slot identity by name: catches provider/consumer built")
+    b.append("     * from different generator runs even when count+hash")
+    b.append("     * happen to collide */")
+    b.append("    for (i = 0; i < GCA_FUNC_COUNT; i++)")
+    b.append("        if (!api->gca_Names[i] || !gca_streq(api->gca_Names[i], gca_wanted[i]))")
+    b.append("            return (int)i + 1;")
+    b.append("    for (i = 0; i < GCA_FUNC_COUNT; i++)")
+    b.append("        __gca_local[i] = api->gca_Func[i];")
+    b.append("    return 0;")
+    b.append("}")
+    atomic_write(os.path.join(args.outdir, "gca_bind.c"),
+                 "\n".join(b) + "\n")
+
+    # ---------- gca_glue.S (consumer trampolines) ----------
+    #
+    # One tail-branch per imported function, loading the target from the
+    # module-local table. Argument-transparent (nothing but the ABI's
+    # intra-procedure scratch register is touched), so varargs, struct
+    # returns and FP arguments all pass through untouched.
+    s_ = ["/* " + guardnote[3:-4] + " */\n"]
+    if args.arch == "arm":
+        s_.append("    .syntax unified")
+        s_.append("    .arm")
+        s_.append("    .text\n")
+        for i, s in enumerate(funcs):
+            s_.append("    .balign 4")
+            s_.append("    .globl __gca_%s" % s)
+            s_.append("    .type __gca_%s, %%function" % s)
+            s_.append("__gca_%s:" % s)
+            s_.append("    ldr ip, 0f")            # ip = &__gca_local
+            s_.append("    ldr pc, [ip, #%d]" % (i * 4))
+            s_.append("0:  .word __gca_local\n")
+    else:   # aarch64
+        s_.append("    .text\n")
+        for i, s in enumerate(funcs):
+            s_.append("    .balign 8")
+            s_.append("    .globl __gca_%s" % s)
+            s_.append("    .type __gca_%s, %%function" % s)
+            s_.append("__gca_%s:" % s)
+            # x16 (IP0) is the ABI's call-boundary scratch register.
+            # The literal is R_AARCH64_ABS64, the reloc every AROS
+            # aarch64 loader handles; no adrp/GOT needed.
+            s_.append("    ldr x16, 0f")           # x16 = &__gca_local
+            s_.append("    ldr x16, [x16, #%d]" % (i * 8))
+            s_.append("    br x16")
+            s_.append("    .balign 8")             # .quad must be aligned
+            s_.append("0:  .quad __gca_local\n")
+    atomic_write(os.path.join(args.outdir, "gca_glue.S"),
+                 "\n".join(s_) + "\n")
+
+    # ---------- gca_redefs.txt (objcopy map) ----------
+    # Symbols defined by private members must not be renamed even if
+    # imported elsewhere; they resolve locally in the consumer module.
+    atomic_write(os.path.join(args.outdir, "gca_redefs.txt"),
+                 "".join("%s __gca_%s\n" % (s, s) for s in funcs))
+
+    # ---------- private object list ----------
+    atomic_write(os.path.join(args.outdir, "gca_private.list"),
+                 "".join(p + "\n" for p in private_objs))
+
+    # ---------- report ----------
+    rep = ["# galliumglue import-set report",
+           "functions (trampolined): %d" % len(funcs),
+           "private data objects:    %s" % ", ".join(
+               os.path.basename(p) for p in private_objs),
+           "residual (libc/AROS):    %d" % len(residual),
+           ""] + ["  residual: " + s for s in residual] + [""]
+    atomic_write(os.path.join(args.outdir, "gca_report.txt"),
+                 "\n".join(rep))
+
+    print("galliumglue: %d trampolines, %d private objects, %d residual, "
+          "hash 0x%08x" % (len(funcs), len(private_objs), len(residual),
+                           abihash))
+
+
+if __name__ == "__main__":
+    main()

--- a/workbench/libs/mesa/libcompiler/mmakefile.src
+++ b/workbench/libs/mesa/libcompiler/mmakefile.src
@@ -172,7 +172,10 @@ $(top_builddir)/$(CUR_MESADIR)/glsl/ir_expression_operation_strings.h:  $(top_sr
 	$(Q)$(ECHO) "Generating $(if $(filter /%,$@),$(if $(filter $(SRCDIR)/%,$(abspath $@)),$(patsubst $(SRCDIR)/%,%,$(abspath $@)),$(patsubst $(TOP)/%,%,$(abspath $@))),$(patsubst $(SRCDIR)/%,%,$(abspath $(SRCDIR)/$(CURDIR)/$@)))"
 	$(Q)cd $(glapi) && $(PYTHON) $(PYTHON_FLAGS) $< strings > $@
 
-ifeq ($(shell test -f $(top_srcdir)/src/util/xxd.py && echo -n yes),yes)
+## Mesa 21.0+ moved xxd.py from src/compiler/glsl/ to src/util/. Use
+## $(wildcard); $(shell test … && echo -n yes) is unreliable as some
+## hosts' shell doesn't strip -n, leaving CHK as "-n yes" (wrong branch).
+ifneq ($(wildcard $(top_srcdir)/src/util/xxd.py),)
 FLOAT64DEP=$(top_srcdir)/src/util/xxd.py
 else
 FLOAT64DEP=$(top_srcdir)/$(CUR_MESADIR)/glsl/xxd.py

--- a/workbench/libs/mesa/mesa-20.0.8-aros.diff
+++ b/workbench/libs/mesa/mesa-20.0.8-aros.diff
@@ -962,3 +962,236 @@ diff -ruN mesa-20.0.8/src/util/u_thread.h mesa-20.0.8.aros/src/util/u_thread.h
     struct timespec ts;
     clockid_t cid;
  
+diff -ruN mesa-20.0.8/src/mesa/main/scissor.c mesa-20.0.8.aros/src/mesa/main/scissor.c
+--- mesa-20.0.8/src/mesa/main/scissor.c	2020-06-12 03:21:18
++++ mesa-20.0.8.aros/src/mesa/main/scissor.c	2026-07-10 20:27:09
+@@ -79,7 +79,23 @@
+ 
+    if (ctx->Driver.Scissor)
+       ctx->Driver.Scissor(ctx);
++}
++
++#ifdef __AROS__
++/* AROS vc4 render-scale: scissor rects are in window units and are
++ * divided ONLY while the window-system framebuffer (fb 0) is bound —
++ * application FBOs are unscaled, same rule as viewport.c. */
++extern unsigned int mesa3dgl_render_scale __attribute__((weak));
++static inline int _aros_rscale_sc(struct gl_context *ctx, int v)
++{
++   if (&mesa3dgl_render_scale && mesa3dgl_render_scale > 1
++       && ctx->DrawBuffer && ctx->DrawBuffer->Name == 0)
++      return v / (int)mesa3dgl_render_scale;
++   return v;
+ }
++#else
++#define _aros_rscale_sc(ctx, v) (v)
++#endif
+ 
+ /**
+  * Called via glScissor
+@@ -88,7 +104,8 @@
+ _mesa_Scissor_no_error(GLint x, GLint y, GLsizei width, GLsizei height)
+ {
+    GET_CURRENT_CONTEXT(ctx);
+-   scissor(ctx, x, y, width, height);
++   scissor(ctx, _aros_rscale_sc(ctx, x), _aros_rscale_sc(ctx, y),
++           _aros_rscale_sc(ctx, width), _aros_rscale_sc(ctx, height));
+ }
+ 
+ void GLAPIENTRY
+@@ -104,7 +121,8 @@
+       return;
+    }
+ 
+-   scissor(ctx, x, y, width, height);
++   scissor(ctx, _aros_rscale_sc(ctx, x), _aros_rscale_sc(ctx, y),
++           _aros_rscale_sc(ctx, width), _aros_rscale_sc(ctx, height));
+ }
+ 
+ 
+diff -ruN mesa-20.0.8/src/mesa/main/viewport.c mesa-20.0.8.aros/src/mesa/main/viewport.c
+--- mesa-20.0.8/src/mesa/main/viewport.c	2020-06-12 03:21:18
++++ mesa-20.0.8.aros/src/mesa/main/viewport.c	2026-07-10 20:27:09
+@@ -116,6 +116,25 @@
+       ctx->Driver.Viewport(ctx);
+ }
+ 
++#ifdef __AROS__
++/* AROS vc4 render-scale (ENV:VC4_RENDER_SCALE, set up in mesa3dgl):
++ * only the window-system framebuffer is HVS-scaled (drawable is 1/N of
++ * the window), so viewport rects — given in window units — are divided
++ * at the API boundary ONLY while fb 0 is bound. Application FBOs render
++ * at full size; their viewports must pass through untouched (else an
++ * FBO-heavy renderer would confine its scene to a 1/N corner). */
++extern unsigned int mesa3dgl_render_scale __attribute__((weak));
++static inline int _aros_rscale(struct gl_context *ctx, int v)
++{
++   if (&mesa3dgl_render_scale && mesa3dgl_render_scale > 1
++       && ctx->DrawBuffer && ctx->DrawBuffer->Name == 0)
++      return v / (int)mesa3dgl_render_scale;
++   return v;
++}
++#else
++#define _aros_rscale(ctx, v) (v)
++#endif
++
+ /**
+  * Set the viewport.
+  * \sa Called via glViewport() or display list execution.
+@@ -127,7 +146,8 @@
+ _mesa_Viewport_no_error(GLint x, GLint y, GLsizei width, GLsizei height)
+ {
+    GET_CURRENT_CONTEXT(ctx);
+-   viewport(ctx, x, y, width, height);
++   viewport(ctx, _aros_rscale(ctx, x), _aros_rscale(ctx, y),
++            _aros_rscale(ctx, width), _aros_rscale(ctx, height));
+ }
+ 
+ void GLAPIENTRY
+@@ -144,7 +164,8 @@
+       return;
+    }
+ 
+-   viewport(ctx, x, y, width, height);
++   viewport(ctx, _aros_rscale(ctx, x), _aros_rscale(ctx, y),
++            _aros_rscale(ctx, width), _aros_rscale(ctx, height));
+ }
+ 
+ 
+diff -ruN mesa-20.0.8/src/mesa/state_tracker/st_extensions.c mesa-20.0.8.aros/src/mesa/state_tracker/st_extensions.c
+--- mesa-20.0.8/src/mesa/state_tracker/st_extensions.c	2020-06-12 01:21:18.000000000 +0000
++++ mesa-20.0.8.aros/src/mesa/state_tracker/st_extensions.c	2026-07-12 11:15:00.000000000 +0000
+@@ -817,10 +817,6 @@
+       { { o(EXT_texture_integer) },
+         { PIPE_FORMAT_R32G32B32A32_UINT,
+           PIPE_FORMAT_R32G32B32A32_SINT } },
+-
+-      { { o(ARB_texture_rg) },
+-        { PIPE_FORMAT_R8_UNORM,
+-          PIPE_FORMAT_R8G8_UNORM } },
+ 
+       { { o(EXT_texture_norm16) },
+         { PIPE_FORMAT_R16_UNORM,
+@@ -851,6 +847,16 @@
+ 
+    /* Required: sampler support */
+    static const struct st_extension_format_mapping texture_mapping[] = {
++      /* AROS: moved here from the render-target list. On vc4 R8/RG8 are
++       * samplable but not renderable, which hid the whole extension and
++       * made GL_RED an invalid internalformat (indexed-colour textures
++       * went undefined -> black screen). Sampling R8 returns
++       * spec-correct (R,0,0,1); RED framebuffer attachments still fail
++       * cleanly via the separate renderability validation. */
++      { { o(ARB_texture_rg) },
++        { PIPE_FORMAT_R8_UNORM,
++          PIPE_FORMAT_R8G8_UNORM } },
++
+       { { o(ARB_texture_compression_rgtc) },
+         { PIPE_FORMAT_RGTC1_UNORM,
+           PIPE_FORMAT_RGTC1_SNORM,
+diff -ruN mesa-20.0.8/src/gallium/drivers/vc4/vc4_qir.h mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_qir.h
+--- mesa-20.0.8/src/gallium/drivers/vc4/vc4_qir.h	2020-06-12 01:21:17.000000000 +0000
++++ mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_qir.h	2026-07-14 10:30:00.000000000 +0000
+@@ -312,6 +312,13 @@
+                                 unsigned wrap_s:3;
+                                 unsigned wrap_t:3;
+                                 bool force_first_level:1;
++                                /* NPOT texture with REPEAT wrap: the TMU
++                                 * wraps at power-of-two bounds only, so the
++                                 * shader must fract() the coordinate (and
++                                 * the P1 wrap field is forced to clamp).
++                                 */
++                                unsigned npot_s:1;
++                                unsigned npot_t:1;
+                         };
+                         struct {
+                                 uint16_t msaa_width, msaa_height;
+diff -ruN mesa-20.0.8/src/gallium/drivers/vc4/vc4_program.c mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_program.c
+--- mesa-20.0.8/src/gallium/drivers/vc4/vc4_program.c	2020-06-12 01:21:17.000000000 +0000
++++ mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_program.c	2026-07-14 10:30:00.000000000 +0000
+@@ -408,6 +408,9 @@
+                                        qir_UNPACK_8_F(c, tex, i));
+         }
+ }
++
++static struct qreg
++ntq_ffract(struct vc4_compile *c, struct qreg src);
+ 
+ static void
+ ntq_emit_tex(struct vc4_compile *c, nir_tex_instr *instr)
+@@ -481,6 +484,17 @@
+                              qir_uniform(c, QUNIFORM_TEXRECT_SCALE_X, unit));
+                 t = qir_FMUL(c, t,
+                              qir_uniform(c, QUNIFORM_TEXRECT_SCALE_Y, unit));
++        }
++
++        /* The TMU only wraps REPEAT coordinates at power-of-two bounds, so
++         * for NPOT textures the wrap is done here instead (the P1 wrap
++         * field is forced to clamp in write_texture_p1).
++         */
++        if (instr->sampler_dim != GLSL_SAMPLER_DIM_CUBE) {
++                if (c->key->tex[unit].npot_s)
++                        s = ntq_ffract(c, s);
++                if (c->key->tex[unit].npot_t)
++                        t = ntq_ffract(c, t);
+         }
+ 
+         if (instr->sampler_dim == GLSL_SAMPLER_DIM_CUBE || is_txl) {
+@@ -2696,6 +2710,18 @@
+                         key->tex[i].wrap_t = sampler_state->wrap_t;
+                         key->tex[i].force_first_level =
+                                 vc4_sampler->force_first_level;
++                        /* The TMU wraps REPEAT coordinates at power-of-two
++                         * bounds only; NPOT + REPEAT samples the (stale)
++                         * POT padding.  Flag it so the shader fract()s the
++                         * coordinate instead (see ntq_emit_tex), and
++                         * write_texture_p1 forces the axis to clamp.
++                         */
++                        key->tex[i].npot_s =
++                                sampler_state->wrap_s == PIPE_TEX_WRAP_REPEAT &&
++                                !util_is_power_of_two_or_zero(sampler->texture->width0);
++                        key->tex[i].npot_t =
++                                sampler_state->wrap_t == PIPE_TEX_WRAP_REPEAT &&
++                                !util_is_power_of_two_or_zero(sampler->texture->height0);
+                 }
+         }
+ 
+diff -ruN mesa-20.0.8/src/gallium/drivers/vc4/vc4_uniforms.c mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_uniforms.c
+--- mesa-20.0.8/src/gallium/drivers/vc4/vc4_uniforms.c	2020-06-12 01:21:17.000000000 +0000
++++ mesa-20.0.8.aros/src/gallium/drivers/vc4/vc4_uniforms.c	2026-07-14 10:30:00.000000000 +0000
+@@ -23,6 +23,7 @@
+ 
+ #include "util/u_pack_color.h"
+ #include "util/u_upload_mgr.h"
++#include "util/u_math.h"
+ #include "util/format_srgb.h"
+ 
+ #include "vc4_context.h"
+@@ -51,8 +52,26 @@
+                 vc4_sampler_view(texstate->textures[unit]);
+         struct vc4_sampler_state *sampler =
+                 vc4_sampler_state(texstate->samplers[unit]);
++        uint32_t p1 = sview->texture_p1 | sampler->texture_p1;
+ 
+-        cl_aligned_u32(uniforms, sview->texture_p1 | sampler->texture_p1);
++        /* The TMU only wraps REPEAT coordinates at power-of-two bounds.
++         * For NPOT + REPEAT the shader fract()s the coordinate into [0, 1)
++         * (see ntq_emit_tex), so clamp here to keep the filter's neighbour
++         * fetches inside the actually-written texels instead of the POT
++         * padding.
++         */
++        if (sampler->base.wrap_s == PIPE_TEX_WRAP_REPEAT &&
++            !util_is_power_of_two_or_zero(sview->base.texture->width0)) {
++                p1 = (p1 & ~VC4_TEX_P1_WRAP_S_MASK) |
++                     VC4_SET_FIELD(1, VC4_TEX_P1_WRAP_S);
++        }
++        if (sampler->base.wrap_t == PIPE_TEX_WRAP_REPEAT &&
++            !util_is_power_of_two_or_zero(sview->base.texture->height0)) {
++                p1 = (p1 & ~VC4_TEX_P1_WRAP_T_MASK) |
++                     VC4_SET_FIELD(1, VC4_TEX_P1_WRAP_T);
++        }
++
++        cl_aligned_u32(uniforms, p1);
+ }
+ 
+ static void

--- a/workbench/libs/mesa/mesa.cfg
+++ b/workbench/libs/mesa/mesa.cfg
@@ -58,11 +58,14 @@ MESA_POSIXC_FLAGS := \
             -DHAVE_TIMESPEC_GET \
             -DPOSIXC_SLOWSTACK_VAARGS
 
-# enabling POSIX_MEMALIGN causes assertion failures...
-ifeq (no,)
-MESA_POSIXC_FLAGS += \
-            -DHAVE_POSIX_MEMALIGN
-endif
+# HAVE_POSIX_MEMALIGN makes os_malloc_aligned() use posix_memalign(). On Mesa
+# 20.0.8 that binds to stdc.library and faults on a NULL StdCBase in the
+# mesa3dgl context (crash at 0xfffffaec); left off, os_malloc_aligned falls back
+# to manual malloc-based alignment via emul_arosc's pool-independent malloc.
+# Mesa 21 removed that posix_memalign path, so the flag is safe to enable on a
+# 21 build (OPT_MESAGL). Keep it off for 20.0.8.
+#MESA_POSIXC_FLAGS += \
+#            -DHAVE_POSIX_MEMALIGN
 
 MESA_BASEFLAGS := \
             $(MESA_STDC_FLAGS) \
@@ -146,8 +149,37 @@ MESA_NOWARNFLAGS := \
 
 MESA_DEBUG :=
 #MESA_DEBUG := -DDEBUG
+#MESA_DEBUG := -DNDEBUG
+# Asserts ON. -DNDEBUG previously suppressed every Mesa assert() (incl.
+# NIR validator aborts) to dodge cosmetic invariants, but it also hid
+# wild-pointer crashes. Keep asserts on; patch a specific cosmetic assert
+# out via mesa-20.0.8-aros.diff rather than disabling them globally.
+
+# Pin to gnu11 (Mesa 21's baseline). gcc-16 defaults to gnu23, whose
+# <stddef.h> 0-arg unreachable() collides with Mesa's 1-arg unreachable(str)
+# in src/util/macros.h (and other C23 macro/keyword changes).
+MESA_STD := -std=gnu11
 
 USER_CPPFLAGS = $(MESA_COMPILEFLAGS) $(MESA_DEBUG)
-USER_CFLAGS =  $(MESA_COMPILEOPTIONS) $(CFLAGS_FAST_MATH) $(CFLAGS_NO_MATH_ERRNO) $(CFLAGS_NO_TRAPPING_MATH) $(CFLAGS_VISIBILITY_HIDDEN) $(CFLAGS_MERGE_CONSTANTS)
+# -fno-strict-aliasing is not optional: upstream Mesa builds with it, and
+# its compiler code (NIR/GLSL/QIR) type-puns freely. gcc exploits strict
+# aliasing far more than clang, which showed up as a hang in the vc4
+# shader compiler on a gcc-16 build.
+USER_CFLAGS =  $(MESA_STD) $(MESA_COMPILEOPTIONS) $(CFLAGS_NO_STRICT_ALIASING) $(CFLAGS_FAST_MATH) $(CFLAGS_NO_MATH_ERRNO) $(CFLAGS_NO_TRAPPING_MATH) $(CFLAGS_VISIBILITY_HIDDEN) $(CFLAGS_MERGE_CONSTANTS)
 USER_CXXFLAGS =  $(MESA_COMPILEOPTIONS) $(CFLAGS_FAST_MATH) $(CFLAGS_NO_MATH_ERRNO) $(CFLAGS_NO_TRAPPING_MATH) $(CFLAGS_VISIBILITY_HIDDEN) $(CFLAGS_MERGE_CONSTANTS)
 #USER_LDFLAGS := -Wl,-Bsymbolic
+
+# Gallium core linklibs statically included into mesa3dgl.library
+# (empty = softpipe only). Pulled into mesa3dgl's uselibs so their
+# Mesa-side code shares one ralloc/util instance.
+MESA3DGL_GALLIUMCORE :=
+
+# raspi/arm: the GalliumCoreAPI provider table (generated gca_table.c).
+# The vc4 pipe driver itself lives in vc4gallium.hidd since the runtime-
+# binding rework; mesa3dgl only exports its compiler core through this
+# table. Built by the vc4gallium hidd's mmakefile, which only builds for
+# AROS_TARGET_CPU=arm - AROS_TARGET_ARCH alone is "raspi" for the aarch64
+# target too, and the generated trampolines are 32-bit ARM.
+ifeq ($(AROS_TARGET_ARCH),raspi)
+MESA3DGL_GALLIUMCORE += galliumcoreapi
+endif

--- a/workbench/libs/mesa/mesa3dgl_gallium.c
+++ b/workbench/libs/mesa/mesa3dgl_gallium.c
@@ -4,6 +4,12 @@
 
 #include <aros/debug.h>
 
+/* aros/debug.h always leaves DEBUG defined (to 0 if unset), which trips
+ * Mesa's u_debug_refcnt.h — it uses `#if defined(DEBUG)` and so emits
+ * refs to debug_reference_slowpath even under -DNDEBUG. Drop the symbol
+ * before pulling in the gallium pipe/util headers. */
+#undef DEBUG
+
 #include <proto/utility.h>
 #include <proto/exec.h>
 #include <proto/gallium.h>
@@ -32,7 +38,6 @@ static BOOL MESA3DGLSelectColorFormat(enum pipe_format * colorFormat,
 
     if (bpp == 16)
     {
-        /* Try PIPE_FORMAT_B5G6R5_UNORM */
         if (screen->is_format_supported(screen,
             PIPE_FORMAT_B5G6R5_UNORM,
             PIPE_TEXTURE_2D,
@@ -47,7 +52,6 @@ static BOOL MESA3DGLSelectColorFormat(enum pipe_format * colorFormat,
     
     if (bpp == 32)
     {
-        /* Try PIPE_FORMAT_B8G8R8A8_UNORM */
         if (screen->is_format_supported(screen,
             PIPE_FORMAT_B8G8R8A8_UNORM,
             PIPE_TEXTURE_2D,
@@ -68,13 +72,11 @@ static BOOL MESA3DGLSelectDepthStencilFormat(enum pipe_format * depthStencilForm
 {
     D(bug("[MESA3DGL] %s()\n", __func__));
 
-    /* Defeaul values */
     *depthStencilFormat = PIPE_FORMAT_NONE;
     
     if (noDepth)
         return TRUE;
     
-    /* Try PIPE_FORMAT_S8_UINT_Z24_UNORM */
     if(!noStencil && (screen->is_format_supported(screen,
             PIPE_FORMAT_S8_UINT_Z24_UNORM,
             PIPE_TEXTURE_2D,
@@ -86,7 +88,6 @@ static BOOL MESA3DGLSelectDepthStencilFormat(enum pipe_format * depthStencilForm
         return TRUE;
     }
     
-    /* Try PIPE_FORMAT_X8Z24_UNORM */
     if(noStencil && (screen->is_format_supported(screen,
             PIPE_FORMAT_X8Z24_UNORM,
             PIPE_TEXTURE_2D,
@@ -98,7 +99,6 @@ static BOOL MESA3DGLSelectDepthStencilFormat(enum pipe_format * depthStencilForm
         return TRUE;
     }
 
-    /* Try PIPE_FORMAT_Z24X8_UNORM */
     if(noStencil && (screen->is_format_supported(screen,
             PIPE_FORMAT_Z24X8_UNORM,
             PIPE_TEXTURE_2D,
@@ -110,7 +110,6 @@ static BOOL MESA3DGLSelectDepthStencilFormat(enum pipe_format * depthStencilForm
         return TRUE;
     }
     
-    /* Try PIPE_FORMAT_Z16_UNORM */
     if(screen->is_format_supported(screen,
             PIPE_FORMAT_Z16_UNORM,
             PIPE_TEXTURE_2D,
@@ -142,21 +141,18 @@ BOOL MESA3DGLFillVisual(struct st_visual * stvis, struct pipe_screen * screen, i
     stvis->render_buffer = ST_ATTACHMENT_FRONT_LEFT;
     stvis->samples = 1;
 
-    /* Color buffer */
     if (!MESA3DGLSelectColorFormat(&stvis->color_format, screen, bpp))
     {
         D(bug("[MESA3DGL] %s: ERROR - No supported color format found\n", __func__));
         return FALSE;
     }
 
-    /* Z-buffer / Stencil buffer */
     if (!MESA3DGLSelectDepthStencilFormat(&stvis->depth_stencil_format, screen, noDepth, noStencil))
     {
         D(bug("[MESA3DGL] %s: ERROR - No supported depth/stencil format found\n", __func__));
         return FALSE;
     }
 
-    /* Accum buffer */
     if (noAccum)
         stvis->accum_format = PIPE_FORMAT_NONE;
     else
@@ -165,7 +161,7 @@ BOOL MESA3DGLFillVisual(struct st_visual * stvis, struct pipe_screen * screen, i
         stvis->buffer_mask |= ST_ATTACHMENT_ACCUM;
     }
 
-    /* Buffers */ /* MESA3DGL uses front buffer as back buffer */
+    /* MESA3DGL uses front buffer as back buffer */
     if (!noDepth || !noStencil)
     stvis->buffer_mask |= ST_ATTACHMENT_DEPTH_STENCIL_MASK;
     
@@ -197,17 +193,23 @@ static VOID MESA3DGLFrameBufferCreateResource(struct mesa3dgl_framebuffer * amfb
     case ST_ATTACHMENT_FRONT_RIGHT:
     case ST_ATTACHMENT_BACK_RIGHT:
         templ.format    = amfb->stvis.color_format;
-        templ.bind      = PIPE_BIND_RENDER_TARGET | PIPE_BIND_SAMPLER_VIEW;
+        /* LINEAR + SCANOUT keep the swap target linear instead of the
+         * GPU's native T-tile: the AROS present path (DisplayResource ->
+         * DMA blit) needs a linear source and can't detile. Drivers that
+         * ignore the flags (or default to linear) are unaffected. */
+        templ.bind      = PIPE_BIND_RENDER_TARGET
+                        | PIPE_BIND_SAMPLER_VIEW
+                        | PIPE_BIND_LINEAR
+                        | PIPE_BIND_SCANOUT;
         break;
     case ST_ATTACHMENT_DEPTH_STENCIL:
         templ.format    = amfb->stvis.depth_stencil_format;
         templ.bind      = PIPE_BIND_DEPTH_STENCIL;
         break;
     default:
-        return; /* Failure */
+        return;
     }
     
-    /* Create resource */
     amfb->textures[statt] = amfb->screen->resource_create(amfb->screen, &templ);
 }
 
@@ -222,19 +224,15 @@ static bool MESA3DGLFrameBufferValidate(struct st_context_iface *stctx,
 
     D(bug("[MESA3DGL] %s()\n", __func__));
 
-    /* Check for resize */
     if (amfb->resized)
     {
         amfb->resized = FALSE;
-        /* Detach "front surface" */
         pipe_resource_reference(&amfb->render_resource, NULL);
 
-        /* Detach all resources */
         for (i = 0; i < ST_ATTACHMENT_COUNT; i++)
             pipe_resource_reference(&amfb->textures[i], NULL);
     }
     
-    /* Create new resources */
     for (i = 0; i < count; i++)
     {
         if (amfb->textures[statts[i]] == NULL)
@@ -265,7 +263,6 @@ static bool MESA3DGLFrameBufferFlushFront(struct st_context_iface *stctx,
 {
     D(bug("[MESA3DGL] %s()\n", __func__));
 
-    /* No Op */
     return TRUE;
 }
 
@@ -318,7 +315,11 @@ VOID MESA3DGLCheckAndUpdateBufferSize(struct mesa3dgl_context * ctx)
     MESA3DGLRecalculateBufferWidthHeight(ctx);
     if (ctx->framebuffer->resized)
     {
-        p_atomic_set(&ctx->framebuffer->base.stamp, 1);
+        /* The state tracker revalidates the framebuffer only when the
+         * stamp DIFFERS from the one it cached at the last validate.
+         * Setting it to a constant made every resize after the first
+         * invisible — increment instead. */
+        p_atomic_inc(&ctx->framebuffer->base.stamp);
     }
 }
 

--- a/workbench/libs/mesa/mesa3dgl_glacreatecontext.c
+++ b/workbench/libs/mesa/mesa3dgl_glacreatecontext.c
@@ -15,9 +15,20 @@
 
 #include <proto/exec.h>
 #include <proto/gallium.h>
+#include <proto/oop.h>
 
 #include "mesa3dgl_support.h"
 #include "mesa3dgl_gallium.h"
+
+/* GalliumCoreAPI table provider (generated gca_table.c). Passed to the
+ * pipe hidd via CPS_GalliumCoreAPI so a runtime-bound pipe driver can
+ * call mesa3dgl's one Mesa compiler core. Builds without a table pass 0;
+ * table-less drivers (softpipe) never look. */
+#ifdef MESA3DGL_HAVE_COREAPI
+extern const void *gallium_core_get_api(void);
+#else
+static inline const void *gallium_core_get_api(void) { return (const void *)0; }
+#endif
 
 /*****************************************************************************
 
@@ -106,6 +117,7 @@
     {
             { CPS_PipeFriendBitMap,     0       },
             { CPS_PipeScreenDriver,     0       },
+            { CPS_GalliumCoreAPI,       0       },
             { TAG_DONE,                 0       }
     };
     struct pipe_screen * pscreen = NULL;
@@ -114,7 +126,6 @@
 
     D(bug("[MESA3DGL] %s()\n", __func__));
 
-    /* Allocate MESA3DGL context */
     if (!(ctx = (struct mesa3dgl_context *)AllocVec(sizeof(struct mesa3dgl_context), MEMF_PUBLIC | MEMF_CLEAR)))
     {
         bug("%s: ERROR - failed to allocate GLAContext\n", __func__);
@@ -137,9 +148,12 @@
 
     MESA3DGLStandardInit(ctx, tagList);
 
+    pscreen_tags[2].ti_Data = (IPTR)gallium_core_get_api();
+
     if (CreatePipeV(pscreen_tags))
     {
         pscreen = CreatePipeScreen(ctx->driver);
+
         if (!pscreen)
         {
             bug("%s: ERROR -  failed to create gallium pipe screen\n", __func__);

--- a/workbench/libs/mesa/mesa3dgl_gladestroycontext.c
+++ b/workbench/libs/mesa/mesa3dgl_gladestroycontext.c
@@ -10,6 +10,7 @@
 #include "mesa3dgl_support.h"
 #include "mesa3dgl_gallium.h"
 
+
 /*****************************************************************************
 
     NAME */
@@ -39,7 +40,6 @@
 {
     struct mesa3dgl_context * _ctx = (struct mesa3dgl_context *)ctx;
 
-    /* Destroy a MESA3DGL context */
     D(bug("[MESA3DGL] %s(ctx @ %x)\n", __func__, ctx));
 
     if (_ctx)
@@ -52,7 +52,6 @@
 
             if (cur_ctx == st_ctx)
             {
-                /* Unbind if current */
                 _ctx->st->flush(_ctx->st, 0, NULL, NULL, NULL);
                 glstapi->make_current(glstapi, NULL, NULL, NULL);
             }
@@ -60,7 +59,12 @@
             _ctx->st->destroy(_ctx->st);
             MESA3DGLFreeFrameBuffer(_ctx->framebuffer);
             MESA3DGLFreeStManager(_ctx->driver, _ctx->stmanager);
-            glstapi->destroy(glstapi);
+            /* glstapi is library-global (created once in Init, freed in
+             * Expunge — mesa3dgl_init.c). Destroying it here left a
+             * dangling pointer, so the NEXT glACreateContext in the same
+             * session (fullscreen/window toggles, SDL's probe context)
+             * ran create_context on freed memory: grey screens or
+             * crashes depending on heap reuse. */
             MESA3DGLFreeContext(_ctx);
         }
     }

--- a/workbench/libs/mesa/mesa3dgl_glaswapbuffers.c
+++ b/workbench/libs/mesa/mesa3dgl_glaswapbuffers.c
@@ -20,6 +20,7 @@
 #include "mesa3dgl_gallium.h"
 
 
+
 /*****************************************************************************
 
     NAME */
@@ -56,10 +57,14 @@
         /* Flush rendering cache before blitting */
         _ctx->st->flush(_ctx->st, ST_FLUSH_FRONT, NULL, NULL, NULL);
 
+        /* gallium.library tries the whole-window DisplayResourceRP method
+         * first (vc4 presents zero-copy there) and falls back to the
+         * per-cliprect DisplayResource loop (softpipe). */
         BltPipeResourceRastPort(_ctx->driver, _ctx->framebuffer->render_resource, 0, 0,
             _ctx->visible_rp, _ctx->left, _ctx->top,
             _ctx->framebuffer->width, _ctx->framebuffer->height);
     }
+
 
     MESA3DGLCheckAndUpdateBufferSize(_ctx);
 }

--- a/workbench/libs/mesa/mesa3dgl_support.c
+++ b/workbench/libs/mesa/mesa3dgl_support.c
@@ -8,11 +8,96 @@
 #include <proto/exec.h>
 #include <proto/graphics.h>
 #include <proto/cybergraphics.h>
+#include <proto/dos.h>
+#include <proto/icon.h>
+
+#include <workbench/workbench.h>
 
 #include <cybergraphx/cybergraphics.h>
 #include <graphics/rpattr.h>
 
 #include "mesa3dgl_support.h"
+
+/* Render-scale divisor (ENV:VC4_RENDER_SCALE, 1-4): GL renders at 1/N
+ * of the drawable size and the vc4 present path shows it through the
+ * HVS hardware scaler — fragment cost drops by N^2. Only honoured when
+ * the vc4 shim is linked in (weak marker below); elsewhere the fallback
+ * blit can't scale and would draw a small image in the corner. */
+ULONG mesa3dgl_render_scale = 1;
+
+/* Marker: the GalliumCoreAPI table exists only in builds that carry a
+ * runtime-bound hw driver (raspi/vc4) — the render-scale feature is
+ * driver-side scaling, so gate on it. */
+#ifdef MESA3DGL_HAVE_COREAPI
+extern const void *gallium_core_get_api(void);
+#else
+static inline const void *gallium_core_get_api(void) { return (const void *)0; }
+#endif
+
+/* Per-program override: VC4_RENDER_SCALE tooltype in the program's icon
+ * (.info next to the executable). Runs in the caller's process context,
+ * so GetProgramDir() and the process name identify the right program. */
+static BOOL MESA3DGLReadScaleToolType(ULONG *scale)
+{
+    struct Library *IconBase;
+    struct Process *me = (struct Process *)FindTask(NULL);
+    struct DiskObject *dob;
+    BPTR progdir, olddir;
+    TEXT name[108];
+    STRPTR val;
+    BOOL found = FALSE;
+
+    if (me->pr_Task.tc_Node.ln_Type != NT_PROCESS)
+        return FALSE;
+
+    progdir = GetProgramDir();
+    if (progdir == BNULL)
+        return FALSE;
+
+    if (GetProgramName(name, sizeof(name)) == DOSFALSE || name[0] == '\0')
+    {
+        /* WB-launched: no CLI name set, the process carries the tool name */
+        name[sizeof(name) - 1] = '\0';
+        strncpy(name, me->pr_Task.tc_Node.ln_Name, sizeof(name) - 1);
+    }
+
+    IconBase = OpenLibrary("icon.library", 0);
+    if (!IconBase)
+        return FALSE;
+
+    olddir = CurrentDir(progdir);
+    dob = GetDiskObject(FilePart(name));
+    if (dob)
+    {
+        val = FindToolType(dob->do_ToolTypes, "VC4_RENDER_SCALE");
+        if (val && val[0] >= '1' && val[0] <= '4' && val[1] == '\0')
+        {
+            *scale = val[0] - '0';
+            found = TRUE;
+        }
+        FreeDiskObject(dob);
+    }
+    CurrentDir(olddir);
+    CloseLibrary(IconBase);
+
+    return found;
+}
+
+static VOID MESA3DGLReadRenderScale(VOID)
+{
+    TEXT buf[8];
+
+    mesa3dgl_render_scale = 1;
+    if (!gallium_core_get_api())
+        return;
+
+    if (GetVar("VC4_RENDER_SCALE", buf, sizeof(buf), 0) > 0
+        && buf[0] >= '1' && buf[0] <= '4')
+        mesa3dgl_render_scale = buf[0] - '0';
+
+    /* Icon tooltype (per program) overrides the env variable (global) */
+    MESA3DGLReadScaleToolType(&mesa3dgl_render_scale);
+}
 
 VOID MESA3DGLSelectRastPort(struct mesa3dgl_context * ctx, struct TagItem * tagList)
 {
@@ -70,6 +155,24 @@ VOID MESA3DGLSelectRastPort(struct mesa3dgl_context * ctx, struct TagItem * tagL
     }
 
     D(bug("[MESA3DGL] %s: Using RastPort @ 0x%p\n", __func__, ctx->visible_rp));
+
+    /* Window/layer geometry at context creation: a fresh SDL window's
+     * layer coming up collapsed (~1px) shows here. */
+    D({
+        struct Layer *l = ctx->visible_rp ? ctx->visible_rp->Layer : NULL;
+
+        bug("[MESA3DGL] ctx: win=%p rp=%p layer=%p", ctx->window,
+            ctx->visible_rp, l);
+        if (ctx->window)
+            bug(" win %ldx%ld at %ld,%ld", (LONG)ctx->window->Width,
+                (LONG)ctx->window->Height, (LONG)ctx->window->LeftEdge,
+                (LONG)ctx->window->TopEdge);
+        if (l)
+            bug(" layer bounds %ld,%ld..%ld,%ld", (LONG)l->bounds.MinX,
+                (LONG)l->bounds.MinY, (LONG)l->bounds.MaxX,
+                (LONG)l->bounds.MaxY);
+        bug("\n");
+    })
 }
 
 BOOL MESA3DGLStandardInit(struct mesa3dgl_context * ctx, struct TagItem *tagList)
@@ -80,6 +183,8 @@ BOOL MESA3DGLStandardInit(struct mesa3dgl_context * ctx, struct TagItem *tagList
     LONG defaultright = 0, defaultbottom = 0;
 
     D(bug("[MESA3DGL] %s(ctx @ 0x%p, taglist @ 0x%p)\n", __func__, ctx, tagList));
+
+    MESA3DGLReadRenderScale();
 
     /* Set the defaults based on window information */
     if (ctx->window)
@@ -165,23 +270,48 @@ VOID MESA3DGLRecalculateBufferWidthHeight(struct mesa3dgl_context * ctx)
     ULONG newheight = 0;
     
     D(bug("[MESA3DGL] %s(0x%p)\n", __func__, ctx));
-    
+
     ctx->visible_rp_width =
         ctx->visible_rp->Layer->bounds.MaxX - ctx->visible_rp->Layer->bounds.MinX + 1;
 
     ctx->visible_rp_height =
         ctx->visible_rp->Layer->bounds.MaxY - ctx->visible_rp->Layer->bounds.MinY + 1;
 
+    /* NOTE: when a window's layer bounds read ~1px while the window
+     * itself is fully sized, faking the framebuffer size here does NOT
+     * help — AROS clips all rendering/blitting to the layer, so
+     * presentation stays confined to those few pixels. Such a bug has to
+     * be fixed where the window and its layer are created, not here.
+     * Left as the plain layer read. */
+
 
     newwidth = ctx->visible_rp_width - ctx->left - ctx->right;
     newheight = ctx->visible_rp_height - ctx->top - ctx->bottom;
-    
+
     if (newwidth < 0) newwidth = 0;
     if (newheight < 0) newheight = 0;
+
+    /* Render-scale: draw at 1/N, present through the HVS scaler. Even
+     * width keeps pixel formats happy; the present path upscales by
+     * the exact src/dest ratio so rounding never skews the aspect. */
+    if (mesa3dgl_render_scale > 1)
+    {
+        newwidth = (newwidth / mesa3dgl_render_scale) & ~1;
+        newheight = newheight / mesa3dgl_render_scale;
+        if (newwidth < 2) newwidth = 2;
+        if (newheight < 2) newheight = 2;
+    }
     
     
     if ((newwidth != ctx->framebuffer->width) || (newheight != ctx->framebuffer->height))
     {
+        /* rp_w/h are pre-scale/pre-border. */
+        D(bug("[MESA3DGL] fb resize: %lux%lu -> %lux%lu (rp %lux%lu, scale %lu)\n",
+            (ULONG)ctx->framebuffer->width, (ULONG)ctx->framebuffer->height,
+            (ULONG)newwidth, (ULONG)newheight,
+            (ULONG)ctx->visible_rp_width, (ULONG)ctx->visible_rp_height,
+            (ULONG)mesa3dgl_render_scale));
+
         /* The drawing area size has changed. Buffer must change */
         D(bug("[MESA3DGL] %s: current height    =   %d\n", __func__, ctx->framebuffer->height));
         D(bug("[MESA3DGL] %s: current width     =   %d\n", __func__, ctx->framebuffer->width));
@@ -222,3 +352,4 @@ VOID MESA3DGLFreeContext(struct mesa3dgl_context * ctx)
         FreeVec(ctx);
     }
 }
+

--- a/workbench/libs/mesa/mesa3dgl_types.h
+++ b/workbench/libs/mesa/mesa3dgl_types.h
@@ -7,7 +7,9 @@
 
 #include <GL/gla.h>
 #include "main/mtypes.h"
-#if defined(GL_PACK_REVERSE_ROW_ORDER_ANGLE)
+/* Mesa 21.0+ renamed st_api.h -> frontend/api.h. __has_include is
+ * reliable here; a #define probe may not be pulled in yet. */
+#if defined(__has_include) && __has_include("frontend/api.h")
 #include "frontend/api.h"
 #else
 #include "state_tracker/st_api.h"

--- a/workbench/libs/mesa/mmakefile.src
+++ b/workbench/libs/mesa/mmakefile.src
@@ -31,9 +31,35 @@ include $(SRCDIR)/$(CURDIR)/mesa.cfg
 
 #MM mesa3dgl-library : includes workbench-libs-dxtn-includes linklibs-galliumauxiliary workbench-libs-gallium-linklib mesa3dgl-linklibs mesa3dgl-library-env
 
+# Per-arch gallium core linklibs, mirroring MESA3DGL_GALLIUMCORE in
+# mesa.cfg. Declare each one's build-order dependency so mmake builds the
+# linklib before mesa3dgl-library consumes it.
+ifeq ($(AROS_TARGET_ARCH),raspi)
+#MM mesa3dgl-library : linklibs-galliumcoreapi
+endif
+
 SHARED_LIB_SOURCES = \
             emul_arosc \
             tls
+
+# raspi: the vc4 pipe driver lives in vc4gallium.hidd (runtime-bound via
+# the GalliumCoreAPI table in MESA3DGL_GALLIUMCORE). aros_drm_shim.c stays
+# here for its libc side — the fprintf/stderr intercepts and the per-task
+# StdCBase resolver that st/mesa and the compiler core need — and for the
+# gallium_core_get_api link anchor. Its drm/posix shims are inert in this
+# module (aros_drm_bridge stays NULL); the hidd compiles its own copy.
+# Gated on arch AND cpu: AROS_TARGET_ARCH is "raspi" for the aarch64
+# target too, where the vc4 hidd (and with it the core table this file
+# anchors) is not built. Excluded elsewhere so libc symbols stay
+# untouched.
+ifeq ($(AROS_TARGET_ARCH),raspi)
+SHARED_LIB_SOURCES += aros_drm_shim
+# Bridge ABI header (shared with the hidd), needed by aros_drm_shim.c.
+USER_INCLUDES += -I$(SRCDIR)/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium
+# The GalliumCoreAPI table linklib exists (galliumcoreapi in
+# MESA3DGL_GALLIUMCORE) — let the sources take a real reference to it.
+USER_CPPFLAGS += -DMESA3DGL_HAVE_COREAPI
+endif
 
 MESA3DGL_SOURCES = \
             mesa3dgl_support \
@@ -81,7 +107,8 @@ USER_LDFLAGS += $(TARGET_CXX_LDFLAGS) -L$(top_libdir)
   conffile="$(SRCDIR)/workbench/libs/gl/gl.conf" \
   confoverride="$(top_srcdir)/mesa3dgl.conf" objdir="$(OBJDIR)/$(MESAGLVERSION)" \
   files="$(MESAGL_LIBRARY_SOURCES_C)" \
-  alwayscxxlink=yes uselibs="glapi mesa mesa-sse41 compiler galliumauxiliary gallium mesautil pthread"
+  alwayscxxlink=yes \
+  uselibs="glapi mesa mesa-sse41 compiler galliumauxiliary gallium mesautil pthread $(MESA3DGL_GALLIUMCORE)"
 
 $(AROS_ENVARC)/SYS:
 	%mkdir_q dir=$@


### PR DESCRIPTION
VC4 Gallium 3D driver (VideoCore IV / Raspberry Pi)

Hardware-accelerated OpenGL on Pi 1–3 by running Mesa's `vc4` gallium driver as an AROS hidd, on top of the HVS display work already merged in #945.

**`vc4gallium.hidd`** — V3D bring-up (register map, clock setup, interrupt/poll servicing), a DRM-shaped BO table and ioctl layer that Mesa's vc4 pipe driver talks to unchanged, command-list validation and relocation, and the present path. The pipe driver is linked into the hidd and bound to mesa3dgl's Mesa core at `CreatePipeScreen`.

**`mesa3dgl` hosts the Mesa compiler core.** `galliumglue.py` generates a versioned, hash-checked function-pointer table from the driver's Mesa-core import set, plus trampolines and an objcopy rename map that route the driver's calls through it. mesa3dgl carries the table and stays driver-agnostic, so more pipe drivers (V3D for Pi 4) can slot in later. A single shared core is required, not just tidier: vc4 is a NIR driver, so `nir_shader`s cross the boundary by pointer and a duplicated core faults on the ralloc/glsl_type singletons.

**Presenting is copy-free wherever the geometry allows.** A fullscreen drawable is scanned out directly by flipping to the rendered BO. A windowed drawable that is a single unobscured cliprect is shown as an HVS overlay plane instead of being blitted, pipelined over a three-page ring so CPU emit overlaps GPU render (frame time becomes `max(CPU, GPU)` rather than the sum). Anything else — obscured windows, overlapping cliprects — falls back to a DMA blit, so correctness never depends on the fast path being available.

**`VC4_RENDER_SCALE`** (ENV: variable, or an icon tooltype per program) renders the drawable at 1/N and upscales it on present through the HVS scaler. Fill rate is the binding constraint on this GPU, so this trades resolution for frame rate at no blit cost; both sides of the module split read the same sources so the drawable size and the present geometry always agree.

**Also in this PR:** `DisplayResourceRP` on the gallium hidd interface (whole-window present; the base class declines and gallium.library falls back to the per-cliprect `DisplayResource` loop) plus a `CPS_GalliumCoreAPI` tag; four additions to the Mesa port patch (fract-based lowering and a P1 clamp so the TMU stops sampling stale power-of-two padding on NPOT `REPEAT` textures, `ARB_texture_rg` moved to the sampler list, viewport/scissor divided at the API boundary under render scale); `gpu_mem=128` in the generated `config.txt`, since the GL stack does not fit in the firmware's 64MB default; and GL bring-up tests (`gltri`, `glclear`, `glcustomscreen`, `gltexfbo`, plus an FPS counter and GLSL probe in `glsimplerendering`).