### PR TITLE
graphics: fix the BitMapScale() sampling positions

### DIFF
--- a/rom/graphics/bitmapscale.c
+++ b/rom/graphics/bitmapscale.c
@@ -22,12 +22,16 @@ static inline UBYTE bms_mask_nbits(ULONG nbits)
     return (UBYTE)m;
 }
 
-/* Helper: clamp v into [lo, hi] (inclusive). */
-static inline ULONG bms_clamp_ul(ULONG v, ULONG lo, ULONG hi)
+/* Destination pixel i samples source pixel (i*sf + c) / df, where the phase
+   c is (sf-1)/2 when enlarging and df/2 when reducing. This is the
+   established sampling convention for BitMapScale(); p96cts pins it
+   pixel-exact against independent implementations. */
+static inline ULONG bms_srcpos(ULONG i, ULONG sf, ULONG df, ULONG srcsize)
 {
-    if(v < lo) return lo;
-    if(v > hi) return v;
-    return v;
+    const ULONG c = sf < df ? (sf - 1) / 2 : df / 2;
+    const ULONG pos = (i * sf + c) / df;
+
+    return pos < srcsize ? pos : srcsize - 1;
 }
 
 /*****************************************************************************
@@ -266,27 +270,14 @@ static inline ULONG bms_clamp_ul(ULONG v, ULONG lo, ULONG hi)
                 goto out;
 
             {
-                ULONG ys0 = (ULONG)bitScaleArgs->bsa_SrcY;
-                ULONG ys  = ys0;
-                ULONG count = 0;
-                ULONG dyd = (ULONG)bitScaleArgs->bsa_DestHeight;
-                ULONG dys = (ULONG)bitScaleArgs->bsa_SrcHeight;
-                LONG  accuys = (LONG)dyd;
-                LONG  accuyd = -((LONG)dys >> 1);
+                const ULONG ys0 = (ULONG)bitScaleArgs->bsa_SrcY;
+                ULONG count;
 
-                /* Highest valid sampled Y (inclusive). */
-                ULONG y_max = ys0 + (ULONG)bitScaleArgs->bsa_SrcHeight - 1;
-
-                while(count < DestHeight) {
-                    accuyd += (LONG)dys;
-                    while(accuyd > accuys) {
-                        ys++;
-                        accuys += (LONG)dyd;
-                    }
-
-                    LinePattern[count] = bms_clamp_ul(ys, ys0, y_max);
-                    count++;
-                }
+                for(count = 0; count < DestHeight; count++)
+                    LinePattern[count] = ys0 + bms_srcpos(count,
+                                                          bitScaleArgs->bsa_YSrcFactor,
+                                                          bitScaleArgs->bsa_YDestFactor,
+                                                          bitScaleArgs->bsa_SrcHeight);
             }
 
             /* Scale */
@@ -301,26 +292,14 @@ static inline ULONG bms_clamp_ul(ULONG v, ULONG lo, ULONG hi)
                 ULONG DestWidthEnd = (ULONG)bitScaleArgs->bsa_DestWidth + destX0;
                 ULONG count = destX0;
 
