### PR TITLE
sdio, bwfm: reach the card interrupt and the right firmware on a Pi 4

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
@@ -939,10 +939,17 @@ static int sdio_do_probe(struct SDIOBase *SDIOBase)
      * The sdio_Present guard above ensures this runs only once. */
     if (SDIOBase->sdio_IRQHandle == NULL)
     {
-        SDIOBase->sdio_IRQHandle = KrnAddIRQHandler(IRQ_VC_ARASANSDIO,
+        /* BCM2711 presents the legacy GPU interrupts a fixed distance up
+         * through the GIC: the card lands on INTID 158, not 62. */
+        unsigned int irq = IRQ_VC_ARASANSDIO;
+
+        if (SDIOBase->sdio_periiobase == BCM2711_PERIIOBASE)
+            irq += BCM2711_GPUIRQ_OFFSET;
+
+        SDIOBase->sdio_IRQHandle = KrnAddIRQHandler(irq,
                                                     sdio_irq_handler, SDIOBase, NULL);
         D(bug("[SDIO] card IRQ handler %p on irq %u\n",
-              SDIOBase->sdio_IRQHandle, IRQ_VC_ARASANSDIO));
+              SDIOBase->sdio_IRQHandle, irq));
     }
     return TRUE;
 }
@@ -951,21 +958,21 @@ static int sdio_do_probe(struct SDIOBase *SDIOBase)
 /* Card interrupt (SDIO DAT1) -> consumer task                             */
 
 /*
- * INT_ENABLE value with the card interrupt suppressed. On the BCM2835 Arasan
- * the card interrupt reaches the ARM whenever it is SET in INT_STATUS, which
- * is gated by INT_ENABLE (0x34) - NOT by SIGNAL_ENABLE (0x38). So masking via
- * SIGNAL_ENABLE does nothing (a storm); we mask/arm the card int by toggling
- * it in INT_ENABLE with constant writes (no read-modify-write race with the
- * handler). The other (command/data) bits stay enabled for the polled path.
+ * INT_ENABLE (0x34) decides which conditions show up in INT_STATUS - the
+ * polled command path reads those, so it wants them all. SIGNAL_ENABLE (0x38)
+ * decides which of them drive int_to_arm, and that is what gates the card
+ * interrupt. Enabling everything there storms: the command path leaves
+ * CMD_COMPLETE and DATA_END set until its own wait loop clears them, so the
+ * level-triggered line re-enters the handler without end.
  */
 #define SDIO_INTEN_BASE  (SDHCI_INT_ALL_MASK & ~SDHCI_INT_CARD_INT)
 
 /*
- * Arasan IRQ handler. The only source we arm is the SDIO card interrupt (the
- * chip pulls DAT1 low when SDPCMD_INTSTATUS has an enabled bit). Mask it here
- * (drop CARD_INT from INT_ENABLE) so it cannot re-fire, and signal the bwfm RX
- * pump. The pump clears the chip's SDPCMD_INTSTATUS - which releases DAT1 -
- * drains its frames, then re-arms via SDIOAckInterrupt().
+ * Arasan IRQ handler. The only armed source is the SDIO card interrupt (the
+ * chip pulls DAT1 low when SDPCMD_INTSTATUS has an enabled bit). Clear
+ * SIGNAL_ENABLE so it cannot re-fire while DAT1 is still low, then signal the
+ * bwfm RX pump: it clears SDPCMD_INTSTATUS, releasing DAT1, drains its frames
+ * and re-arms via SDIOAckInterrupt().
  */
 static void sdio_irq_handler(void *data1, void *data2)
 {
@@ -973,7 +980,7 @@ static void sdio_irq_handler(void *data1, void *data2)
 
     if (sdio_rl(SDIOBase, SDHCI_INT_STATUS) & SDHCI_INT_CARD_INT)
     {
-        sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE);
+        sdio_wl(SDIOBase, SDHCI_SIGNAL_ENABLE, 0);
         if (SDIOBase->sdio_IRQTask)
             Signal(SDIOBase->sdio_IRQTask, SDIOBase->sdio_IRQSig);
     }
@@ -1267,8 +1274,9 @@ AROS_LH2(int, SDIOSetInterrupt,
                          SDIO_CCCR_IEN_MASTER | SDIO_CCCR_IEN_FUNC1, NULL);
     ReleaseSemaphore(&SDIOBase->sdio_Sem);
 
-    /* Arm the card interrupt (gated by INT_ENABLE on this controller). */
+    /* Let the card interrupt reach INT_STATUS, and only it drive int_to_arm. */
     sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE | SDHCI_INT_CARD_INT);
+    sdio_wl(SDIOBase, SDHCI_SIGNAL_ENABLE, SDHCI_INT_CARD_INT);
 
     D(bug("[SDIO] card interrupt armed (CCCR err %d)\n", err));
     return err;
@@ -1285,7 +1293,7 @@ AROS_LH0(void, SDIOAckInterrupt,
 {
     AROS_LIBFUNC_INIT
 
-    sdio_wl(SDIOBase, SDHCI_INT_ENABLE, SDIO_INTEN_BASE | SDHCI_INT_CARD_INT);
+    sdio_wl(SDIOBase, SDHCI_SIGNAL_ENABLE, SDHCI_INT_CARD_INT);
 
     AROS_LIBFUNC_EXIT
 }

--- a/workbench/devs/networks/bwfm/bwfm_dev.c
+++ b/workbench/devs/networks/bwfm/bwfm_dev.c
@@ -29,6 +29,7 @@
 #include <proto/dos.h>
 #include <proto/utility.h>
 #include <proto/bwfm.h>
+#include <proto/openfirmware.h>
 
 #include "bwfm.h"
 
@@ -131,8 +132,15 @@ static void str_append(char **p, const char *s)
         *(*p)++ = *s++;
 }
 
