### PR TITLE
Bsek/bcm2711 pcie

### DIFF
--- a/arch/aarch64-native/kernel/mmu.c
+++ b/arch/aarch64-native/kernel/mmu.c
@@ -54,9 +54,10 @@
     (0x44UL << (MAIR_IDX_NORMAL_NC * 8))   \
 )
 
-/* TCR_EL1 configuration: 4KB granule, 32-bit VA (T0SZ=32), 36-bit PA */
+/* TCR_EL1 configuration: 4KB granule, 35-bit VA (T0SZ=29), 36-bit PA.
+   Must match the boot MMU setup. */
 #define TCR_VALUE ( \
-    (32UL << 0)      | /* T0SZ = 32 (4GB VA space) */ \
+    (29UL << 0)      | /* T0SZ = 29 (32GB VA space) */ \
     (0UL  << 7)      | /* EPD0 = 0 (TTBR0 enabled) */ \
     (1UL  << 8)      | /* IRGN0 = Write-Back */ \
     (1UL  << 10)     | /* ORGN0 = Write-Back */ \

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -383,6 +383,7 @@ void query_memory()
     }
 }
 
+
 void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3)
 {
     uint64_t tmp;
@@ -461,6 +462,52 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     }
     else
         while(1) asm volatile("wfe");
+
+    /*
+     * The Pi 4 describes additional MMIO windows on the /scb bus: the full
+     * 0xFC000000 peripheral block (which contains the PCIe host bridge
+     * registers at 0xFD500000) and the 1GB PCIe outbound window at
+     * 0x6_0000_0000. Map the MMIO entries as device memory and skip the
+     * RAM alias. Pi 2/3 device trees have no /scb node.
+     */
+    e = dt_find_node("/scb");
+    if (e)
+    {
+        of_property_t *p = dt_find_property(e, "ranges");
+        if (p)
+        {
+            of_node_t *rootn = dt_find_node("/");
+            of_property_t *cacp = dt_find_property(e, "#address-cells");
+            of_property_t *cscp = dt_find_property(e, "#size-cells");
+            of_property_t *pacp = dt_find_property(rootn, "#address-cells");
+            uint32_t child_ac = cacp ? AROS_BE2LONG(*(uint32_t *)cacp->op_value) : 1;
+            uint32_t child_sc = cscp ? AROS_BE2LONG(*(uint32_t *)cscp->op_value) : 1;
+            uint32_t parent_ac = pacp ? AROS_BE2LONG(*(uint32_t *)pacp->op_value) : 1;
+            uint32_t entry_cells = child_ac + parent_ac + child_sc;
+
+            volatile uint32_t *ranges = p->op_value;
+            int32_t cells = p->op_length / 4;
+
+            while (cells >= (int32_t)entry_cells)
+            {
+                uint64_t addr_bus = 0, addr_cpu = 0, addr_len = 0;
+
+                for (uint32_t i = 0; i < child_ac; i++)
+                    addr_bus = (addr_bus << 32) | AROS_BE2LONG(*ranges++);
+                for (uint32_t i = 0; i < parent_ac; i++)
+                    addr_cpu = (addr_cpu << 32) | AROS_BE2LONG(*ranges++);
+                for (uint32_t i = 0; i < child_sc; i++)
+                    addr_len = (addr_len << 32) | AROS_BE2LONG(*ranges++);
+
+                (void)addr_bus;
+
+                if (addr_cpu >= 0xFC000000UL)
+                    mmu_map_section(addr_cpu, addr_cpu, addr_len, 0, 0, 3, 0);
+
+                cells -= entry_cells;
+            }
+        }
+    }
 
     serInit();
 

--- a/arch/aarch64-raspi/boot/include/bcm2708_boot.h
+++ b/arch/aarch64-raspi/boot/include/bcm2708_boot.h
@@ -18,6 +18,8 @@
  *   Level 0 (PGD): 512 entries, each covering 512GB -> 1 page  (4KB)
  *   Level 1 (PUD): 512 entries, each covering 1GB   -> 1 page  (4KB)
  *   Level 2 (PMD): 512 entries, each covering 2MB   -> 4 pages (16KB, for 4GB coverage)
+ *   Level 2 high:  512 entries covering the 1GB PCIe outbound window that
+ *                  BCM2711 places at 0x6_0000_0000 -> 1 page (4KB)
  *
  * We use 2MB block descriptors at level 2 (similar to ARM32's 1MB sections).
  */
@@ -30,6 +32,11 @@
 #define PGD_SIZE                        4096     /* Level 0: 512 entries x 8 bytes */
 #define PUD_SIZE                        4096     /* Level 1: 512 entries x 8 bytes */
 #define PMD_SIZE                        (4*4096) /* Level 2: 4 pages for 4GB coverage */
+#define PMD_HI_SIZE                     4096     /* Level 2: 1 page for the PCIe window at 24GB */
+
+/* CPU-side PCIe outbound window on BCM2711 (fixed in the SoC address map) */
+#define BCM2711_PCIE_WIN_BASE           0x600000000UL
+#define BCM2711_PCIE_WIN_SIZE           0x40000000UL
 
 struct bcm2708bootmem
 {
@@ -45,6 +52,7 @@ struct bcm2708bootmem
     uint8_t     bm_pgd[PGD_SIZE];                                        /* Level 0 page table */
     uint8_t     bm_pud[PUD_SIZE];                                        /* Level 1 page table */
     uint8_t     bm_pmd[PMD_SIZE];                                        /* Level 2 page tables (2MB blocks) */
+    uint8_t     bm_pmd_hi[PMD_HI_SIZE];                                  /* Level 2 page table for the PCIe window */
 }  __attribute__((packed));
 
 #define BOOTMEMADDR(offset) (&(((struct bcm2708bootmem *)0x0)->offset))

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -79,7 +79,11 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-hidd-mouse-quick \
 #MM kernel-usb-nopci-quick \
 #MM kernel-usb-usb2otg-quick \
-#MM kernel-usb-romstrap-raspi-quick
+#MM kernel-usb-romstrap-raspi-quick \
+#MM kernel-hidd-pci-quick \
+#MM kernel-pcie-bcm2711-quick \
+#MM kernel-usb-pcixhci-quick \
+#MM kernel-usb-classes-hubss-quick
 
 #MM kernel-package-raspi-aarch64: \
 #MM linklibs-stdc-static \
@@ -137,7 +141,11 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-hidd-mouse \
 #MM kernel-usb-nopci \
 #MM kernel-usb-usb2otg \
-#MM kernel-usb-romstrap-raspi
+#MM kernel-usb-romstrap-raspi \
+#MM kernel-hidd-pci \
+#MM kernel-pcie-bcm2711 \
+#MM kernel-usb-pcixhci \
+#MM kernel-usb-classes-hubss
 
 #MM kernel-package-raspi-aarch64-missing: \
 #MM kernel-battclock
@@ -169,13 +177,15 @@ PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos
 PKG_LIBS_ARCH := expansion
 PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands entropy mbox dma sdio bwfm
 PKG_RSRC_ARCH := processor
-PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg
+PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg USBHardware/pcixhci
 PKG_DEVS_ARCH := timer
 PKG_HANDLERS  := con ram cdrom sfs fat afs
 # vc4gfx drives the BCM283x VideoCore directly and bows out on BCM2711;
 # fbgfx takes over there, painting into the framebuffer the bootstrap set up.
-PKG_HIDDS     := hiddclass inputclass gfx keyboard mouse bus i2c i2c-bcm2708 vc4gfx fbgfx
-PKG_CLASSES   := USB/hub USB/massstorage
+# The PCIe bridge and its xHCI controller only exist on BCM2711; both drivers
+# find nothing on a Pi 2/3 and stay out of the way.
+PKG_HIDDS     := hiddclass inputclass gfx keyboard mouse bus i2c i2c-bcm2708 vc4gfx fbgfx pci pcibcm2711
+PKG_CLASSES   := USB/hub USB/hubss USB/massstorage
 
 %make_package mmake=kernel-package-raspi-aarch64 file=$(AROSDIR)/$(ARM_BSP) \
     libs=$(PKG_LIBS) arch_libs=$(PKG_LIBS_ARCH) res=$(PKG_RSRC) \

--- a/arch/aarch64-raspi/boot/mmu.c
+++ b/arch/aarch64-raspi/boot/mmu.c
@@ -76,6 +76,7 @@
 static uint64_t *pgd;
 static uint64_t *pud;
 static uint64_t *pmd;
+static uint64_t *pmd_hi;
 
 void mmu_init(void)
 {
@@ -84,6 +85,7 @@ void mmu_init(void)
     pgd = (uint64_t *)BOOTMEMADDR(bm_pgd);
     pud = (uint64_t *)BOOTMEMADDR(bm_pud);
     pmd = (uint64_t *)BOOTMEMADDR(bm_pmd);
+    pmd_hi = (uint64_t *)BOOTMEMADDR(bm_pmd_hi);
 
     /* Clear all page table levels */
     for (i = 0; i < 512; i++)
@@ -96,6 +98,9 @@ void mmu_init(void)
     for (i = 0; i < 2048; i++)
         pmd[i] = 0;
 
+    for (i = 0; i < 512; i++)
+        pmd_hi[i] = 0;
+
     /*
      * Set up the page table hierarchy:
      * PGD[0] -> PUD (covers first 512GB, only first entry used)
@@ -103,6 +108,8 @@ void mmu_init(void)
      * PUD[1] -> PMD page 1 (covers 0x40000000 - 0x7FFFFFFF, 1GB)
      * PUD[2] -> PMD page 2 (covers 0x80000000 - 0xBFFFFFFF, 1GB)
      * PUD[3] -> PMD page 3 (covers 0xC0000000 - 0xFFFFFFFF, 1GB)
+     * PUD[24] -> PMD high page (0x600000000 - 0x63FFFFFFF, the BCM2711
+     *            PCIe outbound window; unused and harmless on Pi 2/3)
      */
     pgd[0] = (uint64_t)(uintptr_t)pud | DESC_TABLE;
 
@@ -110,6 +117,21 @@ void mmu_init(void)
     pud[1] = (uint64_t)(uintptr_t)&pmd[1 * 512] | DESC_TABLE;
     pud[2] = (uint64_t)(uintptr_t)&pmd[2 * 512] | DESC_TABLE;
     pud[3] = (uint64_t)(uintptr_t)&pmd[3 * 512] | DESC_TABLE;
+    pud[BCM2711_PCIE_WIN_BASE >> 30] = (uint64_t)(uintptr_t)pmd_hi | DESC_TABLE;
+}
+
+/*
+ * Return the level-2 slot for a virtual address, or NULL if the address
+ * is outside the translated ranges (first 4GB + the PCIe window).
+ */
+static uint64_t *mmu_slot(uintptr_t virt)
+{
+    if (virt < 0x100000000UL)
+        return &pmd[virt >> 21];
+    if (virt >= BCM2711_PCIE_WIN_BASE &&
+        virt < BCM2711_PCIE_WIN_BASE + BCM2711_PCIE_WIN_SIZE)
+        return &pmd_hi[(virt - BCM2711_PCIE_WIN_BASE) >> 21];
+    return (uint64_t *)0;
 }
 
 void mmu_load(void)
@@ -119,6 +141,7 @@ void mmu_load(void)
     aarch64_flush_cache((uintptr_t)pgd, PGD_SIZE);
     aarch64_flush_cache((uintptr_t)pud, PUD_SIZE);
     aarch64_flush_cache((uintptr_t)pmd, PMD_SIZE);
+    aarch64_flush_cache((uintptr_t)pmd_hi, PMD_HI_SIZE);
 
     /* Set MAIR_EL1 */
     tmp = MAIR_VALUE;
@@ -126,14 +149,16 @@ void mmu_load(void)
 
     /*
      * Set TCR_EL1:
-     *   T0SZ = 32  (32-bit VA space = 4GB, bits [5:0])
+     *   T0SZ = 29  (35-bit VA space = 32GB, bits [5:0]; reaches the BCM2711
+     *               PCIe outbound window at 0x6_0000_0000. Lookup still
+     *               starts at level 1 for T0SZ 25-33 with a 4KB granule.)
      *   IRGN0 = 01 (Inner Write-Back Write-Allocate Cacheable, bits [9:8])
      *   ORGN0 = 01 (Outer Write-Back Write-Allocate Cacheable, bits [11:10])
      *   SH0 = 11   (Inner Shareable, bits [13:12])
      *   TG0 = 00   (4KB granule, bits [15:14])
      *   IPS = 001   (36-bit physical address space, bits [34:32])
      */
-    tmp = (32UL << 0)       /* T0SZ = 32 -> 4GB VA space */
+    tmp = (29UL << 0)       /* T0SZ = 29 -> 32GB VA space */
         | (0x1UL << 8)      /* IRGN0 = 01 */
         | (0x1UL << 10)     /* ORGN0 = 01 */
         | (0x3UL << 12)     /* SH0 = 11 (inner shareable) */
@@ -147,7 +172,7 @@ void mmu_load(void)
 
     /*
      * Set TTBR0_EL1 to the Level 1 (PUD) table.
-     * With T0SZ=32 (32-bit VA) and 4KB granule, the initial lookup
+     * With T0SZ=29 (35-bit VA) and 4KB granule, the initial lookup
      * level is 1, so TTBR0 must point to the Level 1 table directly.
      * Level 0 (PGD) is not used.
      */
@@ -180,9 +205,9 @@ void mmu_unmap_section(uintptr_t virt, uintptr_t length)
 
     while (start < end)
     {
-        uint32_t idx = start >> 21; /* 2MB per entry */
-        if (idx < 2048)
-            pmd[idx] = 0;
+        uint64_t *slot = mmu_slot(start);
+        if (slot)
+            *slot = 0;
         start += 2*1024*1024UL;
     }
 }
