### PR TITLE
intuition: accelerate the mouse on speed, not per axis

### DIFF
--- a/rom/intuition/inputhandler.c
+++ b/rom/intuition/inputhandler.c
@@ -1321,11 +1321,21 @@ static struct Gadget *Process_RawMouse(struct InputEvent *ie, struct IIHData *ii
 
             if (GetPrivIBase(IntuitionBase)->ActivePreferences.EnableCLI & MOUSE_ACCEL)
             {
-                /* Acceleration */
-                if (ABS(iihdata->DeltaMouseX) > ACCELERATOR_THRESH)
+                /*
+                 * Acceleration. Decide on the speed of the movement and
+                 * then scale both axes by the same factor, so the
+                 * direction of travel survives.
+                 */
+                LONG speed = ABS(iihdata->DeltaMouseX);
+
+                if (ABS(iihdata->DeltaMouseY) > speed)
+                    speed = ABS(iihdata->DeltaMouseY);
+
+                if (speed > ACCELERATOR_THRESH)
+                {
                     iihdata->DeltaMouseX *= ACCELERATOR_MULTI;
-                if (ABS(iihdata->DeltaMouseY) > ACCELERATOR_THRESH)
                     iihdata->DeltaMouseY *= ACCELERATOR_MULTI;
+                }
             }
 
             switch (GetPrivIBase(IntuitionBase)->ActivePreferences.PointerTicks)


### PR DESCRIPTION
Doubling one axis while leaving the other below the threshold bent the direction of travel. A 500 Hz mouse reports 1-3 counts per axis and straddles the threshold constantly, so one report in seven came out bent by 9-15 degrees and diagonals drew as rippling lines.