### PR TITLE
usb2otg: split-transfer, channel and bulk fixes

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_core.c
@@ -325,7 +325,18 @@ void FNAME_DEV(TermIO)(struct IOUsbHWReq *ioreq,
         D(bug("[USB2OTG:TTCLEAR] completed hub=%d err=%ld\n",
             (int)ioreq->iouh_DevAddr, (LONG)ioreq->iouh_Req.io_Error);)
         ioreq->iouh_Req.io_Message.mn_Node.ln_Type = NT_FREEMSG;
+        Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&USB2OTGBase->hd_Unit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         USB2OTGBase->hd_Unit->hu_TTClearBusy = FALSE;
+        /* Issue the next parked clear, if any (see the pending table). */
+        usb2otg_tt_clear_drain(USB2OTGBase->hd_Unit);
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&USB2OTGBase->hd_Unit->hu_Lock);
+#endif
+        Enable();
+        FNAME_DEV(Cause)(USB2OTGBase, &USB2OTGBase->hd_Unit->hu_PendingInt);
         return;
     }
 
@@ -655,6 +666,7 @@ WORD FNAME_DEV(cmdControlXFer)(struct IOUsbHWReq *ioreq,
     ioreq->iouh_Actual = 0;
     usb2otg_reset_retry_state(ioreq);
 
+
     /* Hotplug diagnostic: SET_ADDRESS marks a fresh enumeration. */
     D(if (ioreq->iouh_SetupData.bRequest == USR_SET_ADDRESS &&
         ioreq->iouh_SetupData.bmRequestType ==
@@ -692,6 +704,7 @@ WORD FNAME_DEV(cmdBulkXFer)(struct IOUsbHWReq *ioreq,
     ioreq->iouh_Req.io_Flags &= ~IOF_QUICK;
     ioreq->iouh_Actual = 0;
     usb2otg_reset_retry_state(ioreq);
+
 
     Disable();
 #if defined(__AROSEXEC_SMP__)
@@ -742,10 +755,22 @@ WORD FNAME_DEV(cmdIntXFer)(struct IOUsbHWReq *ioreq,
      * re-assigned with scheduling info right below). */
     usb2otg_reset_retry_state(ioreq);
 
-    /* Calculate "last time handled" and "next time to be handled" frame numbers */
-    ULONG next_to_handle = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
-    ULONG last_handled = (next_to_handle - usb2otg_clamp_interval(ioreq->iouh_Interval)) & 0x7ff;
+    /*
+     * Schedule the first poll one interval out, the same way the
+     * requeue paths do. Anchoring "last handled" an interval in the
+     * PAST made every submission instantly due at the SOF gate
+     * (usb2otg_intr.c: elapsed >= distance is true at once), so
+     * bInterval only ever throttled the NAK path. A device that
+     * answers every poll with a report instead of NAKing - cheap
+     * optical mice do - was then polled flat out at the split
+     * engine's ceiling: measured 1000 reports/s from a mouse asking
+     * for 10 ms, i.e. 10x the transactions, IRQs and input events
+     * while it moved.
+     */
+    ULONG last_handled = (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
+    ULONG next_to_handle = (last_handled + usb2otg_clamp_interval(ioreq->iouh_Interval)) & 0x7ff;
     ioreq->iouh_DriverPrivate1 = (APTR)(IPTR)((last_handled << 16) | next_to_handle);
+
 
     Disable();
 #if defined(__AROSEXEC_SMP__)

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
@@ -157,10 +157,10 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                     wr32le(USB2OTG_AHB, otg_RegVal);
 
                     D(bug("[USB2OTG] Powering on USB controller\n"));
-                    /* 8-ULONG message + up to 15 bytes alignment slack:
-                     * 9 ULONGs could overflow after the 16-byte round-up. */
-                    pwron = AllocVec(16*sizeof(ULONG), MEMF_CLEAR);
-                    PwrOnMsg = (ULONG*)(((IPTR)pwron + 15) & ~15);
+                    /* MBoxCall invalidates the reply a whole cache line at a
+                     * time, so the message must own its 64-byte line. */
+                    pwron = AllocVec(64 + 63, MEMF_CLEAR);
+                    PwrOnMsg = (ULONG*)(((IPTR)pwron + 63) & ~63);
 
                     D(bug("[USB2OTG] pwron=%p, PwrOnMsg=%p\n", pwron, PwrOnMsg));
 
@@ -232,6 +232,21 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     D(bug("[USB2OTG] %s: Unit Allocated at 0x%p\n",
                                                 __PRETTY_FUNCTION__, USB2OTGBase->hd_Unit));
 
+                                    /* Heap memory (VC bus alias maps it), and 64-byte
+                                     * aligned so DMA cache maintenance owns its lines. */
+                                    USB2OTGBase->hd_Unit->hu_BounceRaw = AllocMem((8 * DMA_BOUNCE_SIZE) + 63,
+                                                                                  MEMF_PUBLIC | MEMF_CLEAR);
+                                    if (USB2OTGBase->hd_Unit->hu_BounceRaw == NULL)
+                                    {
+                                        bug("[USB2OTG] Failed to allocate DMA bounce buffers\n");
+                                        return FALSE;
+                                    }
+                                    for (i = 0; i < 8; i++)
+                                        USB2OTGBase->hd_Unit->hu_BounceBuf[i] =
+                                            (UBYTE *)(((IPTR)USB2OTGBase->hd_Unit->hu_BounceRaw + 63) & ~63)
+                                            + (i * DMA_BOUNCE_SIZE);
+
+
                                     NewList(&USB2OTGBase->hd_Unit->hu_IOPendingQueue);
 
                                     NewList(&USB2OTGBase->hd_Unit->hu_CtrlXFerQueue);
@@ -289,6 +304,8 @@ static int FNAME_DEV(Init)(LIBBASETYPEPTR USB2OTGBase)
                                     }
                                     USB2OTGBase->hd_Unit->hu_BulkOwnerDev[0] = 0;
                                     USB2OTGBase->hd_Unit->hu_BulkOwnerDev[1] = 0;
+                                    for (i = 0; i < USB2OTG_TTCLEAR_PENDING; i++)
+                                        USB2OTGBase->hd_Unit->hu_TTClearPending[i].tc_Hub = 0;
 
                                     USB2OTGBase->hd_Unit->hu_GlobalIRQHandle = KrnAddIRQHandler(IRQ_VC_USB, FNAME_DEV(GlobalIRQHandler), USB2OTGBase->hd_Unit, SysBase);
                                     USB2OTGBase->hd_Unit->hu_USB2OTGBase = USB2OTGBase;
@@ -706,6 +723,7 @@ AROS_LH1(LONG, FNAME_DEV(AbortIO),
             (unsigned long)usb2otg_wd_ticks,
             aborted ? "aborted" : "NOT aborted (channel/not-found)");)
         (void)loc; (void)chan_at;
+
 
         if (aborted)
         {

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_hub.c
@@ -437,6 +437,16 @@ WORD FNAME_ROOTHUB(cmdControlXFer)(struct IOUsbHWReq *ioreq,
 
                     D(bug("[USB2OTG:Hub] GET_PORT_STATUS: HOSTPORT=%08x\n", oldval));
 
+                    /* Only on change — the hub class polls this forever. */
+                    {
+                        static ULONG last_hprt = ~0U;
+
+                        if (oldval != last_hprt)
+                        {
+                            last_hprt = oldval;
+                        }
+                    }
+
                     *mptr = 0;
                     if (oldval & USB2OTG_HOSTPORT_PRTPWR)        *mptr |= AROS_WORD2LE(UPSF_PORT_POWER);
                     if (oldval & USB2OTG_HOSTPORT_PRTENA)        *mptr |= AROS_WORD2LE(UPSF_PORT_ENABLE);

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
@@ -249,15 +249,15 @@ struct USB2OTGUnit
         UBYTE               hc_CsplitRetry;    /* CSPLIT NYET retries this interval; caps to TT result window */
         UBYTE               hc_SplitState;     /* periodic-split SM: USB2OTG_SPLIT_{IDLE,SS,CS} */
         UWORD               hc_SplitSSUframe;  /* HFNUM&0x3fff uframe the SSPLIT was issued in */
-        struct IOUsbHWReq * hc_DiagReq;     /* Last bulk request tracked on this channel */
-        ULONG               hc_DiagStartFrame;
-        ULONG               hc_DiagLastProgressFrame;
-        ULONG               hc_DiagLastActual;
-        UWORD               hc_DiagLastIntr;
-        UBYTE               hc_DiagRequeueCount;
-        UBYTE               hc_DiagNoProgressCount;
+        struct IOUsbHWReq * hc_BulkReq;     /* Last bulk request tracked on this channel */
+        ULONG               hc_BulkStartFrame;
+        ULONG               hc_BulkLastProgressFrame;
+        ULONG               hc_BulkLastActual;
+        UWORD               hc_BulkLastIntr;
+        UBYTE               hc_BulkRequeueCount;
+        UBYTE               hc_BulkNoProgressCount;
         UWORD               hc_BareChhltdTotal; /* cumulative bare-CHHLTD per request; absolute give-up cap */
-        ULONG               hc_StartHfnum;    /* HFNUM at last StartChannel arm; for bulk diag timing */
+        ULONG               hc_StartHfnum;    /* HFNUM at last StartChannel arm; for bulk progress timing */
         UBYTE               hc_NakParked;     /* 1 = bulk-IN parked waiting for NAK gate; SOF re-arms with quick=1 */
         UBYTE               hc_QuietIdleStreak; /* consecutive WAIT-QUIET defers with NPTX queue+FIFO fully idle (wedge signature) */
         UBYTE               hc_OddfrmFlip;    /* invert ODDFRM choice for direct periodic; toggled on deschedule (self-calibrating) */
@@ -265,9 +265,14 @@ struct USB2OTGUnit
         ULONG               hc_LastSampleTsize;
         ULONG               hc_LastSampleActual;
         UWORD               hc_LastSampleIntr;
+        UBYTE               hc_ArmedRole;     /* USB2OTG_CHANROLE_*: role of the last INT arm; role
+                                               * change forces an exorcise (stale periodic-split
+                                               * state kills direct arms with bare CHHLTD) */
         UBYTE               hc_GiveupStreak;  /* consecutive split give-ups; reset on completion; burn at 4 */
-        UBYTE               hc_TraceCount;    /* DIAG: ctrl-split IRQ events since SetupChannel */
-        UBYTE               hc_TraceAnom;     /* DIAG: anomalous events logged for this submission */
+        UBYTE               hc_GiveupDev;     /* device address at streak start */
+        UBYTE               hc_GiveupCross;   /* streak spans more than one device */
+        UBYTE               hc_TraceCount;    /* ctrl-split IRQ events since SetupChannel */
+        UBYTE               hc_TraceAnom;     /* anomalous events logged for this submission */
     }                   hu_Channel[8];
 
 /*
@@ -315,6 +320,21 @@ struct USB2OTGUnit
      */
     struct IOUsbHWReq   hu_TTClearReq;
     BOOL                hu_TTClearBusy;
+
+    /*
+     * Clears that arrived while one was in flight. The old
+     * single-slot "dropped if one is pending" lost the keyboard's
+     * clears while the slot was tied up failing against an unplugged
+     * hub - the internal TT then refused those endpoints forever
+     * (pipes armed, zero completions, until reboot). tc_Hub == 0
+     * marks a free slot; TermIO drains the table in order.
+     */
+#define USB2OTG_TTCLEAR_PENDING 8
+    struct {
+        UBYTE           tc_Hub;
+        UBYTE           tc_Port;
+        UWORD           tc_wValue;
+    }                   hu_TTClearPending[USB2OTG_TTCLEAR_PENDING];
 
     APTR                hu_USB2OTGBase;
 
@@ -377,9 +397,17 @@ struct USB2OTGUnit
  * ULONG arrays guarantee 4-byte alignment for DMA.
  */
     ULONG               hu_StatusDmaBuf[4];
-    /* Cache-line aligned: per-buffer flush won't drag in adjacent data. */
-    ULONG               hu_BounceBuf[8][DMA_BOUNCE_SIZE / sizeof(ULONG)]
-                        __attribute__((aligned(64)));
+    /*
+     * Per-channel bounce rows, 64-byte aligned so cache maintenance never
+     * touches a line a row does not own. aligned(64) on an embedded array
+     * is void in practice: AllocPooled ignores member alignment and lands
+     * the unit at 32 mod 64 (seen on real Pi, IVAC tripwire), so every
+     * invalidate clipped 32 bytes of neighbouring unit fields. The rows
+     * therefore live in their own allocation; hu_BounceRaw keeps the
+     * unaligned base for FreeMem.
+     */
+    APTR                hu_BounceRaw;
+    UBYTE               *hu_BounceBuf[8];
 };
 
 /* PRIVATE device node */
@@ -404,6 +432,7 @@ struct USB2OTGDevice
 #define FNAME_ROOTHUB(x)        USB2OTG__RootHub__ ## x
 
 void                    usb2otg_clear_delayed_channel(int chan);
+void                    usb2otg_exorcise_channel(int chan);
 
 /* INT-pipe activity counters (usb2otg_intr.c) — hotplug diagnostics. */
 extern ULONG usb2otg_int_poll_count[8];
@@ -467,6 +496,25 @@ extern ULONG usb2otg_ctrl_xact_retries;   /* XactErr/DTErr/BNA path */
 #define CHAN_INT_DIRECT_FIRST   CHAN_INT4
 
 /*
+ * INT pool overflow: let a free channel take a request from the OTHER
+ * partition when that partition has no free usable channel, guarded by
+ * an exorcise on every role change (the historical mixed-role poisoning
+ * above predates usb2otg_exorcise_channel — the bet, to be proven on
+ * hardware, is that the forced disable cycle clears the stale split
+ * state). One channel of the target pool is always left free for its
+ * home role: a split INT can park in SSPLIT/CSPLIT for a long time,
+ * and letting two of those fill the direct pool would starve the HS
+ * hub's status-change poll — hotplug blind again, by a new mechanism.
+ * 0 restores the strict partition for A/B testing.
+ */
+#define USB2OTG_INT_POOL_OVERFLOW 1
+
+/* hc_ArmedRole values. */
+#define USB2OTG_CHANROLE_UNUSED 0
+#define USB2OTG_CHANROLE_SPLIT  1
+#define USB2OTG_CHANROLE_DIRECT 2
+
+/*
  * Split-control channel. A halted/failed split sequence poisons its
  * channel: every subsequent NON-split arm on it bare-CHHLTDs in the
  * arming uframe (splits keep working). Observed twice on Pi 3B+:
@@ -490,6 +538,45 @@ extern ULONG usb2otg_ctrl_xact_retries;   /* XactErr/DTErr/BNA path */
  * without a hotplug-induced give-up.
  */
 #define USB2OTG_DEBUG_FORCE_RECOVER_TICK 0
+
+/*
+ * Testing hook: treat every Nth completing control-split CSPLIT as if
+ * the TT had NAKed it (0 = disabled). QEMU's emulated devices never
+ * NAK a control transaction, so the retry path that kills a real
+ * tester's low-speed keyboard is otherwise unreachable here.
+ *
+ * What this can prove: the retry path runs, the channel survives it,
+ * and enumeration still completes. What it CANNOT prove: that the
+ * real fix works - QEMU's split engine is never poisoned to begin
+ * with, so a pass means "no worse", not "fixed".
+ */
+#define USB2OTG_DEBUG_FORCE_CTRL_NAK 0
+
+/*
+ * Monotonic experiment revision, stamped into every trace. Two builds
+ * with identical debug flags were once indistinguishable after the
+ * fact, which cost a hardware round trip. Bump on every behavioural
+ * change handed to a tester.
+ *  1: NAK exorcise + interval fix
+ *  2: burn only on cross-device give-up streaks; TT-clear pending queue
+ *  3: exorcise audit - 11 abandon sites + both in-place ctrl retries
+ *  4: INT pool overflow (split<->direct) with exorcise on role flip
+ */
+#define USB2OTG_BUILD_REV 4
+
+/*
+ * Testing hook: after _AFTER split-interrupt HCINT events have passed
+ * (so enumeration and class binding finish undisturbed), rewrite the
+ * next _BURST of them into ChHltd+XactErr (0 = disabled). Reproduces
+ * the transaction-error burst a hub hot-plug throws onto the interrupt
+ * pipes of already-enumerated LS/FS devices - the storm that used to
+ * burn both split-INT channels. Guarded to devices at address >= 3 so
+ * the first hub's own pipes are spared.
+ */
+#define USB2OTG_DEBUG_FORCE_XACTERR_AFTER 300
+#define USB2OTG_DEBUG_FORCE_XACTERR_BURST 0
+
+
 
 /*
  * Core-reset/power-cycle recovery on split-ctrl give-up. DISABLED —
@@ -594,6 +681,17 @@ extern ULONG usb2otg_ctrl_xact_retries;   /* XactErr/DTErr/BNA path */
  * deliberately; bisected down to 16 (2 ms), verified clean on
  * hardware. Control is enumeration/setup traffic only, so the cost
  * is a few ms per LS control transfer.
+ *
+ * Applied to every split-control re-arm, not just the success path:
+ * the four retry paths (CSPLIT NAK, NYET cap, transient error,
+ * bare-CHHLTD retry-in-place) used to hardcode 8 uframes for no
+ * stated reason.
+ *
+ * This is consistency, not a fix. The 8 was suspected of poisoning
+ * the split engine on a tester's low-speed keyboard; forcing a NAK on
+ * hardware disproved it - the storm follows a NAKed CSPLIT at 16
+ * uframes exactly as it did at 8. The real cause was the missing
+ * engine reset, see usb2otg_exorcise_channel().
  */
 #define USB2OTG_CTRL_SPLIT_PACE_UFRAMES   16
 
@@ -749,7 +847,7 @@ WORD                    FNAME_DEV(cmdIsoXFer)(struct IOUsbHWReq *, struct USB2OT
 
 void                    FNAME_DEV(Cause)(struct USB2OTGDevice *, struct Interrupt *);
 
-static inline BOOL usb2otg_diag_track_bulk_req(struct IOUsbHWReq *req)
+static inline BOOL usb2otg_track_bulk_req(struct IOUsbHWReq *req)
 {
     return req != NULL &&
            req->iouh_Req.io_Command == UHCMD_BULKXFER &&
@@ -770,7 +868,7 @@ static inline BOOL usb2otg_trace_bulk(int chan, struct IOUsbHWReq *req)
 #endif
 }
 
-static inline ULONG usb2otg_diag_frame(void)
+static inline ULONG usb2otg_frame(void)
 {
     return (rd32le(USB2OTG_HOSTFRAMENO) & 0x3fff) >> 3;
 }
@@ -792,6 +890,15 @@ static inline BOOL usb2otg_irq_finish_or_requeue(struct USB2OTGUnit *unit,
         KrnSpinUnLock(&unit->hu_Lock);
         return FALSE;
     }
+#else
+    /* The TOCTOU guard matters on UP too: the watchdog softint runs with
+     * IRQs enabled, so the IRQ handler can take the same channel slot
+     * between the softint's check and its requeue (and vice versa). A
+     * double requeue links the node into two lists — the SOF promotion
+     * walk then chases a cycle forever (observed as a total machine hang,
+     * FIQ sampler pc in GlobalIRQHandler's promotion loop). */
+    if (unit->hu_Channel[chan].hc_Request != req)
+        return FALSE;
 #endif
     if (head)
         ADDHEAD(queue, (struct Node *)req);
@@ -831,9 +938,6 @@ static inline void usb2otg_queue_clear_tt_buffer(struct USB2OTGUnit *unit,
     /* Our emulated root hub has no TT — it would only STALL. */
     if (req->iouh_SplitHubAddr == unit->hu_HubAddr)
         return;
-    if (unit->hu_TTClearBusy)
-        return;
-
     switch (req->iouh_Req.io_Command)
     {
         case UHCMD_CONTROLXFER: eptype = USB2OTG_TT_EPTYPE_CTRL; break;
@@ -851,6 +955,44 @@ static inline void usb2otg_queue_clear_tt_buffer(struct USB2OTGUnit *unit,
     if (req->iouh_Req.io_Command != UHCMD_CONTROLXFER &&
         req->iouh_Dir == UHDIR_IN)
         wValue |= (1 << 15);
+
+    if (unit->hu_TTClearBusy)
+    {
+        /*
+         * Slot busy - park the clear instead of dropping it. A clear
+         * aimed at an unplugged hub takes hundreds of retries to fail,
+         * and every clear dropped while it did meant an endpoint the
+         * TT refused until reboot.
+         */
+        int i, free_slot = -1;
+
+        /* Already in flight for this exact target? */
+        if (unit->hu_TTClearReq.iouh_DevAddr == req->iouh_SplitHubAddr &&
+            AROS_LE2WORD(unit->hu_TTClearReq.iouh_SetupData.wValue) == wValue &&
+            AROS_LE2WORD(unit->hu_TTClearReq.iouh_SetupData.wIndex) ==
+                req->iouh_SplitHubPort)
+            return;
+
+        for (i = USB2OTG_TTCLEAR_PENDING - 1; i >= 0; i--)
+        {
+            if (unit->hu_TTClearPending[i].tc_Hub == 0)
+                free_slot = i;
+            else if (unit->hu_TTClearPending[i].tc_Hub == req->iouh_SplitHubAddr &&
+                     unit->hu_TTClearPending[i].tc_Port == req->iouh_SplitHubPort &&
+                     unit->hu_TTClearPending[i].tc_wValue == wValue)
+                return;         /* already pending */
+        }
+
+        if (free_slot < 0)
+        {
+            return;
+        }
+
+        unit->hu_TTClearPending[free_slot].tc_Hub = (UBYTE)req->iouh_SplitHubAddr;
+        unit->hu_TTClearPending[free_slot].tc_Port = (UBYTE)req->iouh_SplitHubPort;
+        unit->hu_TTClearPending[free_slot].tc_wValue = wValue;
+        return;
+    }
 
     memset(tt, 0, sizeof(*tt));
     tt->iouh_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
@@ -879,31 +1021,90 @@ static inline void usb2otg_queue_clear_tt_buffer(struct USB2OTGUnit *unit,
     ADDHEAD(&unit->hu_CtrlXFerQueue, (struct Node *)tt);
 }
 
-/* Standard diag log cadence: first 5 events, then every 64th. */
-static inline BOOL usb2otg_diag_log_rate(ULONG count)
+/*
+ * Issue a Clear_TT_Buffer from stored parameters (the pending-table
+ * drain; the parameters were computed by usb2otg_queue_clear_tt_buffer
+ * when the slot was busy). Caller must hold hu_Lock.
+ */
+static inline void usb2otg_tt_clear_issue(struct USB2OTGUnit *unit,
+    UBYTE hub, UBYTE port, UWORD wValue)
+{
+    struct IOUsbHWReq *tt = &unit->hu_TTClearReq;
+
+    memset(tt, 0, sizeof(*tt));
+    tt->iouh_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+    tt->iouh_Req.io_Message.mn_Length = sizeof(*tt);
+    tt->iouh_Req.io_Command = UHCMD_CONTROLXFER;
+    tt->iouh_Req.io_Flags = IOF_QUICK;
+    tt->iouh_Req.io_Unit = (struct Unit *)unit;
+    tt->iouh_DevAddr = hub;
+    tt->iouh_Endpoint = 0;
+    tt->iouh_MaxPktSize = 64;
+    tt->iouh_Dir = UHDIR_OUT;
+    tt->iouh_Length = 0;
+    tt->iouh_Data = NULL;
+    tt->iouh_SetupData.bmRequestType = URTF_OUT | URTF_CLASS | URTF_OTHER;
+    tt->iouh_SetupData.bRequest = USR_CLEAR_TT_BUFFER;
+    tt->iouh_SetupData.wValue = AROS_WORD2LE(wValue);
+    tt->iouh_SetupData.wIndex = AROS_WORD2LE(port);
+    tt->iouh_SetupData.wLength = 0;
+
+    unit->hu_TTClearBusy = TRUE;
+    ADDHEAD(&unit->hu_CtrlXFerQueue, (struct Node *)tt);
+}
+
+/*
+ * Drain one pending Clear_TT_Buffer, if any. Called by TermIO right
+ * after the in-flight one released the slot. Caller must hold hu_Lock
+ * (TermIO takes it for this).
+ */
+static inline void usb2otg_tt_clear_drain(struct USB2OTGUnit *unit)
+{
+    int i;
+
+    if (unit->hu_TTClearBusy)
+        return;
+
+    for (i = 0; i < USB2OTG_TTCLEAR_PENDING; i++)
+    {
+        if (unit->hu_TTClearPending[i].tc_Hub != 0)
+        {
+            UBYTE hub = unit->hu_TTClearPending[i].tc_Hub;
+            UBYTE port = unit->hu_TTClearPending[i].tc_Port;
+            UWORD wValue = unit->hu_TTClearPending[i].tc_wValue;
+
+            unit->hu_TTClearPending[i].tc_Hub = 0;
+            usb2otg_tt_clear_issue(unit, hub, port, wValue);
+            return;
+        }
+    }
+}
+
+/* Standard log cadence: first 5 events, then every 64th. */
+static inline BOOL usb2otg_log_rate(ULONG count)
 {
     return count <= 5 || (count & 0x3f) == 0;
 }
 
-static inline void usb2otg_diag_bulk_assign(struct USB2OTGUnit *otg_Unit, int chan,
+static inline void usb2otg_bulk_assign(struct USB2OTGUnit *otg_Unit, int chan,
     struct IOUsbHWReq *req)
 {
     struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
 
-    if (!usb2otg_diag_track_bulk_req(req))
+    if (!usb2otg_track_bulk_req(req))
         return;
 
-    if (hc->hc_DiagReq != req)
+    if (hc->hc_BulkReq != req)
     {
-        ULONG frame = usb2otg_diag_frame();
+        ULONG frame = usb2otg_frame();
 
-        hc->hc_DiagReq = req;
-        hc->hc_DiagStartFrame = frame;
-        hc->hc_DiagLastProgressFrame = frame;
-        hc->hc_DiagLastActual = req->iouh_Actual;
-        hc->hc_DiagLastIntr = 0;
-        hc->hc_DiagRequeueCount = 0;
-        hc->hc_DiagNoProgressCount = 0;
+        hc->hc_BulkReq = req;
+        hc->hc_BulkStartFrame = frame;
+        hc->hc_BulkLastProgressFrame = frame;
+        hc->hc_BulkLastActual = req->iouh_Actual;
+        hc->hc_BulkLastIntr = 0;
+        hc->hc_BulkRequeueCount = 0;
+        hc->hc_BulkNoProgressCount = 0;
         hc->hc_BareChhltdTotal = 0;
         hc->hc_LastSampleHfnum = 0;
         hc->hc_LastSampleTsize = 0;
@@ -912,28 +1113,28 @@ static inline void usb2otg_diag_bulk_assign(struct USB2OTGUnit *otg_Unit, int ch
     }
 }
 
-static inline void usb2otg_diag_bulk_progress(struct USB2OTGUnit *otg_Unit, int chan,
+static inline void usb2otg_bulk_progress(struct USB2OTGUnit *otg_Unit, int chan,
     struct IOUsbHWReq *req, ULONG intr)
 {
     struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
 
-    if (!usb2otg_diag_track_bulk_req(req))
+    if (!usb2otg_track_bulk_req(req))
         return;
 
-    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
-    hc->hc_DiagLastIntr = (UWORD)intr;
+    usb2otg_bulk_assign(otg_Unit, chan, req);
+    hc->hc_BulkLastIntr = (UWORD)intr;
 
-    if (req->iouh_Actual != hc->hc_DiagLastActual)
+    if (req->iouh_Actual != hc->hc_BulkLastActual)
     {
-        D(ULONG prev = hc->hc_DiagLastActual;)
+        D(ULONG prev = hc->hc_BulkLastActual;)
 
-        hc->hc_DiagLastActual = req->iouh_Actual;
-        hc->hc_DiagLastProgressFrame = usb2otg_diag_frame();
+        hc->hc_BulkLastActual = req->iouh_Actual;
+        hc->hc_BulkLastProgressFrame = usb2otg_frame();
 
         D(
-            if (hc->hc_DiagRequeueCount >= 4 || hc->hc_DiagNoProgressCount >= 4)
+            if (hc->hc_BulkRequeueCount >= 4 || hc->hc_BulkNoProgressCount >= 4)
             {
-                bug("[USB2OTG:DIAG] bulk-progress chan=%d dev=%d ep=%d dir=%s %lu->%lu/%lu intr=%04x rq=%u np=%u split=%u\n",
+                bug("[USB2OTG:BULK] bulk-progress chan=%d dev=%d ep=%d dir=%s %lu->%lu/%lu intr=%04x rq=%u np=%u split=%u\n",
                     chan,
                     (int)req->iouh_DevAddr,
                     (int)req->iouh_Endpoint,
@@ -942,45 +1143,45 @@ static inline void usb2otg_diag_bulk_progress(struct USB2OTGUnit *otg_Unit, int 
                     (unsigned long)req->iouh_Actual,
                     (unsigned long)req->iouh_Length,
                     (unsigned int)intr,
-                    (unsigned int)hc->hc_DiagRequeueCount,
-                    (unsigned int)hc->hc_DiagNoProgressCount,
+                    (unsigned int)hc->hc_BulkRequeueCount,
+                    (unsigned int)hc->hc_BulkNoProgressCount,
                     (unsigned int)otg_Unit->hu_Channel[chan].hc_SplitCSplitPending);
             }
         )
 
-        hc->hc_DiagRequeueCount = 0;
-        hc->hc_DiagNoProgressCount = 0;
+        hc->hc_BulkRequeueCount = 0;
+        hc->hc_BulkNoProgressCount = 0;
         hc->hc_BareChhltdTotal = 0;
     }
 }
 
-static inline void usb2otg_diag_bulk_requeue(struct USB2OTGUnit *otg_Unit, int chan,
+static inline void usb2otg_bulk_requeue(struct USB2OTGUnit *otg_Unit, int chan,
     struct IOUsbHWReq *req, ULONG intr, const char *why)
 {
     struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
 
-    if (!usb2otg_diag_track_bulk_req(req))
+    if (!usb2otg_track_bulk_req(req))
         return;
 
-    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
-    hc->hc_DiagLastIntr = (UWORD)intr;
-    hc->hc_DiagRequeueCount++;
+    usb2otg_bulk_assign(otg_Unit, chan, req);
+    hc->hc_BulkLastIntr = (UWORD)intr;
+    hc->hc_BulkRequeueCount++;
 
-    if (req->iouh_Actual == hc->hc_DiagLastActual)
-        hc->hc_DiagNoProgressCount++;
+    if (req->iouh_Actual == hc->hc_BulkLastActual)
+        hc->hc_BulkNoProgressCount++;
     else
     {
-        hc->hc_DiagLastActual = req->iouh_Actual;
-        hc->hc_DiagLastProgressFrame = usb2otg_diag_frame();
-        hc->hc_DiagNoProgressCount = 0;
+        hc->hc_BulkLastActual = req->iouh_Actual;
+        hc->hc_BulkLastProgressFrame = usb2otg_frame();
+        hc->hc_BulkNoProgressCount = 0;
     }
 
     D(
-        if (hc->hc_DiagRequeueCount == 4 ||
-            hc->hc_DiagRequeueCount == 8 ||
-            hc->hc_DiagRequeueCount == 16)
+        if (hc->hc_BulkRequeueCount == 4 ||
+            hc->hc_BulkRequeueCount == 8 ||
+            hc->hc_BulkRequeueCount == 16)
         {
-            ULONG frame = usb2otg_diag_frame();
+            ULONG frame = usb2otg_frame();
             int int_busy = 0;
             int scan;
 
@@ -990,7 +1191,7 @@ static inline void usb2otg_diag_bulk_requeue(struct USB2OTGUnit *otg_Unit, int c
                     int_busy++;
             }
 
-            bug("[USB2OTG:DIAG] bulk-requeue chan=%d dev=%d ep=%d dir=%s act=%lu/%lu intr=%04x why=%s rq=%u np=%u age=%lu bulkq=%d intbusy=%d split=%08x char=%08x tsize=%08x\n",
+            bug("[USB2OTG:BULK] bulk-requeue chan=%d dev=%d ep=%d dir=%s act=%lu/%lu intr=%04x why=%s rq=%u np=%u age=%lu bulkq=%d intbusy=%d split=%08x char=%08x tsize=%08x\n",
                 chan,
                 (int)req->iouh_DevAddr,
                 (int)req->iouh_Endpoint,
@@ -999,9 +1200,9 @@ static inline void usb2otg_diag_bulk_requeue(struct USB2OTGUnit *otg_Unit, int c
                 (unsigned long)req->iouh_Length,
                 (unsigned int)intr,
                 why,
-                (unsigned int)hc->hc_DiagRequeueCount,
-                (unsigned int)hc->hc_DiagNoProgressCount,
-                (unsigned long)((frame - hc->hc_DiagStartFrame) & 0x7ff),
+                (unsigned int)hc->hc_BulkRequeueCount,
+                (unsigned int)hc->hc_BulkNoProgressCount,
+                (unsigned long)((frame - hc->hc_BulkStartFrame) & 0x7ff),
                 (int)IsListEmpty(&otg_Unit->hu_BulkXFerQueue) ? 0 : 1,
                 int_busy,
                 rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)),
@@ -1011,24 +1212,24 @@ static inline void usb2otg_diag_bulk_requeue(struct USB2OTGUnit *otg_Unit, int c
     )
 }
 
-static inline void usb2otg_diag_bulk_finish(struct USB2OTGUnit *otg_Unit, int chan,
+static inline void usb2otg_bulk_finish(struct USB2OTGUnit *otg_Unit, int chan,
     struct IOUsbHWReq *req)
 {
     struct USB2OTGChannel *hc = &otg_Unit->hu_Channel[chan];
 
-    if (!usb2otg_diag_track_bulk_req(req))
+    if (!usb2otg_track_bulk_req(req))
         return;
 
-    usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+    usb2otg_bulk_assign(otg_Unit, chan, req);
 
     D(
         if (req->iouh_Req.io_Error != 0 ||
-            hc->hc_DiagRequeueCount >= 4 ||
-            hc->hc_DiagNoProgressCount >= 4)
+            hc->hc_BulkRequeueCount >= 4 ||
+            hc->hc_BulkNoProgressCount >= 4)
         {
-            ULONG frame = usb2otg_diag_frame();
+            ULONG frame = usb2otg_frame();
 
-            bug("[USB2OTG:DIAG] bulk-finish chan=%d dev=%d ep=%d dir=%s act=%lu/%lu err=%d rq=%u np=%u age=%lu last_intr=%04x split=%u\n",
+            bug("[USB2OTG:BULK] bulk-finish chan=%d dev=%d ep=%d dir=%s act=%lu/%lu err=%d rq=%u np=%u age=%lu last_intr=%04x split=%u\n",
                 chan,
                 (int)req->iouh_DevAddr,
                 (int)req->iouh_Endpoint,
@@ -1036,21 +1237,21 @@ static inline void usb2otg_diag_bulk_finish(struct USB2OTGUnit *otg_Unit, int ch
                 (unsigned long)req->iouh_Actual,
                 (unsigned long)req->iouh_Length,
                 (int)req->iouh_Req.io_Error,
-                (unsigned int)hc->hc_DiagRequeueCount,
-                (unsigned int)hc->hc_DiagNoProgressCount,
-                (unsigned long)((frame - hc->hc_DiagStartFrame) & 0x7ff),
-                (unsigned int)hc->hc_DiagLastIntr,
+                (unsigned int)hc->hc_BulkRequeueCount,
+                (unsigned int)hc->hc_BulkNoProgressCount,
+                (unsigned long)((frame - hc->hc_BulkStartFrame) & 0x7ff),
+                (unsigned int)hc->hc_BulkLastIntr,
                 (unsigned int)otg_Unit->hu_Channel[chan].hc_SplitCSplitPending);
         }
     )
 
-    hc->hc_DiagReq = NULL;
-    hc->hc_DiagStartFrame = 0;
-    hc->hc_DiagLastProgressFrame = 0;
-    hc->hc_DiagLastActual = 0;
-    hc->hc_DiagLastIntr = 0;
-    hc->hc_DiagRequeueCount = 0;
-    hc->hc_DiagNoProgressCount = 0;
+    hc->hc_BulkReq = NULL;
+    hc->hc_BulkStartFrame = 0;
+    hc->hc_BulkLastProgressFrame = 0;
+    hc->hc_BulkLastActual = 0;
+    hc->hc_BulkLastIntr = 0;
+    hc->hc_BulkRequeueCount = 0;
+    hc->hc_BulkNoProgressCount = 0;
     hc->hc_LastSampleHfnum = 0;
     hc->hc_LastSampleTsize = 0;
     hc->hc_LastSampleActual = 0;

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intr.c
@@ -58,6 +58,7 @@ static void usb2otg_quar_log_release(struct USB2OTGUnit *unit,
     {
         if ((prev_mask & (1 << c)) && !(unit->hu_DeadChannels & (1 << c)))
         {
+            /* Release is as important to see as the quarantine. */
             D(ULONG dark = usb2otg_wd_ticks - usb2otg_quar_set_tick[c];)
             D(bug("[USB2OTG:QUAR] chan=%d released (%s) after %lu ticks (~%lu ms)%s\n",
                 c, where, (unsigned long)dark, (unsigned long)(dark * 150),
@@ -286,6 +287,7 @@ static void usb2otg_recover_periodic_queue(struct USB2OTGUnit *USBUnit)
 
         if (rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE)) & USB2OTG_HOSTCHAR_ENABLE)
             usb2otg_halt_channel_preserve_char(chan);
+        usb2otg_exorcise_channel(chan);
         wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
         delayed_channel[chan] = 0;
         USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
@@ -592,10 +594,12 @@ static BOOL usb2otg_set_usb_power(BOOL on)
     if (MBoxBase == NULL)
         return FALSE;
 
-    raw = AllocVec(16 * sizeof(ULONG), MEMF_CLEAR);
+    /* MBoxCall invalidates the reply a whole cache line at a time, so the
+     * message must own its 64-byte line exclusively. */
+    raw = AllocVec(64 + 63, MEMF_CLEAR);
     if (raw == NULL)
         return FALSE;
-    msg = (ULONG *)(((IPTR)raw + 15) & ~15);
+    msg = (ULONG *)(((IPTR)raw + 63) & ~63);
 
     msg[0] = AROS_LE2LONG(8 * sizeof(ULONG));
     msg[1] = AROS_LE2LONG(VCTAG_REQ);
@@ -683,10 +687,18 @@ static void usb2otg_split_fsm_recover(struct USB2OTGUnit *USBUnit, int chan)
  * its own disable path and clears that state. Must be followed by a
  * full reprogram, so HCSPLT/HCCHAR are scrubbed here.
  */
-static void usb2otg_exorcise_channel(int chan)
+void usb2otg_exorcise_channel(int chan)
 {
     ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
     int spin = 200000;
+
+    /*
+     * Recorded, not printed. This runs on the IRQ path, and the STALL
+     * origin alone fires ~34 times per PsdDevLister round (devices
+     * stall the string indices they do not implement) - serial output
+     * at that rate moves split timing, which is what the ring exists
+     * to avoid. The trace shows origin, channel and HCCHAR instead.
+     */
 
     wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE),
         hcchar | USB2OTG_HOSTCHAR_ENABLE | USB2OTG_HOSTCHAR_DISABLE);
@@ -699,8 +711,9 @@ static void usb2otg_exorcise_channel(int chan)
     wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), 0);
     wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), 0);
 
-    bug("[USB2OTG] split-engine reset on chan %d%s\n", chan,
-        (spin > 0) ? "" : " (halt timed out)");
+    /* Only the failure is worth the serial line. */
+    if (spin <= 0)
+        bug("[USB2OTG] split-engine reset on chan %d: halt timed out\n", chan);
 }
 
 /*
@@ -710,16 +723,49 @@ static void usb2otg_exorcise_channel(int chan)
  * the channel is only a backstop for one that keeps failing without a
  * single completed transfer in between.
  */
-static void usb2otg_split_giveup_recover(struct USB2OTGUnit *USBUnit, int chan)
+/*
+ * engine_fault says what the give-up proves about the CHANNEL. Only a
+ * bare-CHHLTD storm does (armed transactions the core never executes);
+ * NAK and XactErr are received handshakes and wire errors - the channel
+ * demonstrably ran its transactions, the problem is the device or the
+ * bus. Hot-plugging a hub throws a burst of XactErr onto the interrupt
+ * pipes of already-enumerated LS/FS devices, and counting those toward
+ * the burn threshold retired both split-INT channels for good inside
+ * 100 ms - after which no device behind any TT could interrupt-poll
+ * until reboot (hub reinsertion "not detected").
+ */
+static void usb2otg_split_giveup_recover(struct USB2OTGUnit *USBUnit, int chan,
+    BOOL engine_fault, UBYTE dev)
 {
     struct USB2OTGChannel *hc = &USBUnit->hu_Channel[chan];
+
+    usb2otg_exorcise_channel(chan);
+
+    if (!engine_fault)
+        return;
+
+    /*
+     * A streak of bare-CHHLTD give-ups all for ONE device address is
+     * explained by that device vanishing: the TT refuses transactions
+     * to a gone device with the same bare CHHLTD a poisoned engine
+     * produces, and exorcise (above) is the right response. Burning
+     * exists for the channel that hurts OTHERS - the historical case
+     * was dead-device ctrl poisoning the channel for live devices'
+     * ctrl - so the streak must span more than one device to count.
+     * Without this, every hub unplug burned one channel for good.
+     */
+    if (hc->hc_GiveupStreak == 0)
+    {
+        hc->hc_GiveupDev = dev;
+        hc->hc_GiveupCross = 0;
+    }
+    else if (hc->hc_GiveupDev != dev)
+        hc->hc_GiveupCross = 1;
 
     if (hc->hc_GiveupStreak < 255)
         hc->hc_GiveupStreak++;
 
-    usb2otg_exorcise_channel(chan);
-
-    if (hc->hc_GiveupStreak >= 4 &&
+    if (hc->hc_GiveupStreak >= 4 && hc->hc_GiveupCross &&
         !(USBUnit->hu_BurnedChannels & (1 << chan)))
     {
         /*
@@ -902,10 +948,20 @@ static void handle_SOF(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase, UL
 #if defined(__AROSEXEC_SMP__)
             KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
 #endif
+            int walk_guard = 0;
+
             ForeachNodeSafe(&USBUnit->hu_IntXFerQueue, req, next)
             {
                 ULONG last_handled = (ULONG)(IPTR)req->iouh_DriverPrivate1 >> 16;
                 ULONG next_to_handle = (ULONG)(IPTR)req->iouh_DriverPrivate1 & 0x7ff;
+
+                /* A cross-linked node turns this walk into a cycle (seen
+                 * hanging the machine); bail loudly instead of spinning. */
+                if (++walk_guard > 128)
+                {
+                    bug("[USB2OTG] SOF: IntXFerQueue walk runaway — list cycle, aborting walk\n");
+                    break;
+                }
 
                 /*
                  * Due when the frames elapsed since last_handled reach
@@ -1030,6 +1086,7 @@ static void handle_SOF(struct USB2OTGUnit *USBUnit, struct ExecBase *SysBase, UL
                             (int)sreq->iouh_DevAddr, (int)sreq->iouh_Endpoint,
                             (unsigned long)stall_count);
 
+
                     wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                     usb2otg_halt_channel_preserve_char(chan);
                     /* Heal the halt-on-armed-SSPLIT poison before reuse. */
@@ -1118,6 +1175,52 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                  * needed at final completion to exclude the watchdog.
                  */
                 req = USBUnit->hu_Channel[chan].hc_Request;
+
+#if USB2OTG_DEBUG_FORCE_CTRL_NAK
+                /* Synthesise the TT NAK QEMU never produces — see the define. */
+                if (req != NULL && chan == USBUnit->hu_CtrlSplitChan &&
+                    req->iouh_Req.io_Command == UHCMD_CONTROLXFER &&
+                    (req->iouh_Flags & UHFF_SPLITTRANS) &&
+                    (intr & USB2OTG_INTRCHAN_TRANSFERCOMPLETE) &&
+                    (rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL)) &
+                     USB2OTG_HCSPLT_SPLITEN))
+                {
+                    static ULONG forced = 0;
+
+                    if ((++forced % USB2OTG_DEBUG_FORCE_CTRL_NAK) == 0)
+                    {
+                        bug("[USB2OTG:FORCE] faking ctrl-split NAK #%lu chan=%d dev=%d\n",
+                            (unsigned long)forced, chan, (int)req->iouh_DevAddr);
+                        intr = USB2OTG_INTR_HALT_NAK;
+                    }
+                }
+#endif
+
+#if USB2OTG_DEBUG_FORCE_XACTERR_BURST
+                /* Synthesise the hub-hot-plug XactErr burst — see the
+                 * define. The ring records the faked intr as HCINT. */
+                if (req != NULL &&
+                    (req->iouh_Flags & UHFF_SPLITTRANS) &&
+                    req->iouh_Req.io_Command == UHCMD_INTXFER &&
+                    req->iouh_DevAddr >= 3 &&
+                    (intr & USB2OTG_INTRCHAN_HALT))
+                {
+                    static ULONG seen = 0;
+
+                    seen++;
+                    if (seen > USB2OTG_DEBUG_FORCE_XACTERR_AFTER &&
+                        seen <= USB2OTG_DEBUG_FORCE_XACTERR_AFTER +
+                                USB2OTG_DEBUG_FORCE_XACTERR_BURST)
+                    {
+                        if (seen == USB2OTG_DEBUG_FORCE_XACTERR_AFTER + 1)
+                            bug("[USB2OTG:FORCE] XactErr burst begins (%d events)\n",
+                                USB2OTG_DEBUG_FORCE_XACTERR_BURST);
+                        intr = USB2OTG_INTRCHAN_HALT |
+                               USB2OTG_INTRCHAN_TRANSACTIONERROR;
+                    }
+                }
+#endif
+
 
                 /*
                  * DIAG: ctrl-split event trace. First 6 events of every
@@ -1258,9 +1361,10 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
 
                         wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                         usb2otg_halt_channel_preserve_char(chan);
+                        usb2otg_exorcise_channel(chan);
 
                         USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
-                        usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-nak");
+                        usb2otg_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-nak");
                         /* Helper does TOCTOU vs watchdog. */
                         usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
                             usb2otg_gate_dir(req), USB2OTG_BULK_NAK_GATE_UFRAMES);
@@ -1288,6 +1392,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
 
                             /* Disable channel without clearing MPS/ep metadata */
                             usb2otg_halt_channel_preserve_char(chan);
+                            usb2otg_exorcise_channel(chan);
 
                             /* Put transfer back into queue with updated timing */
                             if (req->iouh_Req.io_Command == UHCMD_INTXFER)
@@ -1353,7 +1458,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                     USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
                                     USBUnit->hu_Channel[chan].hc_CsplitRetry = 0;
                                     USBUnit->hu_Channel[chan].hc_SplitState = USB2OTG_SPLIT_SS;
-                                    delayed_channel[chan] = 8;
+                                    delayed_channel[chan] = USB2OTG_CTRL_SPLIT_PACE_UFRAMES;
                                     req = NULL;
                                 }
                                 else
@@ -1444,7 +1549,8 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                         usb2otg_split_fsm_recover(USBUnit, chan);
                                 }
                                 /* Give-up teardown poisons the channel. */
-                                usb2otg_split_giveup_recover(USBUnit, chan);
+                                /* NAK = the TT answered; not an engine fault. */
+                                usb2otg_split_giveup_recover(USBUnit, chan, FALSE, req->iouh_DevAddr);
                                 req = NULL;
                             }
                             else
@@ -1462,27 +1568,59 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                  */
                                 D(bug("[USB2OTG] IRQ: ctrl split-NAK %lu, retrying SSPLIT chan=%d dev=%d\n",
                                     (unsigned long)naks, chan, (int)req->iouh_DevAddr);)
+                                /*
+                                 * Abandoning the NAKed CSPLIT leaves the
+                                 * split engine in the same poisoned state
+                                 * a STALL does: the re-issued SSPLIT is
+                                 * descheduled with a bare CHHLTD in its
+                                 * arming microframe, forever (a tester's
+                                 * low-speed keyboard died here on every
+                                 * enumeration, while its mouse - which
+                                 * never NAKed a control transaction -
+                                 * was fine). Reset the engine the way the
+                                 * STALL path does, but around a save and
+                                 * restore of the channel programming:
+                                 * exorcising zeroes HCCHAR/HCSPLT, and
+                                 * SetupChannel would restart a control
+                                 * transfer from its SETUP packet rather
+                                 * than resume this phase.
+                                 */
                                 {
-                                    ULONG splt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                    ULONG hctsiz = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                    ULONG hcsplt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    ULONG hcdma  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
 
-                                    splt &= ~USB2OTG_HCSPLT_COMPLSPLT;
-                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), splt);
+                                    usb2otg_exorcise_channel(chan);
+
+                                    /* Next transaction is an SSPLIT, and
+                                     * the channel must come back disarmed
+                                     * for StartChannel to enable it. */
+                                    hcsplt &= ~USB2OTG_HCSPLT_COMPLSPLT;
+                                    hcchar &= ~(USB2OTG_HOSTCHAR_ENABLE |
+                                                USB2OTG_HOSTCHAR_DISABLE);
+
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), hcdma);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE), hctsiz);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), hcsplt);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
                                 }
                                 USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
                                 USBUnit->hu_Channel[chan].hc_CsplitRetry = 0;
                                 USBUnit->hu_Channel[chan].hc_SplitState = USB2OTG_SPLIT_SS;
                                 req->iouh_DriverPrivate2 = (APTR)(IPTR)naks;
-                                /* ~1 frame pause; SOF re-arms via
-                                 * StartChannel(quick=1) while the req
-                                 * still owns the channel. */
-                                delayed_channel[chan] = 8;
+                                /* SOF re-arms via StartChannel(quick=1)
+                                 * while the req still owns the channel,
+                                 * at the full pace — see the constant. */
+                                delayed_channel[chan] = USB2OTG_CTRL_SPLIT_PACE_UFRAMES;
                                 req = NULL;
                             }
                         }
                         else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
                         {
+                            usb2otg_exorcise_channel(chan);
                             USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
-                            usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-begin-nak");
+                            usb2otg_bulk_requeue(USBUnit, chan, req, intr, "split-begin-nak");
                             D(
                                 if (usb2otg_trace_bulk_ep2(chan, req))
                                     bug("[USB2OTG:TRACE] REQUEUE-BEGIN-BULKQ chan=%d req=%p\n", chan, req);
@@ -1504,6 +1642,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                     {
                         wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                         usb2otg_halt_channel_preserve_char(chan);
+                        usb2otg_exorcise_channel(chan);
 
                         D(
                             if (usb2otg_trace_bulk_ep2(chan, req))
@@ -1511,7 +1650,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                         )
 
                         USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
-                        usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-halt");
+                        usb2otg_bulk_requeue(USBUnit, chan, req, intr, "split-csplit-halt");
                         usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
                             usb2otg_gate_dir(req), USB2OTG_BULK_NAK_GATE_UFRAMES);
 
@@ -1603,6 +1742,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 chan, req->iouh_DevAddr, req->iouh_Endpoint, intr);
                             wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                             usb2otg_halt_channel_preserve_char(chan);
+                            usb2otg_exorcise_channel(chan);
                             req->iouh_Req.io_Error = UHIOERR_HOSTERROR;
                         }
                         else if ((intr & (USB2OTG_INTRCHAN_TRANSACTIONERROR |
@@ -1641,17 +1781,31 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                     (unsigned)intr, (unsigned long)retries + 1,
                                     USB2OTG_TRANSIENT_RETRY_LIMIT, chan,
                                     (int)req->iouh_DevAddr);)
+                                /* Reset-and-restore, exactly the proven
+                                 * NAK-path medicine: the abandoned CSPLIT
+                                 * poisons the engine the same way here. */
                                 {
-                                    ULONG splt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                    ULONG hctsiz = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                    ULONG hcsplt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    ULONG hcdma  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
 
-                                    splt &= ~USB2OTG_HCSPLT_COMPLSPLT;
-                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), splt);
+                                    usb2otg_exorcise_channel(chan);
+
+                                    hcsplt &= ~USB2OTG_HCSPLT_COMPLSPLT;
+                                    hcchar &= ~(USB2OTG_HOSTCHAR_ENABLE |
+                                                USB2OTG_HOSTCHAR_DISABLE);
+
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), hcdma);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE), hctsiz);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), hcsplt);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
                                 }
                                 USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
                                 USBUnit->hu_Channel[chan].hc_CsplitRetry = 0;
                                 USBUnit->hu_Channel[chan].hc_SplitState = USB2OTG_SPLIT_SS;
                                 req->iouh_DriverPrivate2 = (APTR)(IPTR)(retries + 1);
