### PR TITLE
test/smp: add SMP stress and regression tests

### DIFF
--- a/developer/debug/test/smp/mmakefile.src
+++ b/developer/debug/test/smp/mmakefile.src
@@ -1,3 +1,30 @@
 #
 #MM- test : test-smp
 #MM- test-quick : test-smp-quick
+#
+#MM- test-smp : test-smp-stress test-smp-trace test-smp-smp test-smp-smp-smallpt test-smp-preempt test-smp-sigrace
+#MM- test-smp-quick : test-smp-stress-quick test-smp-trace-quick test-smp-smp-quick test-smp-smp-smallpt-quick test-smp-preempt-quick test-smp-sigrace-quick
+
+include $(SRCDIR)/config/aros.cfg
+
+EXEDIR := $(AROS_TESTS)/smp
+
+USER_CFLAGS := $(PARANOIA_CFLAGS)
+
+%build_prog mmake=test-smp-stress \
+    files=smpstress targetdir=$(EXEDIR) \
+    progname=SMP-Stress
+
+%build_prog mmake=test-smp-trace \
+    files=smptrace targetdir=$(EXEDIR) \
+    progname=SMP-Trace
+
+%build_prog mmake=test-smp-preempt \
+    files=smppreempt targetdir=$(EXEDIR) \
+    progname=SMP-Preempt
+
+%build_prog mmake=test-smp-sigrace \
+    files=smpsigrace targetdir=$(EXEDIR) \
+    progname=SMP-SigRace
+
+%common

--- a/developer/debug/test/smp/smp-smallpt/main.c
+++ b/developer/debug/test/smp/smp-smallpt/main.c
@@ -182,7 +182,7 @@ int main()
 
         if (max_cpus > 0 && coreCount > max_cpus)
             coreCount = max_cpus;
-        
+
         if (max_iter == 0)
             max_iter = 16;
 
@@ -267,7 +267,7 @@ int main()
         cmd.mm_Body.Startup.explicitMode = explicit_mode;
 
         D(bug("[SMP-Smallpt] %s: renderer alive. sending startup message\n", __func__);)
-        
+
         PutMsg(rendererPort, &cmd.mm_Message);
         WaitPort(mainPort);
         GetMsg(mainPort);
@@ -343,12 +343,12 @@ int main()
                                             displayWin->BorderLeft + msg->mm_Body.RedrawTile.TileX * TILE_SIZE, displayWin->BorderTop + msg->mm_Body.RedrawTile.TileY * TILE_SIZE,
                                             TILE_SIZE, TILE_SIZE, 0xC0);
                                 break;
-                            
+
                             case MSG_STATS:
                                 tasksWork = msg->mm_Body.Stats.tasksWork;
                                 tasksIn = msg->mm_Body.Stats.tasksIn;
                                 tasksOut = msg->mm_Body.Stats.tasksOut;
-                                
+
                                 GetSysTime(&now);
                                 SubTime(&now, &start_time);
                                 NewRawDoFmt("SMP-Smallpt renderer (%d in work, %d waiting, %d done): %d:%02d:%02d", RAWFMTFUNC_STRING,
@@ -394,8 +394,16 @@ int main()
             WaitPort(mainPort);
             struct MyMessage *msg;
             while ((msg = (struct MyMessage *)GetMsg(mainPort)))
+            {
                 if (msg->mm_Type == MSG_DIE)
+                {
                     can_quit = 1;
+                }
+                else if (msg->mm_Message.mn_Length == sizeof(struct MyMessage))
+                {
+                    ReplyMsg(&msg->mm_Message);
+                }
+            }
         } while(!can_quit);
 
         DeleteMsgPort(mainPort);

--- a/developer/debug/test/smp/smp-smallpt/renderer.c
+++ b/developer/debug/test/smp/smp-smallpt/renderer.c
@@ -16,6 +16,7 @@
 
 extern void render_tile(int w, int h, int samps, int tile_x, int tile_y, ULONG *buffer, struct Task *gfx);
 extern void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort, struct MsgPort **myPort);
+extern void ConfigureSmallPTScene(int explicit_mode);
 
 struct Worker {
     struct Task *   task;
@@ -61,7 +62,7 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
     D(bug("[SMP-Smallpt-Renderer] Renderer started, ParentMailBox = %p\n", ParentMailbox));
 
     port = CreateMsgPort();
-    
+
     if (port)
     {
         struct Message startup;
@@ -79,14 +80,14 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
         /* Prepare initial message and wait for startup msg */
         startup.mn_Length = sizeof(startup);
         startup.mn_ReplyPort = port;
- 
+
         D(bug("[SMP-Smallpt-Renderer] Sending welcome msg to parent\n"));
         PutMsg(ParentMailbox, &startup);
 
         while(width == 0)
         {
             struct MyMessage *msg;
-            
+
             WaitPort(port);
 
             while ((msg = (struct MyMessage *)GetMsg(port)))
@@ -141,6 +142,8 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
 
         D(bug("[SMP-Smallpt-Renderer] worker stack size : %d bytes\n", workerStack));
 
+        ConfigureSmallPTScene(expl_mode);
+
         for (ULONG i=0; i < numberOfCores; i++)
         {
             void *coreAffinity = KrnAllocCPUMask();
@@ -158,6 +161,12 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
                                     TASKTAG_ARG3,           &workers[i].port,
                                     TASKTAG_STACKSIZE,      workerStack,
                                     TAG_DONE);
+        }
+
+        for (ULONG i=0; i < numberOfCores; i++)
+        {
+            while (workers[i].port == NULL)
+                Wait(1 << port->mp_SigBit);
         }
         cores_alive = numberOfCores;
 
@@ -210,7 +219,7 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
                         struct MsgPort *workerPort = msg->mm_Message.mn_ReplyPort;
                         ReplyMsg(&msg->mm_Message);
 
-                        if (!IsMinListEmpty(&workList))
+                        if (!deathMessage && !IsMinListEmpty(&workList))
                         {
                             struct MyMessage *m = AllocMyMessage(&msgPool);
 
@@ -238,9 +247,12 @@ void Renderer(struct ExecBase *ExecBase, struct MsgPort *ParentMailbox)
                     {
                         struct tileWork *work = msg->mm_Body.RenderTile.tile;
                         ReplyMsg(&msg->mm_Message);
-                        ADDHEAD(&doneList, work);
-                        tasks_out++;
-                        tasks_work--;
+                        if (work)
+                        {
+                            ADDHEAD(&doneList, work);
+                            tasks_out++;
+                            tasks_work--;
+                        }
                     }
                     if (deathMessage == NULL)
                     {

--- a/developer/debug/test/smp/smp-smallpt/smallpt.cc
+++ b/developer/debug/test/smp/smp-smallpt/smallpt.cc
@@ -78,6 +78,21 @@ Sphere spheres[] = {//Scene: radius, position, emission, color, material
 
 const int numSpheres = sizeof(spheres)/sizeof(Sphere);
 
+/*
+ * Explicit light sampling wants a small bright light where the naive
+ * integrator wants a large dim one, so spheres[0] differs between the two.
+ * Every worker used to rewrite it on each tile, which races once the
+ * workers really run at the same time on different cores - the renderer
+ * calls this once instead, before any worker exists.
+ */
+extern "C" void ConfigureSmallPTScene(int explicit_mode)
+{
+    if (explicit_mode)
+        spheres[0] = Sphere(5, Vec(50,81.6-16.5,81.6),Vec(4,4,4)*20,  Vec(), DIFF);
+    else
+        spheres[0] = Sphere(600, Vec(50,681.6-.27,81.6),Vec(12,12,12),  Vec(), DIFF);
+}
+
 inline double clamp(double x)
 {
     return x<0 ? 0 : x>1 ? 1 : x;
@@ -308,6 +323,7 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
     struct MsgPort *syncPort = CreateMsgPort();
     struct MinList msgPool;
     struct Task *me = FindTask(NULL);
+    int pendingMsgs = 0;
 
     c = (Vec *)AllocMem(sizeof(Vec) * TILE_SIZE * TILE_SIZE, MEMF_ANY | MEMF_CLEAR);
 
@@ -330,7 +346,7 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
         ULONG signals;
         BOOL doWork = TRUE;
         BOOL redraw = TRUE;
-        
+
         m = AllocMsg(&msgPool);
         if (m)
         {
@@ -338,6 +354,7 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
             m->mm_Message.mn_ReplyPort = port;
             m->mm_Type = MSG_HUNGRY;
             PutMsg(masterPort, &m->mm_Message);
+            pendingMsgs++;
         }
         
         D(bug("[SMP-SmallPT-Task] Just told renderer I'm hungry\n"));
@@ -356,7 +373,10 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
                 {
                     if (m->mm_Message.mn_Node.ln_Type == NT_REPLYMSG)
                     {
+                        if (pendingMsgs > 0)
+                            pendingMsgs--;
                         FreeMsg(&msgPool, m);
+                        redraw = TRUE;
                         continue;
                     }
                     else
@@ -377,11 +397,6 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
                             int tile_y = m->mm_Body.RenderTile.tile->y;
                             struct MsgPort *guiPort = m->mm_Body.RenderTile.guiPort;
                             int explicit_mode = m->mm_Body.RenderTile.explicitMode;
-
-                            if (explicit_mode)
-                                spheres[0] = Sphere(5, Vec(50,81.6-16.5,81.6),Vec(4,4,4)*20,  Vec(), DIFF);
-                            else
-                                spheres[0] = Sphere(600, Vec(50,681.6-.27,81.6),Vec(12,12,12),  Vec(), DIFF);
 
                             ReplyMsg(&m->mm_Message);
 
@@ -464,6 +479,7 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
                                 m->mm_Body.RedrawTile.TileX = tile_x;
                                 m->mm_Body.RedrawTile.TileY = tile_y;
                                 PutMsg(guiPort, &m->mm_Message);
+                                pendingMsgs++;
                                 
                                 redraw = TRUE;
                             }
@@ -475,6 +491,7 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
                                 m->mm_Type = MSG_RENDERREADY;
                                 m->mm_Body.RenderTile.tile = tile;
                                 PutMsg(masterPort, &m->mm_Message);
+                                pendingMsgs++;
                             }
 
                             m = AllocMsg(&msgPool);
@@ -483,17 +500,32 @@ extern "C" void RenderTile(struct ExecBase *SysBase, struct MsgPort *masterPort,
                                 m->mm_Message.mn_ReplyPort = port;
                                 m->mm_Type = MSG_HUNGRY;
                                 PutMsg(masterPort, &m->mm_Message);
+                                pendingMsgs++;
                             }
                         }
                     }
                 }
             }
 
-            if (signals & SIGBREAKB_CTRL_C)
+            if (signals & SIGBREAKF_CTRL_C)
                 doWork = FALSE;
 
         } while(doWork);
