### PR TITLE
vc4gfx: report free GPU memory

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gfx/vc4gfx_hiddclass.c
@@ -229,7 +229,8 @@ VOID MNAME_ROOT(Get)(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
                 if (matstate)
                 {
                     struct TagItem *matag;
-                    IPTR memsize = (IPTR)(XSD(cl)->vcsd_GPUMemManage.mhe_MemHeader.mh_Upper - XSD(cl)->vcsd_GPUMemManage.mhe_MemHeader.mh_Lower);
+                    struct MemHeaderExt *gpumem = &XSD(cl)->vcsd_GPUMemManage;
+                    IPTR memsize = (IPTR)(gpumem->mhe_MemHeader.mh_Upper - gpumem->mhe_MemHeader.mh_Lower);
                     while ((matag = NextTagItem(&matstate)))
                     {
                         switch(matag->ti_Tag)
@@ -237,6 +238,16 @@ VOID MNAME_ROOT(Get)(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
                         case tHidd_Gfx_MemTotal:
                         case tHidd_Gfx_MemAddressableTotal:
                             matag->ti_Data = memsize;
+                            break;
+
+                        /*
+                         * All of the GPU heap is CPU addressable here, so
+                         * the addressable figures match the plain ones.
+                         */
+                        case tHidd_Gfx_MemFree:
+                        case tHidd_Gfx_MemAddressableFree:
+                            matag->ti_Data = gpumem->mhe_Avail ?
+                                gpumem->mhe_Avail(gpumem, MEMF_ANY) : 0;
                             break;
                         }
                     }


### PR DESCRIPTION
SysMon's free video memory field stayed empty on the Raspberry Pi.

`aoHidd_Gfx_MemoryAttribs` answered the total-size tags (`tHidd_Gfx_MemTotal`, `tHidd_Gfx_MemAddressableTotal`) but left the free ones untouched, so the caller got back the zero it passed in. SysMon queries the totals once at startup and the free figures on every refresh, which is why only that one field was blank.

The GPU heap is a managed `MemHeaderExt` that already maintains `mh_Free` in its alloc/free paths and exposes it through `mhe_Avail`, so the fix just answers the tags from there rather than reading the field directly.

`MemFree` and `MemAddressableFree` get the same value, matching what the existing code already does for the two total tags - the whole GPU heap is CPU addressable on this hardware.

Tested on a Raspberry Pi 3B: the field now tracks the driver's heap usage, and free never exceeds total (`InitMem` starts them equal).