-                                delayed_channel[chan] = 8;
+                                delayed_channel[chan] = USB2OTG_CTRL_SPLIT_PACE_UFRAMES;
                                 req = NULL;
                             }
                             else if ((req->iouh_Req.io_Command == UHCMD_CONTROLXFER ||
@@ -1666,7 +1820,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 ULONG tsize_snap =
                                     rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
                                 ULONG act_before_helper = req->iouh_Actual;
-                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, why);
+                                usb2otg_bulk_requeue(USBUnit, chan, req, intr, why);
                                 D(bug("[USB2OTG] IRQ: %s chan=%d dev=%d intr=%04x, retry %ld/%d\n",
                                     why, chan, req->iouh_DevAddr, intr,
                                     retries + 1, USB2OTG_TRANSIENT_RETRY_LIMIT));
@@ -1704,6 +1858,10 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 else
                                 {
 #endif
+                                /* Abandoning a ctrl transfer mid-phase
+                                 * poisons the channel like on splits. */
+                                if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
+                                    usb2otg_exorcise_channel(chan);
                                 if (req->iouh_Req.io_Command == UHCMD_CONTROLXFER)
                                     ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
                                 else
@@ -1771,9 +1929,19 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                  * only cover the control endpoint).
                                  */
                                 usb2otg_queue_clear_tt_buffer(USBUnit, req);
-                                /* Give-up teardown poisons the channel. */
+                                /* Give-up teardown poisons the channel;
+                                 * XactErr is a wire error, not an engine
+                                 * fault - do not count it toward burning.
+                                 * Non-split channels need the same reset:
+                                 * ctrl to a vanished HS hub poisoned ch0
+                                 * and every later arm to the (soldered!)
+                                 * internal hub bare-CHHLTDed - hub.class
+                                 * lost port management and tore down every
+                                 * device on the bus. */
                                 if (req->iouh_Flags & UHFF_SPLITTRANS)
-                                    usb2otg_split_giveup_recover(USBUnit, chan);
+                                    usb2otg_split_giveup_recover(USBUnit, chan, FALSE, req->iouh_DevAddr);
+                                else
+                                    usb2otg_exorcise_channel(chan);
                             }
                         }
                         else if (intr & USB2OTG_INTRCHAN_STALL)