-                ULONG dxd = (ULONG)bitScaleArgs->bsa_DestWidth;
-                ULONG dxs = (ULONG)bitScaleArgs->bsa_SrcWidth;
-
-                LONG accuxs = (LONG)dxd;
-                LONG accuxd = -((LONG)dxs >> 1);
-
-                /* Highest valid sampled X (inclusive). */
-                ULONG x_max = srcX0 + (ULONG)bitScaleArgs->bsa_SrcWidth - 1;
-
                 while(count < DestWidthEnd) {
-                    ULONG xs;
                     ULONG possible_columns, columncounter, this_x;
 
                     /* DDA: map dest x -> source x */
-                    accuxd += (LONG)dxs;
-                    while(accuxd > accuxs) {
-                        accuxs += (LONG)dxd;
-                    }
-                    xs = srcX0 + ((accuxs - accuxd + (LONG)dxs - 1) / (LONG)dxd);
-                    xs = bms_clamp_ul(xs, srcX0, x_max);
+                    ULONG xs = srcX0 + bms_srcpos(count - destX0,
+                                                  bitScaleArgs->bsa_XSrcFactor,
+                                                  bitScaleArgs->bsa_XDestFactor,
+                                                  bitScaleArgs->bsa_SrcWidth);
 
                     /*
                      * Try to group adjacent columns which map to adjacent source columns
@@ -339,32 +318,21 @@ static inline ULONG bms_clamp_ul(ULONG v, ULONG lo, ULONG hi)
                     this_x = xs;
 
                     {
-                        LONG  accuxd_tmp = accuxd;
-                        LONG  accuxs_tmp = accuxs;
-                        ULONG next_x = xs;
                         ULONG count2 = count + 1;
 
                         while(possible_columns > 0 && count2 < DestWidthEnd) {
                             /* where's the next x-source-coordinate going to be? */
-                            accuxd_tmp += (LONG)dxs;
-                            while(accuxd_tmp > accuxs_tmp) {
-                                next_x++;
-                                accuxs_tmp += (LONG)dxd;
-                            }
-                            if(next_x > x_max)
-                                next_x = x_max;
+                            ULONG next_x = srcX0 + bms_srcpos(count2 - destX0,
+                                                              bitScaleArgs->bsa_XSrcFactor,
+                                                              bitScaleArgs->bsa_XDestFactor,
+                                                              bitScaleArgs->bsa_SrcWidth);
 
-                            if(this_x + 1 == next_x) {
-                                columncounter++;
-                                this_x++;
-                                count2++;
-                                /* Always advance accumulators when we consume a column */
-                                accuxd = accuxd_tmp;
-                                accuxs = accuxs_tmp;
-                            } else {
+                            if(this_x + 1 != next_x)
                                 break;
-                            }
 
+                            columncounter++;
+                            this_x++;
+                            count2++;
                             possible_columns--;
                         }
                     }