+
+        while (pendingMsgs > 0)
+        {
+            WaitPort(port);
+            while ((m = (struct MyMessage *)GetMsg(port)))
+            {
+                if (m->mm_Message.mn_Node.ln_Type == NT_REPLYMSG)
+                {
+                    pendingMsgs--;
+                    FreeMsg(&msgPool, m);
+                }
+            }
+        }
     }
+
     D(bug("[SMP-SmallPT-Task] cleaning up stuff\n"));
     FreeMem(msg, sizeof(struct MyMessage) * 20);
     DeleteMsgPort(port);

--- a/developer/debug/test/smp/smp-test/master.c
+++ b/developer/debug/test/smp/smp-test/master.c
@@ -54,7 +54,7 @@ void SMPTestMaster(struct ExecBase *SysBase)
                 workMsg->smpwm_End = workMsg->smpwm_Start + msgWork - 1;
                 if  ((((workMaster->smpm_Width * workMaster->smpm_Height)/ msgWork) <= (msgNo + 1)) &&
                       (workMsg->smpwm_End < (workMaster->smpm_Width * workMaster->smpm_Height)))
-                    workMsg->smpwm_End = workMaster->smpm_Width * workMaster->smpm_Height;
+                    workMsg->smpwm_End = workMaster->smpm_Width * workMaster->smpm_Height - 1;
 
                 /* send out the work to an available worker... */
                 do {

--- a/developer/debug/test/smp/smp-test/smpt_main.c
+++ b/developer/debug/test/smp/smp-test/smpt_main.c
@@ -138,7 +138,7 @@ int main()
         if (oversample)
             workMaster.smpm_Oversample = oversample;
 
-        KrnSpinInit(&workMaster.smpm_Lock);
+        InitSemaphore(&workMaster.smpm_Lock);
 
         for (core = 0; core < max_cpus; core++)
         {
@@ -186,7 +186,9 @@ int main()
                         {
                             workMaster.smpm_WorkerCount++;
                             Wait(SIGBREAKF_CTRL_C);
+                            ObtainSemaphore(&workMaster.smpm_Lock);
                             AddTail(&workMaster.smpm_Workers, &coreWorker->smpw_Node);
+                            ReleaseSemaphore(&workMaster.smpm_Lock);
                             AddHead(&coreWorker->smpw_Task->tc_MemEntry, &coreML->ml_Node);
                         }
                     }
@@ -207,15 +209,18 @@ int main()
 
         do {
             complete = TRUE;
+            ObtainSemaphoreShared(&workMaster.smpm_Lock);
             ForeachNode(&workMaster.smpm_Workers, coreWorker)
             {
                 if (coreWorker->smpw_Node.ln_Type != 1)
                 {
                     complete = FALSE;
-                    Reschedule();
                     break;
                 }
             }
+            ReleaseSemaphore(&workMaster.smpm_Lock);
+            if (!complete)
+                Reschedule();
         } while (!complete);
 
         /*
@@ -302,11 +307,13 @@ int main()
                         complete = FALSE;
 
                     /* Are workers still working ? */
+                    ObtainSemaphoreShared(&workMaster.smpm_Lock);
                     ForeachNode(&workMaster.smpm_Workers, coreWorker)
                     {
                         if (!IsListEmpty(&coreWorker->smpw_MsgPort->mp_MsgList))
                             complete = FALSE;
                     }
+                    ReleaseSemaphore(&workMaster.smpm_Lock);
 
                     D(bug("[SMP-Test] %s: Updating work output ...\n", __func__);)
                     WritePixelArray(workMaster.smpm_WorkBuffer,
@@ -360,6 +367,7 @@ int main()
 
             D(bug("[SMP-Test] %s: Letting workers know we are finished ...\n", __func__);)
 
+            ObtainSemaphoreShared(&workMaster.smpm_Lock);
             ForeachNode(&workMaster.smpm_Workers, coreWorker)
             {
                 /* Tell the workers they are finished ... */
@@ -369,7 +377,8 @@ int main()
                     PutMsg(coreWorker->smpw_MsgPort, (struct Message *)workMsg);
                 }
             }
-            FreeMem(workMaster.smpm_WorkBuffer, workMaster.smpm_Width * workMaster.smpm_Height * sizeof(ULONG));
+            ReleaseSemaphore(&workMaster.smpm_Lock);
+
             CloseWindow(displayWin);
             outBMRastPort->BitMap = NULL;
             FreeRastPort(outBMRastPort);
@@ -385,9 +394,22 @@ int main()
     {
         while ((signals = Wait(SIGBREAKF_CTRL_C)) != 0)
         {
-            if ((signals & SIGBREAKF_CTRL_C) && IsListEmpty(&workMaster.smpm_Workers))
-                break;
+            if (signals & SIGBREAKF_CTRL_C)
+            {
+                BOOL workers_left;
+
+                ObtainSemaphoreShared(&workMaster.smpm_Lock);
+                workers_left = !IsListEmpty(&workMaster.smpm_Workers);
+                ReleaseSemaphore(&workMaster.smpm_Lock);
+
+                if (!workers_left)
+                    break;
+            }
         }
+
+        if (workMaster.smpm_WorkBuffer)
+            FreeMem(workMaster.smpm_WorkBuffer, workMaster.smpm_Width * workMaster.smpm_Height * sizeof(ULONG));
+
         DeleteMsgPort(workMaster.smpm_MasterPort);
     }
 

--- a/developer/debug/test/smp/smp-test/work.h
+++ b/developer/debug/test/smp/smp-test/work.h
@@ -2,7 +2,7 @@
     Copyright (C) 2017, The AROS Development Team. All rights reserved.
 */
 
-#include <aros/types/spinlock_s.h>
+#include <exec/semaphores.h>
 #include <exec/tasks.h>
 #include <exec/ports.h>
 
@@ -15,7 +15,7 @@ struct SMPMaster
     ULONG                       *smpm_WorkBuffer;
     UWORD                       smpm_Width;
     UWORD                       smpm_Height;    
-    spinlock_t                  smpm_Lock;
+    struct SignalSemaphore      smpm_Lock;
     ULONG                       smpm_MaxWork;
     ULONG                       smpm_Oversample;
     BOOL                        smpm_Buddha;
@@ -28,7 +28,7 @@ struct SMPWorker
     struct MsgPort              *smpw_MasterPort;
     struct MsgPort              *smpw_MsgPort;
     struct Task                 *smpw_SyncTask;
-    spinlock_t                  *smpw_Lock;
+    struct SignalSemaphore      *smpw_Lock;
     ULONG                       smpw_MaxWork;
     ULONG                       smpw_Oversample;
 };
@@ -42,7 +42,7 @@ struct SMPWorkMessage
     ULONG                       smpwm_Height;
     ULONG                       smpwm_Start;
     ULONG                       smpwm_End;
-    spinlock_t                  *smpwm_Lock;
+    struct SignalSemaphore      *smpwm_Lock;
 };
 
 #define SPMWORKTYPE_FINISHED    (1 << 0)

--- a/developer/debug/test/smp/smp-test/worker.c
+++ b/developer/debug/test/smp/smp-test/worker.c
@@ -30,7 +30,7 @@ struct WorkersWork
     ULONG         workMax;
     ULONG         workOversamp;
     ULONG         workOver2;
-    spinlock_t      *lock;
+    struct SignalSemaphore *lock;
     complexno_t workTrajectories[];
 };
 
@@ -105,7 +105,7 @@ void processWork(struct WorkersWork *workload, ULONG *workBuffer, ULONG workWidt
             {
                 ULONG pos;
                 int i;
-                KrnSpinLock(workload->lock, NULL, SPINLOCK_MODE_WRITE);
+                ObtainSemaphore(workload->lock);
                 for(i = 0; i < trajectoryLength; i++)
                 {
                     IPTR px = (workload->workTrajectories[i].r + 2.0) / diff_sr;
@@ -127,7 +127,7 @@ void processWork(struct WorkersWork *workload, ULONG *workBuffer, ULONG workWidt
 
                         }
                         }
-                KrnSpinUnLock(workload->lock);
+                ReleaseSemaphore(workload->lock);
             }
         }
         else
@@ -238,7 +238,9 @@ void SMPTestWorker(struct ExecBase *SysBase)
             }
             FreeMem(workPrivate, sizeof(struct WorkersWork) + (workPrivate->workMax * sizeof(complexno_t)));
         }
+        ObtainSemaphore(worker->smpw_Lock);
         Remove(&worker->smpw_Node);
+        ReleaseSemaphore(worker->smpw_Lock);
         DeleteMsgPort(worker->smpw_MsgPort);
         Signal(worker->smpw_MasterPort->mp_SigTask, SIGBREAKF_CTRL_C);
     }