@@ -1851,7 +2019,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                             bug("[USB2OTG:TRACE] IRQ-CSPLIT-NAK-REQUEUE chan=%d req=%p\n", chan, req);
                                     )
                                     USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
-                                    usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "bulk-csplit-nak");
+                                    usb2otg_bulk_requeue(USBUnit, chan, req, intr, "bulk-csplit-nak");
                                     /* 1 ms gate; prevents NAK-storm pegging CPU 0. */
                                     usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
                                                          usb2otg_gate_dir(req),
@@ -1879,7 +2047,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 usb2otg_halt_channel_preserve_char(chan);
                                 usb2otg_bulk_out_advance_pktcnt(USBUnit, chan, req, tsize_snap);
                                 USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
-                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "bulk-nak");
+                                usb2otg_bulk_requeue(USBUnit, chan, req, intr, "bulk-nak");
                                 usb2otg_nak_gate_set(USBUnit, req->iouh_DevAddr,
                                                      usb2otg_gate_dir(req),
                                                      USB2OTG_BULK_NAK_GATE_UFRAMES);
@@ -1905,6 +2073,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 chan, req->iouh_DevAddr, req->iouh_Endpoint);
                             wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                             usb2otg_halt_channel_preserve_char(chan);
+                            usb2otg_exorcise_channel(chan);
                             req->iouh_Req.io_Error = UHIOERR_BABBLE;
                         }
                         else if (intr & USB2OTG_INTRCHAN_FRAMEOVERRUN)