--- a/rom/hidds/gfx/gfx_bitmapclass.c
+++ b/rom/hidds/gfx/gfx_bitmapclass.c
@@ -4907,25 +4907,26 @@ VOID BM__Hidd_BitMap__ReleaseDirectAccess(OOP_Class *cl, OOP_Object *o,
 
 *****************************************************************************************/
 
+/* Destination pixel i samples source pixel (i*sf + c) / df, where the phase
+   c is (sf-1)/2 when enlarging and df/2 when reducing. This is the
+   established sampling convention for BitMapScale(); p96cts pins it
+   pixel-exact against independent implementations. */
+static inline ULONG scale_srcpos(ULONG i, ULONG sf, ULONG df, ULONG srcsize)
+{
+    const ULONG c = sf < df ? (sf - 1) / 2 : df / 2;
+    const ULONG pos = (i * sf + c) / df;
+
+    return pos < srcsize ? pos : srcsize - 1;
+}
+
 VOID BM__Hidd_BitMap__BitMapScale(OOP_Class * cl, OOP_Object *o,
                                   struct pHidd_BitMap_BitMapScale * msg)
 {
     struct BitScaleArgs *bsa = msg->bsa;
     ULONG *srcbuf, *dstbuf;
-    WORD srcline = -1;
     UWORD *linepattern;
-    UWORD count;
-    UWORD ys = bsa->bsa_SrcY;
-    UWORD xs = bsa->bsa_SrcX;
-    UWORD dyd = bsa->bsa_DestHeight;
-    UWORD dxd = bsa->bsa_DestWidth;
-    LONG accuys = dyd;
-    LONG accuxs = dxd;
-    UWORD dxs = bsa->bsa_SrcWidth;
-    UWORD dys = bsa->bsa_SrcHeight;
-    LONG accuyd = - (dys >> 1);
-    LONG accuxd = - (dxs >> 1);
-    UWORD x;
+    LONG srcline = -1;
+    UWORD x, y;
 
     if ((srcbuf = AllocVec(bsa->bsa_SrcWidth * sizeof(ULONG), 0)) == NULL)
         return;
@@ -4941,26 +4942,11 @@ VOID BM__Hidd_BitMap__BitMapScale(OOP_Class * cl, OOP_Object *o,
         return;
     }
 
-    count = 0;
-    while (count < bsa->bsa_DestWidth) {
-        accuxd += dxs;
-        while (accuxd > accuxs) {
-            xs++;
-            accuxs += dxd;
-        }
+    for (x = 0; x < bsa->bsa_DestWidth; x++)
+        linepattern[x] = scale_srcpos(x, bsa->bsa_XSrcFactor, bsa->bsa_XDestFactor, bsa->bsa_SrcWidth);
 
-        linepattern[count] = xs;
-
-        count++;
-    }
-
-    count = bsa->bsa_DestY;
-    while (count < bsa->bsa_DestHeight + bsa->bsa_DestY) {
-        accuyd += dys;
-        while (accuyd > accuys) {
-            ys++;
-            accuys += dyd;
-        }
+    for (y = 0; y < bsa->bsa_DestHeight; y++) {
+        const LONG ys = scale_srcpos(y, bsa->bsa_YSrcFactor, bsa->bsa_YDestFactor, bsa->bsa_SrcHeight);
 
         if (srcline != ys) {
             HIDD_BM_GetImage(msg->src, (UBYTE *) srcbuf, bsa->bsa_SrcWidth * sizeof(ULONG), bsa->bsa_SrcX, bsa->bsa_SrcY + ys, bsa->bsa_SrcWidth, 1, vHidd_StdPixFmt_Native32);
@@ -4970,9 +4956,7 @@ VOID BM__Hidd_BitMap__BitMapScale(OOP_Class * cl, OOP_Object *o,
                 dstbuf[x] = srcbuf[linepattern[x]];
         }
 
-        HIDD_BM_PutImage(msg->dst, msg->gc, (UBYTE *) dstbuf, bsa->bsa_DestWidth * sizeof(ULONG), bsa->bsa_DestX, count, bsa->bsa_DestWidth, 1, vHidd_StdPixFmt_Native32);
-
-        count++;
+        HIDD_BM_PutImage(msg->dst, msg->gc, (UBYTE *) dstbuf, bsa->bsa_DestWidth * sizeof(ULONG), bsa->bsa_DestX, bsa->bsa_DestY + y, bsa->bsa_DestWidth, 1, vHidd_StdPixFmt_Native32);
     }
 
     FreeVec(linepattern);


### PR DESCRIPTION
Fixes #950.

BitMapScale() upscales came out as garbage and downscales sampled the
wrong rows and columns. Three causes:

- Both scalers ran their DDA over SrcWidth:DestWidth instead of
  bsa_XSrcFactor:bsa_XDestFactor. Those are different ratios (320:107
  does not sample like 3:1), so even correct-looking output drifted.
- In the gfx hidd path, `linepattern[]` held absolute source X but
  indexed a row buffer that already starts at bsa_SrcX, reading past
  the buffer for any nonzero source X.
- The same path added bsa_SrcY twice, once in the DDA start and once in
  the GetImage call. Together with the previous point this is why
  upscaling from a source crop was completely broken.

Both paths now use the closed form: dest pixel i samples source pixel
`(i*sf + c)/df` with `c = sf<df ? (sf-1)/2 : df/2`. The phase was pinned
empirically with a 1bpp probe that dumps the sampling map for 26
ratio/offset pairs, and the AROS output is now byte for byte identical
to the maps captured on an independent implementation. The p96cts
BitMapScale scenes pass at all depths on PAL and ZZ9000; the remaining
truecolor down/ratios "failures" are exactly the red flag squares and
the one-pixel overshoot that the 16/24-bit goldens record from the
reference's own scaler bug (every differing pixel classified, none
outside those two sets).

The accumulator loops are gone in favor of the closed form, which also
removes a buggy clamp helper whose upper bound returned the unclamped
value.
