### PR TITLE
bcm2708: give mailbox messages their own cache lines

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/vc4_init.c
@@ -181,7 +181,7 @@ static int HiddVC4Gallium_ExpungeLib(LIBBASETYPEPTR LIBBASE)
 
     if (LIBBASE->sd.mbox_msg_raw)
     {
-        FreeMem(LIBBASE->sd.mbox_msg_raw, 256 + 16);
+        FreeMem(LIBBASE->sd.mbox_msg_raw, 256 + (MBOX_MSG_ALIGN - 1));
         LIBBASE->sd.mbox_msg_raw = NULL;
         LIBBASE->sd.mbox_msg = NULL;
     }
@@ -230,10 +230,8 @@ static int HiddVC4Gallium_InitLib(LIBBASETYPEPTR LIBBASE)
         return FALSE;
     }
 
-    /* Allocate 16-byte aligned mailbox message buffer.
-     * MBoxWrite silently fails if the address isn't 16-byte aligned
-     * (lower 4 bits encode channel number). */
-    LIBBASE->sd.mbox_msg_raw = AllocMem(256 + 16, MEMF_PUBLIC | MEMF_CLEAR);
+    /* Own our cache lines; see <proto/mbox.h>. */
+    LIBBASE->sd.mbox_msg_raw = AllocMem(256 + (MBOX_MSG_ALIGN - 1), MEMF_PUBLIC | MEMF_CLEAR);
     if (!LIBBASE->sd.mbox_msg_raw)
     {
         bug("[VC4Gallium] Failed to alloc mailbox buffer\n");
@@ -241,7 +239,7 @@ static int HiddVC4Gallium_InitLib(LIBBASETYPEPTR LIBBASE)
         CloseLibrary(LIBBASE->sd.UtilityBase);
         return FALSE;
     }