@@ -204,7 +229,7 @@ void mmu_map_section(uintptr_t phys, uintptr_t virt, uintptr_t length, int norma
     uintptr_t start = virt & ~(2*1024*1024UL - 1);
     uintptr_t end = (virt + length + 2*1024*1024UL - 1) & ~(2*1024*1024UL - 1);
     uintptr_t count = (end - start) >> 21;
-    uint32_t idx = start >> 21;
+    uintptr_t va = start;
     uintptr_t pa = phys >> 21;
 
     DMMU(kprintf("[BOOT] MMU map %p:%p->%p:%p, normal=%d, cacheable=%d, ap=%x, tex=%x\n",
@@ -243,10 +268,13 @@ void mmu_map_section(uintptr_t phys, uintptr_t virt, uintptr_t length, int norma
 
         desc |= (pa << 21);
 
-        if (idx < 2048)
-            pmd[idx] = desc;
+        {
+            uint64_t *slot = mmu_slot(va);
+            if (slot)
+                *slot = desc;
+        }
 
         pa++;
-        idx++;
+        va += 2*1024*1024UL;
     }
 }

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/videocore.h
@@ -42,6 +42,7 @@
 #define VCTAG_GETPOWER          0x00020001
 #define VCTAG_GETTIMING         0x00020002
 #define VCTAG_SETPOWER	        0x00028001
+#define VCTAG_NOTIFYXHCI        0x00030058
 
 /* Clock ids for the VCTAG_*CLK* tags */
 #define VCCLOCK_EMMC            1

--- a/arch/arm-native/soc/broadcom/2708/usb/poseidon/usbromstartup.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/poseidon/usbromstartup.c
@@ -91,6 +91,7 @@ AROS_UFH3(static IPTR, usbromstartup_init,
         D(bug("[USBROMStartup] Adding classes...\n"));
 
         psdAddClass("hub.class", 0);
+        psdAddClass("hubss.class", 0);
         msdclass = psdAddClass("massstorage.class", 0);
         /* hid/bootmouse/bootkeyboard are loaded from disk by AddUSBClasses in Startup-Sequence */
 
@@ -102,6 +103,23 @@ AROS_UFH3(static IPTR, usbromstartup_init,
             D(bug("[USBROMStartup] Added usb2otg.device unit %u\n", 0));
 
             psdEnumerateHardware(phw);
+        }
+
+        /*
+         * The Pi 4 hangs its USB-A ports off a VL805 xHCI controller behind
+         * the PCIe bridge; the OTG core there serves the USB-C socket only.
+         * On a Pi 2/3 there is no bridge and this finds nothing.
+         */
+        {
+            ULONG unit = 0;
+
+            while ((phw = psdAddHardware("pcixhci.device", unit)))
+            {
+                D(bug("[USBROMStartup] Added pcixhci.device unit %u\n", unit));
+
+                psdEnumerateHardware(phw);
+                unit++;
+            }
         }
 
         D(bug("[USBROMStartup] Scanning classes...\n"));

--- a/arch/arm-native/soc/broadcom/2711/pcie/driverclass.c
+++ b/arch/arm-native/soc/broadcom/2711/pcie/driverclass.c
@@ -1,0 +1,440 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: BCM2711 PCIe host bridge driver.
+*/
+
+#define __OOP_NOATTRBASES__
+
+#include <exec/types.h>
+#include <hidd/pci.h>
+#include <oop/oop.h>
+
+#include <utility/tagitem.h>
+
+#include <proto/exec.h>
+#include <proto/utility.h>
+#include <proto/oop.h>
+
+#define __NOLIBBASE__
+#include <proto/kernel.h>
+/* KrnMapGlobal() and friends resolve through the driver's own copy. */
+#define KernelBase      (PSD(cl)->kernelBase)
+
+#include <aros/symbolsets.h>
+
+#include <string.h>
+
+#include <hardware/pci.h>
+
+#include "pcie.h"
+
+#include <aros/debug.h>
+
+#undef HiddPCIDriverAttrBase
+#undef HiddPCIDeviceAttrBase
+#undef HiddAttrBase
+
+#define HiddPCIDriverAttrBase   (PSD(cl)->hiddPCIDriverAB)
+#define HiddPCIDeviceAttrBase   (PSD(cl)->hiddPCIDeviceAB)
+#define HiddAttrBase            (PSD(cl)->hiddAB)
+
+static inline uint32_t rd32(struct pci_staticdata *psd, uint32_t reg)
+{
+    return *(volatile uint32_t *)(psd->regs + reg);
+}
+
+static inline void wr32(struct pci_staticdata *psd, uint32_t reg, uint32_t val)
+{
+    *(volatile uint32_t *)(psd->regs + reg) = val;
+}
+
+OOP_Object *PCIBcm2711__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    struct pRoot_New mymsg;
+
+    struct TagItem mytags[] = {
+        { aHidd_Name, (IPTR)"PCINative" },
+        { aHidd_HardwareName, (IPTR)"BCM2711 PCIe host bridge" },
+        { TAG_DONE, 0 }
+    };
+
+    mymsg.mID = msg->mID;
+    mymsg.attrList = (struct TagItem *)&mytags;
+
+    if (msg->attrList)
+    {
+        mytags[2].ti_Tag = TAG_MORE;
+        mytags[2].ti_Data = (IPTR)msg->attrList;
+    }
+
+    msg = &mymsg;
+
+    return (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+/*
+ * Devices on this bus get the subclass below, which adds message
+ * signalled interrupts; everything else is the base class's answer.
+ */
+VOID PCIBcm2711__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
+{
+    ULONG idx;
+
+    if (IS_PCIDRV_ATTR(msg->attrID, idx) && (idx == aoHidd_PCIDriver_DeviceClass))
+    {
+        *msg->storage = (IPTR)PSD(cl)->deviceClass;
+        return;
+    }
+
+    OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+}
+
+/*
+ * Configuration space access. The root complex header is memory mapped
+ * at offset 0 of the register block; everything on the external bus is
+ * reached through the indexed window. The link is a single point to
+ * point lane, so only device 0 exists on the external bus.
+ */
+static ULONG ReadConfigLong(struct pci_staticdata *psd, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg)
+{
+    ULONG val = 0xffffffff;
+
+    if (bus == 0)
+    {
+        if (dev == 0 && sub == 0)
+            val = rd32(psd, reg & 0xffc);
+    }
+    else if (dev == 0)
+    {
+        Disable();
+        wr32(psd, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(bus, dev, sub));
+        val = rd32(psd, PCIE_EXT_CFG_DATA + (reg & 0xffc));
+        Enable();
+    }
+
+    /*
+     * INT_LINE is left holding whatever the endpoint powered up with.
+     * Interrupts on this bus are message signalled and handed out by
+     * ObtainVectors; there is no pin routing to report.
+     */
+    return val;
+}
+
+static void WriteConfigLong(struct pci_staticdata *psd, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg, ULONG val)
+{
+    if (bus == 0)
+    {
+        if (dev == 0 && sub == 0)
+            wr32(psd, reg & 0xffc, val);
+    }
+    else if (dev == 0)
+    {
+        /* The endpoint runs no code until its driver enables it; that
+           enable is the agreed moment to have its firmware loaded. */
+        if ((reg & 0xffc) == PCI_CMD && (val & (PCI_CMD_MEMORY | PCI_CMD_MASTER)))
+            EnsureEndpointFirmware(psd);
+
+        Disable();
+        wr32(psd, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(bus, dev, sub));
+        wr32(psd, PCIE_EXT_CFG_DATA + (reg & 0xffc), val);
+        Enable();
+    }
+}
+
+ULONG PCIBcm2711__Hidd_PCIDriver__ReadConfigLong(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigLong *msg)
+{
+    return ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+}
+
+UWORD PCIBcm2711__Hidd_PCIDriver__ReadConfigWord(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigWord *msg)
+{
+    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+
+    return (val >> ((msg->reg & 2) * 8)) & 0xffff;
+}
+
+UBYTE PCIBcm2711__Hidd_PCIDriver__ReadConfigByte(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigByte *msg)
+{
+    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+
+    return (val >> ((msg->reg & 3) * 8)) & 0xff;
+}
+
+void PCIBcm2711__Hidd_PCIDriver__WriteConfigLong(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigLong *msg)
+{
+    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg, msg->val);
+}
+
+void PCIBcm2711__Hidd_PCIDriver__WriteConfigWord(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigWord *msg)
+{
+    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+    ULONG shift = (msg->reg & 2) * 8;
+
+    val = (val & ~(0xffffUL << shift)) | ((ULONG)msg->val << shift);
+    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg, val);
+}
+
+void PCIBcm2711__Hidd_PCIDriver__WriteConfigByte(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigByte *msg)
+{
+    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+    ULONG shift = (msg->reg & 3) * 8;
+
+    val = (val & ~(0xffUL << shift)) | ((ULONG)msg->val << shift);
+    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg, val);
+}
+
+/*
+ * A bus master reaches system memory through the inbound window, which
+ * the firmware does not place at address zero: what the CPU calls
+ * address X, the bus calls X plus this offset. Drivers ask for the
+ * translation through these two methods.
+ */
+APTR PCIBcm2711__Hidd_PCIDriver__CPUtoPCI(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_CPUtoPCI *msg)
+{
+    return (APTR)((uintptr_t)msg->address + PSD(cl)->dma_offset);
+}
+
+APTR PCIBcm2711__Hidd_PCIDriver__PCItoCPU(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_PCItoCPU *msg)
+{
+    return (APTR)((uintptr_t)msg->address - PSD(cl)->dma_offset);
+}
+
+/*
+ * BAR addresses live on the PCI bus at BCM2711_PCIE_PCI_WIN; the CPU
+ * reaches them through the outbound window. The window is already
+ * mapped by the bootstrap.
+ */
+void *PCIBcm2711__Hidd_PCIDriver__MapPCI(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_MapPCI *msg)
+{
+    uintptr_t addr = (uintptr_t)msg->PCIAddress;
+
+    if (addr >= BCM2711_PCIE_PCI_WIN &&
+        addr - BCM2711_PCIE_PCI_WIN < BCM2711_PCIE_WIN_SIZE)
+        return (void *)(BCM2711_PCIE_CPU_WIN + (addr - BCM2711_PCIE_PCI_WIN));
+
+    return (void *)addr;
+}
+
+/*
+ * Descriptor memory a bus master shares with us. The PCIe masters on this
+ * SoC are not cache coherent, and a ring the controller writes while the
+ * CPU reads it cannot be made to work with cache maintenance alone, so the
+ * memory is mapped Normal Non-Cacheable for as long as we hold it.
+ *
+ * That attribute belongs to whole pages, so the allocation takes whole
+ * pages and hands back the head of them: anything sharing the page would
+ * otherwise be made uncacheable too, silently and for good.
+ *
+ * FreePCIMem() is given only an address, so the raw pointer and the mapped
+ * length are kept in the two words ahead of the one returned - which is
+ * also why the raw allocation carries a page of slack.
+ */
+#define PCIMEM_PAGE     4096
+#define PCIMEM_ROUND(x) (((x) + PCIMEM_PAGE - 1) & ~(uintptr_t)(PCIMEM_PAGE - 1))
+
+APTR PCIBcm2711__Hidd_PCIDriver__AllocPCIMem(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_AllocPCIMem *msg)
+{
+    uintptr_t mapped = PCIMEM_ROUND(msg->Size);
+    APTR raw, addr;
+
+    if (!msg->Size)
+        return NULL;
+
+    raw = AllocMem(mapped + PCIMEM_PAGE, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!raw)
+        return NULL;
+
+    addr = (APTR)PCIMEM_ROUND((uintptr_t)raw + 2 * sizeof(APTR));
+    ((APTR *)addr)[-1] = raw;
+    ((APTR *)addr)[-2] = (APTR)mapped;
+
+    /*
+     * Write the pages back before they stop being cacheable: a dirty line
+     * left behind would land in memory later, on top of whatever the
+     * controller had put there.
+     */
+    CacheClearE(addr, mapped, CACRF_ClearD);
+
+    if (!KrnMapGlobal(addr, KrnVirtualToPhysical(addr), mapped,
+                      MAP_Readable | MAP_Writable | MAP_WriteThrough))
+    {
+        bug("[PCIBcm2711] could not map %u bytes uncached\n", (unsigned)mapped);
+        FreeMem(raw, mapped + PCIMEM_PAGE);
+        return NULL;
+    }
+
+    D(bug("[PCIBcm2711] AllocPCIMem(%u) = %p (%u bytes uncached)\n",
+          (unsigned)msg->Size, addr, (unsigned)mapped));
+
+    return addr;
+}
+
+VOID PCIBcm2711__Hidd_PCIDriver__FreePCIMem(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_FreePCIMem *msg)
+{
+    APTR addr = msg->Address;
+    APTR raw;
+    uintptr_t mapped;
+
+    if (!addr)
+        return;
+
+    raw    = ((APTR *)addr)[-1];
+    mapped = (uintptr_t)((APTR *)addr)[-2];
+
+    /* Cacheable again before it goes back, or the next owner gets
+       uncached memory without having asked for it. */
+    KrnMapGlobal(addr, KrnVirtualToPhysical(addr), mapped,
+                 MAP_Readable | MAP_Writable);
+
+    FreeMem(raw, mapped + PCIMEM_PAGE);
+}
+
+/*
+ * Message signalled interrupts for a device on this bus.
+ *
+ * The bridge funnels every vector into one interrupt output and records
+ * which vector arrived in INTR2_INT_STATUS, so the "interrupt" a driver
+ * is handed is that single output. Drivers sharing it tell themselves
+ * apart by looking at their own hardware, exactly as they would on a
+ * shared pin.
+ */
+BOOL PCIBcm2711Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_ObtainVectors *msg)
+{
+    struct pci_staticdata *psd = PSD(cl);
+    struct PCIBcm2711DevData *data = OOP_INST_DATA(cl, o);
+    IPTR bus = 0, dev = 0, sub = 0;
+    ULONG cap, guard;
+    LONG vector;
+
+    /* No handler on the bridge output means nobody would answer */
+    if (!psd->msi_handle)
+        return FALSE;
+
+    /* Every vector lands on the same interrupt, so more than one buys a
+       caller nothing; nobody has asked for more than one either. */
+    if (GetTagData(tHidd_PCIVector_Min, 1, (struct TagItem *)msg->requirements) > 1)
+        return FALSE;
+
+    if (data->msiVector)
+        return TRUE;    /* already ours */
+
+    OOP_GetAttr(o, aHidd_PCIDevice_Bus, &bus);
+    OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
+    OOP_GetAttr(o, aHidd_PCIDevice_Sub, &sub);
+
+    /* The capability list only answers once the endpoint runs its firmware */
+    EnsureEndpointFirmware(psd);
+
+    if (!((ReadConfigLong(psd, bus, dev, sub, PCI_CMD) >> 16) & PCISTF_CAPABILITIES))
+        return FALSE;
+
+    cap = ReadConfigLong(psd, bus, dev, sub, 0x34) & 0xfc;
+
+    for (guard = 12; cap && guard; guard--)
+    {
+        ULONG head = ReadConfigLong(psd, bus, dev, sub, cap);
+
+        if ((head & 0xff) == PCICAP_MSI)
+        {
+            UWORD ctrl = (UWORD)(head >> 16);
+            ULONG dataReg = (ctrl & PCIMSIF_64BIT) ? (cap + PCIMSI_DATA64)
+                                                   : (cap + PCIMSI_DATA32);
+
+            /* The target sits above 4GB, so a function that can only put
+               32 bits on the bus cannot reach it. */
+            if (!(ctrl & PCIMSIF_64BIT) && ((BCM2711_MSI_TARGET >> 32) != 0))
+                return FALSE;
+
+            for (vector = 0; vector < BCM2711_MSI_VECTORS; vector++)
+                if (!(psd->msi_used & (1UL << vector)))
+                    break;
+            if (vector >= BCM2711_MSI_VECTORS)
+                return FALSE;
+
+            WriteConfigLong(psd, bus, dev, sub, cap + PCIMSI_ADDRESSLO,
+                            (uint32_t)BCM2711_MSI_TARGET);
+            if (ctrl & PCIMSIF_64BIT)
+                WriteConfigLong(psd, bus, dev, sub, cap + PCIMSI_ADDRESSHI,
+                                (uint32_t)(BCM2711_MSI_TARGET >> 32));
+            WriteConfigLong(psd, bus, dev, sub, dataReg, BCM2711_MSI_DATA(vector));
+
+            /* One message, enabled. What it may send is ours to set in
+               6:4; what it could send in 3:1 is read only. */
+            ctrl = (ctrl & ~PCIMSIF_MMEN_MASK) | PCIMSIF_ENABLE;
+            WriteConfigLong(psd, bus, dev, sub, cap,
+                            (head & 0xffff) | ((ULONG)ctrl << 16));
+
+            psd->msi_used |= (1UL << vector);
+            data->msiVector = vector + 1;
+            data->msiCap = cap;
+
+            bug("[PCIBcm2711] %02x:%02x.%x signals by message: vector %d -> INTID %u\n",
+                (unsigned)bus, (unsigned)dev, (unsigned)sub,
+                (int)vector, (unsigned)psd->msi_irq);
+
+            return TRUE;
+        }
+
+        cap = (head >> 8) & 0xfc;
+    }
+
+    return FALSE;
+}
+
+VOID PCIBcm2711Dev__Hidd_PCIDevice__ReleaseVectors(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_ReleaseVectors *msg)
+{
+    struct pci_staticdata *psd = PSD(cl);
+    struct PCIBcm2711DevData *data = OOP_INST_DATA(cl, o);
+    IPTR bus = 0, dev = 0, sub = 0;
+    ULONG head;
+
+    if (!data->msiVector)
+        return;
+
+    OOP_GetAttr(o, aHidd_PCIDevice_Bus, &bus);
+    OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
+    OOP_GetAttr(o, aHidd_PCIDevice_Sub, &sub);
+
+    head = ReadConfigLong(psd, bus, dev, sub, data->msiCap);
+    WriteConfigLong(psd, bus, dev, sub, data->msiCap,
+                    head & ~((ULONG)PCIMSIF_ENABLE << 16));
+
+    psd->msi_used &= ~(1UL << (data->msiVector - 1));
+    data->msiVector = 0;
+}
+
+VOID PCIBcm2711Dev__Hidd_PCIDevice__GetVectorAttribs(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_GetVectorAttribs *msg)
+{
+    struct pci_staticdata *psd = PSD(cl);
+    struct PCIBcm2711DevData *data = OOP_INST_DATA(cl, o);
+    struct TagItem *tag, *tstate = msg->attribs;
+
+    while ((tag = NextTagItem(&tstate)) != NULL)
+    {
+        switch (tag->ti_Tag)
+        {
+        case tHidd_PCIVector_Native:
+            tag->ti_Data = data->msiVector ? (data->msiVector - 1) : (IPTR)-1;
+            break;
+
+        case tHidd_PCIVector_Int:
+            tag->ti_Data = data->msiVector ? psd->msi_irq : (IPTR)-1;
+            break;
+        }
+    }
+}