@@ -1912,6 +2081,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                             /* Frame overrun: requeue with updated timing. */
                             wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                             usb2otg_halt_channel_preserve_char(chan);
+                            usb2otg_exorcise_channel(chan);
 #if defined(__AROSEXEC_SMP__)
                             KrnSpinLock(&USBUnit->hu_Lock, NULL, SPINLOCK_MODE_WRITE);
                             if (USBUnit->hu_Channel[chan].hc_Request != req)
@@ -1937,7 +2107,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 ADDHEAD(&USBUnit->hu_CtrlXFerQueue, req);
                             else if (req->iouh_Req.io_Command == UHCMD_BULKXFER)
                             {
-                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr, "frame-overrun");
+                                usb2otg_bulk_requeue(USBUnit, chan, req, intr, "frame-overrun");
                                 ADDHEAD(&USBUnit->hu_BulkXFerQueue, req);
                             }
                             USBUnit->hu_Channel[chan].hc_Request = NULL;
@@ -2102,9 +2272,12 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                     /* Reset only for blocked enumeration — see split-NAK site. */
                                     if (req->iouh_DevAddr == 0)
                                         usb2otg_split_fsm_recover(USBUnit, chan);
-                                    /* Give-up teardown poisons the channel. */
+                                    /* Bare CHHLTD = the engine never ran
+                                     * the transaction; this one counts. */
                                     if (req->iouh_Flags & UHFF_SPLITTRANS)
