### PR TITLE
vc4gfx: survive a failed DMA copy, and guard the NEON copies

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
@@ -242,6 +242,8 @@ AROS_LH2(int, DMAWaitChannel,
     BYTE dsig = -1;
     BYTE tsig = -1;
     int ret = -1;
+    BOOL do_reset = FALSE;
+    const char *reason = NULL;
 
     if ((channel < 0) || (channel > 14) ||
         !(DMABase->dma_InUse & (1 << channel)))
@@ -297,12 +299,14 @@ AROS_LH2(int, DMAWaitChannel,
         }
         if (!(v & DMA_CS_ACTIVE))
         {
-            *cs = AROS_LONG2LE(DMA_CS_RESET);
+            reason = "stopped";
+            do_reset = TRUE;
             break;
         }
         if ((dma_now_us(DMABase) - start) > timeout_us)
         {
-            *cs = AROS_LONG2LE(DMA_CS_RESET);
+            reason = "timeout";
+            do_reset = TRUE;
             break;
         }
 
@@ -335,6 +339,27 @@ AROS_LH2(int, DMAWaitChannel,
             WaitIO((struct IORequest *)&tr);
         }
         /* else: bounded poll until END/timeout */
+    }
+
+    /* Drain the reset: while RESET is asserted the channel ignores CONBLK_AD
+     * writes, so the next transfer would silently run the old control block. */
+    if (do_reset)
+    {
+        int try = 10000;
+
+        /* Before the reset wipes them. DEBUG bit 0 READ_LAST_NOT_SET, 1
+         * FIFO_ERROR, 2 READ_ERROR; CS bit 0 ACTIVE, 1 END, 8 ERROR. */
+        bug("[DMA] channel %d %s after %uus: cs=0x%08x debug=0x%08x\n",
+            channel, reason, timeout_us, AROS_LE2LONG(*cs),
+            AROS_LE2LONG(*(volatile ULONG *)DMA_DEBUG(channel)));
+
+        *cs = AROS_LONG2LE(DMA_CS_RESET);
+        while (try-- > 0)
+        {
+            if (!(AROS_LE2LONG(*cs) & DMA_CS_RESET))
+                break;
+        }
+        *cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
     }
 
     if (dsig >= 0)

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_dma.c
@@ -89,9 +89,26 @@ int FNAME_SUPPORT(InitDMA)(struct VideoCoreGfx_staticdata *xsd)
     return TRUE;
 }
 
+/*
+ * A flat deadline does not work: a full-window scroll moves ~4 MB each way,
+ * which takes on the order of 100 ms once the HVS competes for the SDRAM.
+ * Budget a pessimistic 25 MB/s, capped so a wedged channel is noticed.
+ *
+ * 128-bit SRC_WIDTH/DEST_WIDTH would be several times faster but needs the
+ * row length a multiple of 16; what the engine does with the trailing
+ * partial write otherwise is unverified.
+ */
+static ULONG vc4_dma_timeout_us(ULONG bytes)
+{
+    ULONG us = 50000 + bytes / 25;
+
+    return us > 300000 ? 300000 : us;
+}
+
 /* Kick the prepared CB and wait for completion. Must be called with
  * vcsd_DMALock held. Returns FALSE (after a channel reset) on timeout. */
-static BOOL vc4_dma_run(struct VideoCoreGfx_staticdata *xsd, const char *op)
+static BOOL vc4_dma_run(struct VideoCoreGfx_staticdata *xsd, const char *op,
+                        ULONG bytes)
 {
     volatile ULONG *dma_cs = (volatile ULONG *)DMA_CS(xsd->vcsd_DMAChannel);
     volatile ULONG *dma_cb = (volatile ULONG *)DMA_CONBLK_AD(xsd->vcsd_DMAChannel);
@@ -122,10 +139,19 @@ static BOOL vc4_dma_run(struct VideoCoreGfx_staticdata *xsd, const char *op)
 
     /* IRQ-driven wait via dma.resource (INTEN set in the CBs): sleeps the
      * task, handles the wedge-safe timeout, resets the channel on failure. */
-    if (DMAWaitChannel(xsd->vcsd_DMAChannel, 100000) == 0)
+    if (DMAWaitChannel(xsd->vcsd_DMAChannel, vc4_dma_timeout_us(bytes)) == 0)
         return TRUE;
 
-    bug("[VideoCoreGfx] DMA %s timeout\n", op);
+    /* Unconditional - rare, and the damage is visible. CS/DEBUG come from
+     * dma.resource, which samples them before resetting the channel. */
+    bug("[VideoCoreGfx] DMA %s failed after %uus: "
+        "ti=0x%08x len=0x%08x stride=0x%08x src=0x%08x dst=0x%08x\n",
+        op, (unsigned)vc4_dma_timeout_us(bytes),
+        AROS_LE2LONG(xsd->vcsd_DMACB->ti),
+        AROS_LE2LONG(xsd->vcsd_DMACB->txfr_len),
+        AROS_LE2LONG(xsd->vcsd_DMACB->stride),
+        AROS_LE2LONG(xsd->vcsd_DMACB->source_ad),
+        AROS_LE2LONG(xsd->vcsd_DMACB->dest_ad));
     return FALSE;
 }
 