--- a/developer/debug/test/smp/smppreempt.c
+++ b/developer/debug/test/smp/smppreempt.c
@@ -1,0 +1,210 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP per-core preemption (time-slicing) verification.
+
+          Pins TWO equal-priority, purely CPU-bound tasks to the SAME
+          secondary CPU and lets them run for a fixed wall-clock window.
+          Each worker does nothing but increment its own counter in a
+          tight loop - it never calls Delay/Wait/Forbid, so the ONLY way
+          the second task can ever run is if the kernel PREEMPTS the first
+          (quantum expiry driven by that core's scheduler heartbeat).
+
+          Without a per-core timer the first worker monopolises the core
+          and the second never gets scheduled: its w_Cpu stays at the
+          NO_CPU sentinel and its counter stays 0 -> FAIL. With a working
+          per-core heartbeat both workers are time-sliced: both counters
+          are large and roughly balanced -> PASS.
+
+          The test is run once per CPU (0 .. ncpus-1), including the boot
+          CPU: on this port every core expires its quantum from its own
+          per-core heartbeat.
+*/
+
+#include <exec/memory.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+
+#define STACKSIZE   16384
+#define RUN_TICKS   100             /* busy window per core (~2s at 50Hz) */
+#define NO_CPU      (~0UL)          /* w_Cpu sentinel: "never scheduled" */
+
+struct Worker
+{
+    volatile ULONG  w_Counter;      /* iterations completed in the window */
+    volatile ULONG  w_Cpu;          /* CPU it first ran on, NO_CPU if never */
+    volatile ULONG  w_Done;
+    volatile ULONG *w_Stop;         /* shared stop flag */
+    cpumask_t      *w_Affinity;
+};
+
+static volatile ULONG g_Stop;
+
+/* Pure busy loop. Records which CPU it landed on (proof it was scheduled),
+ * then spins until told to stop. No yielding calls - the other worker only
+ * advances if this one is preempted. */
+static void BusyWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct Worker *w = (struct Worker *)me->tc_UserData;
+
+    w->w_Cpu = (ULONG)KrnGetCPUNumber();
+    __sync_synchronize();
+
+    while (!*(w->w_Stop))
+        w->w_Counter++;
+
+    w->w_Done = 1;
+    __sync_synchronize();
+    Wait(0);
+}
+
+/* Returns: 1 = PASS, 0 = FAIL, -1 = INVALID (affinity not honoured) */
+static int run_one(int cpu)
+{
+    struct Worker w[2];
+    struct Task  *t[2] = { NULL, NULL };
+    char          names[2][32];
+    ULONG         a, b, ca, cb, lo, hi;
+    int           i;
+
+    g_Stop = 0;
+
+    for (i = 0; i < 2; i++)
+    {
+        memset(&w[i], 0, sizeof(w[i]));
+        w[i].w_Cpu  = NO_CPU;
+        w[i].w_Stop = &g_Stop;
+        w[i].w_Affinity = KrnAllocCPUMask();
+        if (w[i].w_Affinity)
+        {
+            KrnClearCPUMask(w[i].w_Affinity);
+            KrnGetCPUMask(cpu, w[i].w_Affinity);
+        }
+        snprintf(names[i], sizeof(names[i]), "preempt.cpu%d.%c", cpu, 'A' + i);
+        t[i] = NewCreateTask(TASKTAG_NAME,      (IPTR)names[i],
+                             TASKTAG_PRI,       0,
+                             TASKTAG_PC,        (IPTR)BusyWorker,
+                             TASKTAG_STACKSIZE, STACKSIZE,
+                             TASKTAG_USERDATA,  (IPTR)&w[i],
+                             TASKTAG_AFFINITY,  (IPTR)w[i].w_Affinity,
+                             TAG_DONE);
+        if (t[i] == NULL)
+        {
+            bug("[smppreempt] FAIL: could not create %s\n", (IPTR)names[i]);
+            if (t[0])
+            {
+                int j;
+
+                /* Stop and reap worker A before returning - it busy-loops
+                 * on w[0]/g_Stop in THIS stack frame and would keep
+                 * writing to a dead frame after run_one returns. */
+                g_Stop = 1;
+                __sync_synchronize();
+                for (j = 0; j < 200 && !w[0].w_Done; j++)
+                    Delay(1);
+                Forbid();
+                RemTask(t[0]);
+                Permit();
+            }
+            return -1;
+        }
+    }
+
+    /* Both workers busy-loop on `cpu` while we sleep. */
+    Delay(RUN_TICKS);
+
+    /* Snapshot progress BEFORE stopping: in the broken case the starved
+     * worker only gets to run once the other exits, which would set its
+     * w_Cpu after the fact and hide the starvation. */
+    __sync_synchronize();
+    a  = w[0].w_Counter; b  = w[1].w_Counter;
+    ca = w[0].w_Cpu;     cb = w[1].w_Cpu;
+
+    /* Stop and let both quiesce into Wait(0) before removing them. */
+    g_Stop = 1;
+    __sync_synchronize();
+    for (i = 0; i < 200 && (!w[0].w_Done || !w[1].w_Done); i++)
+        Delay(1);
+
+    Forbid();
+    for (i = 0; i < 2; i++)
+        if (t[i]) RemTask(t[i]);
+    Permit();
+
+    bug("[smppreempt] CPU #%02d: A cpu=%ld iters=%lu | B cpu=%ld iters=%lu\n",
+        cpu, (LONG)ca, a, (LONG)cb, b);
+
+    if (ca == NO_CPU || cb == NO_CPU)
+    {
+        bug("[smppreempt] CPU #%02d: *** FAIL *** a worker was never scheduled "
+            "(no per-core preemption - starved)\n", cpu);
+        return 0;
+    }
+    if (ca != (ULONG)cpu || cb != (ULONG)cpu)
+    {
+        bug("[smppreempt] CPU #%02d: INVALID - affinity not honoured "
+            "(ran on %ld/%ld)\n", cpu, (LONG)ca, (LONG)cb);
+        return -1;
+    }
+    if (a == 0 || b == 0)
+    {
+        bug("[smppreempt] CPU #%02d: *** FAIL *** a worker made no progress\n", cpu);
+        return 0;
+    }
+
+    lo = (a < b) ? a : b;
+    hi = (a > b) ? a : b;
+    if (hi / lo > 3)
+        bug("[smppreempt] CPU #%02d: PASS (imbalanced ~%lu:1, but both time-sliced)\n",
+            cpu, hi / lo);
+    else
+        bug("[smppreempt] CPU #%02d: PASS - both tasks time-sliced (ratio ~%lu:1)\n",
+            cpu, hi / lo);
+    return 1;
+}
+
+int main(void)
+{
+    int ncpus, cpu;
+    int pass = 0, fail = 0, inval = 0;
+
+    KernelBase = OpenResource("kernel.resource");
+    ncpus = KernelBase ? KrnGetCPUCount() : 1;
+
+    bug("[smppreempt] start: cpus=%ld, window=%ld ticks/core\n",
+        (LONG)ncpus, (LONG)RUN_TICKS);
+
+    if (ncpus < 2)
+    {
+        bug("[smppreempt] only %ld CPU online - per-core preemption needs SMP; SKIP\n",
+            (LONG)ncpus);
+        return RETURN_WARN;
+    }
+
+    for (cpu = 0; cpu < ncpus; cpu++)
+    {
+        int r = run_one(cpu);
+        if (r > 0)      pass++;
+        else if (r == 0) fail++;
+        else            inval++;
+    }
+
+    bug("[smppreempt] DONE: %ld PASS, %ld FAIL, %ld INVALID (of %ld CPUs)\n",
+        (LONG)pass, (LONG)fail, (LONG)inval, (LONG)ncpus);
+
+    return fail ? RETURN_FAIL : RETURN_OK;
+}

