### PR TITLE
NListtree.mcc: fix heap corruption in tree image string building

### DIFF
--- a/workbench/classes/zune/nlist/nlisttree_mcc/NListtree.c
+++ b/workbench/classes/zune/nlist/nlisttree_mcc/NListtree.c
@@ -2795,15 +2795,15 @@ static void InsertTreeImages( struct NListtree_Data *data, struct MUI_NListtree_
 
     if ( ( x1 != -1 ) && x2 )
     {
-      char tmpbuf[DATA_BUF_SIZE];
+      char tmp[128];
 
       if ( x1 == SPEC_Space )
         otn->tn_Space += x2 + data->IndentWidth;
 
       if ( otn->tn_Space > 0 )
       {
-        snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)SPEC_Space, (int)otn->tn_Space );
-        strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+        snprintf(tmp, sizeof(tmp), "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)SPEC_Space, (int)otn->tn_Space);
+        strlcat(data->buf, tmp, DATA_BUF_SIZE);
 
         otn->tn_ImagePos += otn->tn_Space;
         otn->tn_Space = 0;
@@ -2818,8 +2818,8 @@ static void InsertTreeImages( struct NListtree_Data *data, struct MUI_NListtree_
         */
         if(isFlagSet(data->Flags, NLTF_NO_ROOT_TREE) && gp->tn_Parent == NULL)
         {
-          snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)SPEC_Space, (int)x2 );
-          strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+          snprintf(tmp, sizeof(tmp), "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)SPEC_Space, (int)x2);
+          strlcat(data->buf, tmp, DATA_BUF_SIZE);
 
           otn->tn_ImagePos += x2;
         }
@@ -2830,8 +2830,8 @@ static void InsertTreeImages( struct NListtree_Data *data, struct MUI_NListtree_
           if(data->IndentWidth > 0)
             x2 += 2;
 
-          snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)x1, (int)x2 );
-          strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+          snprintf(tmp, sizeof(tmp), "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)x1, (int)x2);
+          strlcat(data->buf, tmp, DATA_BUF_SIZE);
 
           otn->tn_ImagePos += x2;
         }
@@ -2843,7 +2843,7 @@ static void InsertTreeImages( struct NListtree_Data *data, struct MUI_NListtree_
 static void InsertImage( struct NListtree_Data *data, struct MUI_NListtree_TreeNode *otn )
 {
   struct MUI_NListtree_ListNode *ln = CLN( otn );
-  char tmpbuf[DATA_BUF_SIZE];
+  char tmp[128];
   LONG x1 = -1;
 
   InsertTreeImages( data, otn, otn, 0 );
@@ -2859,22 +2859,22 @@ static void InsertImage( struct NListtree_Data *data, struct MUI_NListtree_TreeN
       x1 = IMAGE_Closed;
     }
 
-    snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p]", (APTR)data->Image[x1].ListImage );
-    strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+    snprintf(tmp, sizeof(tmp), "\033O[%p]", (APTR)data->Image[x1].ListImage);
+    strlcat(data->buf, tmp, DATA_BUF_SIZE);
 
     x1 = SPEC_Hor;
 
     // add some indent width
     if(data->IndentWidth > 0)
     {
-      snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)x1, (unsigned int)data->IndentWidth);
-      strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+      snprintf(tmp, sizeof(tmp), "\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)x1, (int)data->IndentWidth);
+      strlcat(data->buf, tmp, DATA_BUF_SIZE);
     }
 
     if(data->UseFolderImage == TRUE)
     {
-      snprintf(tmpbuf, DATA_BUF_SIZE, "\033O[%p]\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Folder].ListImage, (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (unsigned int)SPEC_Space, 3);
-      strncat(data->buf, tmpbuf, DATA_BUF_SIZE);
+      snprintf(tmp, sizeof(tmp), "\033O[%p]\033O[%p;%x;%d,%d]", (APTR)data->Image[IMAGE_Folder].ListImage, (APTR)data->Image[IMAGE_Tree].ListImage, (unsigned int)MUIA_TI_Spec, (int)SPEC_Space, (int)3);
+      strlcat(data->buf, tmp, DATA_BUF_SIZE);
     }
   }
 }


### PR DESCRIPTION
strncat() with n set to the full size of the destination buffer can write past its end when data->buf is almost full, overwriting the header of the adjacent heap block. With enough memory (e.g. hosted AROS with -m 4096) this caused crashes in tlsf_freevec() when the corrupted blocks were freed, and was reproducible in Prefs/Zune -> NListtree -> Expand.

Restore the upstream NList behaviour (commit 8d073d73): format each image spec into a small tmp[64] buffer and append it with the bounded strlcat(). This matches the upstream code so the files stay in sync and are easier to update.