### PR TITLE
amigavideo: Initialize LOFList and SHFList in initcustom. 

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -1858,6 +1858,8 @@ VOID initcustom(struct amigavideo_staticdata *csd)
     COPPEROUT(c, 0x0106, csd->bplcon3)  // Push the display bplcon3 again
     COPPEROUT(c, 0xffff, 0xfffe)
 
+    GfxBase->LOFlist = GfxBase->SHFlist = csd->copper2_backup;
+
     custom->cop1lc = (ULONG)csd->copper1;
     custom->cop2lc = (ULONG)csd->copper2_backup;
 


### PR DESCRIPTION
Initialize LOFList and SHFList in initcustom. COPLC2 was set  to zero  in VB handler until first screen was opened.