-/* Build "DEVS:Firmware/brcmfmac<id>-sdio<ext>" for the detected chip. */
-static int fw_filename(char *out, ULONG chip, const char *ext)
+#define BWFM_FW_BOARD_MAX       48
+
+/*
+ * Build "DEVS:Firmware/brcmfmac<id>-sdio[.<board>]<ext>". The board component
+ * separates machines carrying the same part: a Pi 3B+ and a Pi 4 both answer
+ * as a BCM43455 but need different nvram. Named after the device tree's root
+ * compatible string, as brcmfmac does, so its blobs drop in unrenamed.
+ */
+static int fw_filename(char *out, ULONG chip, const char *board, const char *ext)
 {
     const char *id;
     char *p = out;
@@ -147,9 +155,46 @@ static int fw_filename(char *out, ULONG chip, const char *ext)
     str_append(&p, BWFM_FW_DIR "brcmfmac");
     str_append(&p, id);
     str_append(&p, "-sdio");
+    if (board)
+    {
+        *p++ = '.';
+        str_append(&p, board);
+    }
     str_append(&p, ext);
     *p = '\0';
     return 0;
+}
+
+/*
+ * The most specific entry of the tree's root compatible list, e.g.
+ * "raspberrypi,4-model-b". NULL with no tree, or a name too long to build a
+ * filename from; the caller then falls back to the unsuffixed one.
+ */
+static const char *fw_board_name(void)
+{
+    void *OpenFirmwareBase = OpenResource("openfirmware.resource");
+    void *node, *prop;
+    const char *value;
+    ULONG len, i;
+
+    if (OpenFirmwareBase == NULL)
+        return NULL;
+
+    node = OF_OpenKey("/");
+    prop = node ? OF_FindProperty(node, "compatible") : NULL;
+    value = prop ? OF_GetPropValue(prop) : NULL;
+    if (value == NULL)
+        return NULL;
+
+    /* A compatible list is a run of NUL-terminated strings, most specific
+     * first, so the first one names the board itself. */
+    len = OF_GetPropLen(prop);
+    for (i = 0; i < len && i < BWFM_FW_BOARD_MAX; i++)
+    {
+        if (value[i] == '\0')
+            return value;
+    }
+    return NULL;
 }
 
 /* Read a whole file into a freshly AllocVec'd buffer. */
@@ -542,7 +587,7 @@ static void tx_request(struct bwfm_unit *unit, struct IOSana2Req *req)
 /* One-time chip firmware bring-up. Returns TRUE on success. */
 static int load_firmware(LIBBASETYPEPTR LIBBASE)
 {
-    char name[64];
+    char name[sizeof(BWFM_FW_DIR "brcmfmac00000-sdio.") + BWFM_FW_BOARD_MAX + 16];
     APTR fw = NULL, nvtxt = NULL, nvbin = NULL;
     ULONG fwlen = 0, nvtxtlen = 0, nvbinlen = 0;
     ULONG chip;
@@ -562,7 +607,7 @@ static int load_firmware(LIBBASETYPEPTR LIBBASE)
     }
 
     chip = BWFMChipID();
-    if (chip == 0 || fw_filename(name, chip, ".bin"))
+    if (chip == 0 || fw_filename(name, chip, NULL, ".bin"))
     {
         D(bug("[bwfm.device] no firmware mapping for chip %x\n", chip));
         return FALSE;
@@ -575,11 +620,17 @@ static int load_firmware(LIBBASETYPEPTR LIBBASE)
         goto out;
     }
 
-    if (fw_filename(name, chip, ".txt") == 0)
     {
-        nvtxt = read_file(name, &nvtxtlen);
+        const char *board = fw_board_name();
+
+        if (board && fw_filename(name, chip, board, ".txt") == 0)
+            nvtxt = read_file(name, &nvtxtlen);
+        if (!nvtxt && fw_filename(name, chip, NULL, ".txt") == 0)
+            nvtxt = read_file(name, &nvtxtlen);
         if (nvtxt)
             nvbin = nvram_convert(nvtxt, nvtxtlen, &nvbinlen);
+        D(else bug("[bwfm.device] no nvram for board '%s'\n",
+                   board ? board : "(unknown)"));
     }
 
     D(bug("[bwfm.device] starting firmware (%u bytes, nvram %u bytes)\n",
@@ -603,7 +654,7 @@ static int load_firmware(LIBBASETYPEPTR LIBBASE)
          * the radio has no valid channels and scanning fails (NOTUP). The
          * Pi 3 (43430) firmware has built-in regulatory and ships no blob, so
          * a missing file is not an error. */
-        if (fw_filename(name, chip, ".clm_blob") == 0)
+        if (fw_filename(name, chip, NULL, ".clm_blob") == 0)
         {
             ULONG clmlen = 0;
             APTR clm = read_file(name, &clmlen);


### PR DESCRIPTION
The card interrupt was gated with INT_ENABLE, which only decides what shows up in INT_STATUS - the polled command path needs those bits set. SIGNAL_ENABLE is what drives int_to_arm, and enabling everything there storms, because the command path leaves CMD_COMPLETE and DATA_END asserted until its own wait loop clears them. Only the card interrupt belongs in it. The BCM2711 also presents the line 96 higher through the GIC.

bwfm now looks for nvram named after the device tree's root compatible string, as brcmfmac does. A Pi 3B+ and a Pi 4 both answer as a BCM43455 but need different antenna and regulatory settings, so one file cannot serve both.