### PR TITLE
openfirmware: find device tree nodes by their binding

### DIFF
--- a/rom/openfirmware/of_init.c
+++ b/rom/openfirmware/of_init.c
@@ -201,6 +201,75 @@ AROS_LH1I(void *, OF_GetPropValue,
 }
 
 
+/* Does this node's "compatible" list - a run of NUL terminated strings -
+   name the given binding? */
+static BOOL of_is_compatible(of_node_t *node, const char *compatible)
+{
+    of_property_t *p;
+    const char *v;
+    uint32_t len, i;
+
+    ForeachNode(&node->on_properties, p)
+    {
+        if (my_strcmp(p->op_name, "compatible"))
+            continue;
+
+        v = (const char *)p->op_value;
+        len = p->op_length;
+        if (!v)
+            return FALSE;
+
+        for (i = 0; i < len; i++)
+        {
+            if (!my_strcmp(&v[i], compatible))
+                return TRUE;
+            while (i < len && v[i] != '\0')
+                i++;
+        }
+        return FALSE;
+    }
+    return FALSE;
+}
+
+static of_node_t *of_search_compatible(of_node_t *node, const char *compatible)
+{
+    of_node_t *child, *found;
+
+    if (of_is_compatible(node, compatible))
+        return node;
+
+    ForeachNode(&node->on_children, child)
+    {
+        if ((found = of_search_compatible(child, compatible)) != NULL)
+            return found;
+    }
+    return NULL;
+}
+
+/*
+ * Find a node by what it is rather than where it sits. Unit addresses in
+ * node names are bus addresses and move between SoC generations - the
+ * Broadcom RNG is rng@7e104000 on a Pi 3 and rng@7d208000 on a Pi 5 - so a
+ * driver that hardcodes a path silently stops matching, or worse, matches
+ * nothing and carries on. The binding string is the stable identifier.
+ */
+AROS_LH2(void *, OF_FindNodeByCompatible,
+         AROS_LHA(void *, Start, A0),
+         AROS_LHA(char *, Compatible, A1),
+         struct OpenFirmwareBase *, OpenFirmwareBase, 9, Openfirmware)
+{
+    AROS_LIBFUNC_INIT
+
+    of_node_t *from = Start ? (of_node_t *)Start : LIBBASE->of_Root;
+
+    if (!from || !Compatible)
+        return NULL;
+
+    return of_search_compatible(from, Compatible);
+
+    AROS_LIBFUNC_EXIT
+}
+
 static int OF_Init(LIBBASETYPEPTR LIBBASE)
 {
         void *KernelBase = OpenResource("kernel.resource");

--- a/rom/openfirmware/openfirmware.conf
+++ b/rom/openfirmware/openfirmware.conf
@@ -20,4 +20,5 @@ void *OF_GetProperty(void *key, void *prev) (A0, A1)
 uint32_t OF_GetPropLen(void *prop) (A0)
 void *OF_GetPropValue(void *prop) (A0)
 char *OF_GetPropName(void *prop) (A0)
+void *OF_FindNodeByCompatible(void *start, char *compatible) (A0, A1)
 ##end functionlist


### PR DESCRIPTION
A path locates one board's tree and no other, so a driver keyed on one is really asking whether it is running on the machine it was written for. OF_FindNodeByCompatible() answers what the caller means: whether the tree describes a core with this binding, wherever it sits.

Used to separate raspi 3 devices from raspi 4 devices