-                                        usb2otg_split_giveup_recover(USBUnit, chan);
+                                        usb2otg_split_giveup_recover(USBUnit, chan, TRUE, req->iouh_DevAddr);
+                                    else
+                                        usb2otg_exorcise_channel(chan);
                                 }
                                 else if (req->iouh_Flags & UHFF_SPLITTRANS)
                                 {
@@ -2120,10 +2293,27 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                      * bare in its arming microframe, so the
                                      * first stray halt turned into all 64.
                                      */
-                                    ULONG splt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    /* Reset-and-restore, the proven NAK-
+                                     * path medicine - COMPLSPLT-clear alone
+                                     * left the engine poisoned, which is
+                                     * why one stray halt became all 64. */
+                                    {
+                                    ULONG hcchar = rd32le(USB2OTG_CHANNEL_REG(chan, CHARBASE));
+                                    ULONG hctsiz = rd32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE));
+                                    ULONG hcsplt = rd32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL));
+                                    ULONG hcdma  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
 
-                                    splt &= ~USB2OTG_HCSPLT_COMPLSPLT;
-                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), splt);
+                                    usb2otg_exorcise_channel(chan);
+
+                                    hcsplt &= ~USB2OTG_HCSPLT_COMPLSPLT;
+                                    hcchar &= ~(USB2OTG_HOSTCHAR_ENABLE |
+                                                USB2OTG_HOSTCHAR_DISABLE);
+
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, DMAADDR), hcdma);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, TRANSSIZE), hctsiz);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, SPLITCTRL), hcsplt);
+                                    wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), hcchar);
+                                }
 
                                     D(bug("[USB2OTG] IRQ: ctrl bare-CHHLTD %lu, retrying SSPLIT chan=%d dev=%d\n",
                                         (unsigned long)chhs, chan, (int)req->iouh_DevAddr);)