-    LIBBASE->sd.mbox_msg = (volatile ULONG *)(((IPTR)LIBBASE->sd.mbox_msg_raw + 0xF) & ~0xF);
+    LIBBASE->sd.mbox_msg = (volatile ULONG *)(((IPTR)LIBBASE->sd.mbox_msg_raw + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
 
     InitSemaphore(&LIBBASE->sd.bo_lock);
     InitSemaphore(&LIBBASE->sd.mbox_lock);

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_init.c
@@ -116,11 +116,12 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
     if (!(MBoxBase = OpenResource("mbox.resource")))
         goto failure;
 
-    if (!(xsd->vcsd_MBoxBuff = (IPTR)AllocVec(16 + (sizeof(IPTR) * 2 * MAX_TAGS), MEMF_CLEAR)))
+    /* Own our cache lines; see <proto/mbox.h>. */
+    if (!(xsd->vcsd_MBoxBuff = (IPTR)AllocVec(MBOX_MSG_ALIGN + (sizeof(IPTR) * 2 * MAX_TAGS), MEMF_CLEAR)))
         goto failure;
 
     xsd->vcsd_MBoxMessage =
-        (unsigned int *)((xsd->vcsd_MBoxBuff + 0xF) & ~0x0000000F);
+        (unsigned int *)((xsd->vcsd_MBoxBuff + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
 
     /* Init the mailbox lock before the first MBoxWrite/Read so every
      * transaction (even those before InitMem) can take it. */

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox.conf
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox.conf
@@ -6,6 +6,22 @@ libbasetype struct MBoxBase
 ##end config
 ##begin cdef
 #include <inttypes.h>
+
+/*
+ * Message buffers must start on a 64-byte cache line and own their lines
+ * exclusively - allocate size + 63 and round the pointer up.
+ *
+ * The firmware writes its reply straight to memory, so the reply is made
+ * visible with a pure invalidate: a clean would push the CPU's stale copy
+ * over the answer. Invalidates work on whole lines, so a message sharing
+ * an edge line with a neighbour leaves no correct outcome. Dropping the
+ * line loses whatever the neighbour had pending - seen on real hardware as
+ * unrelated allocations reverting to stale contents - and writing it back
+ * puts the CPU's copy over what the firmware just answered.
+ *
+ * MBoxCall names callers that get this wrong.
+ */
+#define MBOX_MSG_ALIGN          64
 ##end cdef
 ##begin cdefprivate
 #include "mbox_private.h"

--- a/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
+++ b/arch/arm-native/soc/broadcom/2708/mbox/mbox_init.c
@@ -42,6 +42,12 @@ volatile unsigned int *mbox_call_locked(struct MBoxBase *MBoxBase, void *mb,
     if ((((unsigned int)msg & VCMB_CHAN_MASK) != 0) || (chan > VCMB_CHAN_MAX))
         return (volatile unsigned int *)-1;
 
+    /* Messages must own their cache lines; see <proto/mbox.h> for why. */
+    if (((IPTR)msg & (MBOX_MSG_ALIGN - 1)) != 0)
+        bug("[MBox] WARNING: message @ 0x%p not cache-line aligned — "
+            "reply invalidate will clip neighbouring memory (caller %p)\n",
+            msg, __builtin_return_address(0));
+
     length = AROS_LE2LONG(((ULONG *)msg)[0]);
     phys_addr = CachePreDMA(msg, &length, DMA_ReadFromRAM);
 
@@ -153,6 +159,11 @@ AROS_LH2(volatile unsigned int *, MBoxRead,
             uint32_t len = AROS_LE2LONG(addr[0]);
 
             ReleaseSemaphore(&MBoxBase->mbox_Sem);
+
+            /* See mbox_call_locked: the invalidate clips whole lines. */
+            if (((IPTR)addr & 63) != 0)
+                bug("[MBox] WARNING: reply @ 0x%p not cache-line aligned — "
+                    "invalidate will clip neighbouring memory\n", addr);
 
             CacheClearE(addr, len, CACRF_InvalidateD);
 

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -83,8 +83,9 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
     IPTR                ctrlBase;
     ULONG               ctrlClock, ctrlIRQ;
     BOOL                isEMMC2;
-    unsigned int *MBoxMessage_ = AllocMem(8*4+16, MEMF_PUBLIC | MEMF_CLEAR);
-    unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + 15) & ~15);
+    /* Own our cache lines; see <proto/mbox.h>. */
+    unsigned int *MBoxMessage_ = AllocMem(MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1), MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
 
     DINIT(bug("[SDCard--] %s()\n", __PRETTY_FUNCTION__));
 
@@ -127,7 +128,7 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
          */
         D(bug("[SDCard--] %s: card slot is on SDHOST for this SoC\n", __PRETTY_FUNCTION__));
         if (MBoxMessage_)
-            FreeMem(MBoxMessage_, 8*4+16);
+            FreeMem(MBoxMessage_, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
         return TRUE;
     }
 
@@ -336,7 +337,7 @@ bcminit_clock:
 bcminit_fail:
 
     if (MBoxMessage_)
-        FreeMem(MBoxMessage_, 8*4+16);
+        FreeMem(MBoxMessage_, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
 
     return retVal;
 }

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
@@ -130,8 +130,9 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
     struct sdcard_Bus       *bus;
     struct sdhost_private   *priv;
     int                     retVal = FALSE;
-    unsigned int *MBoxMessage_ = AllocMem(8*4+16, MEMF_PUBLIC | MEMF_CLEAR);
-    unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + 15) & ~15);
+    /* Own our cache lines; see <proto/mbox.h>. */
+    unsigned int *MBoxMessage_ = AllocMem(MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1), MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *MBoxMessage = (unsigned int *)((((IPTR)MBoxMessage_) + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
 
     D(bug("[SDHost] %s()\n", __PRETTY_FUNCTION__));
 
@@ -145,7 +146,7 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
     {
         D(bug("[SDHost] %s: not the card controller on this SoC\n", __PRETTY_FUNCTION__));
         if (MBoxMessage_)
-            FreeMem(MBoxMessage_, 8*4+16);
+            FreeMem(MBoxMessage_, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
         return TRUE;
     }
 
@@ -331,7 +332,7 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
 
 sdhost_fail:
     if (MBoxMessage_)
-        FreeMem(MBoxMessage_, 8*4+16);
+        FreeMem(MBoxMessage_, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
 
     return retVal;
 }

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
@@ -327,14 +327,15 @@ static void sdio_wifi_clock(struct SDIOBase *SDIOBase)
  */
 static void sdio_wifi_power(struct SDIOBase *SDIOBase)
 {
-    unsigned int *raw = AllocMem(16 * 4 + 16, MEMF_PUBLIC | MEMF_CLEAR);
+    /* Own our cache lines; see <proto/mbox.h>. */
+    unsigned int *raw = AllocMem(MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1), MEMF_PUBLIC | MEMF_CLEAR);
     unsigned int *msg;
     unsigned int gpio = RPI_EXP_GPIO_BASE + RPI_EXP_GPIO_WL_ON;
     int state;
 
     if (!raw)
         return;
-    msg = (unsigned int *)((((IPTR)raw) + 15) & ~15);
+    msg = (unsigned int *)((((IPTR)raw) + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
 
     /* Configure the expander pin as an output (initial level low) */
     msg[0] = AROS_LONG2LE(12 * 4);
@@ -383,7 +384,7 @@ static void sdio_wifi_power(struct SDIOBase *SDIOBase)
     D(bug("[SDIO] GET_GPIO_STATE gpio %u -> state %u (tag 0x%08x)\n",
           gpio, AROS_LE2LONG(msg[6]), AROS_LE2LONG(msg[4])));
 
-    FreeMem(raw, 16 * 4 + 16);
+    FreeMem(raw, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
 
     D(bug("[SDIO] WL_REG_ON sequence done\n"));
 }
@@ -393,8 +394,9 @@ static void sdio_wifi_power(struct SDIOBase *SDIOBase)
 
 static int sdio_mbox_setup(struct SDIOBase *SDIOBase)
 {
-    unsigned int *raw = AllocMem(8 * 4 + 16, MEMF_PUBLIC | MEMF_CLEAR);
-    unsigned int *msg = (unsigned int *)((((IPTR)raw) + 15) & ~15);
+    /* Own our cache lines; see <proto/mbox.h>. */
+    unsigned int *raw = AllocMem(MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1), MEMF_PUBLIC | MEMF_CLEAR);
+    unsigned int *msg = (unsigned int *)((((IPTR)raw) + (MBOX_MSG_ALIGN - 1)) & ~(IPTR)(MBOX_MSG_ALIGN - 1));
     int ok = FALSE;
 
     if (!raw)
@@ -444,7 +446,7 @@ static int sdio_mbox_setup(struct SDIOBase *SDIOBase)
         ok = (SDIOBase->sdio_ClockMax != 0);
     }
 
-    FreeMem(raw, 8 * 4 + 16);
+    FreeMem(raw, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
     return ok;
 }
 


### PR DESCRIPTION
A buffer another agent writes has to own its cache lines. Sharing an edge line with a neighbour leaves no correct choice at invalidate time: dropping the line loses whatever the neighbour had pending, and writing it back puts the CPU's stale copy over what the firmware just answered