### PR TITLE
exec: add SMP spinlocks to the public exec structures

### DIFF
--- a/compiler/include/exec/interrupts.h
+++ b/compiler/include/exec/interrupts.h
@@ -9,11 +9,16 @@
     Lang: english
 */
 
+#include <aros/config.h>
+
 #ifndef EXEC_LISTS_H
 #   include <exec/lists.h>
 #endif
 #ifndef EXEC_NODES_H
 #   include <exec/nodes.h>
+#endif
+#if defined(__AROSPLATFORM_SMP__)
+#include <aros/types/spinlock_s.h>
 #endif
 
 /* CPU-dependent struct ExceptionContext */
@@ -59,6 +64,13 @@ struct SoftIntList
 {
     struct List sh_List;
     UWORD       sh_Pad;
+#if defined(__AROSPLATFORM_SMP__)
+#if defined(__AROSEXEC_SMP__)
+    spinlock_t  sh_SpinLock;        /* SMP per-priority softint list lock */
+#else
+    spinlock_t  sh_SpinPad;
+#endif
+#endif
 };
 
 #define SIH_PRIMASK (0xf0)

--- a/compiler/include/exec/libraries.h
+++ b/compiler/include/exec/libraries.h
@@ -9,8 +9,13 @@
     Lang: english
 */
 
+#include <aros/config.h>
+
 #ifndef EXEC_NODES_H
 #   include <exec/nodes.h>
+#endif
+#if defined(__AROSPLATFORM_SMP__)
+#include <aros/types/spinlock_s.h>
 #endif
 
 /* Library constants
@@ -47,6 +52,13 @@ struct Library {
     UWORD   lib_OpenCnt;        /* how many people use us right now? */
 #ifdef AROS_NEED_LONG_ALIGN
     UWORD   lib_pad2;           /* make sure it is longword aligned */
+#endif
+#if defined(__AROSPLATFORM_SMP__)
+#if defined(__AROSEXEC_SMP__)
+    spinlock_t lib_SpinLock;    /* SMP per-library lock (lib_OpenCnt, lib_Flags, vectors) */
+#else
+    spinlock_t lib_Pad;
+#endif
 #endif
 };
 

--- a/compiler/include/exec/memory.h
+++ b/compiler/include/exec/memory.h
@@ -9,8 +9,13 @@
     Lang: english
 */
 
+#include <aros/config.h>
+
 #ifndef EXEC_NODES_H
 #   include <exec/nodes.h>
+#endif
+#if defined(__AROSPLATFORM_SMP__)
+#include <aros/types/spinlock_s.h>
 #endif
 
 struct MemHeader
@@ -21,6 +26,13 @@ struct MemHeader
     APTR              mh_Lower;
     APTR              mh_Upper;
     IPTR              mh_Free;
+#if defined(__AROSPLATFORM_SMP__)
+#if defined(__AROSEXEC_SMP__)
+    spinlock_t        mh_SpinLock;          /* SMP per-memheader lock (mh_First, mh_Free) */
+#else
+    spinlock_t        mh_Pad;
+#endif
+#endif
 };
 
 struct MemChunk

--- a/compiler/include/exec/tasks.h
+++ b/compiler/include/exec/tasks.h
@@ -9,6 +9,8 @@
     Lang: english
 */
 
+#include <aros/config.h>
+
 #ifndef EXEC_NODES_H
 #   include <exec/nodes.h>
 #endif
@@ -20,6 +22,9 @@
 #endif
 #ifndef UTILITY_TAGITEM_H
 #   include <utility/tagitem.h>
+#endif
+#if defined(__AROSPLATFORM_SMP__)
+#include <aros/types/spinlock_s.h>
 #endif
 
 struct ETask;
@@ -56,6 +61,13 @@ struct Task
     VOID            (* tc_Launch)();                        /* Task gets CPU */
     struct List     tc_MemEntry;                            /* Allocated memory. Freed by RemTask(). */
     APTR            tc_UserData;                            /* For use by the task; no restrictions! */
+#if defined(__AROSPLATFORM_SMP__)
+#if defined(__AROSEXEC_SMP__)
+    spinlock_t      tc_SpinLock;                            /* SMP per-task lock (tc_State, tc_Sig*, tc_Flags, tc_MemEntry) */
+#else
+    spinlock_t      tc_Pad;
+#endif
+#endif
 };
 
 #define tc_TrapAlloc                tc_UnionETask.tc_ETrap.tc_ETrapAlloc


### PR DESCRIPTION
**exec: add SMP spinlocks to the public exec structures**

Adds a spinlock to `Task`, `Library`, `MemHeader` and the soft interrupt list. No code uses the new fields yet.

**Why these need a lock**

Each structure gets its own lock instead of one global one, so work on unrelated objects still runs in parallel:

- **`Task.tc_SpinLock`** protects `tc_State`, the signal fields (`tc_SigRecvd`, `tc_SigWait`, `tc_SigExcept`), `tc_Flags` and `tc_MemEntry`. `Signal()`, `Wait()`, `SetSignal()`, `RemTask()` and the scheduler all change these. Without the lock, `Signal()` can see a task in `TS_WAIT` and start moving it to the ready list while another core is already taking it off the wait list.
- **`Library.lib_SpinLock`** protects `lib_OpenCnt`, `lib_Flags` and the jump table, which `OpenLibrary`, `CloseLibrary`, `SetFunction` and `SumLibrary` write to.
- **`MemHeader.mh_SpinLock`** protects `mh_First` and `mh_Free`, the list of free chunks that `Allocate`, `Deallocate`, `AllocMem` and `FreeMem` change. One lock per header means the walk over the memory list stays parallel, and only the header actually being used gets locked.
- **`SoftIntList.sh_SpinLock`** protects the per-priority lists that `Cause()` adds to and the soft interrupt handler takes from.

**Why spinlocks and not semaphores**

All four are used from places that are not allowed to block: interrupt handlers, the scheduler, and the memory allocator. 

**Effect on the structures**

The new fields only exist when `__AROSPLATFORM_SMP__` is set, so platforms without SMP support are not affected at all. The structures do get bigger than they are today, by the size of one spinlock — 8 bytes on arm, and more on architectures where `AROS_SPINLOCK_ISOLATION` adds padding.