@@ -2132,14 +2322,24 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                     USBUnit->hu_Channel[chan].hc_CsplitRetry = 0;
                                     USBUnit->hu_Channel[chan].hc_SplitState = USB2OTG_SPLIT_SS;
                                     req->iouh_DriverPrivate2 = (APTR)(IPTR)chhs;
-                                    /* ~1 frame pause; SOF re-arms via
-                                     * StartChannel(quick=1) while the req
-                                     * still owns the channel. */
-                                    delayed_channel[chan] = 8;
+                                    /* SOF re-arms via StartChannel(quick=1)
+                                     * while the req still owns the channel,
+                                     * at the full pace — see the constant. */
+                                    delayed_channel[chan] = USB2OTG_CTRL_SPLIT_PACE_UFRAMES;
                                     keep_channel = TRUE;
                                 }
                                 else
                                 {
+                                    /*
+                                     * Reset the engine before the retry:
+                                     * a bare CHHLTD leaves the channel FSM
+                                     * poisoned exactly as on the split
+                                     * channels, and SetupChannel's HCCHAR
+                                     * zeroing alone does not clear it. The
+                                     * requeue re-programs everything, so
+                                     * nothing needs preserving.
+                                     */
+                                    usb2otg_exorcise_channel(chan);
                                     req->iouh_DriverPrivate2 = (APTR)(IPTR)chhs;
                                     /* Timed backoff + tail: no retry storm/HOL. */
                                     req->iouh_DriverPrivate1 =
@@ -2152,12 +2352,12 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 /* Multi-packet bulk-OUT progress accounting. */
                                 usb2otg_bulk_out_advance_pktcnt(USBUnit, chan, req, chhltd_tsize);
 
-                                usb2otg_diag_bulk_requeue(USBUnit, chan, req, intr,
+                                usb2otg_bulk_requeue(USBUnit, chan, req, intr,
                                     "bare-chhltd");
 
                                 {
                                     struct USB2OTGChannel *hc = &USBUnit->hu_Channel[chan];
-                                    UBYTE np = hc->hc_DiagNoProgressCount;
+                                    UBYTE np = hc->hc_BulkNoProgressCount;
 
                                     /* Absolute cap: not reset by np-reset below. */
                                     if (hc->hc_BareChhltdTotal < 0xFFFF)
@@ -2194,7 +2394,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                                     "  NPTXSTS=%08x HFNUM=%08x HOSTPORT=%08x\n"
                                                     "  start_hfnum=%08x ufdelta=%d coreINTR=%08x HAINT=%08x PID=%u\n",
                                                     (unsigned)np,
-                                                    (unsigned)hc->hc_DiagRequeueCount,
+                                                    (unsigned)hc->hc_BulkRequeueCount,
                                                     bare_chhltd_total,
                                                     chan,
                                                     (int)req->iouh_DevAddr,
@@ -2246,7 +2446,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                         {
                                             static ULONG giveup_count = 0;
                                             giveup_count++;
-                                            if (usb2otg_diag_log_rate(giveup_count))
+                                            if (usb2otg_log_rate(giveup_count))
                                                 bug("[USB2OTG:MSS] BARE-CHHLTD giving up after %u no-progress chan=%d dev=%d ep=%d dir=%s act=%lu/%lu streak=%u (#%lu)\n",
                                                     (unsigned)np, chan,
                                                     (int)req->iouh_DevAddr,
@@ -2276,7 +2476,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                             {
                                                 static ULONG flush_count = 0;
                                                 flush_count++;
-                                                if (usb2otg_diag_log_rate(flush_count))
+                                                if (usb2otg_log_rate(flush_count))
                                                     bug("[USB2OTG:MSS] BARE-CHHLTD NP-TX-FIFO-FLUSH after giveup chan=%d dev=%d ep=%d (#%lu)\n",
                                                         chan,
                                                         (int)req->iouh_DevAddr,
@@ -2288,7 +2488,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                          * a marginal device. Canonical recovery
                                          * is BOT Reset + CLEAR_HALT, handled
                                          * in TermIO. */
-                                        usb2otg_diag_bulk_finish(USBUnit, chan, req);
+                                        usb2otg_bulk_finish(USBUnit, chan, req);
                                         USBUnit->hu_Channel[chan].hc_SplitCSplitPending = 0;
                                         USBUnit->hu_Channel[chan].hc_Request = NULL;
                                         ADDTAIL(&USBUnit->hu_FinishedXfers, (struct Node *)req);
@@ -2301,7 +2501,7 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                             /* IN-idle long backoff. */
                                             usb2otg_nak_gate_set(USBUnit,
                                                 req->iouh_DevAddr, 1, 200);
-                                            hc->hc_DiagNoProgressCount = 0;
+                                            hc->hc_BulkNoProgressCount = 0;
                                         }
                                         else
                                         {
@@ -2328,13 +2528,14 @@ void FNAME_DEV(GlobalIRQHandler)(struct USB2OTGUnit *USBUnit, struct ExecBase *S
                                 intr, chan, req->iouh_DevAddr, req->iouh_Endpoint));
                             wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                             usb2otg_halt_channel_preserve_char(chan);
+                            usb2otg_exorcise_channel(chan);
                         }
 
 
                         /* req==NULL means already requeued (NAK/frame-overrun/split-NYET). */
                         if (cont == 0 && req != NULL)
                         {
-                            usb2otg_diag_bulk_finish(USBUnit, chan, req);
+                            usb2otg_bulk_finish(USBUnit, chan, req);
                             usb2otg_irq_finish_or_requeue(USBUnit, chan, req,
                                 &USBUnit->hu_FinishedXfers, FALSE);
                         }
@@ -2431,11 +2632,19 @@ AROS_INTH1(FNAME_DEV(PendingInt), struct USB2OTGUnit *, otg_Unit)
     AROS_INTFUNC_INIT
 
     struct USB2OTGDevice * USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+    BOOL ret;
 
     if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
         return FALSE;
 
-    return usb2otg_process_pending(otg_Unit);
+    /* Softints run with IRQs enabled; the shared transfer queues are
+     * otherwise juggled concurrently with GlobalIRQHandler (list
+     * cross-link -> the SOF promotion walk spins forever). */
+    Disable();
+    ret = usb2otg_process_pending(otg_Unit);
+    Enable();
+
+    return ret;
 
     AROS_INTFUNC_EXIT
 }
@@ -2704,7 +2913,7 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
                             wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
 
                             req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
-                            usb2otg_diag_bulk_finish(otg_Unit, chan, req);
+                            usb2otg_bulk_finish(otg_Unit, chan, req);
                             otg_Unit->hu_Channel[chan].hc_Request = NULL;
                             otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
                             /* Force-halting a live split is where the TT
@@ -2842,6 +3051,7 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
 #endif
                         wr32le(USB2OTG_CHANNEL_REG(chan, INTR), USB2OTG_INTR_CLEAR_ALL);
                         usb2otg_halt_channel_preserve_char(chan);
+                        usb2otg_exorcise_channel(chan);
 
                         if (req->iouh_DevAddr < 8)
                             usb2otg_int_nak_count[req->iouh_DevAddr]++;
@@ -3000,7 +3210,7 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
                     {
                         static ULONG wd_count = 0;
                         wd_count++;
-                        if (usb2otg_diag_log_rate(wd_count))
+                        if (usb2otg_log_rate(wd_count))
                         {
                             /* Extended wedge dump for post-mortem. */
                             ULONG w_dmaa  = rd32le(USB2OTG_CHANNEL_REG(chan, DMAADDR));
@@ -3139,7 +3349,7 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
                     }
 
                     req->iouh_Req.io_Error = UHIOERR_TIMEOUT;
-                    usb2otg_diag_bulk_finish(otg_Unit, chan, req);
+                    usb2otg_bulk_finish(otg_Unit, chan, req);
                     /* Abandoned split → unjam the TT (see helper). */
                     usb2otg_queue_clear_tt_buffer(otg_Unit, req);
                     ADDTAIL(&otg_Unit->hu_FinishedXfers, (struct Node *)req);
@@ -3177,6 +3387,13 @@ static BOOL usb2otg_process_naktimeout(struct USB2OTGUnit *otg_Unit)
             ULONG next_to_handle = (ULONG)(IPTR)req->iouh_DriverPrivate1 & 0x7ff;
 
             q_count++;
+
+            /* See the SOF walk: a cross-linked node makes this cycle. */
+            if (q_count > 128)
+            {
+                bug("[USB2OTG] WD: IntXFerQueue walk runaway — list cycle, aborting walk\n");
+                break;
+            }
 
             /* Wrap-safe due test — see the SOF promotion for rationale. */
             if (((frnm - last_handled) & 0x7ff) >=
@@ -3402,11 +3619,17 @@ AROS_INTH1(FNAME_DEV(NakTimeoutInt), struct USB2OTGUnit *, otg_Unit)
     AROS_INTFUNC_INIT
 
     struct USB2OTGDevice *USB2OTGBase = otg_Unit->hu_USB2OTGBase;
+    BOOL ret;
 
     if (!usb2otg_require_cpu0(USB2OTGBase, __PRETTY_FUNCTION__))
         return FALSE;
 
-    return usb2otg_process_naktimeout(otg_Unit);
+    /* See PendingInt: serialize the watchdog against GlobalIRQHandler. */
+    Disable();
+    ret = usb2otg_process_naktimeout(otg_Unit);
+    Enable();
+
+    return ret;
 
     AROS_INTFUNC_EXIT
 }

--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_schedule.c
@@ -413,7 +413,7 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
      * event.
      */
     otg_Unit->hu_Channel[chan].hc_WatchdogCount = 0;
-    /* DIAG: fresh event-trace budget for this submission. */
+    /* fresh event-trace budget for this submission. */
     otg_Unit->hu_Channel[chan].hc_TraceCount = 0;
     otg_Unit->hu_Channel[chan].hc_TraceAnom = 0;
     /* Cancel a previous owner's pending CSPLIT re-arm on this channel. */
@@ -768,6 +768,7 @@ BOOL FNAME_DEV(SetupChannel)(struct USB2OTGUnit *otg_Unit, int chan)
             pid, req->iouh_MaxPktSize, req->iouh_Length, req->iouh_Data));
     }
 