@@ -177,7 +203,8 @@ BOOL vc4_dma_copy(struct VideoCoreGfx_staticdata *xsd,
     cb->reserved[0] = 0;
     cb->reserved[1] = 0;
 
-    ok = vc4_dma_run(xsd, bottom_up ? "copy^" : "copy");
+    ok = vc4_dma_run(xsd, bottom_up ? "copy^" : "copy",
+                     width_bytes * height);
 
     ReleaseSemaphore(&xsd->vcsd_DMALock);
     return ok;
@@ -232,7 +259,7 @@ BOOL vc4_dma_put(struct VideoCoreGfx_staticdata *xsd,
     cb->reserved[0] = 0;
     cb->reserved[1] = 0;
 
-    ok = vc4_dma_run(xsd, "put");
+    ok = vc4_dma_run(xsd, "put", width_bytes * height);
 
     ReleaseSemaphore(&xsd->vcsd_DMALock);
     return ok;
@@ -291,7 +318,7 @@ BOOL vc4_dma_get(struct VideoCoreGfx_staticdata *xsd,
         cb->reserved[0] = 0;
         cb->reserved[1] = 0;
 
-        ok = vc4_dma_run(xsd, "get");
+        ok = vc4_dma_run(xsd, "get", width_bytes * n);
 
         if (ok)
         {
@@ -351,7 +378,7 @@ BOOL vc4_dma_fill(struct VideoCoreGfx_staticdata *xsd,
     cb->reserved[0] = 0;
     cb->reserved[1] = 0;
 
-    ok = vc4_dma_run(xsd, "fill");
+    ok = vc4_dma_run(xsd, "fill", width_bytes * height);
 
     ReleaseSemaphore(&xsd->vcsd_DMALock);
     return ok;

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
@@ -630,6 +630,16 @@ VOID MNAME_GFX(CopyBox)(OOP_Class *cl, OOP_Object *o, struct pHidd_Gfx_CopyBox *
                          (ULONG)(IPTR)drow_base, dst_pitch,
                          row_bytes, msg->height, (y_step < 0)))
             return;
+
+        /* A failed DMA already overwrote part of the destination. Where the
+         * rectangles alias (a scroll) the clobbered source rows are gone, so
+         * the row loop below would paint garbage over the rows the engine did
+         * get right. Stale pixels repaint on the next damage pass. */
+        if (src_buf == dst_buf && msg->destY != msg->srcY
+            && (ULONG)(msg->destY > msg->srcY ? msg->destY - msg->srcY
+                                              : msg->srcY - msg->destY)
+               < (ULONG)msg->height)
+            return;
     }
 
     for (y = y_start; y != y_end; y += y_step)

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_neon.h
@@ -17,8 +17,19 @@
 
 #define NEON_PREFIX ".fpu neon\n\t"
 
+/* vldm/vstm and the word loops fault on unaligned operands whatever SCTLR.A
+ * says. PutImage/GetImage pass the caller's pixel buffer, so check. */
+#define NEON_UNALIGNED(a, b) ((((IPTR)(a)) | ((IPTR)(b))) & 3)
+
 static inline void neon_copyline(UBYTE *dst, const UBYTE *src, ULONG bytes)
 {
+    if (NEON_UNALIGNED(dst, src))
+    {
+        while (bytes--)
+            *dst++ = *src++;
+        return;
+    }
+
     /* 64-byte bulk copy using NEON: vldm/vstm with 4 q-regs (d0-d7) */
 #if defined(__arm__)
     while (bytes >= 64)
@@ -53,6 +64,15 @@ static inline void neon_copyline_rev(UBYTE *dst, const UBYTE *src, ULONG bytes)
 {
     dst += bytes;
     src += bytes;
+
+    /* Descending, so it is the end addresses that must be aligned. */
+    if (NEON_UNALIGNED(dst, src))
+    {
+        while (bytes--)
+            *--dst = *--src;
+        return;
+    }
+
 #if defined(__arm__)
     while (bytes >= 64)
     {


### PR DESCRIPTION
Scrolling a large window timed out and corrupted the text. The deadline was a flat 100ms, but a full-window scroll moves ~4MB each way and the engine runs 32-bit transfers, which takes about that long once the HVS competes for the SDRAM. It now scales with the transfer size.

The NEON copies check alignment: PutImage and GetImage pass the caller's pixel buffer, and vldm/vstm fault on unaligned operands whatever SCTLR.A says.