--- a/arch/arm-native/soc/broadcom/2711/pcie/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2711/pcie/mmakefile.src
@@ -1,0 +1,10 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+USER_LDFLAGS := -static
+
+%build_module mmake=kernel-pcie-bcm2711 \
+  modname=pcibcm2711 modtype=hidd \
+  files="pcie_init driverclass"
+
+%common

--- a/arch/arm-native/soc/broadcom/2711/pcie/pcibcm2711.conf
+++ b/arch/arm-native/soc/broadcom/2711/pcie/pcibcm2711.conf
@@ -1,0 +1,49 @@
+##begin config
+basename    PCIBcm2711
+libbasetype struct pcibcm2711base
+version     1.0
+residentpri     87
+classptr_field  psd.driverClass
+superclass      CLID_Hidd_PCIDriver
+options         noexpunge
+##end config
+
+##begin cdefprivate
+#include <hidd/pci.h>
+#include "pcie.h"
+##end cdefprivate
+
+##begin methodlist
+.interface Root
+New
+Get
+.interface Hidd_PCIDriver
+ReadConfigByte
+ReadConfigWord
+ReadConfigLong
+WriteConfigByte
+WriteConfigWord
+WriteConfigLong
+MapPCI
+CPUtoPCI
+PCItoCPU
+AllocPCIMem
+FreePCIMem
+##end methodlist
+
+##begin class
+##begin config
+basename       PCIBcm2711Dev
+type           hidd
+superclass     CLID_Hidd_PCIDevice
+classptr_field psd.deviceClass
+classdatatype  struct PCIBcm2711DevData
+##end config
+
+##begin methodlist
+.interface Hidd_PCIDevice
+ObtainVectors
+ReleaseVectors
+GetVectorAttribs
+##end methodlist
+##end class

