### PR TITLE
Correct mb() macro

### DIFF
--- a/workbench/hidds/nouveau/include/drm-compat/drm_compat_funcs.h
+++ b/workbench/hidds/nouveau/include/drm-compat/drm_compat_funcs.h
@@ -45,7 +45,7 @@
 #define likely(x)                       __builtin_expect((IPTR)(x),1)
 #define unlikely(x)                     __builtin_expect((IPTR)(x),0)
 #if defined(__i386__) || defined(__x86_64__)
-#define mb()                            __asm __volatile("lock; addl $0,0(%%esp)" : : : "memory");
+#define mb()                            __asm __volatile("mfence" : : : "memory");
 #define rmb()                           __asm __volatile("" : : : "memory");
 #define wmb()                           __asm __volatile("" : : : "memory");
 #else

--- a/workbench/hidds/nouveau/nouveau.conf
+++ b/workbench/hidds/nouveau/nouveau.conf
@@ -1,5 +1,5 @@
 ##begin config
-version         49.8
+version         49.9
 options         noexpunge
 basename        Nouveau
 libbasetype     struct IntHIDDNouveauBase


### PR DESCRIPTION
Using just %esp was causing crash under certain configurations