--- a/developer/debug/test/smp/smpsigrace.c
+++ b/developer/debug/test/smp/smpsigrace.c
@@ -1,0 +1,457 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: Cross-CPU Signal() vs RemTask() lifetime race check.
+
+          The cross-CPU Signal() path queues an IPI entry carrying a raw
+          Task pointer on the target CPU. If the task is torn down and its
+          memory freed before that CPU drains its queue, signal_hook spins
+          on a freed (mungwall-poisoned) tc_SpinLock inside the FIQ handler
+          and the CPU wedges. This test makes that window deterministic:
+
+          Phase 0: functional check - a cross-CPU Signal() must still wake
+          a waiting task (guards against lost wakeups in the fixed path).
+
+          Phase 1: a "blocker" task holds Disable() on the target CPU (FIQ
+          masked, so the IPI queue cannot drain) while the main task sends
+          a Signal() to a task parked there and immediately RemTask()s it,
+          freeing its memory. On a kernel without IPI cancellation the
+          stale entry is then guaranteed to be drained AFTER the free: the
+          blocker's Enable() delivers the pending FIQ straight into the
+          use-after-free and never returns (run with mungwall to make the
+          freed lock word poisoned). On a fixed kernel RemTask() sweeps
+          the entry and the blocker finishes - its completion is the
+          pass/fail signal.
+
+          Phase 3: pool-exhaustion deadlock check. The per-CPU IPI entry
+          pools are finite; a sender whose target pool is empty spins for
+          a free entry, and under Disable() its own CPU cannot drain its
+          inbound queue (FIQ masked). Two Disable()-d CPUs storming more
+          signals than the pool size at tasks on each other's CPU
+          therefore deadlocked - each waited for a drain only the other
+          could trigger. The kernel now drains its own inbound queue
+          inline while spinning Disabled; without that both storm workers
+          hang forever with interrupts masked.
+
+          Phase 2: best-effort storm against the suicide teardown path -
+          signals are fired at a worker that exits (by itself) right
+          afterwards, then a canary confirms the target CPU still
+          schedules. All signals are sent before the worker is released to
+          exit, so the test never violates the "task pointer valid during
+          the Signal() call" contract - it only exercises the queue
+          extending the pointer's life beyond the call.
+*/
+
+#include <exec/memory.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+
+#define STACKSIZE       16384
+#define DISABLE_SPIN    2000000     /* blocker's Disable() window */
+#define BUSY_TIMEOUT    400000000   /* bound for busy flag waits */
+#define WAIT_TICKS      250         /* 5s bound for Delay-based waits */
+#define PHASE1_ITERS    8           /* per secondary CPU */
+#define PHASE2_ITERS    128
+#define PHASE2_SIGNALS  32
+#define PHASE3_SIGNALS  200         /* > the per-CPU IPI pool (128) */
+
+struct SigWorker
+{
+    volatile ULONG  w_Started;
+    volatile ULONG  w_InDisable;
+    volatile ULONG  w_Go;
+    volatile ULONG  w_Dying;
+    volatile ULONG  w_Done;
+    volatile ULONG  w_Spin;
+    struct Task * volatile w_Target;
+};
+
+static volatile ULONG g3_Go;
+
+static struct SigWorker *myworker(void)
+{
+    return (struct SigWorker *)FindTask(NULL)->tc_UserData;
+}
+
+/* Phase 0: prove a cross-CPU Signal() still wakes a waiter. */
+static void WakeWorker(void)
+{
+    struct SigWorker *w = myworker();
+
+    w->w_Started = 1;
+    Wait(SIGBREAKF_CTRL_C);
+    w->w_Done = 1;
+    Wait(0);
+}
+
+/* Phase 1 victim: park forever; only ever woken by RemTask(). */
+static void ParkWorker(void)
+{
+    struct SigWorker *w = myworker();
+
+    w->w_Started = 1;
+    Wait(0);
+}
+
+/* Phase 1 blocker: hold Disable() (FIQ masked -> IPI queue frozen) long
+ * enough for the main task to Signal()+RemTask() the parked victim. The
+ * Enable() then delivers the pending Signal-IPI: on a broken kernel
+ * signal_hook spins on the freed task's lock and w_Done is never set. */
+static void BlockerWorker(void)
+{
+    struct SigWorker *w = myworker();
+    ULONG n;
+
+    Disable();
+    w->w_InDisable = 1;
+    __sync_synchronize();
+    for (n = 0; n < DISABLE_SPIN; n++)
+        w->w_Spin++;
+    Enable();
+
+    w->w_Done = 1;
+}
+
+/* Phase 2 victim: spin until released, then exit (suicide RemTask path). */
+static void ExitWorker(void)
+{
+    struct SigWorker *w = myworker();
+
+    w->w_Started = 1;
+    while (!w->w_Go)
+        w->w_Spin++;
+    w->w_Dying = 1;
+}
+
+/* Phase 3: storm more cross-CPU signals than the IPI pool holds, under
+ * Disable() so this CPU's own inbound queue cannot drain via FIQ. Two of
+ * these on different CPUs, targeting tasks on each other's CPU, exhaust
+ * both pools simultaneously. */
+static void StormWorker(void)
+{
+    struct SigWorker *w = myworker();
+    int k;
+
+    w->w_Started = 1;
+    while (!g3_Go)
+        w->w_Spin++;
+
+    Disable();
+    for (k = 0; k < PHASE3_SIGNALS; k++)
+        Signal(w->w_Target, SIGBREAKF_CTRL_C);
+    Enable();
+
+    w->w_Done = 1;
+}
+
+/* Phase 2 canary: proves its CPU still schedules tasks. */
+static void CanaryWorker(void)
+{
+    struct SigWorker *w = myworker();
+
+    w->w_Done = 1;
+}
+
+static struct Task *spawn(const char *name, APTR pc, LONG pri, int cpu,
+                          struct SigWorker *w)
+{
+    cpumask_t *mask = KrnAllocCPUMask();
+
+    if (mask == NULL)
+        return NULL;
+    KrnClearCPUMask(mask);
+    KrnGetCPUMask(cpu, mask);
+
+    /* The mask becomes iet_CpuAffinity and is freed by exec at teardown. */
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       pri,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TASKTAG_AFFINITY,  (IPTR)mask,
+                         TAG_DONE);
+}
+
+static int wait_flag(volatile ULONG *flag, int ticks)
+{
+    int i;
+
+    for (i = 0; i < ticks && !*flag; i++)
+        Delay(1);
+    return *flag != 0;
+}
+
+/* No Delay() here: the gap between seeing the flag and acting must stay
+ * well inside the blocker's Disable() window. */
+static int busy_wait_flag(volatile ULONG *flag)
+{
+    ULONG i;
+
+    for (i = 0; i < BUSY_TIMEOUT && !*flag; i++)
+        ;
+    return *flag != 0;
+}
+
+static int phase0_one(int cpu)
+{
+    struct SigWorker wake;
+    struct Task *t;
+    static char name[32];
+
+    memset(&wake, 0, sizeof(wake));
+    snprintf(name, sizeof(name), "sigrace.wake.%d", cpu);
+
+    t = spawn(name, WakeWorker, 0, cpu, &wake);
+    if (t == NULL || !wait_flag(&wake.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d: INVALID - wake worker did not start\n", cpu);
+        return -1;
+    }
+    Delay(1);   /* let it reach Wait() */
+
+    Signal(t, SIGBREAKF_CTRL_C);
+
+    if (!wait_flag(&wake.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d: *** FAIL *** cross-CPU Signal() lost - "
+            "waiter never woke\n", cpu);
+        return 0;
+    }
+    RemTask(t);
+    return 1;
+}
+
+static int phase1_one(int cpu, int iter)
+{
+    struct SigWorker park, blk;
+    struct Task *tpark, *tblk;
+    static char pname[32], bname[32];
+
+    memset(&park, 0, sizeof(park));
+    memset(&blk, 0, sizeof(blk));
+    snprintf(pname, sizeof(pname), "sigrace.park.%d.%d", cpu, iter);
+    snprintf(bname, sizeof(bname), "sigrace.blk.%d.%d", cpu, iter);
+
+    tpark = spawn(pname, ParkWorker, 0, cpu, &park);
+    if (tpark == NULL || !wait_flag(&park.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d: INVALID - park worker did not start\n", cpu);
+        return -1;
+    }
+    Delay(1);   /* let it reach Wait(0) */
+
+    tblk = spawn(bname, BlockerWorker, 5, cpu, &blk);
+    if (tblk == NULL)
+    {
+        RemTask(tpark);
+        return -1;
+    }
+
+    if (!busy_wait_flag(&blk.w_InDisable))
+    {
+        bug("[smpsigrace] CPU #%02d: INVALID - blocker never entered Disable()\n", cpu);
+        RemTask(tpark);
+        return -1;
+    }
+
+    /*
+     * The target CPU's FIQ is masked: this entry stays queued there...
+     */
+    Signal(tpark, SIGBREAKF_CTRL_C);
+    /*
+     * ...and this frees the task's memory. Without cancellation the queue
+     * now holds a dangling Task pointer that WILL be drained on Enable().
+     */
+    RemTask(tpark);
+
+    if (!wait_flag(&blk.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d iter %d: *** FAIL *** blocker never returned - "
+            "CPU wedged draining a stale Signal-IPI after the task was freed\n",
+            cpu, iter);
+        return 0;
+    }
+    return 1;
+}
+
+static int phase2_one(int cpu, int iter)
+{
+    struct SigWorker w, canary;
+    struct Task *t, *tc;
+    static char wname[32], cname[32];
+    int k;
+
+    memset(&w, 0, sizeof(w));
+    memset(&canary, 0, sizeof(canary));
+    snprintf(wname, sizeof(wname), "sigrace.exit.%d.%d", cpu, iter);
+    snprintf(cname, sizeof(cname), "sigrace.cnry.%d.%d", cpu, iter);
+
+    t = spawn(wname, ExitWorker, 0, cpu, &w);
+    if (t == NULL || !wait_flag(&w.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d: INVALID - exit worker did not start\n", cpu);
+        return -1;
+    }
+
+    /* All signals go out while the worker provably lives (it spins until
+     * w_Go). Only the queued entries race its exit + teardown. */
+    for (k = 0; k < PHASE2_SIGNALS; k++)
+        Signal(t, SIGBREAKF_CTRL_C);
+    w.w_Go = 1;
+    __sync_synchronize();
+    /* From here on `t` is never touched again. */
+
+    if (!wait_flag(&w.w_Dying, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d: INVALID - exit worker never exited\n", cpu);
+        return -1;
+    }
+    Delay(1);   /* let the service task free it while the queue drains */
+
+    tc = spawn(cname, CanaryWorker, 0, cpu, &canary);
+    if (tc == NULL || !wait_flag(&canary.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d iter %d: *** FAIL *** canary never ran - "
+            "CPU wedged after signal storm on an exiting task\n", cpu, iter);
+        return 0;
+    }
+    return 1;
+}
+
+/* Cross-Disable signal storm between cpuA and cpuB. */
+static int phase3_one(int cpuA, int cpuB)
+{
+    struct SigWorker parkA, parkB, stormA, stormB;
+    struct Task *tparkA, *tparkB, *tstormA, *tstormB;
+    static char names[4][32];
+
+    memset(&parkA, 0, sizeof(parkA));
+    memset(&parkB, 0, sizeof(parkB));
+    memset(&stormA, 0, sizeof(stormA));
+    memset(&stormB, 0, sizeof(stormB));
+    g3_Go = 0;
+
+    snprintf(names[0], sizeof(names[0]), "sigrace.p3park.%d", cpuA);
+    snprintf(names[1], sizeof(names[1]), "sigrace.p3park.%d", cpuB);
+    snprintf(names[2], sizeof(names[2]), "sigrace.p3storm.%d", cpuA);
+    snprintf(names[3], sizeof(names[3]), "sigrace.p3storm.%d", cpuB);
+
+    tparkA = spawn(names[0], ParkWorker, 0, cpuA, &parkA);
+    tparkB = spawn(names[1], ParkWorker, 0, cpuB, &parkB);
+    if (!tparkA || !tparkB ||
+        !wait_flag(&parkA.w_Started, WAIT_TICKS) ||
+        !wait_flag(&parkB.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsigrace] phase 3: INVALID - park workers did not start\n");
+        return -1;
+    }
+    Delay(1);
+
+    /* Each storm targets the task parked on the OTHER storm's CPU. */
+    stormA.w_Target = tparkB;
+    stormB.w_Target = tparkA;
+    tstormA = spawn(names[2], StormWorker, 0, cpuA, &stormA);
+    tstormB = spawn(names[3], StormWorker, 0, cpuB, &stormB);
+    if (!tstormA || !tstormB ||
+        !wait_flag(&stormA.w_Started, WAIT_TICKS) ||
+        !wait_flag(&stormB.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsigrace] phase 3: INVALID - storm workers did not start\n");
+        return -1;
+    }
+
+    g3_Go = 1;
+    __sync_synchronize();
+
+    if (!wait_flag(&stormA.w_Done, WAIT_TICKS) ||
+        !wait_flag(&stormB.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsigrace] CPU #%02d/#%02d: *** FAIL *** cross-Disable signal "
+            "storm never completed - IPI pool exhaustion deadlock\n",
+            cpuA, cpuB);
+        return 0;
+    }
+
+    /* Leftover queued entries for the victims are swept here. */
+    RemTask(tparkA);
+    RemTask(tparkB);
+    return 1;
+}
+
+int main(void)
+{
+    int ncpus, cpu, iter;
+    int pass = 0, fail = 0, inval = 0;
+
+    KernelBase = OpenResource("kernel.resource");
+    ncpus = KernelBase ? KrnGetCPUCount() : 1;
+
+    bug("[smpsigrace] start: cpus=%ld (mungwall recommended to expose the pre-fix UAF)\n",
+        (LONG)ncpus);
+
+    if (ncpus < 2)
+    {
+        bug("[smpsigrace] only %ld CPU online - needs SMP; SKIP\n", (LONG)ncpus);
+        return RETURN_WARN;
+    }
+
+    for (cpu = 1; cpu < ncpus; cpu++)
+    {
+        int r = phase0_one(cpu);
+        if (r > 0)       pass++;
+        else if (r == 0) fail++;
+        else             inval++;
+    }
+    bug("[smpsigrace] phase 0 (cross-CPU wake) done\n");
+
+    for (cpu = 1; cpu < ncpus && !fail; cpu++)
+    {
+        for (iter = 0; iter < PHASE1_ITERS; iter++)
+        {
+            int r = phase1_one(cpu, iter);
+            if (r > 0)       pass++;
+            else if (r == 0) { fail++; break; }
+            else             inval++;
+        }
+    }
+    bug("[smpsigrace] phase 1 (Signal vs foreign RemTask, drain frozen) done\n");
+
+    for (iter = 0; iter < PHASE2_ITERS && !fail; iter++)
+    {
+        int r = phase2_one(1 + (iter % (ncpus - 1)), iter);
+        if (r > 0)       pass++;
+        else if (r == 0) fail++;
+        else             inval++;
+    }
+    bug("[smpsigrace] phase 2 (signal storm vs suicide exit) done\n");
+
+    if (ncpus >= 3 && !fail)
+    {
+        for (cpu = 1; cpu + 1 < ncpus && !fail; cpu += 2)
+        {
+            int r = phase3_one(cpu, cpu + 1);
+            if (r > 0)       pass++;
+            else if (r == 0) fail++;
+            else             inval++;
+        }
+        bug("[smpsigrace] phase 3 (cross-Disable pool-exhaustion storm) done\n");
+    }
+
+    bug("[smpsigrace] DONE: %ld PASS, %ld FAIL, %ld INVALID\n",
+        (LONG)pass, (LONG)fail, (LONG)inval);
+
+    return fail ? RETURN_FAIL : RETURN_OK;
+}

--- a/developer/debug/test/smp/smpstress.c
+++ b/developer/debug/test/smp/smpstress.c
@@ -1,0 +1,1116 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP stress test for exec primitives.
+          Tests concurrent semaphores, pool allocation, message passing,
+          and software interrupts from multiple tasks pinned across CPUs.
+*/
+
+#include <exec/semaphores.h>
+#include <exec/memory.h>
+#include <exec/ports.h>
+#include <exec/interrupts.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <clib/alib_protos.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+#if defined(__AROSEXEC_SMP__)
+#include <aros/atomic.h>
+#endif
+
+APTR KernelBase;
+static int g_NumCPUs = 1;
+
+#define NUM_WORKERS     4
+#define STACKSIZE       16384
+static cpumask_t *g_WorkerMasks[NUM_WORKERS + 1];
+
+/* Number of iterations per test */
+#define SEM_ITERS       50000
+#define POOL_ITERS      5000
+#define MSG_ITERS       10000
+#define SOFTINT_ITERS   5000
+
+/* Signals for synchronization */
+#define SIGF_READY      SIGBREAKF_CTRL_D
+#define SIGF_GO         SIGBREAKF_CTRL_E
+#define SIGF_DONE       SIGBREAKF_CTRL_F
+
+/*
+ * Helper: wait for all workers to signal SIGF_READY / SIGF_DONE.
+ * Signals are bitmasks and coalesce — if multiple workers signal
+ * before the main task wakes, only one Wait() return occurs.
+ * We use a shared volatile counter to track actual completions.
+ */
+static BOOL g_Aborted = FALSE;
+
+static BOOL WaitAllSignals(const char *phase, ULONG sigf, volatile LONG *counter, int target)
+{
+    ULONG stagnant_ticks = 0;
+    LONG last = *counter;
+
+    while (*counter < target)
+    {
+        ULONG sigs = SetSignal(0, 0);
+        if (sigs & SIGBREAKF_CTRL_C)
+        {
+            g_Aborted = TRUE;
+            return FALSE;
+        }
+
+        if (*counter != last)
+        {
+            last = *counter;
+            stagnant_ticks = 0;
+        }
+        else if (++stagnant_ticks >= 250)
+        {
+            bug(" TIMEOUT (%s %ld/%d)\n", phase, (long)*counter, target);
+            g_Aborted = TRUE;
+            return FALSE;
+        }
+
+        Delay(1);
+    }
+
+    return TRUE;
+}
+
+/*
+ * Create a worker task pinned to CPU (worker_index % g_NumCPUs).
+ * Spreads workers across all available CPUs for real SMP stress.
+ *
+ * NOTE: CleanupETask frees the task's iet_CpuAffinity via KrnFreeCPUMask,
+ * so our g_WorkerMasks[i] pointer becomes invalid after RemTask.
+ * Call InvalidateWorkerMasks() after each RemTask batch.
+ */
+static struct Task *CreateWorkerTask(const char *name, APTR entry, int worker_index,
+                                     LONG pri, IPTR userdata)
+{
+    struct Task *t;
+
+    if (KernelBase && g_NumCPUs > 1)
+    {
+        if (worker_index >= 0 && worker_index <= NUM_WORKERS)
+        {
+            if (!g_WorkerMasks[worker_index])
+                g_WorkerMasks[worker_index] = KrnAllocCPUMask();
+
+            if (g_WorkerMasks[worker_index])
+            {
+                KrnClearCPUMask(g_WorkerMasks[worker_index]);
+                KrnGetCPUMask(worker_index % g_NumCPUs, g_WorkerMasks[worker_index]);
+                t = NewCreateTask(TASKTAG_NAME, (IPTR)name,
+                                  TASKTAG_PRI, pri,
+                                  TASKTAG_PC, (IPTR)entry,
+                                  TASKTAG_STACKSIZE, STACKSIZE,
+                                  TASKTAG_USERDATA, userdata,
+                                  TASKTAG_AFFINITY, (IPTR)g_WorkerMasks[worker_index],
+                                  TAG_DONE);
+                return t;
+            }
+        }
+    }
+
+    return NewCreateTask(TASKTAG_NAME, (IPTR)name,
+                         TASKTAG_PRI, pri,
+                         TASKTAG_PC, (IPTR)entry,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA, userdata,
+                         TAG_DONE);
+}
+
+/*
+ * CleanupETask calls KrnFreeCPUMask on iet_CpuAffinity, which frees
+ * the memory our g_WorkerMasks[] entries point to.  Clear the pointers
+ * so CreateWorkerTask re-allocates fresh masks for the next test.
+ */
+static void InvalidateWorkerMasks(void)
+{
+    int i;
+    for (i = 0; i <= NUM_WORKERS; i++)
+        g_WorkerMasks[i] = NULL;
+}
+
+/******************************************************************************/
+
+/* Shared state for semaphore test */
+struct SemTestData
+{
+    struct SignalSemaphore  std_Sem;
+    struct Task            *std_MainTask;
+    volatile LONG           std_Counter;
+    volatile LONG           std_Errors;
+    volatile LONG           std_ReadyCount;
+    volatile LONG           std_DoneCount;
+    ULONG                   std_Iters;
+};
+
+/* Shared state for pool test */
+struct PoolTestData
+{
+    APTR                    ptd_Pool;
+    struct Task            *ptd_MainTask;
+    volatile LONG           ptd_Errors;
+    volatile LONG           ptd_ReadyCount;
+    volatile LONG           ptd_DoneCount;
+    ULONG                   ptd_Iters;
+};
+
+/* Shared state for message test */
+struct MsgTestData
+{
+    struct MsgPort         *mtd_ServerPort;
+    struct Task            *mtd_MainTask;
+    volatile LONG           mtd_Received;
+    volatile LONG           mtd_Errors;
+    volatile LONG           mtd_ReadyCount;
+    volatile LONG           mtd_DoneCount;
+    ULONG                   mtd_Iters;
+};
+
+/* Simple test message */
+struct TestMessage
+{
+    struct Message  tm_Msg;
+    ULONG           tm_Value;
+    ULONG           tm_WorkerID;
+};
+
+/* Shared state for softint test */
+struct SoftIntTestData
+{
+    struct Task            *sitd_MainTask;
+    volatile LONG           sitd_Counter;
+    volatile LONG           sitd_Errors;
+    volatile LONG           sitd_ReadyCount;
+    volatile LONG           sitd_DoneCount;
+    ULONG                   sitd_Iters;
+};
+
+/******************************************************************************/
+/*  Test 1: Semaphore contention                                              */
+/*                                                                            */
+/*  Multiple tasks obtain/release a shared semaphore while incrementing a     */
+/*  shared counter. The final counter value must equal NUM_WORKERS * iters.   */
+/******************************************************************************/
+
+static void SemWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct SemTestData *data = (struct SemTestData *)me->tc_UserData;
+    ULONG i;
+
+    __sync_add_and_fetch(&data->std_ReadyCount, 1);
+    Signal(data->std_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    for (i = 0; i < data->std_Iters; i++)
+    {
+        ObtainSemaphore(&data->std_Sem);
+        data->std_Counter++;
+        ReleaseSemaphore(&data->std_Sem);
+        D(
+            if (i % 1000 == 0)
+                bug("[smpstress] SemWorker '%s' iter %lu/%lu\n",
+                    me->tc_Node.ln_Name, (unsigned long)i, (unsigned long)data->std_Iters);
+        )
+    }
+
+    __sync_add_and_fetch(&data->std_DoneCount, 1);
+    Signal(data->std_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static void SemSharedWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct SemTestData *data = (struct SemTestData *)me->tc_UserData;
+    ULONG i;
+    LONG val;
+
+    __sync_add_and_fetch(&data->std_ReadyCount, 1);
+    Signal(data->std_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    for (i = 0; i < data->std_Iters; i++)
+    {
+        ObtainSemaphoreShared(&data->std_Sem);
+        val = data->std_Counter;
+        if (val < 0)
+            __sync_add_and_fetch(&data->std_Errors, 1);
+        ReleaseSemaphore(&data->std_Sem);
+        D(
+            if (i % 1000 == 0)
+                bug("[smpstress] SemSharedWorker '%s' iter %lu/%lu\n",
+                    me->tc_Node.ln_Name, (unsigned long)i, (unsigned long)data->std_Iters);
+        )
+    }
+
+    __sync_add_and_fetch(&data->std_DoneCount, 1);
+    Signal(data->std_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static BOOL TestSemaphores(ULONG iters)
+{
+    struct SemTestData data;
+    struct Task *workers[NUM_WORKERS];
+    char names[NUM_WORKERS][32];
+    ULONG expected;
+    int i;
+
+    bug("  Semaphore exclusive contention (%u iters x %d tasks)...", (unsigned)iters, NUM_WORKERS);
+
+    memset(&data, 0, sizeof(data));
+    InitSemaphore(&data.std_Sem);
+    data.std_MainTask = FindTask(NULL);
+    data.std_Iters = iters;
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "SemWorker.%d", i);
+        workers[i] = CreateWorkerTask(names[i], SemWorker, i, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create task %d)\n", i);
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            return FALSE;
+        }
+    }
+
+    if (!WaitAllSignals("sem-ready", SIGF_READY, &data.std_ReadyCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    expected = (ULONG)NUM_WORKERS * iters;
+
+    /* Monitor std_Counter (increments every iteration) instead of
+     * std_DoneCount (increments only when a worker finishes ALL iters).
+     * With 200k sequential semaphore handoffs on Pi hardware, no single
+     * worker finishes within 5s, but the counter shows steady progress. */
+    if (!WaitAllSignals("sem-done", SIGF_DONE, &data.std_Counter, (int)expected))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    /* Workers are finishing up — brief wait for DoneCount */
+    if (!WaitAllSignals("sem-cleanup", SIGF_DONE, &data.std_DoneCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+    InvalidateWorkerMasks();
+
+    if ((ULONG)data.std_Counter != expected)
+    {
+        bug(" FAIL (counter=%ld, expected=%lu)\n", (long)data.std_Counter, (unsigned long)expected);
+        return FALSE;
+    }
+    bug(" OK\n");
+
+    /* Now test shared + exclusive mix */
+    bug("  Semaphore shared/exclusive mix (%u iters x %d tasks)...", (unsigned)iters, NUM_WORKERS);
+
+    data.std_Counter = 0;
+    data.std_Errors = 0;
+    data.std_ReadyCount = 0;
+    data.std_DoneCount = 0;
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "SemMixWorker.%d", i);
+        workers[i] = CreateWorkerTask(names[i],
+                                      i < NUM_WORKERS / 2 ? (APTR)SemWorker : (APTR)SemSharedWorker,
+                                      i, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create task %d)\n", i);
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            return FALSE;
+        }
+    }
+
+    if (!WaitAllSignals("sem-mix-ready", SIGF_READY, &data.std_ReadyCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    expected = (ULONG)(NUM_WORKERS / 2) * iters;
+
+    if (!WaitAllSignals("sem-mix-done", SIGF_DONE, &data.std_Counter, (int)expected))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    if (!WaitAllSignals("sem-mix-cleanup", SIGF_DONE, &data.std_DoneCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+    InvalidateWorkerMasks();
+
+    if ((ULONG)data.std_Counter != expected || data.std_Errors != 0)
+    {
+        bug(" FAIL (counter=%ld, expected=%lu, errors=%ld)\n",
+               (long)data.std_Counter, (unsigned long)expected, (long)data.std_Errors);
+        return FALSE;
+    }
+    bug(" OK\n");
+    return TRUE;
+}
+
+/******************************************************************************/
+/*  Test 2: Pool allocation stress                                            */
+/*                                                                            */
+/*  Multiple tasks allocate and free from a shared pool. Tests that the pool  */
+/*  allocator doesn't corrupt its internal structures under contention.       */
+/******************************************************************************/
+
+static void PoolWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct PoolTestData *data = (struct PoolTestData *)me->tc_UserData;
+    ULONG i;
+
+    __sync_add_and_fetch(&data->ptd_ReadyCount, 1);
+    Signal(data->ptd_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    for (i = 0; i < data->ptd_Iters; i++)
+    {
+        ULONG size = 16 + (i % 7) * 32;
+        APTR mem = AllocPooled(data->ptd_Pool, size);
+        if (!mem)
+        {
+            __sync_add_and_fetch(&data->ptd_Errors, 1);
+            continue;
+        }
+        memset(mem, 0xAA, size);
+        FreePooled(data->ptd_Pool, mem, size);
+        D(
+            if (i % 1000 == 0)
+                bug("[smpstress] PoolWorker '%s' iter %lu/%lu\n",
+                    me->tc_Node.ln_Name, (unsigned long)i, (unsigned long)data->ptd_Iters);
+        )
+    }
+
+    __sync_add_and_fetch(&data->ptd_DoneCount, 1);
+    Signal(data->ptd_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static BOOL TestPools(ULONG iters)
+{
+    struct PoolTestData data;
+    struct Task *workers[NUM_WORKERS];
+    char names[NUM_WORKERS][32];
+    int i;
+
+    bug("  Pool concurrent alloc/free (%u iters x %d tasks)...", (unsigned)iters, NUM_WORKERS);
+
+    memset(&data, 0, sizeof(data));
+    data.ptd_Pool = CreatePool(MEMF_ANY | MEMF_SEM_PROTECTED, 8192, 4096);
+    data.ptd_MainTask = FindTask(NULL);
+    data.ptd_Iters = iters;
+
+    if (!data.ptd_Pool)
+    {
+        bug(" FAIL (can't create pool)\n");
+        return FALSE;
+    }
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "PoolWorker.%d", i);
+        workers[i] = CreateWorkerTask(names[i], PoolWorker, i, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create task %d)\n", i);
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            DeletePool(data.ptd_Pool);
+            return FALSE;
+        }
+    }
+
+    if (!WaitAllSignals("pool-ready", SIGF_READY, &data.ptd_ReadyCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        DeletePool(data.ptd_Pool);
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    if (!WaitAllSignals("pool-done", SIGF_DONE, &data.ptd_DoneCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        DeletePool(data.ptd_Pool);
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+    InvalidateWorkerMasks();
+
+    DeletePool(data.ptd_Pool);
+
+    if (data.ptd_Errors != 0)
+    {
+        bug(" FAIL (%ld allocation failures)\n", (long)data.ptd_Errors);
+        return FALSE;
+    }
+    bug(" OK\n");
+    return TRUE;
+}
+
+/******************************************************************************/
+/*  Test 3: Message passing stress                                            */
+/*                                                                            */
+/*  Multiple tasks send messages to a single server port. The server task     */
+/*  receives and replies. Tests PutMsg/GetMsg/ReplyMsg under contention.      */
+/******************************************************************************/
+
+static void MsgSendWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct MsgTestData *data = (struct MsgTestData *)me->tc_UserData;
+    struct MsgPort *replyPort;
+    struct TestMessage msg;
+    ULONG i;
+
+    replyPort = CreateMsgPort();
+    if (!replyPort)
+    {
+        __sync_add_and_fetch(&data->mtd_Errors, 1);
+        __sync_add_and_fetch(&data->mtd_ReadyCount, 1);
+        Signal(data->mtd_MainTask, SIGF_READY);
+        Wait(SIGF_GO);
+        __sync_add_and_fetch(&data->mtd_DoneCount, 1);
+        Signal(data->mtd_MainTask, SIGF_DONE);
+        Wait(0);
+        return;
+    }
+
+    __sync_add_and_fetch(&data->mtd_ReadyCount, 1);
+    Signal(data->mtd_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    memset(&msg, 0, sizeof(msg));
+    msg.tm_Msg.mn_ReplyPort = replyPort;
+    msg.tm_Msg.mn_Length = sizeof(struct TestMessage);
+
+    for (i = 0; i < data->mtd_Iters; i++)
+    {
+        msg.tm_Value = i;
+        PutMsg(data->mtd_ServerPort, &msg.tm_Msg);
+        WaitPort(replyPort);
+        GetMsg(replyPort);
+        D(
+            if (i % 1000 == 0)
+                bug("[smpstress] MsgSender '%s' iter %lu/%lu\n",
+                    me->tc_Node.ln_Name, (unsigned long)i, (unsigned long)data->mtd_Iters);
+        )
+    }
+
+    DeleteMsgPort(replyPort);
+    __sync_add_and_fetch(&data->mtd_DoneCount, 1);
+    Signal(data->mtd_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static void MsgServerTask(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct MsgTestData *data = (struct MsgTestData *)me->tc_UserData;
+    struct MsgPort *port;
+    ULONG total = (ULONG)NUM_WORKERS * data->mtd_Iters;
+    ULONG count = 0;
+
+    /* Server must create its own port so mp_SigTask = this task.
+     * If main created it, PutMsg would signal main instead of us. */
+    port = CreateMsgPort();
+    if (!port)
+    {
+        __sync_add_and_fetch(&data->mtd_Errors, 1);
+        __sync_add_and_fetch(&data->mtd_ReadyCount, 1);
+        Signal(data->mtd_MainTask, SIGF_READY);
+        Wait(SIGF_GO);
+        __sync_add_and_fetch(&data->mtd_DoneCount, 1);
+        Signal(data->mtd_MainTask, SIGF_DONE);
+        Wait(0);
+        return;
+    }
+
+    /* Publish port so senders can find it */
+    data->mtd_ServerPort = port;
+
+    __sync_add_and_fetch(&data->mtd_ReadyCount, 1);
+    Signal(data->mtd_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    while (count < total)
+    {
+        struct TestMessage *tmsg;
+
+        WaitPort(port);
+        while ((tmsg = (struct TestMessage *)GetMsg(port)) != NULL)
+        {
+            count++;
+            ReplyMsg(&tmsg->tm_Msg);
+            D(
+                if (count % 1000 == 0)
+                    bug("[smpstress] MsgServer received %lu/%lu\n",
+                        (unsigned long)count, (unsigned long)total);
+            )
+        }
+    }
+
+    data->mtd_Received = count;
+    DeleteMsgPort(port);
+    data->mtd_ServerPort = NULL;
+    __sync_add_and_fetch(&data->mtd_DoneCount, 1);
+    Signal(data->mtd_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static BOOL TestMessages(ULONG iters)
+{
+    struct MsgTestData data;
+    struct Task *workers[NUM_WORKERS];
+    struct Task *server;
+    char names[NUM_WORKERS][32];
+    ULONG expected;
+    int i;
+
+    bug("  Message passing (%u iters x %d senders)...", (unsigned)iters, NUM_WORKERS);
+
+    memset(&data, 0, sizeof(data));
+    data.mtd_MainTask = FindTask(NULL);
+    data.mtd_Iters = iters;
+
+    /* Server task creates its own port (so mp_SigTask is correct) */
+    server = CreateWorkerTask("MsgServer", MsgServerTask, 0, 1, (IPTR)&data);
+    if (!server)
+    {
+        bug(" FAIL (can't create server task)\n");
+        return FALSE;
+    }
+
+    /* Wait for server to be ready (port is now published) */
+    if (!WaitAllSignals("msg-server-ready", SIGF_READY, &data.mtd_ReadyCount, 1))
+    {
+        Forbid();
+        RemTask(server);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    if (!data.mtd_ServerPort)
+    {
+        bug(" FAIL (server couldn't create port)\n");
+        Forbid();
+        RemTask(server);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    /* Create sender tasks — server port is guaranteed valid now */
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "MsgSender.%d", i);
+        workers[i] = CreateWorkerTask(names[i], MsgSendWorker, i + 1, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create sender %d)\n", i);
+            Signal(server, SIGF_GO);
+            Forbid();
+            RemTask(server);
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            return FALSE;
+        }
+    }
+
+    /* Wait for all senders to be ready */
+    if (!WaitAllSignals("msg-ready", SIGF_READY, &data.mtd_ReadyCount, NUM_WORKERS + 1))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        RemTask(server);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    /* Start everyone simultaneously */
+    Forbid();
+    Signal(server, SIGF_GO);
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    /* Wait for all senders + server to finish */
+    if (!WaitAllSignals("msg-done", SIGF_DONE, &data.mtd_DoneCount, NUM_WORKERS + 1))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        RemTask(server);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    RemTask(server);
+    Permit();
+    InvalidateWorkerMasks();
+
+    expected = (ULONG)NUM_WORKERS * iters;
+    if ((ULONG)data.mtd_Received != expected || data.mtd_Errors != 0)
+    {
+        bug(" FAIL (received=%ld, expected=%lu, errors=%ld)\n",
+               (long)data.mtd_Received, (unsigned long)expected, (long)data.mtd_Errors);
+        return FALSE;
+    }
+    bug(" OK\n");
+    return TRUE;
+}
+
+/******************************************************************************/
+/*  Test 4: Software interrupt stress                                         */
+/*                                                                            */
+/*  Multiple tasks Cause() software interrupts that increment a counter.      */
+/*  Tests the SoftInts list protection under contention.                      */
+/******************************************************************************/
+
+static volatile LONG g_SoftIntCounter;
+
+AROS_INTH1(SoftIntHandler, APTR, data)
+{
+    AROS_INTFUNC_INIT
+
+    __sync_add_and_fetch(&g_SoftIntCounter, 1);
+
+    return FALSE;
+
+    AROS_INTFUNC_EXIT
+}
+
+static void SoftIntWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct SoftIntTestData *data = (struct SoftIntTestData *)me->tc_UserData;
+    struct Interrupt softint;
+    ULONG i;
+
+    memset(&softint, 0, sizeof(softint));
+    softint.is_Code = (VOID_FUNC)SoftIntHandler;
+    softint.is_Data = NULL;
+    softint.is_Node.ln_Type = NT_INTERRUPT;
+    softint.is_Node.ln_Pri = 0;
+    softint.is_Node.ln_Name = "SMP SoftInt Test";
+
+    __sync_add_and_fetch(&data->sitd_ReadyCount, 1);
+    Signal(data->sitd_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    for (i = 0; i < data->sitd_Iters; i++)
+    {
+        while (*(volatile UBYTE *)&softint.is_Node.ln_Type == NT_SOFTINT)
+            asm volatile("" ::: "memory");
+        Cause(&softint);
+        D(
+            if (i % 1000 == 0)
+                bug("[smpstress] SoftIntWorker '%s' iter %lu/%lu\n",
+                    me->tc_Node.ln_Name, (unsigned long)i, (unsigned long)data->sitd_Iters);
+        )
+    }
+
+    while (*(volatile UBYTE *)&softint.is_Node.ln_Type == NT_SOFTINT)
+        asm volatile("" ::: "memory");
+
+    __sync_add_and_fetch(&data->sitd_DoneCount, 1);
+    Signal(data->sitd_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static BOOL TestSoftInts(ULONG iters)
+{
+    struct SoftIntTestData data;
+    struct Task *workers[NUM_WORKERS];
+    char names[NUM_WORKERS][32];
+    ULONG expected;
+    int i;
+
+    bug("  Software interrupts (%u iters x %d tasks)...", (unsigned)iters, NUM_WORKERS);
+
+    memset(&data, 0, sizeof(data));
+    data.sitd_MainTask = FindTask(NULL);
+    data.sitd_Iters = iters;
+    g_SoftIntCounter = 0;
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "SoftIntWorker.%d", i);
+        workers[i] = CreateWorkerTask(names[i], SoftIntWorker, i, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create task %d)\n", i);
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            return FALSE;
+        }
+    }
+
+    if (!WaitAllSignals("softint-ready", SIGF_READY, &data.sitd_ReadyCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    if (!WaitAllSignals("softint-done", SIGF_DONE, &data.sitd_DoneCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+    InvalidateWorkerMasks();
+
+    expected = (ULONG)NUM_WORKERS * iters;
+    if ((ULONG)g_SoftIntCounter != expected)
+    {
+        bug(" FAIL (counter=%ld, expected=%lu)\n",
+               (long)g_SoftIntCounter, (unsigned long)expected);
+        return FALSE;
+    }
+    bug(" OK\n");
+    return TRUE;
+}
+
+/******************************************************************************/
+/*  Test 5: AttemptSemaphore contention                                       */
+/*                                                                            */
+/*  Multiple tasks use AttemptSemaphore in a tight loop. On failure they      */
+/*  yield and retry. Tests the try-lock path under contention.                */
+/******************************************************************************/
+
+struct AttemptTestData
+{
+    struct SignalSemaphore  atd_Sem;
+    struct Task            *atd_MainTask;
+    volatile LONG           atd_Counter;
+    volatile LONG           atd_ReadyCount;
+    volatile LONG           atd_DoneCount;
+    ULONG                   atd_Iters;
+};
+
+static void AttemptWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct AttemptTestData *data = (struct AttemptTestData *)me->tc_UserData;
+    ULONG done = 0;
+
+    __sync_add_and_fetch(&data->atd_ReadyCount, 1);
+    Signal(data->atd_MainTask, SIGF_READY);
+    Wait(SIGF_GO);
+
+    while (done < data->atd_Iters)
+    {
+        if (AttemptSemaphore(&data->atd_Sem))
+        {
+            data->atd_Counter++;
+            done++;
+            ReleaseSemaphore(&data->atd_Sem);
+            D(
+                if (done % 1000 == 0)
+                    bug("[smpstress] AttemptWorker '%s' iter %lu/%lu\n",
+                        me->tc_Node.ln_Name, (unsigned long)done, (unsigned long)data->atd_Iters);
+            )
+        }
+    }
+
+    __sync_add_and_fetch(&data->atd_DoneCount, 1);
+    Signal(data->atd_MainTask, SIGF_DONE);
+    Wait(0);
+}
+
+static BOOL TestAttemptSemaphore(ULONG iters)
+{
+    struct AttemptTestData data;
+    struct Task *workers[NUM_WORKERS];
+    char names[NUM_WORKERS][32];
+    ULONG expected;
+    int i;
+
+    bug("  AttemptSemaphore contention (%u iters x %d tasks)...", (unsigned)iters, NUM_WORKERS);
+
+    memset(&data, 0, sizeof(data));
+    InitSemaphore(&data.atd_Sem);
+    data.atd_MainTask = FindTask(NULL);
+    data.atd_Iters = iters;
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "AttemptWorker.%d", i);
+        workers[i] = CreateWorkerTask(names[i], AttemptWorker, i, 0, (IPTR)&data);
+        if (!workers[i])
+        {
+            bug(" FAIL (can't create task %d)\n", i);
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            InvalidateWorkerMasks();
+            return FALSE;
+        }
+    }
+
+    if (!WaitAllSignals("attempt-ready", SIGF_READY, &data.atd_ReadyCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        Signal(workers[i], SIGF_GO);
+    Permit();
+
+    expected = (ULONG)NUM_WORKERS * iters;
+
+    /* Monitor atd_Counter (advances every successful attempt), not
+     * atd_DoneCount - same rationale as Test 1: no single worker may
+     * finish all its iterations inside the stagnation window even
+     * though the test as a whole makes steady progress. */
+    if (!WaitAllSignals("attempt-done", SIGF_DONE, &data.atd_Counter, (int)expected))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    if (!WaitAllSignals("attempt-cleanup", SIGF_DONE, &data.atd_DoneCount, NUM_WORKERS))
+    {
+        Forbid();
+        for (i = 0; i < NUM_WORKERS; i++)
+            if (workers[i])
+                RemTask(workers[i]);
+        Permit();
+        InvalidateWorkerMasks();
+        return FALSE;
+    }
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+    InvalidateWorkerMasks();
+
+    if ((ULONG)data.atd_Counter != expected)
+    {
+        bug(" FAIL (counter=%ld, expected=%lu)\n",
+               (long)data.atd_Counter, (unsigned long)expected);
+        return FALSE;
+    }
+    bug(" OK\n");
+    return TRUE;
+}
+
+/******************************************************************************/
+/*  Main                                                                      */
+/******************************************************************************/
+
+int main(int argc, char **argv)
+{
+    int passed = 0, failed = 0;
+    ULONG sem_iters = SEM_ITERS;
+    ULONG pool_iters = POOL_ITERS;
+    ULONG msg_iters = MSG_ITERS;
+    ULONG softint_iters = SOFTINT_ITERS;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        g_NumCPUs = KrnGetCPUCount();
+
+    if (argc > 1 && strcmp(argv[1], "QUICK") == 0)
+    {
+        sem_iters /= 10;
+        pool_iters /= 10;
+        msg_iters /= 10;
+        softint_iters /= 10;
+    }
+
+    bug("SMP Stress Test (%d workers, %d CPUs)\n", NUM_WORKERS, g_NumCPUs);
+    bug("======================================\n\n");
+
+    bug("Test 1: Semaphores\n");
+    if (TestSemaphores(sem_iters))
+        passed += 2;
+    else
+        failed += 2;
+
+    bug("\nTest 2: Memory Pools\n");
+    if (TestPools(pool_iters))
+        passed++;
+    else
+        failed++;
+
+    bug("\nTest 3: Message Passing\n");
+    if (TestMessages(msg_iters))
+        passed++;
+    else
+        failed++;
+
+    bug("\nTest 4: Software Interrupts\n");
+    if (TestSoftInts(softint_iters))
+        passed++;
+    else
+        failed++;
+
+    bug("\nTest 5: AttemptSemaphore\n");
+    if (TestAttemptSemaphore(sem_iters))
+        passed++;
+    else
+        failed++;
+
+    bug("\n======================================\n");
+    bug("Results: %d passed, %d failed\n", passed, failed);
+
+    return failed ? RETURN_ERROR : RETURN_OK;
+}

--- a/developer/debug/test/smp/smptrace.c
+++ b/developer/debug/test/smp/smptrace.c
@@ -1,0 +1,209 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP stress test for exec primitives.
+          Workers on each CPU hammer semaphores and memory allocation
+          concurrently.  Logs progress so hangs are easy to localize.
+*/
+
+#include <exec/memory.h>
+#include <exec/semaphores.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+
+#define NUM_WORKERS 4
+#define STACKSIZE   16384
+#define SEM_ITERS   500
+#define ALLOC_ITERS 200
+
+enum
+{
+    STAGE_INIT = 0,
+    STAGE_READY,
+    STAGE_GO,
+    STAGE_SEM,
+    STAGE_ALLOC,
+    STAGE_DONE
+};
+
+struct TraceData
+{
+    struct SignalSemaphore td_Sem;
+    volatile LONG          td_Counter;
+    volatile LONG          td_ReadyCount;
+    volatile LONG          td_DoneCount;
+    volatile LONG          td_GoFlag;
+    volatile ULONG         td_Stage[NUM_WORKERS];
+    volatile ULONG         td_CPUReady[NUM_WORKERS];
+    volatile ULONG         td_CPUGo[NUM_WORKERS];
+    volatile ULONG         td_CPUDone[NUM_WORKERS];
+    volatile ULONG         td_AllocCount[NUM_WORKERS];
+};
+
+struct TraceWorkerCtx
+{
+    struct TraceData *twc_Data;
+    ULONG             twc_WorkerID;
+    cpumask_t        *twc_Affinity;
+};
+
+static void TraceWorker(void)
+{
+    struct Task *me = FindTask(NULL);
+    struct TraceWorkerCtx *ctx = (struct TraceWorkerCtx *)me->tc_UserData;
+    struct TraceData *data = ctx->twc_Data;
+    ULONG worker_id = ctx->twc_WorkerID;
+    ULONG i;
+
+    data->td_CPUReady[worker_id] = KrnGetCPUNumber();
+    data->td_Stage[worker_id] = STAGE_READY;
+    __sync_add_and_fetch(&data->td_ReadyCount, 1);
+
+    while (!data->td_GoFlag)
+        Delay(1);
+
+    data->td_CPUGo[worker_id] = KrnGetCPUNumber();
+    data->td_Stage[worker_id] = STAGE_GO;
+
+    data->td_Stage[worker_id] = STAGE_SEM;
+    for (i = 0; i < SEM_ITERS; i++)
+    {
+        ObtainSemaphore(&data->td_Sem);
+        data->td_Counter++;
+        ReleaseSemaphore(&data->td_Sem);
+    }
+
+    data->td_Stage[worker_id] = STAGE_ALLOC;
+    for (i = 0; i < ALLOC_ITERS; i++)
+    {
+        APTR mem = AllocVec(128 + (i * 16), MEMF_PUBLIC | MEMF_CLEAR);
+
+        if (mem != NULL)
+        {
+            data->td_AllocCount[worker_id]++;
+            FreeVec(mem);
+        }
+    }
+
+    data->td_CPUDone[worker_id] = KrnGetCPUNumber();
+    data->td_Stage[worker_id] = STAGE_DONE;
+    __sync_add_and_fetch(&data->td_DoneCount, 1);
+    Wait(0);
+}
+
+int main(void)
+{
+    struct TraceData data;
+    struct TraceWorkerCtx worker_ctx[NUM_WORKERS];
+    struct Task *workers[NUM_WORKERS];
+    char names[NUM_WORKERS][32];
+    ULONG expected_counter;
+    int i, ncpus;
+
+    KernelBase = OpenResource("kernel.resource");
+    ncpus = KernelBase ? KrnGetCPUCount() : 1;
+
+    bug("[smptrace] start: workers=%ld cpus=%ld sem_iters=%ld alloc_iters=%ld\n",
+           (LONG)NUM_WORKERS, (LONG)ncpus, (LONG)SEM_ITERS, (LONG)ALLOC_ITERS);
+
+    memset(&data, 0, sizeof(data));
+    InitSemaphore(&data.td_Sem);
+
+    for (i = 0; i < NUM_WORKERS; i++)
+    {
+        snprintf(names[i], sizeof(names[i]), "smptrace.%d", i);
+        worker_ctx[i].twc_Data = &data;
+        worker_ctx[i].twc_WorkerID = (ULONG)i;
+        worker_ctx[i].twc_Affinity = NULL;
+        if (KernelBase)
+        {
+            worker_ctx[i].twc_Affinity = KrnAllocCPUMask();
+            if (worker_ctx[i].twc_Affinity)
+                KrnGetCPUMask(i % ncpus, worker_ctx[i].twc_Affinity);
+        }
+        bug("[smptrace] creating %s cpu=%ld affinity=%08lx\n",
+               (IPTR)names[i], (LONG)(i % ncpus),
+               worker_ctx[i].twc_Affinity ? *worker_ctx[i].twc_Affinity : 0);
+        workers[i] = NewCreateTask(TASKTAG_NAME, (IPTR)names[i],
+                                   TASKTAG_PC, (IPTR)TraceWorker,
+                                   TASKTAG_STACKSIZE, STACKSIZE,
+                                   TASKTAG_USERDATA, (IPTR)&worker_ctx[i],
+                                   TASKTAG_AFFINITY, (IPTR)worker_ctx[i].twc_Affinity,
+                                   TAG_DONE);
+        if (workers[i] == NULL)
+        {
+            bug("[smptrace] FAIL: create %s\n", (IPTR)names[i]);
+            /* Reap the ones already created - they poll td_GoFlag on THIS
+             * stack frame and would spin on a dead frame after we return. */
+            Forbid();
+            while (--i >= 0)
+                RemTask(workers[i]);
+            Permit();
+            return RETURN_FAIL;
+        }
+    }
+
+    bug("[smptrace] waiting for workers to be ready...\n");
+    while (data.td_ReadyCount < NUM_WORKERS)
+    {
+        Delay(1);
+    }
+    bug("[smptrace] all ready: cpus=%lu,%lu,%lu,%lu\n",
+           data.td_CPUReady[0], data.td_CPUReady[1],
+           data.td_CPUReady[2], data.td_CPUReady[3]);
+
+    bug("[smptrace] GO!\n");
+    data.td_GoFlag = 1;
+
+    while (data.td_DoneCount < NUM_WORKERS)
+    {
+        ULONG done_mask = 0;
+
+        Delay(1);
+        for (i = 0; i < NUM_WORKERS; i++)
+        {
+            if (data.td_Stage[i] >= STAGE_DONE)
+                done_mask |= (1UL << i);
+        }
+        bug("[smptrace] progress: done=%02lx stages=%lu,%lu,%lu,%lu\n",
+               done_mask,
+               data.td_Stage[0], data.td_Stage[1],
+               data.td_Stage[2], data.td_Stage[3]);
+    }
+
+    expected_counter = NUM_WORKERS * SEM_ITERS;
+    bug("[smptrace] RESULT: counter=%ld expected=%lu %s\n",
+           (LONG)data.td_Counter, expected_counter,
+           (IPTR)(data.td_Counter == (LONG)expected_counter ? "OK" : "MISMATCH"));
+    bug("[smptrace] cpus: ready=%lu,%lu,%lu,%lu go=%lu,%lu,%lu,%lu done=%lu,%lu,%lu,%lu\n",
+           data.td_CPUReady[0], data.td_CPUReady[1],
+           data.td_CPUReady[2], data.td_CPUReady[3],
+           data.td_CPUGo[0], data.td_CPUGo[1],
+           data.td_CPUGo[2], data.td_CPUGo[3],
+           data.td_CPUDone[0], data.td_CPUDone[1],
+           data.td_CPUDone[2], data.td_CPUDone[3]);
+    bug("[smptrace] allocs: %lu,%lu,%lu,%lu\n",
+           data.td_AllocCount[0], data.td_AllocCount[1],
+           data.td_AllocCount[2], data.td_AllocCount[3]);
+
+    Forbid();
+    for (i = 0; i < NUM_WORKERS; i++)
+        RemTask(workers[i]);
+    Permit();
+
+    bug("[smptrace] exit\n");
+    return RETURN_OK;
+}


### PR DESCRIPTION
Add stress, trace, preemption and signal-race tests that pin workers across cores. SMP-SigRace covers cross-CPU Signal against task teardown and IPI pool exhaustion.