+
     return TRUE;
 }
 
@@ -880,9 +881,14 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
         /*
          * Post-DMA invalidate for direct transfers; ARM speculative
          * prefetch can refill stale lines during the split-CSPLIT gap.
-         * Cover ≥1 MaxPktSize so a following IN doesn't read stale.
+         * Cover ≥1 MaxPktSize so a following IN doesn't read stale —
+         * but never past what was armed: a ZLP with MaxPktSize larger
+         * than the armed size would invalidate lines beyond the
+         * caller's buffer and drop a neighbour's dirty data.
          */
         ULONG inval_len = txsize > 0 ? txsize : req->iouh_MaxPktSize;
+        if (inval_len > otg_Unit->hu_Channel[chan].hc_XferSize)
+            inval_len = otg_Unit->hu_Channel[chan].hc_XferSize;
         CacheClearE(completed_buf, inval_len, CACRF_InvalidateD);
     }
 
@@ -912,7 +918,7 @@ int FNAME_DEV(AdvanceChannel)(struct USB2OTGUnit *otg_Unit, int chan)
     /* Update the transferred size unless it was control channel in setup phase */
     req->iouh_Actual += txsize;
     req->iouh_Req.io_Error = 0;
-    usb2otg_diag_bulk_progress(otg_Unit, chan, req, USB2OTG_INTRCHAN_TRANSFERCOMPLETE);
+    usb2otg_bulk_progress(otg_Unit, chan, req, USB2OTG_INTRCHAN_TRANSFERCOMPLETE);
 
     /* Completion = device alive; reset the dead-device giveup streak. */
     otg_Unit->hu_BulkGiveupStreak[req->iouh_DevAddr] = 0;
