### PR TITLE
amigavideo: scroll oversized screens vertically

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -234,8 +234,10 @@ VOID AmigaVideoBM__Root__Set(OOP_Class *cl, OOP_Object *o, struct pRoot_Set *msg
     }
     OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
 
-    if (newyoffset < 0)
-        newyoffset = 0;
+    /* Negative offsets scroll an oversized screen: the surplus becomes a
+       bitplane offset in setcopperscroll(). Keep at least one line in view. */
+    if (newyoffset <= -data->height)
+        newyoffset = -(data->height - 1);
     if (newyoffset >= data->height)
         newyoffset = data->height - 1;
 

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_chipset.c
@@ -261,10 +261,13 @@ static VOID setcopperscroll2(struct amigavideo_staticdata *csd, struct amigabm_d
     x = bm->leftedge;
     y = csd->starty + (bm->topedge >> bm->interlace);
 
+    /* A screen positioned above the view top is scrolled, not moved: pin the
+       display window at the top and turn the surplus into a bitplane offset,
+       so the lower part of an oversized bitmap comes into view. */
     yscroll = 0;
-    if (y < 10) {
-        yscroll = y - 10;
-        y = 10;
+    if (y < csd->starty) {
+        yscroll = y - csd->starty;
+        y = csd->starty;
     }
 
     xmaxscroll = 1 << (1 + csd->fmode_bpl);
@@ -898,7 +901,10 @@ VOID setspritevisible(struct amigavideo_staticdata *csd, BOOL visible)
             struct amigabm_data *bm;
             ForeachNode(csd->compositedbms, bm)
             {
-                if (csd->spritey < ((bm->topedge + bm->displayheight) >> bm->interlace))
+                /* A scrolled screen (negative topedge) starts its display band at the top */
+                WORD bmtop = bm->topedge < 0 ? 0 : bm->topedge;
+
+                if (csd->spritey < ((bmtop + bm->displayheight) >> bm->interlace))
                 {
                     setfmode(csd, bm);
                     break;
@@ -923,7 +929,10 @@ VOID new_setspritevisible(struct amigavideo_staticdata *csd, BOOL visible, int s
             struct amigabm_data *bm;
             ForeachNode(csd->compositedbms, bm)
             {
-                if (csd->new_spritey[spritenum] < ((bm->topedge + bm->displayheight) >> bm->interlace))
+                /* A scrolled screen (negative topedge) starts its display band at the top */
+                WORD bmtop = bm->topedge < 0 ? 0 : bm->topedge;
+
+                if (csd->new_spritey[spritenum] < ((bmtop + bm->displayheight) >> bm->interlace))
                 {
                     setfmode(csd, bm);
                     break;


### PR DESCRIPTION
A Workbench screen larger than the display (e.g. 1000x1000 on PAL)
autoscrolled horizontally but never vertically.

Three pieces:

- The amigavideo bitmap class clamped a negative TopEdge to 0, so every
  vertical scroll request from intuition was undone before it reached the
  copper. The horizontal offset has no such clamp, which is why only that
  axis worked. The clamp now allows scrolling down to -(height-1),
  symmetric with the existing lower bound.
- setcopperscroll2() only converted a screen position into a bitplane
  offset below raster line 10, which is inside the vertical blank; between
  there and the view top the display window itself crawled up into the
  border. A screen positioned above the view top now keeps its window
  pinned at the top and scrolls by bitplane offset instead.
- The sprite fmode search compared the pointer position against
  topedge + displayheight, which goes far negative for a scrolled screen;
  the display band of a scrolled screen starts at the view top.

Verified on Copperline with a banded 640x1000 PAL screen stepped through
the full TopEdge range and back, and with an oversized AUTOSCROLL
Workbench driven by the mouse.