--- a/arch/arm-native/soc/broadcom/2711/pcie/pcie.h
+++ b/arch/arm-native/soc/broadcom/2711/pcie/pcie.h
@@ -1,0 +1,227 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    The Broadcom register map and the bring-up sequence below follow OpenBSD's
+    sys/dev/fdt/bcm2711_pcie.c. The BCM2711 PCIe block is not covered by the
+    published BCM2711 ARM Peripherals documentation, so that driver is the
+    reference this one is written against:
+
+    Copyright (c) 2020, 2025 Mark Kettenis <kettenis@openbsd.org>
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef PCIE_BCM2711_H
+#define PCIE_BCM2711_H
+
+#include <inttypes.h>
+#include <exec/types.h>
+#include <exec/libraries.h>
+#include <oop/oop.h>
+
+#include LC_LIBDEFS_FILE
+
+/*
+ * BCM2711 PCIe host bridge (single root port, gen2 x1). The register
+ * block sits outside the main peripheral window, at a fixed place in
+ * the SoC address map.
+ */
+#define BCM2711_PCIE_REG_BASE           0xFD500000UL
+#define BCM2711_PCIE_REG_SIZE           0x9310
+
+/* CPU-side outbound window (fixed in the SoC address map) and the PCI
+ * bus address programmed into it. */
+#define BCM2711_PCIE_CPU_WIN            0x600000000ULL
+#define BCM2711_PCIE_PCI_WIN            0xC0000000UL
+#define BCM2711_PCIE_WIN_SIZE           0x04000000UL    /* 64MB */
+
+/* The root complex configuration header is memory mapped at offset 0;
+ * external configuration space is reached through an indexed window. */
+#define PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1         0x0188
+/* Byte order of the inbound window. OpenBSD leaves this at its reset value
+   and never defines these bits; the field is documented here as hardware. */
+#define  PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_MASK            (0x3 << 2)
+#define  PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_LITTLE          (0x0 << 2)
+#define PCIE_RC_CFG_PRIV1_ID_VAL3                       0x043c
+#define  PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_MASK           (0xffffff << 0)
+#define PCIE_RC_CFG_PRIV1_LINK_CAP                      0x04dc
+#define  PCIE_RC_CFG_PRIV1_LINK_CAP_ASPM_SUPPORT_MASK   (0x3 << 10)
+
+#define PCIE_MISC_MISC_CTRL                             0x4008
+#define  PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN              (1 << 12)
+#define  PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE           (1 << 13)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK        (0x3 << 20)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_128         (0x0 << 20)
+#define  PCIE_MISC_MISC_CTRL_SCB0_SIZE_MASK             (0x1fU << 27)
+#define  PCIE_MISC_MISC_CTRL_SCB0_SIZE_SHIFT            27
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO                0x400c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI                0x4010
+#define PCIE_MISC_RC_BAR1_CONFIG_LO                     0x402c
+#define  PCIE_MISC_RC_BAR1_CONFIG_SIZE_MASK             (0x1f << 0)
+#define PCIE_MISC_RC_BAR1_CONFIG_HI                     0x4030
+#define PCIE_MISC_RC_BAR2_CONFIG_LO                     0x4034
+#define PCIE_MISC_RC_BAR2_CONFIG_HI                     0x4038
+#define PCIE_MISC_RC_BAR3_CONFIG_LO                     0x403c
+#define PCIE_MISC_PCIE_CTRL                             0x4064
+#define PCIE_MISC_PCIE_STATUS                           0x4068
+#define  PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP           (1 << 4)
+#define  PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE           (1 << 5)
+#define PCIE_MISC_REVISION                              0x406c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT        0x4070
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI           0x4080
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI          0x4084
+#define PCIE_HARD_DEBUG                                 0x4204
+#define  PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE            (1 << 1)
+#define  PCIE_HARD_DEBUG_SERDES_IDDQ                    (1 << 27)
+
+/*
+ * The bridge's own MSI machinery. A bus master signals by writing a data
+ * word to the address in MSI_BAR_CONFIG; the bridge catches the write,
+ * raises the corresponding bit in INTR2_INT_STATUS and asserts its "msi"
+ * interrupt output. DATA_CONFIG holds the pattern the data word is matched
+ * against, with the low bits left free to select one of 32 vectors.
+ */
+#define PCIE_MISC_MSI_BAR_CONFIG_LO                     0x4044
+#define  PCIE_MISC_MSI_BAR_CONFIG_LO_EN                 (1 << 0)
+#define PCIE_MISC_MSI_BAR_CONFIG_HI                     0x4048
+#define PCIE_MISC_MSI_DATA_CONFIG                       0x404c
+#define  PCIE_MISC_MSI_DATA_CONFIG_32                   0xfff86540
+
+#define PCIE_MSI_INTR2_INT_STATUS                       0x4500
+#define PCIE_MSI_INTR2_INT_CLR                          0x4508
+#define PCIE_MSI_INTR2_INT_MASK_SET                     0x4510
+#define PCIE_MSI_INTR2_INT_MASK_CLR                     0x4514
+
+#define BCM2711_MSI_VECTORS                             32
+
+/* The data word carries the match pattern with the vector in the free low
+   bits, so vector n signals as (pattern | n). */
+#define BCM2711_MSI_DATA(vec) \
+    ((PCIE_MISC_MSI_DATA_CONFIG_32 & 0xffff) | (vec))
+
+/*
+ * Where a bus master aims its MSI writes. Any address the inbound window
+ * does not claim will do - the match is exact and nothing is stored there -
+ * so it sits at the very top of what the matcher can hold, far above the
+ * 4GB window this board uses.
+ */
+#define BCM2711_MSI_TARGET                              0xffffffffcULL
+
+/* Configuration header command register */
+#define PCI_CMD                         0x04
+
+/* GIC interrupt IDs start above the 32 SGIs and PPIs; the device tree
+   numbers shared peripheral interrupts from zero. */
+#define GIC_SPI_BASE                    32
+
+/*
+ * Bring-up tracing. Nothing here can be exercised under emulation - QEMU's
+ * raspi4b has no PCIe - so the first run on real hardware is also the first
+ * test. Leave this on until a controller has been seen to enumerate.
+ */
+#define PCIE_BRINGUP                    1
+
+#if PCIE_BRINGUP
+#define BRINGUP(x)                      x
+#else
+#define BRINGUP(x)
+#endif
+
+/* The attached USB controller reports the firmware it is running here;
+   zero means it has none and will execute no command. */
+#define VL805_CFG_FWVERSION             0x50
+#define PCI_CMD_MEMORY                  (1 << 1)
+#define PCI_CMD_MASTER                  (1 << 2)
+
+#define PCIE_EXT_CFG_DATA                               0x8000
+#define PCIE_EXT_CFG_INDEX                              0x9000
+#define PCIE_RGR1_SW_INIT_1                             0x9210
+#define  PCIE_RGR1_SW_INIT_1_PERST                      (1 << 0)
+#define  PCIE_RGR1_SW_INIT_1_INIT                       (1 << 1)
+
+/* Inbound window and SCB size fields both hold log2 of the size, less 15. */
+#define RC_BAR_SIZE(exp)                ((exp) - 15)
+#define MISC_CTRL_SCB0_SIZE(exp)        (((exp) - 15) << PCIE_MISC_MISC_CTRL_SCB0_SIZE_SHIFT)
+
+/* Fallback for a device tree that does not describe dma-ranges: the Pi 4
+   lets a bus master reach the low 3GB, and the window covering it is the
+   next power of two up. DMARangesFromDT() reads the real figure. */
+#define BCM2711_DMA_EXP                 32
+
+/* External config index encoding */
+#define EXT_CFG_ADDR(bus, dev, func)    (((bus) << 20) | ((dev) << 15) | ((func) << 12))
+
+/* The bridge's "msi" interrupt output as a GIC INTID (SPI 148).
+   MSIIrqFromDT() reads the real figure; this covers a tree without one. */
+#define BCM2711_PCIE_MSI                180
+
+/* Uncached DMA memory allocator: page-granular bitmap over the block the
+ * bootstrap reserved. xHCI controllers may use a 64KB page size and ask
+ * for scratchpad areas of a megabyte or more, so the block is sized in
+ * tens of megabytes and a single allocation is not artificially capped. */
+
+struct pci_staticdata {
+    OOP_AttrBase    hiddPCIDriverAB;
+    OOP_AttrBase    hiddPCIDeviceAB;
+    OOP_AttrBase    hiddAB;
+    OOP_Class       *driverClass;
+    APTR            kernelBase;         /* kernel.resource, for KrnMapGlobal() */
+    OOP_Class       *deviceClass;
+
+    volatile uint8_t *regs;
+    BOOL            preinitialised;     /* firmware left the link trained */
+    BOOL            fw_loaded;          /* endpoint firmware load already handled */
+
+    /*
+     * What a bus master must add to a system address to reach it. The
+     * firmware picks this to suit the memory fitted and publishes it in
+     * the device tree, so it is read at run time rather than assumed.
+     */
+    uint64_t        dma_offset;
+
+    /*
+     * log2 of the inbound window, likewise from dma-ranges: the window has
+     * to be a power of two, so it is the smallest one covering what the
+     * bus may reach.
+     */
+    uint32_t        dma_exp;
+
+    /* The bridge's "msi" output as a GIC INTID, and the handler on it.
+       A zero handle means MSI delivery is not available. */
+    uint32_t        msi_irq;
+    APTR            msi_handle;
+    uint32_t        msi_used;           /* one bit per handed-out vector */
+
+};
+
+/*
+ * Per-device side of the vector bookkeeping. msiVector holds the assigned
+ * vector plus one, so a freshly created (zeroed) device reads as "none".
+ */
+struct PCIBcm2711DevData {
+    ULONG           msiVector;
+    ULONG           msiCap;             /* config space offset of the MSI capability */
+};
+
+struct pcibcm2711base {
+    struct Library          LibNode;
+    struct pci_staticdata   psd;
+};
+
+#define BASE(lib) ((struct pcibcm2711base *)(lib))
+#define PSD(cl)   (&((struct pcibcm2711base *)cl->UserData)->psd)
+
+/* One-shot endpoint firmware load, called when its driver enables it. */
+void EnsureEndpointFirmware(struct pci_staticdata *psd);
+
+#endif

