### PR TITLE
amigavideo: fix cursor jumps over scrolled screens

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_hiddclass.c
@@ -1016,10 +1016,13 @@ BOOL AmigaVideoDisplay__Hidd_Display__SetCursorPos(OOP_Class *cl, OOP_Object *o,
     struct amigabm_data *bm;
     ForeachNode(csd->compositedbms, bm)
     {
+        /* A scrolled screen (negative topedge) starts its display band at the top */
+        WORD bmtop = bm->topedge < 0 ? 0 : bm->topedge;
+
         cursy = msg->y;
         if (csd->interlaced)
             cursy >>= 1;
-        if (cursy < ((bm->topedge + bm->displayheight) >> bm->interlace))
+        if (cursy < ((bmtop + bm->displayheight) >> bm->interlace))
         {
             res = bm->res;
             interlace = (bm->interlace != 0);
@@ -1040,10 +1043,13 @@ BOOL AmigaVideoCl__Hidd_AmigaGfx__SetSpritePos(OOP_Class *cl, OOP_Object *o, str
     struct amigabm_data *bm;
     ForeachNode(csd->compositedbms, bm)
     {
+        /* A scrolled screen (negative topedge) starts its display band at the top */
+        WORD bmtop = bm->topedge < 0 ? 0 : bm->topedge;
+
         cursy = msg->y;
         if (csd->interlaced)
             cursy >>= 1;
-        if (cursy < ((bm->topedge + bm->displayheight) >> bm->interlace))
+        if (cursy < ((bmtop + bm->displayheight) >> bm->interlace))
         {
             res = bm->res;
             interlace = (bm->interlace != 0);


### PR DESCRIPTION
Follow-up to #981: with a screen scrolled up a little, the mouse cursor
jumped horizontally whenever the pointer entered the bottom rows of the
display, by an amount that grew with its x position.

SetCursorPos (and the AmigaGfx SetSpritePos twin) picks the screen under
the cursor with the same topedge + displayheight band test that #981
clamped in the sprite fmode loops, but these two call sites kept the raw
negative topedge. The pointer in the bottom N rows of a screen scrolled
up by N then matched no screen at all and the resolution fell back to
lores, doubling the x scale that setspritepos applies to the same
pointer position - a leap of half its x coordinate, snapping back when
the pointer left the band. The display band of a scrolled screen starts
at the view top, same clamp as #981.

Confirmed by tracing the sprite 0 control words the driver writes: the
fetched hstart ran smoothly, then leapt by ~110 lores pixels the frame
the pointer crossed into the unmatched band. With the clamp, the same
motion traces continuously and the visible jump is gone.
