### PR TITLE
Include A80000-B7FFFF 1M ROM region if main ROM or ext ROM start..

### DIFF
--- a/arch/m68k-amiga/boot/mmu.c
+++ b/arch/m68k-amiga/boot/mmu.c
@@ -305,6 +305,10 @@ static AROS_UFH3 (APTR, Init,
         /* ROM areas */
         mmuprotect(KernelBase, 0x00e00000, 0x00080000);
         mmuprotect(KernelBase, 0x00f80000, 0x00080000);
+        if (((UWORD*)&_rom_start >= (UWORD*)0xa80000 && (UWORD*)&_rom_start <(UWORD*)0xb80000) ||
+        	((UWORD*)&_ext_start >= (UWORD*)0xa80000 && (UWORD*)&_ext_start < (UWORD*)0xb80000)) {
+	        mmuprotect(KernelBase, 0x00a80000, 0x00100000);
+       	}
 
         mmuprotectextrom(KernelBase);
 

--- a/arch/m68k-amiga/kernel/romsupport.c
+++ b/arch/m68k-amiga/kernel/romsupport.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2019, The AROS Development Team. All rights reserved.
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
 */
 
 #define __KERNEL_NOLIBBASE__
@@ -17,6 +17,10 @@
 #include "kernel_debug.h"
 #include "kernel_intern.h"
 
+extern BYTE _rom_start;
+extern BYTE _rom_end;
+extern BYTE _ext_start;
+extern BYTE _ext_end;
 
 #define ROMSIZE2MB              (1 << 21)
 #define ROMSIZE1MB              (1 << 20)
@@ -64,9 +68,11 @@ static int AMiGAROMSupport_Init(struct KernelBase *KernelBase)
     D(bug("[Kernel:Am68k] %s: platformdata @ 0x%p\n", __func__, pd);)
 
     id = (UBYTE)ReadGayle();
-    if ((id > 0) &&
+    if (((id > 0) &&
         AMiGAROM_IsValid((APTR)0xA80000) &&
-        !AMiGAROM_MatchWords((APTR)0xA80000, (APTR)0xF80000))
+        !AMiGAROM_MatchWords((APTR)0xA80000, (APTR)0xF80000)) ||
+        (((UWORD*)&_rom_start >= (UWORD*)0xA80000 && (UWORD*)&_rom_start <(UWORD*)0xB80000) ||
+        ((UWORD*)&_ext_start >= (UWORD*)0xA80000 && (UWORD*)&_ext_start < (UWORD*)0xB80000)))
     {
         bug("ROMInfo: 2MiB ROM detected\n");
         romsize = ROMSIZE2MB;
@@ -83,7 +89,7 @@ static int AMiGAROMSupport_Init(struct KernelBase *KernelBase)
     {
         bug("ROMInfo: 512KiB ROM detected\n");
         romsize = ROMSIZE512;
-        imgcnt = 2;
+        imgcnt = 1;
     }
 
     if (pd->mmu_type)


### PR DESCRIPTION
Include A80000-B7FFFF 1M ROM region if main ROM or ext ROM start is inside the address space. Second 1M space can exist without Gayle in emulators or if modern CPU expansion is installed. Without this MMU would  map the address space as invalid and would cause immediate hang after MMU enable.