--- a/arch/arm-native/soc/broadcom/2711/pcie/pcie_init.c
+++ b/arch/arm-native/soc/broadcom/2711/pcie/pcie_init.c
@@ -1,0 +1,758 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: BCM2711 PCIe host bridge bring-up and driver registration.
+*/
+
+#define __OOP_NOATTRBASES__
+
+#include <aros/symbolsets.h>
+
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <hidd/pci.h>
+#include <oop/oop.h>
+
+#include <proto/exec.h>
+#include <proto/oop.h>
+#include <proto/mbox.h>
+#include <proto/openfirmware.h>
+#include <proto/bootloader.h>
+
+#include <aros/bootloader.h>
+
+#define __NOLIBBASE__
+#include <proto/kernel.h>
+
+IPTR __arm_periiobase __attribute__((used)) = 0;
+#define ARM_PERIIOBASE __arm_periiobase
+
+#include <hardware/bcm2708.h>
+#include <hardware/videocore.h>
+
+#include <aros/macros.h>
+
+#include <string.h>
+
+#include "pcie.h"
+
+#include <aros/debug.h>
+
+APTR MBoxBase;
+void *OpenFirmwareBase;
+APTR BootLoaderBase;
+
+/* "PCIE=disable" on the kernel command line keeps the bridge untouched. */
+static BOOL PCIeEnabled(void)
+{
+    struct List *list;
+    struct Node *node;
+
+    BootLoaderBase = OpenResource("bootloader.resource");
+    if (!BootLoaderBase)
+        return TRUE;
+
+    list = (struct List *)GetBootInfo(BL_Args);
+    if (!list)
+        return TRUE;
+
+    ForeachNode(list, node)
+    {
+        if (strncmp(node->ln_Name, "PCIE=", 5) == 0 &&
+            strstr(&node->ln_Name[5], "disable"))
+        {
+            D(bug("[PCIBcm2711] disabled on the command line\n"));
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+/*
+ * The bridge registers raise an external abort when the block is absent
+ * (emulators mark the device tree node disabled instead of modelling
+ * it), so consult the tree before the first register access.
+ */
+static BOOL PCIeNodeUsable(void)
+{
+    void *key, *prop;
+    const char *val;
+
+    OpenFirmwareBase = OpenResource("openfirmware.resource");
+    if (!OpenFirmwareBase)
+        return FALSE;
+
+    key = OF_OpenKey("/scb/pcie@7d500000");
+    if (!key)
+    {
+        D(bug("[PCIBcm2711] no PCIe node in the device tree\n"));
+        return FALSE;
+    }
+
+    /* OF_OpenKey falls back to the last resolved node; make sure this
+     * really is the PCIe controller. */
+    prop = OF_FindProperty(key, "compatible");
+    if (!prop)
+    {
+        D(bug("[PCIBcm2711] PCIe node has no compatible property\n"));
+        return FALSE;
+    }
+    val = OF_GetPropValue(prop);
+    if (!val || !strstr(val, "2711-pcie"))
+    {
+        D(bug("[PCIBcm2711] node is not the PCIe controller (%s)\n", val ? val : "?"));
+        return FALSE;
+    }
+
+    prop = OF_FindProperty(key, "status");
+    if (prop)
+    {
+        val = OF_GetPropValue(prop);
+        if (val && strcmp(val, "okay") != 0)
+        {
+            D(bug("[PCIBcm2711] node status '%s', leaving the bridge alone\n", val));
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+/*
+ * Read the inbound mapping the firmware published: dma-ranges gives the
+ * bus address that system memory appears at, which is not the system
+ * address itself on a board whose memory does not fit below the window.
+ */
+/*
+ * The firmware picks both the bus-address offset and how much of memory a
+ * bus master may reach, to suit the RAM fitted, and publishes them in
+ * dma-ranges. Read both rather than assuming: the inbound window has to be
+ * a power of two covering the reachable span, and a board with a different
+ * split needs a different one.
+ */
+static void DMARangesFromDT(uint64_t *offset, uint32_t *exp)
+{
+    void *key, *prop;
+    const uint32_t *r;
+    uint64_t pci, cpu, size;
+    uint32_t shift;
+
+    *offset = 0;
+    *exp = BCM2711_DMA_EXP;
+
+    if (!OpenFirmwareBase)
+        return;
+
+    key = OF_FindNodeByCompatible(NULL, "brcm,bcm2711-pcie");
+    if (!key)
+        return;
+
+    prop = OF_FindProperty(key, "dma-ranges");
+    if (!prop || OF_GetPropLen(prop) < 7 * 4)
+        return;
+
+    /* <pci flags, pci hi, pci lo, cpu hi, cpu lo, size hi, size lo> */
+    r = (const uint32_t *)OF_GetPropValue(prop);
+    pci  = ((uint64_t)AROS_BE2LONG(r[1]) << 32) | AROS_BE2LONG(r[2]);
+    cpu  = ((uint64_t)AROS_BE2LONG(r[3]) << 32) | AROS_BE2LONG(r[4]);
+    size = ((uint64_t)AROS_BE2LONG(r[5]) << 32) | AROS_BE2LONG(r[6]);
+
+    *offset = pci - cpu;
+
+    for (shift = 0; shift < 64 && ((uint64_t)1 << shift) < size; shift++)
+        ;
+
+    /* RC_BAR_SIZE() encodes 64KB..64GB; anything else means we misread the
+       property, so keep the value that suits the boards we know. */
+    if (shift >= 16 && shift <= 36)
+        *exp = shift;
+
+    D(bug("[PCIBcm2711] dma-ranges: bus %08x%08x <- cpu %08x%08x, size %08x%08x (2^%u)\n",
+          (unsigned)(pci >> 32), (unsigned)pci,
+          (unsigned)(cpu >> 32), (unsigned)cpu,
+          (unsigned)(size >> 32), (unsigned)size, (unsigned)*exp));
+}
+
+/*
+ * Which of the node's interrupt outputs is the MSI one. The "interrupts"
+ * property lists GIC specifiers of three cells each - <type, number, flags>,
+ * SPIs as type 0 - and "interrupt-names" names them in the same order.
+ */
+static void MSIIrqFromDT(struct pci_staticdata *psd)
+{
+    void *key, *prop;
+    const uint32_t *ints;
+    const char *names, *n;
+    uint32_t nints, idx, len;
+
+    psd->msi_irq = BCM2711_PCIE_MSI;
+
+    if (!OpenFirmwareBase)
+        return;
+
+    key = OF_FindNodeByCompatible(NULL, "brcm,bcm2711-pcie");
+    if (!key)
+        return;
+
+    prop = OF_FindProperty(key, "interrupts");
+    if (!prop)
+        return;
+    ints = (const uint32_t *)OF_GetPropValue(prop);
+    nints = OF_GetPropLen(prop) / (3 * 4);
+
+    prop = OF_FindProperty(key, "interrupt-names");
+    if (!prop)
+        return;
+    names = (const char *)OF_GetPropValue(prop);
+    len = OF_GetPropLen(prop);
+
+    /*
+     * The names sit back to back, each NUL terminated - but the property
+     * comes from firmware, so the terminator is looked for inside it rather
+     * than trusted to be there.
+     */
+    for (idx = 0, n = names; (idx < nints) && (n < names + len); idx++)
+    {
+        const char *end = memchr(n, '\0', (names + len) - n);
+
+        if (!end)
+            break;      /* unterminated: the rest of the property is not names */
+
+        if (strcmp(n, "msi") == 0)
+        {
+            psd->msi_irq = GIC_SPI_BASE + AROS_BE2LONG(ints[idx * 3 + 1]);
+            BRINGUP(bug("[PCIBcm2711] MSI output -> SPI %u (INTID %u)\n",
+                        (unsigned)AROS_BE2LONG(ints[idx * 3 + 1]),
+                        (unsigned)psd->msi_irq));
+            return;
+        }
+
+        n = end + 1;
+    }
+
+    BRINGUP(bug("[PCIBcm2711] no \"msi\" entry in interrupt-names, assuming INTID %u\n",
+                (unsigned)psd->msi_irq));
+}
+
+static inline uint32_t rd32(volatile uint8_t *regs, uint32_t reg)
+{
+    return *(volatile uint32_t *)(regs + reg);
+}
+
+static inline void wr32(volatile uint8_t *regs, uint32_t reg, uint32_t val)
+{
+    *(volatile uint32_t *)(regs + reg) = val;
+}
+
+/*
+ * All 32 vectors funnel into this one interrupt; what distinguishes them
+ * is the bit the bridge set in INTR2_INT_STATUS. The status is cleared
+ * here - the endpoint handlers hang off the same interrupt and run after
+ * us, and a level output nobody clears never falls.
+ */
+static void PCIeMSIHandler(void *data, void *unused)
+{
+#if PCIE_BRINGUP
+    static uint32_t seen = 0;
+#endif
+    struct pci_staticdata *psd = data;
+    uint32_t status = rd32(psd->regs, PCIE_MSI_INTR2_INT_STATUS);
+
+    if (status)
+    {
+        wr32(psd->regs, PCIE_MSI_INTR2_INT_CLR, status);
+#if PCIE_BRINGUP
+        /* The first few prove delivery; after that they are just traffic. */
+        if (seen < 4)
+        {
+            seen++;
+            bug("[PCIBcm2711] MSI vectors %08x (%u)\n", (unsigned)status, (unsigned)seen);
+        }
+#endif
+    }
+}
+
+/* Busy wait on the generic counter; init runs before timer.device. */
+static void delay_us(uint32_t us)
+{
+    uint64_t freq, now, end;
+
+    asm volatile("mrs %0, CNTFRQ_EL0" : "=r"(freq));
+    asm volatile("mrs %0, CNTPCT_EL0" : "=r"(now));
+    end = now + (freq * us) / 1000000;
+
+    do {
+        asm volatile("mrs %0, CNTPCT_EL0" : "=r"(now));
+    } while (now < end);
+}
+
+/*
+ * Ask the firmware to load the VL805 xHCI controller firmware. On
+ * boards whose bootloader EEPROM already carries it this returns
+ * without effect. The argument encodes the controller's PCI address.
+ */
+static void NotifyXHCIReset(void)
+{
+    unsigned int *msg_, *msg;
+
+    if ((MBoxBase = OpenResource("mbox.resource")) == NULL)
+        return;
+
+    /* Own our cache lines; see <proto/mbox.h>. */
+    msg_ = AllocMem(MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1), MEMF_CLEAR);
+    if (!msg_)
+        return;
+    msg = (unsigned int *)(((uintptr_t)msg_ + (MBOX_MSG_ALIGN - 1)) & ~(uintptr_t)(MBOX_MSG_ALIGN - 1));
+
+    msg[0] = AROS_LONG2LE(7 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(VCTAG_NOTIFYXHCI);
+    msg[3] = AROS_LONG2LE(4);
+    msg[4] = AROS_LONG2LE(4);
+    msg[5] = AROS_LONG2LE(EXT_CFG_ADDR(1, 0, 0));
+    msg[6] = 0;
+
+    MBoxWrite((APTR)VCMB_BASE, VCMB_PROPCHAN, msg);
+    if (MBoxRead((APTR)VCMB_BASE, VCMB_PROPCHAN) == msg)
+        BRINGUP(bug("[PCIBcm2711] VL805 firmware notify: status %08x, tag %08x, value %08x\n",
+              AROS_LE2LONG(msg[1]), AROS_LE2LONG(msg[4]), AROS_LE2LONG(msg[5])));
+    else
+        BRINGUP(bug("[PCIBcm2711] VL805 firmware notify got no reply\n"));
+
+    FreeMem(msg_, MBOX_MSG_ALIGN + (MBOX_MSG_ALIGN - 1));
+}
+
+static BOOL BridgeInit(struct pci_staticdata *psd)
+{
+    volatile uint8_t *regs = psd->regs;
+    uint32_t tmp;
+    int i;
+
+    /*
+     * The register core may be held in SW_INIT out of power-on; while it
+     * is, everything but the reset block answers with a bus error, so the
+     * reset block is the only thing that may be read first.
+     *
+     * If the firmware has already trained the link, leave it alone. Taking
+     * the bus through reset costs the attached controller the firmware the
+     * bootloader loaded into it, and with it the power it supplies to the
+     * ports.
+     */
+    tmp = rd32(regs, PCIE_RGR1_SW_INIT_1);
+    if (!(tmp & PCIE_RGR1_SW_INIT_1_INIT))
+    {
+        uint32_t status = rd32(regs, PCIE_MISC_PCIE_STATUS);
+
+        D(bug("[PCIBcm2711] bridge is already running, status %08x\n", status));
+
+        if ((status & (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE)) ==
+            (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE))
+        {
+            psd->preinitialised = TRUE;
+            D(bug("[PCIBcm2711] link already trained, keeping it\n"));
+        }
+    }
+
+    if (!psd->preinitialised)
+    {
+        D(bug("[PCIBcm2711] resetting the bridge\n"));
+        wr32(regs, PCIE_RGR1_SW_INIT_1, PCIE_RGR1_SW_INIT_1_PERST | PCIE_RGR1_SW_INIT_1_INIT);
+        delay_us(200);
+
+        /* Release the bridge core, keep PERST# asserted */
+        wr32(regs, PCIE_RGR1_SW_INIT_1, PCIE_RGR1_SW_INIT_1_PERST);
+        delay_us(200);
+
+        D(bug("[PCIBcm2711] bridge revision %08x\n", rd32(regs, PCIE_MISC_REVISION)));
+
+        /* Power up the PHY */
+        tmp = rd32(regs, PCIE_HARD_DEBUG);
+        wr32(regs, PCIE_HARD_DEBUG, tmp & ~PCIE_HARD_DEBUG_SERDES_IDDQ);
+        delay_us(200);
+    }
+
+    /*
+     * SCB/inbound setup: one region at PCI address 0. The size follows
+     * the DMA range the SoC allows a bus master to reach, rounded up to
+     * a power of two, not the memory that happens to be fitted: on this
+     * SoC that range is 3GB and the window is therefore 4GB.
+     */
+    wr32(regs, PCIE_MISC_MISC_CTRL,
+         PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN | PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE |
+         PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_128 | MISC_CTRL_SCB0_SIZE(psd->dma_exp));
+
+    wr32(regs, PCIE_MISC_RC_BAR2_CONFIG_LO,
+         (uint32_t)psd->dma_offset | RC_BAR_SIZE(psd->dma_exp));
+    wr32(regs, PCIE_MISC_RC_BAR2_CONFIG_HI, (uint32_t)(psd->dma_offset >> 32));
+
+    /*
+     * Present the inbound window in the byte order the rest of the system
+     * uses. Left as it comes out of reset, everything a bus master reads
+     * from memory arrives swapped.
+     */
+    tmp = rd32(regs, PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1);
+    tmp = (tmp & ~PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_MASK) |
+          PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_LITTLE;
+    wr32(regs, PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1, tmp);
+
+
+    wr32(regs, PCIE_MISC_RC_BAR1_CONFIG_LO, 0);
+    wr32(regs, PCIE_MISC_RC_BAR3_CONFIG_LO, 0);
+
+    /*
+     * Aim the MSI matcher and open all 32 vectors. Nothing signals yet -
+     * a device only writes here once ObtainVectors has programmed its MSI
+     * capability - but the target has to be standing before that happens.
+     */
+    wr32(regs, PCIE_MISC_MSI_BAR_CONFIG_LO,
+         (uint32_t)BCM2711_MSI_TARGET | PCIE_MISC_MSI_BAR_CONFIG_LO_EN);
+    wr32(regs, PCIE_MISC_MSI_BAR_CONFIG_HI, (uint32_t)(BCM2711_MSI_TARGET >> 32));
+    wr32(regs, PCIE_MISC_MSI_DATA_CONFIG, PCIE_MISC_MSI_DATA_CONFIG_32);
+    wr32(regs, PCIE_MSI_INTR2_INT_CLR, 0xffffffff);
+    wr32(regs, PCIE_MSI_INTR2_INT_MASK_CLR, 0xffffffff);
+
+    /* Outbound window: CPU 0x6_0000_0000 -> PCI 0xC0000000, 64MB */
+    wr32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO, BCM2711_PCIE_PCI_WIN);
+    wr32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI, 0);
+    {
+        uint32_t base_mb  = BCM2711_PCIE_CPU_WIN >> 20;
+        uint32_t limit_mb = (BCM2711_PCIE_CPU_WIN + BCM2711_PCIE_WIN_SIZE - 1) >> 20;
+
+        wr32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
+             ((base_mb & 0xfff) << 4) | ((limit_mb & 0xfff) << 20));
+        wr32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI, base_mb >> 12);
+        wr32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI, limit_mb >> 12);
+    }
+
+    /* Deassert PERST# and wait for the link */
+    if (!psd->preinitialised)
+    {
+        D(bug("[PCIBcm2711] releasing PERST#\n"));
+        wr32(regs, PCIE_RGR1_SW_INIT_1, 0);
+    }
+
+    for (i = 0; i < 100; i++)
+    {
+        tmp = rd32(regs, PCIE_MISC_PCIE_STATUS);
+        if ((tmp & (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE)) ==
+            (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE))
+            break;
+        delay_us(5000);
+    }
+
+    if ((tmp & (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE)) !=
+        (PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP | PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE))
+    {
+        bug("[PCIBcm2711] link did not come up (status %08x)\n", tmp);
+        return FALSE;
+    }
+
+    BRINGUP(bug("[PCIBcm2711] link up after %dms (status %08x)\n", i * 5, tmp));
+
+
+#if PCIE_BRINGUP
+    /*
+     * Everything the bring-up depends on, in one place: if a controller
+     * fails to appear on real hardware, this says whether the fault is the
+     * bridge, the windows, the endpoint, or the routing.
+     */
+    bug("[PCIBcm2711] --- bring-up state ---\n");
+    bug("[PCIBcm2711]   misc_ctrl=%08x (scb0_size field %u)\n",
+        rd32(regs, PCIE_MISC_MISC_CTRL),
+        (unsigned)((rd32(regs, PCIE_MISC_MISC_CTRL) >> 27) & 0x1f));
+    bug("[PCIBcm2711]   inbound  bar2=%08x:%08x (offset %08x%08x, 2^%u)\n",
+        rd32(regs, PCIE_MISC_RC_BAR2_CONFIG_HI),
+        rd32(regs, PCIE_MISC_RC_BAR2_CONFIG_LO),
+        (unsigned)(psd->dma_offset >> 32), (unsigned)psd->dma_offset,
+        (unsigned)psd->dma_exp);
+    bug("[PCIBcm2711]   outbound win0 lo=%08x hi=%08x baselimit=%08x\n",
+        rd32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO),
+        rd32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI),
+        rd32(regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT));
+    {
+        ULONG id, cls;
+
+        Disable();
+        wr32(regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(1, 0, 0));
+        id  = rd32(regs, PCIE_EXT_CFG_DATA + 0x00);
+        cls = rd32(regs, PCIE_EXT_CFG_DATA + 0x08);
+        Enable();
+
+        if (id == 0xffffffff)
+            bug("[PCIBcm2711]   endpoint 1:0.0: no response yet (its firmware "
+                "loads when a driver enables it)\n");
+        else
+            bug("[PCIBcm2711]   endpoint 1:0.0: %04x:%04x class %06x\n",
+                (unsigned)(id & 0xffff), (unsigned)(id >> 16),
+                (unsigned)(cls >> 8));
+    }
+    bug("[PCIBcm2711] ----------------------\n");
+#endif
+
+    /* Present the root port as a PCI-PCI bridge */
+    tmp = rd32(regs, PCIE_RC_CFG_PRIV1_ID_VAL3);
+    wr32(regs, PCIE_RC_CFG_PRIV1_ID_VAL3, (tmp & ~0xffffffUL) | 0x060400);
+
+    /* Bus numbers: primary 0, secondary 1, subordinate 1 */
+    tmp = rd32(regs, 0x18);
+    wr32(regs, 0x18, (tmp & 0xff000000) | 0x00010100);
+
+    /* Forward the memory window through the bridge */
+    wr32(regs, 0x20, ((BCM2711_PCIE_PCI_WIN + BCM2711_PCIE_WIN_SIZE - 0x100000) & 0xfff00000)
+                     | (BCM2711_PCIE_PCI_WIN >> 16));
+
+    /* Enable memory decode and bus mastering on the root port. Devices
+       signal by message; the legacy pin block stays as reset left it,
+       which is masked. */
+    tmp = rd32(regs, PCI_CMD);
+    wr32(regs, PCI_CMD, tmp | PCI_CMD_MEMORY | PCI_CMD_MASTER);
+
+    return TRUE;
+}
+
+/*
+ * The endpoint has no firmware-assigned resources; place its BAR at
+ * the bottom of the window and route its interrupt.
+ */
+static void SetupEndpoint(struct pci_staticdata *psd)
+{
+    volatile uint8_t *regs = psd->regs;
+    uint32_t id, tmp;
+
+    Disable();
+    wr32(regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(1, 0, 0));
+    id = rd32(regs, PCIE_EXT_CFG_DATA + 0x00);
+
+    if (id != 0xffffffff && id != 0)
+    {
+        /* 64-bit memory BAR0. Keep whatever the firmware placed there:
+           moving a controller it has already set up loses us its work. */
+        uint32_t bar = rd32(regs, PCIE_EXT_CFG_DATA + 0x10) & ~0xfUL;
+
+        if (!psd->preinitialised || bar == 0)
+        {
+            wr32(regs, PCIE_EXT_CFG_DATA + 0x10, BCM2711_PCIE_PCI_WIN);
+            wr32(regs, PCIE_EXT_CFG_DATA + 0x14, 0);
+        }
+        else
+            D(bug("[PCIBcm2711] keeping firmware BAR0 %08x\n", bar));
+
+        /* Cache line size, as every reference stack programs */
+        tmp = rd32(regs, PCIE_EXT_CFG_DATA + 0x0c);
+        wr32(regs, PCIE_EXT_CFG_DATA + 0x0c, (tmp & ~0xffUL) | 16);
+
+        /*
+         * The command register is left alone: the endpoint stays
+         * addressed but quiescent until its own driver enables it,
+         * which is the moment the firmware load happens.
+         */
+    }
+    Enable();
+
+    D(bug("[PCIBcm2711] endpoint 1:0.0 id %08x\n", id));
+}
+
+static uint32_t EndpointCfgRead(struct pci_staticdata *psd, uint32_t reg)
+{
+    uint32_t val;
+
+    Disable();
+    wr32(psd->regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(1, 0, 0));
+    val = rd32(psd->regs, PCIE_EXT_CFG_DATA + reg);
+    Enable();
+
+    return val;
+}
+
+static void EndpointCfgWrite(struct pci_staticdata *psd, uint32_t reg, uint32_t val)
+{
+    Disable();
+    wr32(psd->regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(1, 0, 0));
+    wr32(psd->regs, PCIE_EXT_CFG_DATA + reg, val);
+    Enable();
+}
+
+/*
+ * The loader leaves the controller advertising larger payloads than the
+ * root complex is set up for; bring it down to match. Error status is
+ * sticky across everything but a reset, so clear it too: anything seen
+ * later was earned later.
+ */
+static void EndpointPostLoad(struct pci_staticdata *psd)
+{
+    uint32_t cap, guard;
+
+    cap = EndpointCfgRead(psd, 0x34) & 0xff;
+    for (guard = 12; cap && guard; guard--)
+    {
+        uint32_t hdr = EndpointCfgRead(psd, cap);
+
+        if ((hdr & 0xff) == 0x10)
+        {
+            uint32_t devctl = EndpointCfgRead(psd, cap + 0x08);
+
+            EndpointCfgWrite(psd, cap + 0x08, devctl & ~(7 << 5));
+            /* Device status is W1C in the same dword */
+            EndpointCfgWrite(psd, cap + 0x08,
+                             EndpointCfgRead(psd, cap + 0x08));
+            break;
+        }
+        cap = (hdr >> 8) & 0xff;
+    }
+
+    EndpointCfgWrite(psd, 0x104, EndpointCfgRead(psd, 0x104));
+    EndpointCfgWrite(psd, 0x110, EndpointCfgRead(psd, 0x110));
+}
+
+/* Firmware revision of the attached controller, 0 if it is running none. */
+static uint32_t EndpointFWVersion(struct pci_staticdata *psd)
+{
+    uint32_t ver;
+
+    Disable();
+    wr32(psd->regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(1, 0, 0));
+    ver = rd32(psd->regs, PCIE_EXT_CFG_DATA + VL805_CFG_FWVERSION);
+    Enable();
+
+    return (ver == 0xffffffff) ? 0 : ver;
+}
+
+/*
+ * Runs when the controller's driver first enables it, immediately
+ * before the driver initialises it. A controller that carries its own
+ * firmware store, or that survived a warm restart, is already running
+ * and is left alone: reloading a live controller leaves it inert.
+ */
+void EnsureEndpointFirmware(struct pci_staticdata *psd)
+{
+    int ms;
+
+    if (psd->fw_loaded)
+        return;
+
+    if (EndpointFWVersion(psd))
+    {
+        psd->fw_loaded = TRUE;
+        BRINGUP(bug("[PCIBcm2711] controller firmware %08x already running, no load needed\n",
+                    EndpointFWVersion(psd)));
+        EndpointPostLoad(psd);
+        return;
+    }
+
+    NotifyXHCIReset();
+
+    for (ms = 0; ms < 1000; ms += 10)
+    {
+        if (EndpointFWVersion(psd))
+            break;
+        delay_us(10000);
+    }
+
+    /* The version reports in a little before the controller is ready;
+       a failed load stays unmarked so the next enable tries again. */
+    if (EndpointFWVersion(psd))
+    {
+        psd->fw_loaded = TRUE;
+        D(bug("[PCIBcm2711] controller firmware %08x, %dms after load request\n",
+              EndpointFWVersion(psd), ms));
+        delay_us(1000);
+        EndpointPostLoad(psd);
+    }
+    else
+        bug("[PCIBcm2711] controller firmware did not load\n");
+}
+
+static int PCIBcm2711_InitClass(LIBBASETYPEPTR LIBBASE)
+{
+    struct pci_staticdata *psd = &LIBBASE->psd;
+    APTR KernelBase;
+    OOP_Object *pci;
+
+    KernelBase = OpenResource("kernel.resource");
+    psd->kernelBase = KernelBase;
+    if (!KernelBase)
+        return TRUE;
+
+    __arm_periiobase = (IPTR)KrnGetSystemAttr(KATTR_PeripheralBase);
+
+    /* BCM2711 only */
+    if (__arm_periiobase != BCM2711_PERIIOBASE)
+        return TRUE;
+
+    if (!PCIeEnabled())
+    {
+        BRINGUP(bug("[PCIBcm2711] switched off on the command line\n"));
+        return TRUE;
+    }
+
+    if (!PCIeNodeUsable())
+    {
+        BRINGUP(bug("[PCIBcm2711] no usable brcm,bcm2711-pcie node in the device tree\n"));
+        return TRUE;
+    }
+
+    BRINGUP(bug("[PCIBcm2711] starting bring-up (peripheral base %p)\n",
+                (APTR)__arm_periiobase));
+
+    psd->regs = (volatile uint8_t *)BCM2711_PCIE_REG_BASE;
+    DMARangesFromDT(&psd->dma_offset, &psd->dma_exp);
+    MSIIrqFromDT(psd);
+    D(bug("[PCIBcm2711] bus master address offset %08x%08x\n",
+          (unsigned)(psd->dma_offset >> 32), (unsigned)psd->dma_offset));
+
+
+    if (!BridgeInit(psd))
+        return TRUE;    /* no link; nothing to drive, but do not stop boot */
+
+    /*
+     * Own the bridge's MSI output. This handler only acknowledges; the
+     * device handlers that care about the event join the same interrupt
+     * and run after it.
+     */
+    psd->msi_handle = KrnAddIRQHandler(psd->msi_irq, PCIeMSIHandler, psd, NULL);
+    BRINGUP(bug("[PCIBcm2711] MSI target %08x%08x, INTID %u, handler @ 0x%p\n",
+                (unsigned)(BCM2711_MSI_TARGET >> 32), (unsigned)BCM2711_MSI_TARGET,
+                (unsigned)psd->msi_irq, psd->msi_handle));
+
+    /* Address the endpoint; the firmware load waits for its driver. */
+    SetupEndpoint(psd);
+    D(bug("[PCIBcm2711] controller firmware %08x at init\n",
+          EndpointFWVersion(psd)));
+
+    psd->hiddPCIDriverAB = OOP_ObtainAttrBase(IID_Hidd_PCIDriver);
+    psd->hiddPCIDeviceAB = OOP_ObtainAttrBase(IID_Hidd_PCIDevice);
+    psd->hiddAB = OOP_ObtainAttrBase(IID_Hidd);
+    if (psd->hiddPCIDriverAB == 0 || psd->hiddPCIDeviceAB == 0 || psd->hiddAB == 0)
+    {
+        D(bug("[PCIBcm2711] ObtainAttrBases failed\n"));
+        return TRUE;
+    }
+
+    struct pHidd_PCI_AddHardwareDriver msg;
+
+    msg.driverClass = psd->driverClass;
+    msg.mID = OOP_GetMethodID(IID_Hidd_PCI, moHidd_PCI_AddHardwareDriver);
+
+    pci = OOP_NewObject(NULL, CLID_Hidd_PCI, NULL);
+    if (pci)
+    {
+        OOP_DoMethod(pci, (OOP_Msg)&msg);
+        OOP_DisposeObject(pci);
+        D(bug("[PCIBcm2711] driver registered\n"));
+    }
+
+    return TRUE;
+}
+
+static int PCIBcm2711_ExpungeClass(LIBBASETYPEPTR LIBBASE)
+{
+    OOP_ReleaseAttrBase(IID_Hidd_PCIDriver);
+    OOP_ReleaseAttrBase(IID_Hidd_PCIDevice);
+    OOP_ReleaseAttrBase(IID_Hidd);
+
+    return TRUE;
+}
+
+ADD2INITLIB(PCIBcm2711_InitClass, 0)
+ADD2EXPUNGELIB(PCIBcm2711_ExpungeClass, 0)


### PR DESCRIPTION
bcm2711: PCIe host bridge driver. OpenBSD's sys/dev/fdt/bcm2711_pcie.c used as reference.