@@ -1477,6 +1483,7 @@ void FNAME_DEV(StartChannel)(struct USB2OTGUnit *otg_Unit, int chan, int quick)
     }
 
     wr32le(USB2OTG_CHANNEL_REG(chan, CHARBASE), tmp);
+
 }
 
 /*
@@ -1676,7 +1683,7 @@ void FNAME_DEV(ScheduleBulkTDs)(struct USB2OTGUnit *otg_Unit)
 
         REMOVE(req);
         otg_Unit->hu_Channel[chan].hc_Request = req;
-        usb2otg_diag_bulk_assign(otg_Unit, chan, req);
+        usb2otg_bulk_assign(otg_Unit, chan, req);
 
         KrnSpinUnLock(&otg_Unit->hu_Lock);
         Enable();
@@ -1684,6 +1691,32 @@ void FNAME_DEV(ScheduleBulkTDs)(struct USB2OTGUnit *otg_Unit)
         if (FNAME_DEV(SetupChannel)(otg_Unit, chan))
             FNAME_DEV(StartChannel)(otg_Unit, chan, 0);
     }
+}
+
+/*
+ * Free usable channels in one INT partition (split or direct home
+ * role). Feeds the overflow decision in ScheduleIntTDs. Caller holds
+ * hu_Lock.
+ */
+static int usb2otg_int_pool_free_count(struct USB2OTGUnit *otg_Unit,
+    BOOL direct)
+{
+    int chan;
+    int count = 0;
+
+    for (chan = CHAN_INT1; chan <= CHAN_INT_LAST; chan++)
+    {
+        if (chan == otg_Unit->hu_CtrlSplitChan)
+            continue;
+        if ((otg_Unit->hu_DeadChannels | otg_Unit->hu_BurnedChannels) &
+            (1 << chan))
+            continue;
+        if ((chan >= CHAN_INT_DIRECT_FIRST) != direct)
+            continue;
+        if (otg_Unit->hu_Channel[chan].hc_Request == NULL)
+            count++;
+    }
+    return count;
 }
 
 /* Schedule INT transfers from Scheduled list (SOF maintains IntXferQueue). */
@@ -1721,17 +1754,27 @@ void FNAME_DEV(ScheduleIntTDs)(struct USB2OTGUnit *otg_Unit)
         }
         /* Pick first INT req not already in flight (shared TT state).
          * Partitioned: split reqs below CHAN_INT_DIRECT_FIRST, direct
-         * reqs at/above it — see the define for the rationale. */
+         * reqs at/above it — see the define for the rationale. With
+         * USB2OTG_INT_POOL_OVERFLOW an off-role candidate is taken
+         * when its home pool is full, as long as this pool keeps one
+         * other channel free for its home role (see the define). */
         {
             struct IOUsbHWReq *candidate, *cnext;
             BOOL chan_is_direct = (chan >= CHAN_INT_DIRECT_FIRST);
+            BOOL allow_overflow = FALSE;
+
+#if USB2OTG_INT_POOL_OVERFLOW
+            allow_overflow =
+                usb2otg_int_pool_free_count(otg_Unit, !chan_is_direct) == 0 &&
+                usb2otg_int_pool_free_count(otg_Unit, chan_is_direct) > 1;
+#endif
             req = NULL;
             ForeachNodeSafe(&otg_Unit->hu_IntXFerScheduled, candidate, cnext)
             {
                 BOOL cand_is_direct =
                     !(candidate->iouh_Flags & UHFF_SPLITTRANS);
 
-                if (cand_is_direct != chan_is_direct)
+                if (cand_is_direct != chan_is_direct && !allow_overflow)
                     continue;
                 if (!usb2otg_endpoint_in_flight(otg_Unit, candidate) &&
                     !usb2otg_tt_in_flight(otg_Unit, candidate))
@@ -1745,11 +1788,42 @@ void FNAME_DEV(ScheduleIntTDs)(struct USB2OTGUnit *otg_Unit)
 
         if (req)
         {
+            UBYTE new_role = (req->iouh_Flags & UHFF_SPLITTRANS)
+                                 ? USB2OTG_CHANROLE_SPLIT
+                                 : USB2OTG_CHANROLE_DIRECT;
+            UBYTE old_role = otg_Unit->hu_Channel[chan].hc_ArmedRole;
+
             /* Channel was free and there is request available. Assign the request to given channel now */
             otg_Unit->hu_Channel[chan].hc_Request = req;
+            otg_Unit->hu_Channel[chan].hc_ArmedRole = new_role;
             if (req->iouh_DevAddr < 8)
                 usb2otg_int_poll_count[req->iouh_DevAddr]++;
             KrnSpinUnLock(&otg_Unit->hu_Lock);
+
+            /*
+             * Role changed since the last arm: reset the split engine
+             * before reprogramming. Stale per-channel periodic-split
+             * state kills direct arms with bare CHHLTD (the reason the
+             * partition exists); the forced disable cycle is the bet
+             * that makes mixing roles safe. The ODDFRM calibration
+             * belonged to the previous role's endpoint, so drop it.
+             * Still inside Disable(): the forced disable raises a
+             * CHHLTD, and the IRQ handler must not see it half-done on
+             * a channel that now has hc_Request set.
+             */
+            if (old_role != USB2OTG_CHANROLE_UNUSED && old_role != new_role)
+            {
+                /* Rare and pre-arm, so a serial line is safe here —
+                 * unlike the IRQ-path exorcises, which are ring-only. */
+                D(bug("[USB2OTG:ROLEFLIP] chan=%d %s->%s dev=%d ep=%d tick=%lu\n",
+                    chan,
+                    old_role == USB2OTG_CHANROLE_SPLIT ? "split" : "direct",
+                    new_role == USB2OTG_CHANROLE_SPLIT ? "split" : "direct",
+                    (int)req->iouh_DevAddr, (int)req->iouh_Endpoint,
+                    (unsigned long)usb2otg_wd_ticks));
+                usb2otg_exorcise_channel(chan);
+                otg_Unit->hu_Channel[chan].hc_OddfrmFlip = 0;
+            }
             Enable();
 
             D(bug("[USB2OTG] ScheduleIntTD: chan=%d dev=%ld ep=%ld len=%ld\n",


### PR DESCRIPTION
Split-engine reset on every abandoned sequence, a dedicated split-control channel, INT channels that flow between the split and direct pools, a Clear_TT_Buffer queue, per-device bulk channel ownership and a bulk NAK rate gate.