### PR TITLE
build: keep SHN_COMMON out of kernel objects

### DIFF
--- a/config/make.cfg.in
+++ b/config/make.cfg.in
@@ -29,6 +29,10 @@ include $(GENDIR)/config/target.cfg
 include $(HOSTGENDIR)/config/host.cfg
 include $(GENDIR)/config/build.cfg
 
+# Bootstrap ELF relocators cannot allocate SHN_COMMON symbols. Append the
+# feature-detected flag after USER_CFLAGS so -fcommon cannot leak into kernels.
+KERNEL_CFLAGS                += $(CFLAGS_NO_COMMON)
+
 # Cross tools installation directory.
 CROSSTOOLSDIR                 := @AROS_CROSSTOOLSDIR@
 


### PR DESCRIPTION
Bootstrap ELF relocators cannot allocate common symbols. Append the feature-detected flag after USER_CFLAGS so -fcommon cannot leak in.

This should fix gcc 9.5.0 raspi build