### PR TITLE
Raspi4 hdmi audio

### DIFF
--- a/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
@@ -20,7 +20,8 @@ struct RPiHDMIBase {
     struct DosLibrary *dosbase;
     ULONG periiobase;
 
-    struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
+    struct RPiHDMISoc *soc[2]; /* Pointers to underlaying SOC implementation */
+    UBYTE num_outputs;
 };
 
 #define DRIVERBASE_SIZEOF (sizeof(struct RPiHDMIBase))
@@ -67,6 +68,7 @@ struct RPiHDMIData {
     ULONG frame_counter;        /* Current frame within IEC958 block (0-191) */
 
     struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
+    UBYTE output;
 };
 
 #endif /* AHI_Drivers_RPiHDMI_DriverData_h */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
@@ -43,6 +43,7 @@ struct RPiHDMIData {
     /* Hardware state */
     ULONG periiobase;
     LONG dma_channel;     /* Allocated from dma.resource, -1 = none */
+    ULONG dma_dreq;
 
     /* DMA control blocks (32-byte aligned) */
     struct BCM2708DMACB *cb_base; /* Allocated block (for free) */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
@@ -10,6 +10,8 @@
 /* Shared BCM2835 DMA control block layout (32-byte aligned). */
 #include <hardware/bcm2708_dma.h>
 
+#include "rpihdmi-soc.h"
+
 /*
  * Driver library base
  */
@@ -17,6 +19,8 @@ struct RPiHDMIBase {
     struct DriverBase driverbase;
     struct DosLibrary *dosbase;
     ULONG periiobase;
+
+    const struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
 };
 
 #define DRIVERBASE_SIZEOF (sizeof(struct RPiHDMIBase))
@@ -60,6 +64,8 @@ struct RPiHDMIData {
     UBYTE channel_status_l[24]; /* Left channel status block (192 bits) */
     UBYTE channel_status_r[24]; /* Right channel status block (192 bits) */
     ULONG frame_counter;        /* Current frame within IEC958 block (0-191) */
+
+    const struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
 };
 
 #endif /* AHI_Drivers_RPiHDMI_DriverData_h */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
@@ -20,7 +20,7 @@ struct RPiHDMIBase {
     struct DosLibrary *dosbase;
     ULONG periiobase;
 
-    const struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
+    struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
 };
 
 #define DRIVERBASE_SIZEOF (sizeof(struct RPiHDMIBase))
@@ -66,7 +66,7 @@ struct RPiHDMIData {
     UBYTE channel_status_r[24]; /* Right channel status block (192 bits) */
     ULONG frame_counter;        /* Current frame within IEC958 block (0-191) */
 
-    const struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
+    struct RPiHDMISoc *soc; /* Pointer to underlaying SOC implementation */
 };
 
 #endif /* AHI_Drivers_RPiHDMI_DriverData_h */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
@@ -9,6 +9,6 @@ srcdir		= @srcdir@
 DRIVER		= rpihdmi.audio
 MODEFILE	= RPIHDMI
 
-OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o
+OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o rpihdmi-iec958.o
 
 include ../Common/Makefile.common

--- a/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
@@ -9,6 +9,6 @@ srcdir		= @srcdir@
 DRIVER		= rpihdmi.audio
 MODEFILE	= RPIHDMI
 
-OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o rpihdmi-iec958.o
+OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o rpihdmi-iec958.o rpihdmi-dma.o rpihdmi-bcm283x.o rpihdmi-bcm2711.o
 
 include ../Common/Makefile.common

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
@@ -46,6 +46,8 @@ struct RPiHDMISoc rpihdmi_bcm2711_hdmi0_soc = {
 
     .mai_dreq_threshold  = 0x1C,
     .mai_panic_threshold = 0x10,
+    .hdmi_mai_channel_map = 0x10,
+    .name = "HDMI 0",
 
     .init         = hdmi_mai_init,
     .stop         = hdmi_mai_stop
@@ -81,6 +83,7 @@ struct RPiHDMISoc rpihdmi_bcm2711_hdmi1_soc = {
     .mai_dreq_threshold = 0x1C,
     .mai_panic_threshold = 0x10,
     .hdmi_mai_channel_map = 0x10,
+    .name = "HDMI 1",
 
     .init         = hdmi_mai_init,
     .stop         = hdmi_mai_stop

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
@@ -1,6 +1,10 @@
 #include "DriverData.h"
 #include "rpihdmi-soc.h"
 
-const struct RPiHDMISoc rpihdmi_bcm2711_soc = {
-    0
+struct RPiHDMISoc rpihdmi_bcm2711_hdmi0_soc = {
+    .dma_dreq = 10,
+};
+
+struct RPiHDMISoc rpihdmi_bcm2711_hdmi1_soc = {
+    .dma_dreq = 17,
 };

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
@@ -1,0 +1,6 @@
+#include "DriverData.h"
+#include "rpihdmi-soc.h"
+
+const struct RPiHDMISoc rpihdmi_bcm2711_soc = {
+    0
+};

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2711.c
@@ -1,10 +1,87 @@
+/*
+ *  BCM2711 (VC5) HDMI audio register map.
+ *
+ *  Unlike BCM2835/2836 the HD block is shared by both HDMI controllers:
+ *  one 0x100 byte region (bus 0x7EF20000) holding two MAI register sets,
+ *  HDMI0 at +0x10 and HDMI1 at +0x30. The RAM packet memory has moved out
+ *  of the HDMI block into its own region, so packet_start is 0.
+ *
+ *  mai_base/hdmi_base/packet_base and dma_dreq are filled in from the
+ *  device tree at init time; the values here are the register offsets
+ *  within those blocks.
+ *
+ *  The MAI audio clock is the 108 MHz DVP clock, not the HSM clock.
+ */
+
 #include "DriverData.h"
 #include "rpihdmi-soc.h"
+#include "rpihdmi-hwaccess.h"
 
 struct RPiHDMISoc rpihdmi_bcm2711_hdmi0_soc = {
     .dma_dreq = 10,
+    .hsm_clock = 108000000,
+
+    .regs = {
+        /* HD block, HDMI0 set */
+        .mai_ctl            = 0x010,
+        .mai_thr            = 0x014,
+        .mai_fmt            = 0x018,
+        .mai_data           = 0x01C,
+        .mai_smp            = 0x020,
+
+        /* HDMI block */
+        .mai_channel_map   = 0x09C,
+        .mai_config        = 0x0A0,
+        .audio_packet_cfg  = 0x0B8,
+        .ram_packet_cfg    = 0x0BC,
+        .ram_packet_status  = 0x0C4,
+        .crp_cfg           = 0x0C8,
+        .cts_0             = 0x0CC,
+        .cts_1             = 0x0D0,
+        .scheduler_control = 0x0E0,
+
+        /* Packet block */
+        .packet_start      = 0x000,
+    },
+
+    .mai_dreq_threshold  = 0x1C,
+    .mai_panic_threshold = 0x10,
+
+    .init         = hdmi_mai_init,
+    .stop         = hdmi_mai_stop
 };
 
 struct RPiHDMISoc rpihdmi_bcm2711_hdmi1_soc = {
     .dma_dreq = 17,
+    .hsm_clock = 108000000,
+
+    .regs = {
+        /* HD block, HDMI1 set */
+        .mai_ctl            = 0x030,
+        .mai_thr            = 0x034,
+        .mai_fmt            = 0x038,
+        .mai_data           = 0x03C,
+        .mai_smp            = 0x040,
+
+        /* HDMI block */
+        .mai_channel_map   = 0x09C,
+        .mai_config        = 0x0A0,
+        .audio_packet_cfg  = 0x0B8,
+        .ram_packet_cfg    = 0x0BC,
+        .ram_packet_status  = 0x0C4,
+        .crp_cfg           = 0x0C8,
+        .cts_0             = 0x0CC,
+        .cts_1             = 0x0D0,
+        .scheduler_control = 0x0E0,
+
+        /* Packet block */
+        .packet_start      = 0x000,
+    },
+
+    .mai_dreq_threshold = 0x1C,
+    .mai_panic_threshold = 0x10,
+    .hdmi_mai_channel_map = 0x10,
+
+    .init         = hdmi_mai_init,
+    .stop         = hdmi_mai_stop
 };

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
@@ -1,0 +1,14 @@
+#include "DriverData.h"
+#include "rpihdmi-soc.h"
+#include "rpihdmi-hwaccess.h"
+
+const struct RPiHDMISoc rpihdmi_bcm283x_soc = {
+    .mai_base     = 0x808000,
+    .hdmi_base    = 0x902000,
+    .mai_data_bus = 0x7E808020,
+    .dma_dreq     = 17,
+    .hsm_clock    = 163680000,
+
+    .init         = hdmi_mai_init,
+    .stop         = hdmi_mai_stop
+};

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
@@ -31,6 +31,7 @@ const struct RPiHDMISoc rpihdmi_bcm283x_soc = {
     .mai_dreq_threshold = 0x10,
     .mai_panic_threshold = 0x10,
     .hdmi_mai_channel_map = 0x08,
+    .name = "HDMI Audio",
 
     .init         = hdmi_mai_init,
     .stop         = hdmi_mai_stop

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
@@ -28,6 +28,10 @@ const struct RPiHDMISoc rpihdmi_bcm283x_soc = {
         .packet_start      = 0x400,
     },
 
+    .mai_dreq_threshold = 0x10,
+    .mai_panic_threshold = 0x10,
+    .hdmi_mai_channel_map = 0x08,
+
     .init         = hdmi_mai_init,
     .stop         = hdmi_mai_stop
 };

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm283x.c
@@ -9,6 +9,25 @@ const struct RPiHDMISoc rpihdmi_bcm283x_soc = {
     .dma_dreq     = 17,
     .hsm_clock    = 163680000,
 
+    .regs = {
+        .mai_ctl            = 0x014,
+        .mai_thr            = 0x018,
+        .mai_fmt            = 0x01C,
+        .mai_data           = 0x020,
+        .mai_smp            = 0x02C,
+
+        .mai_channel_map   = 0x090,
+        .mai_config        = 0x094,
+        .audio_packet_cfg  = 0x09C,
+        .ram_packet_cfg    = 0x0A0,
+        .ram_packet_status = 0x0A4,
+        .crp_cfg           = 0x0A8,
+        .cts_0             = 0x0AC,
+        .cts_1             = 0x0B0,
+        .scheduler_control = 0x0C0,
+        .packet_start      = 0x400,
+    },
+
     .init         = hdmi_mai_init,
     .stop         = hdmi_mai_stop
 };

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
@@ -1,3 +1,4 @@
+#include <aros/debug.h>
 #include <proto/exec.h>
 #include <aros/macros.h>
 
@@ -32,7 +33,7 @@ void dma_build_control_blocks(struct RPiHDMIData *dd)
         struct BCM2708DMACB *cb = dd->cb[i];
 
         cb->ti = DMA_TI_INTEN | DMA_TI_WAIT_RESP | DMA_TI_DEST_DREQ | DMA_TI_SRC_INC | DMA_TI_BURST_LENGTH(2) |
-                 DMA_TI_PERMAP(soc->dma_dreq) | DMA_TI_NO_WIDE_BURSTS;
+                 DMA_TI_PERMAP(dd->dma_dreq) | DMA_TI_NO_WIDE_BURSTS;
 
         cb->source_ad = GPU_BUS_ADDR(dd->dmabuf[i]);
         cb->dest_ad = soc->mai_data_bus;
@@ -101,4 +102,64 @@ void dma_irq_handler(struct RPiHDMIData *data, void *data2)
             Signal((struct Task *) data->slavetask, 1L << data->slavesignal);
         }
     }
+}
+
+ULONG dma_probe_dreq(struct RPiHDMIData *dd, ULONG expect)
+{
+    IPTR peribase = dd->periiobase;
+    IPTR dma_base = peribase + 0x007000 + dd->dma_channel * 0x100;
+    ULONG len = dd->dmabuf_size;
+    ULONG best = 0;
+    ULONG best_err = ~0U;
+    ULONG n;
+
+    for (n = 1; n < 32; n++) {
+        ULONG left, moved, err;
+
+        wr32le(dma_base + 0x00, DMA_CS_RESET);
+        udelay(peribase, 100);
+
+        dd->cb[0]->ti = DMA_TI_WAIT_RESP | DMA_TI_DEST_DREQ | DMA_TI_SRC_INC |
+                        DMA_TI_PERMAP(n) | DMA_TI_NO_WIDE_BURSTS;
+
+        dd->cb[0]->source_ad = GPU_BUS_ADDR(dd->dmabuf[0]);
+        dd->cb[0]->dest_ad = dd->soc->mai_data_bus;
+        dd->cb[0]->txfr_len = len;
+        dd->cb[0]->stride = 0;
+        dd->cb[0]->nextconbk = 0;
+
+        CacheClearE(dd->cb[0], sizeof(struct BCM2708DMACB), CACRF_ClearD);
+
+        wr32le(dma_base + 0x04, GPU_BUS_ADDR(dd->cb[0]));
+        wr32le(dma_base + 0x00, DMA_CS_ACTIVE);
+
+        udelay(peribase, 10000);
+
+        left = rd32le(dma_base + 0x14);          /* TXFR_LEN, counts down */
+        wr32le(dma_base + 0x00, DMA_CS_RESET);
+
+        moved = (left < len) ? (len - left) / sizeof(ULONG) : 0;
+        if (moved == 0)
+            continue;
+
+        err = (moved > expect) ? (moved - expect) : (expect - moved);
+        bug("[RPiHDMI] dreq probe: permap %u moved %u words in 10 ms (want ~%u)\n",
+            n, moved, expect);
+
+        if (err < best_err) {
+            best_err = err;
+            best = n;
+        }
+    }
+
+    /* Within a quarter of the expected rate is the paced one; anything else is
+     * some other peripheral's request line and no use to us. */
+    if (best_err > expect / 4) {
+        bug("[RPiHDMI] dreq probe: nothing paced at ~%u words/10 ms, keeping %u\n",
+            expect, dd->soc->dma_dreq);
+        best = dd->soc->dma_dreq;
+    } else
+        bug("[RPiHDMI] dreq probe: using permap %u\n", best);
+
+    return best;
 }

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
@@ -1,3 +1,4 @@
+#define DEBUG 0
 #include <aros/debug.h>
 #include <proto/exec.h>
 #include <aros/macros.h>
@@ -63,10 +64,10 @@ void dma_setup(struct RPiHDMIData *dd)
     wr32le(dma_base + 0x00, BCM2708_DMA_CS_RUN);
     udelay(peribase, 10);
 
-    bug("[RPiHDMI] DMA after setup: CS=%08lx CB=%08lx TXFR=%08lx\n",
+    D(bug("[RPiHDMI] DMA after setup: CS=%08lx CB=%08lx TXFR=%08lx\n",
         rd32le(dma_base + 0x00),
         rd32le(dma_base + 0x04),
-        rd32le(dma_base + 0x14));
+        rd32le(dma_base + 0x14)));
 }
 
 void dma_stop(struct RPiHDMIData *dd)
@@ -99,18 +100,7 @@ void dma_irq_handler(struct RPiHDMIData *data, void *data2)
     ULONG dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
     ULONG cs = rd32le(dma_base + 0x00);
 
-    static ULONG debug_irq_count;
-
     if (cs & DMA_CS_INT) {
-        // if (debug_irq_count < 10) {
-        //     bug("[RPiHDMI] DMA IRQ: CS=%08lx CB=%08lx TXFR=%08lx\n",
-        //         cs,
-        //         rd32le(dma_base + 0x04),
-        //         rd32le(dma_base + 0x14));
-
-        //     debug_irq_count++;
-        // }
-
         /* Must carry the run state, not just ACTIVE: the AXI priorities
          * share the register. See bcm2708_dma.h. */
         wr32le(dma_base + 0x00, BCM2708_DMA_CS_ACK);
@@ -160,8 +150,8 @@ ULONG dma_probe_dreq(struct RPiHDMIData *dd, ULONG expect)
             continue;
 
         err = (moved > expect) ? (moved - expect) : (expect - moved);
-        bug("[RPiHDMI] dreq probe: permap %u moved %u words in 10 ms (want ~%u)\n",
-            n, moved, expect);
+        D(bug("[RPiHDMI] dreq probe: permap %u moved %u words in 10 ms (want ~%u)\n",
+            n, moved, expect));
 
         if (err < best_err) {
             best_err = err;
@@ -172,11 +162,11 @@ ULONG dma_probe_dreq(struct RPiHDMIData *dd, ULONG expect)
     /* Within a quarter of the expected rate is the paced one; anything else is
      * some other peripheral's request line and no use to us. */
     if (best_err > expect / 4) {
-        bug("[RPiHDMI] dreq probe: nothing paced at ~%u words/10 ms, keeping %u\n",
-            expect, dd->soc->dma_dreq);
+        D(bug("[RPiHDMI] dreq probe: nothing paced at ~%u words/10 ms, keeping %u\n",
+            expect, dd->soc->dma_dreq));
         best = dd->soc->dma_dreq;
     } else
-        bug("[RPiHDMI] dreq probe: using permap %u\n", best);
+        D(bug("[RPiHDMI] dreq probe: using permap %u\n", best));
 
     return best;
 }

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
@@ -47,11 +47,12 @@ void dma_build_control_blocks(struct RPiHDMIData *dd)
 
 void dma_setup(struct RPiHDMIData *dd)
 {
+    struct DriverBase *AHIsubBase =
+        (struct DriverBase *) dd->ahisubbase;
     ULONG peribase = dd->periiobase;
     ULONG channel = dd->dma_channel;
     ULONG cb_bus_addr = GPU_BUS_ADDR(dd->cb[0]);
     ULONG dma_base = peribase + 0x007000 + channel * 0x100;
-
     /* The channel is already enabled by dma.resource at allocation. */
     wr32le(dma_base + 0x00, DMA_CS_RESET);
     udelay(peribase, 10);
@@ -61,6 +62,11 @@ void dma_setup(struct RPiHDMIData *dd)
      * survive the session; see bcm2708_dma.h. */
     wr32le(dma_base + 0x00, BCM2708_DMA_CS_RUN);
     udelay(peribase, 10);
+
+    bug("[RPiHDMI] DMA after setup: CS=%08lx CB=%08lx TXFR=%08lx\n",
+        rd32le(dma_base + 0x00),
+        rd32le(dma_base + 0x04),
+        rd32le(dma_base + 0x14));
 }
 
 void dma_stop(struct RPiHDMIData *dd)
@@ -93,7 +99,18 @@ void dma_irq_handler(struct RPiHDMIData *data, void *data2)
     ULONG dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
     ULONG cs = rd32le(dma_base + 0x00);
 
+    static ULONG debug_irq_count;
+
     if (cs & DMA_CS_INT) {
+        // if (debug_irq_count < 10) {
+        //     bug("[RPiHDMI] DMA IRQ: CS=%08lx CB=%08lx TXFR=%08lx\n",
+        //         cs,
+        //         rd32le(dma_base + 0x04),
+        //         rd32le(dma_base + 0x14));
+
+        //     debug_irq_count++;
+        // }
+
         /* Must carry the run state, not just ACTIVE: the AXI priorities
          * share the register. See bcm2708_dma.h. */
         wr32le(dma_base + 0x00, BCM2708_DMA_CS_ACK);

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
@@ -1,0 +1,104 @@
+#include <proto/exec.h>
+#include <aros/macros.h>
+
+#include "rpihdmi-dma.h"
+#include "DriverData.h"
+
+#include "rpihdmi-hwaccess.h"
+
+/*
+ * Microsecond delay using a busy loop on the system timer.
+ */
+static void udelay(ULONG peribase, ULONG us)
+{
+    volatile ULONG *clo = (volatile ULONG *) (ULONG) (peribase + 0x003004);
+    ULONG start = AROS_LE2LONG(*clo);
+
+    while ((AROS_LE2LONG(*clo) - start) < us)
+        ;
+}
+
+/******************************************************************************
+** DMA setup ******************************************************************
+******************************************************************************/
+
+void dma_build_control_blocks(struct RPiHDMIData *dd)
+{
+    const struct RPiHDMISoc *soc = dd->soc;
+
+    int i;
+
+    for (i = 0; i < 2; i++) {
+        struct BCM2708DMACB *cb = dd->cb[i];
+
+        cb->ti = DMA_TI_INTEN | DMA_TI_WAIT_RESP | DMA_TI_DEST_DREQ | DMA_TI_SRC_INC | DMA_TI_BURST_LENGTH(2) |
+                 DMA_TI_PERMAP(soc->dma_dreq) | DMA_TI_NO_WIDE_BURSTS;
+
+        cb->source_ad = GPU_BUS_ADDR(dd->dmabuf[i]);
+        cb->dest_ad = soc->mai_data_bus;
+        cb->txfr_len = dd->dmabuf_size;
+        cb->stride = 0;
+        cb->nextconbk = GPU_BUS_ADDR(dd->cb[1 - i]);
+        cb->reserved[0] = 0;
+        cb->reserved[1] = 0;
+    }
+}
+
+void dma_setup(struct RPiHDMIData *dd)
+{
+    ULONG peribase = dd->periiobase;
+    ULONG channel = dd->dma_channel;
+    ULONG cb_bus_addr = GPU_BUS_ADDR(dd->cb[0]);
+    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
+
+    /* The channel is already enabled by dma.resource at allocation. */
+    wr32le(dma_base + 0x00, DMA_CS_RESET);
+    udelay(peribase, 10);
+    wr32le(dma_base + 0x00, DMA_CS_INT | DMA_CS_END);
+    wr32le(dma_base + 0x04, cb_bus_addr);
+    /* The handler re-writes this with the W1C flags added, so the priorities
+     * survive the session; see bcm2708_dma.h. */
+    wr32le(dma_base + 0x00, BCM2708_DMA_CS_RUN);
+    udelay(peribase, 10);
+}
+
+void dma_stop(struct RPiHDMIData *dd)
+{
+    ULONG peribase = dd->periiobase;
+    ULONG channel = dd->dma_channel;
+    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
+
+    wr32le(dma_base + 0x00, 0);
+    udelay(peribase, 50);
+    wr32le(dma_base + 0x00, DMA_CS_RESET);
+    udelay(peribase, 100);
+    wr32le(dma_base + 0x04, 0);
+    wr32le(dma_base + 0x00, DMA_CS_INT | DMA_CS_END);
+}
+
+/******************************************************************************
+** DMA interrupt handler ******************************************************
+******************************************************************************/
+
+/*
+ * This is called from the DMA IRQ context via KrnAddIRQHandler.
+ * We acknowledge the DMA interrupt and signal the slave task.
+ */
+#undef SysBase
+
+void dma_irq_handler(struct RPiHDMIData *data, void *data2)
+{
+    struct ExecBase *SysBase = (struct ExecBase *) data2;
+    ULONG dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
+    ULONG cs = rd32le(dma_base + 0x00);
+
+    if (cs & DMA_CS_INT) {
+        /* Must carry the run state, not just ACTIVE: the AXI priorities
+         * share the register. See bcm2708_dma.h. */
+        wr32le(dma_base + 0x00, BCM2708_DMA_CS_ACK);
+
+        if (data->slavetask != NULL && data->slavesignal != -1) {
+            Signal((struct Task *) data->slavetask, 1L << data->slavesignal);
+        }
+    }
+}

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.h
@@ -1,0 +1,33 @@
+#ifndef AHI_Drivers_RPiHDMI_dma_h
+#define AHI_Drivers_RPiHDMI_dma_h
+
+#include <exec/types.h>
+
+#include "DriverData.h"
+
+void dma_build_control_blocks(struct RPiHDMIData *dd);
+void dma_setup(struct RPiHDMIData *dd);
+void dma_stop(struct RPiHDMIData *dd);
+void dma_irq_handler(struct RPiHDMIData *data, void *data2);
+
+/* The audio DMA channel is allocated at runtime from dma.resource. */
+
+/* DMA control block TI bits */
+#define DMA_TI_INTEN           (1 << 0)
+#define DMA_TI_WAIT_RESP       (1 << 3)
+#define DMA_TI_DEST_DREQ       (1 << 6)
+#define DMA_TI_SRC_INC         (1 << 8)
+#define DMA_TI_BURST_LENGTH(x) (((x) & 0xF) << 12)
+#define DMA_TI_PERMAP(x)       (((x) & 0x1F) << 16)
+#define DMA_TI_NO_WIDE_BURSTS  (1 << 26)
+
+/* DMA CS bits */
+/* Run state and acknowledge live in bcm2708_dma.h, shared with the other
+ * DMA-driven AHI driver - they have to agree. */
+#define DMA_CS_ACTIVE          (1 << 0)
+#define DMA_CS_END             (1 << 1)
+#define DMA_CS_INT             (1 << 2)
+#define DMA_CS_ABORT           (1 << 30)
+#define DMA_CS_RESET           (1 << 31)
+
+#endif

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.h
@@ -10,6 +10,7 @@ void dma_setup(struct RPiHDMIData *dd);
 void dma_stop(struct RPiHDMIData *dd);
 void dma_irq_handler(struct RPiHDMIData *data, void *data2);
 
+ULONG dma_probe_dreq(struct RPiHDMIData *dd, ULONG expect);
 /* The audio DMA channel is allocated at runtime from dma.resource. */
 
 /* DMA control block TI bits */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -19,15 +19,9 @@
 #include <exec/types.h>
 #include <aros/macros.h>
 
+#include "DriverData.h"
 #include "rpihdmi-hwaccess.h"
 #include "rpihdmi-iec958.h"
-
-/*
- * HDMI State Machine (HSM) clock feeding the MAI sample-rate divider.
- * Owned by the firmware and not queryable here; measured on Pi 3B+ at
- * ~163.68 MHz (the 216 MHz assumed before gave 0.7578x playback speed).
- */
-#define HDMI_HSM_CLOCK 163680000
 
 /*
  * Microsecond delay using a busy loop on the system timer.
@@ -147,9 +141,9 @@ static UBYTE srate_to_cea_sf(ULONG samplerate)
     }
 }
 
-static void hdmi_write_audio_infoframe(ULONG pb, ULONG samplerate)
+static void hdmi_write_audio_infoframe(struct RPiHDMIData *dd)
 {
-    ULONG slot_base = pb + HDMI_OFFSET + 0x400 + 4 * 0x24;
+    ULONG slot_base = dd->periiobase + dd->soc->hdmi_base + 0x400 + 4 * 0x24;
     UBYTE infoframe[14];
     UBYTE checksum;
     int i;
@@ -162,7 +156,7 @@ static void hdmi_write_audio_infoframe(ULONG pb, ULONG samplerate)
     /* Data bytes */
     infoframe[3] = 0x00;                                      /* Checksum (computed below) */
     infoframe[4] = 0x11;                                      /* CC=1 (2ch), CT=1 (L-PCM) */
-    infoframe[5] = (srate_to_cea_sf(samplerate) << 2) | 0x01; /* SF | SS=16bit */
+    infoframe[5] = (srate_to_cea_sf(dd->samplerate) << 2) | 0x01; /* SF | SS=16bit */
     infoframe[6] = 0x00;                                      /* Format dependent */
     infoframe[7] = 0x00;                                      /* CA = 0 (FL/FR) */
     infoframe[8] = 0x00;                                      /* DM_INH=0, LSV=0 */
@@ -191,7 +185,7 @@ static void hdmi_write_audio_infoframe(ULONG pb, ULONG samplerate)
     }
 
     /* Enable the audio infoframe packet (bit 4 = packet_id 4) */
-    wr32le(HDMI_RAM_PKT_CFG(pb), rd32le(HDMI_RAM_PKT_CFG(pb)) | (1 << 4));
+    wr32le(HDMI_RAM_PKT_CFG(dd), rd32le(HDMI_RAM_PKT_CFG(dd)) | (1 << 4));
 }
 
 
@@ -223,25 +217,25 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
      * Three separate writes: RESET, then clear ERRORF, then FLUSH.
      * This resets the internal channel counter and FIFO state.
      */
-    wr32le(HDMI_MAI_CTL(pb), MAI_CTL_RESET);
+    wr32le(HDMI_MAI_CTL(dd), MAI_CTL_RESET);
     udelay(pb, 100);
-    wr32le(HDMI_MAI_CTL(pb), MAI_CTL_ERRORF);
-    wr32le(HDMI_MAI_CTL(pb), MAI_CTL_FLUSH);
+    wr32le(HDMI_MAI_CTL(dd), MAI_CTL_ERRORF);
+    wr32le(HDMI_MAI_CTL(dd), MAI_CTL_FLUSH);
     udelay(pb, 100);
 
     /* Set audio format: PCM at bits 23:16, sample rate at bits 15:8 */
-    wr32le(HDMI_MAI_FMT(pb), MAI_FMT_FORMAT_PCM | MAI_FMT_RATE(srate_enum));
+    wr32le(HDMI_MAI_FMT(dd), MAI_FMT_FORMAT_PCM | MAI_FMT_RATE(srate_enum));
 
     /*
      * FIFO thresholds (all 0x10).
      */
-    wr32le(HDMI_MAI_THR(pb), MAI_THR_DREQL(0x10) | MAI_THR_DREQH(0x10) | MAI_THR_PANICL(0x10) | MAI_THR_PANICH(0x10));
+    wr32le(HDMI_MAI_THR(dd), MAI_THR_DREQL(0x10) | MAI_THR_DREQH(0x10) | MAI_THR_PANICL(0x10) | MAI_THR_PANICH(0x10));
 
     /* MAI_CONFIG: BIT_REVERSE | FORMAT_REVERSE | channel_mask=0x03 (stereo) */
-    wr32le(HDMI_MAI_CONFIG(pb), MAI_CONFIG_BIT_REVERSE | MAI_CONFIG_FORMAT_REVERSE | MAI_CONFIG_CHANNEL_MASK(0x03));
+    wr32le(HDMI_MAI_CONFIG(dd), MAI_CONFIG_BIT_REVERSE | MAI_CONFIG_FORMAT_REVERSE | MAI_CONFIG_CHANNEL_MASK(0x03));
 
     /* Channel map for stereo: 3-bit fields at bits 2:0 (ch0) and 6:4 (ch1) */
-    wr32le(HDMI_MAI_CHANNEL_MAP(pb), 0x08);
+    wr32le(HDMI_MAI_CHANNEL_MAP(dd), 0x08);
 
     /*
      * Audio packet config:
@@ -250,7 +244,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
      *   ZERO_DATA_ON_INACTIVE_CHANNELS
      *   ZERO_DATA_ON_SAMPLE_FLAT
      */
-    wr32le(HDMI_AUDIO_PKT_CFG(pb),
+    wr32le(HDMI_AUDIO_PKT_CFG(dd),
            AUDIO_PKT_ZERO_DATA_ON_FLAT | AUDIO_PKT_ZERO_DATA_ON_INACTIVE | AUDIO_PKT_B_FRAME_ID(0x8) |
                AUDIO_PKT_CEA_MASK(0x03));
 
@@ -260,8 +254,8 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
      * Clock ratio = N / (M+1) = hsm_clock / samplerate. Round N (rather than
      * truncate) to halve the residual rate error.
      */
-    wr32le(HDMI_MAI_SMP(pb),
-           ((HDMI_HSM_CLOCK + dd->samplerate / 2) / dd->samplerate) << 8);
+    wr32le(HDMI_MAI_SMP(dd),
+           ((dd->soc->hsm_clock + dd->samplerate / 2) / dd->samplerate) << 8);
 
     /*
      * CTS/N audio clock recovery.
@@ -272,20 +266,20 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
      * RPi 3B+ default pixel clock ≈ 148500 kHz (1080p60) or 74250 kHz (720p60).
      * We read CTS_0 first to get the hardware-derived value, then write it back.
      */
-    wr32le(HDMI_CRP_CFG(pb), CRP_CFG_EXTERNAL_CTS_EN | CRP_CFG_N(n_value));
+    wr32le(HDMI_CRP_CFG(dd), CRP_CFG_EXTERNAL_CTS_EN | CRP_CFG_N(n_value));
 
     {
-        ULONG cts = rd32le(HDMI_CTS_0(pb));
+        ULONG cts = rd32le(HDMI_CTS_0(dd));
         if (cts == 0) {
             /* Fallback: compute CTS assuming 148500 kHz pixel clock */
             cts = (148500UL * n_value) / (128 * (dd->samplerate / 1000));
         }
-        wr32le(HDMI_CTS_0(pb), cts);
-        wr32le(HDMI_CTS_1(pb), cts);
+        wr32le(HDMI_CTS_0(dd), cts);
+        wr32le(HDMI_CTS_1(dd), cts);
     }
 
     /* Write Audio InfoFrame to RAM packet memory */
-    hdmi_write_audio_infoframe(pb, dd->samplerate);
+    hdmi_write_audio_infoframe(dd);
 
     /*
      * Enable MAI.
@@ -294,7 +288,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
      * Note: DLATE/ERRORE/ERRORF are deliberately left cleared at
      * enable time.
      */
-    wr32le(HDMI_MAI_CTL(pb), MAI_CTL_CHALIGN | MAI_CTL_WHOLSMP | MAI_CTL_CHNUM(2) | MAI_CTL_ENABLE);
+    wr32le(HDMI_MAI_CTL(dd), MAI_CTL_CHALIGN | MAI_CTL_WHOLSMP | MAI_CTL_CHNUM(2) | MAI_CTL_ENABLE);
 
     /* Initialize IEC958 channel status for this sample rate (separate L/R) */
     spdif_setup_channel_status(dd->channel_status_l, dd->channel_status_r, dd->samplerate);
@@ -306,61 +300,7 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
  */
 void hdmi_mai_stop(struct RPiHDMIData *dd)
 {
-    ULONG pb = dd->periiobase;
+    wr32le(HDMI_MAI_CTL(dd), MAI_CTL_FLUSH | MAI_CTL_DLATE | MAI_CTL_ERRORE | MAI_CTL_ERRORF);
 
-    wr32le(HDMI_MAI_CTL(pb), MAI_CTL_FLUSH | MAI_CTL_DLATE | MAI_CTL_ERRORE | MAI_CTL_ERRORF);
-
-    udelay(pb, 100);
-}
-
-
-/******************************************************************************
-** DMA setup ******************************************************************
-******************************************************************************/
-
-void dma_build_control_blocks(struct RPiHDMIData *dd, ULONG peribase)
-{
-    int i;
-
-    for (i = 0; i < 2; i++) {
-        struct BCM2708DMACB *cb = dd->cb[i];
-
-        cb->ti = DMA_TI_INTEN | DMA_TI_WAIT_RESP | DMA_TI_DEST_DREQ | DMA_TI_SRC_INC | DMA_TI_BURST_LENGTH(2) |
-                 DMA_TI_PERMAP(DMA_DREQ_HDMI) | DMA_TI_NO_WIDE_BURSTS;
-
-        cb->source_ad = GPU_BUS_ADDR(dd->dmabuf[i]);
-        cb->dest_ad = HDMI_MAI_DATA_BUS;
-        cb->txfr_len = dd->dmabuf_size;
-        cb->stride = 0;
-        cb->nextconbk = GPU_BUS_ADDR(dd->cb[1 - i]);
-        cb->reserved[0] = 0;
-        cb->reserved[1] = 0;
-    }
-}
-
-void dma_setup(ULONG peribase, ULONG channel, ULONG cb_bus_addr)
-{
-    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
-
-    /* The channel is already enabled by dma.resource at allocation. */
-    wr32le(dma_base + 0x00, DMA_CS_RESET);
-    udelay(peribase, 10);
-    wr32le(dma_base + 0x00, DMA_CS_INT | DMA_CS_END);
-    wr32le(dma_base + 0x04, cb_bus_addr);
-    /* The handler re-writes this with the W1C flags added, so the priorities
-     * survive the session; see bcm2708_dma.h. */
-    wr32le(dma_base + 0x00, BCM2708_DMA_CS_RUN);
-    udelay(peribase, 10);
-}
-
-void dma_stop(ULONG peribase, ULONG channel)
-{
-    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
-
-    wr32le(dma_base + 0x00, 0);
-    udelay(peribase, 50);
-    wr32le(dma_base + 0x00, DMA_CS_RESET);
-    udelay(peribase, 100);
-    wr32le(dma_base + 0x04, 0);
-    wr32le(dma_base + 0x00, DMA_CS_INT | DMA_CS_END);
+    udelay(dd->periiobase, 100);
 }

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -20,6 +20,7 @@
 #include <aros/macros.h>
 
 #include "rpihdmi-hwaccess.h"
+#include "rpihdmi-iec958.h"
 
 /*
  * HDMI State Machine (HSM) clock feeding the MAI sample-rate divider.
@@ -78,44 +79,6 @@ static ULONG srate_to_mai_enum(ULONG samplerate)
 }
 
 /*
- * Map sample rate to IEC958 channel status byte 3 value.
- * IEC 60958-3 Table 3 (sampling frequency).
- */
-static UBYTE srate_to_iec958_cs3(ULONG samplerate)
-{
-    switch (samplerate) {
-    case 22050:
-        return 0x04;
-    case 44100:
-        return 0x00;
-    case 88200:
-        return 0x08;
-    case 176400:
-        return 0x0C;
-    case 24000:
-        return 0x06;
-    case 48000:
-        return 0x02;
-    case 96000:
-        return 0x0A;
-    case 192000:
-        return 0x0E;
-    case 32000:
-        return 0x03;
-    case 8000:
-        return 0x06;
-    case 11025:
-        return 0x00;
-    case 12000:
-        return 0x02;
-    case 16000:
-        return 0x03;
-    default:
-        return 0x02;
-    }
-}
-
-/*
  * Get N value for HDMI audio clock recovery.
  * Standard N values from HDMI spec Table 7-1/7-2/7-3.
  */
@@ -142,118 +105,6 @@ static ULONG srate_to_n(ULONG samplerate)
 }
 
 
-/******************************************************************************
-** IEC958 channel status setup ************************************************
-******************************************************************************/
-
-/*
- * Set up IEC 60958-3 channel status for left and right channels.
- * Byte 2 bits 7:4 = channel number: 1=left, 2=right per IEC 60958-3.
- */
-void spdif_setup_channel_status(UBYTE *cs_left, UBYTE *cs_right, ULONG samplerate)
-{
-    int i;
-
-    for (i = 0; i < 24; i++)
-        cs_left[i] = cs_right[i] = 0;
-
-    /* Both channels share the same base settings */
-    cs_left[0] = cs_right[0] = 0x04; /* Consumer, PCM, no copyright */
-    cs_left[1] = cs_right[1] = 0x00; /* Category code = general */
-    cs_left[3] = cs_right[3] = srate_to_iec958_cs3(samplerate);
-    cs_left[4] = cs_right[4] = 0x02; /* 16-bit word length */
-
-    /* Byte 2: bits 7:4 = channel number (1=left, 2=right) */
-    cs_left[2] = 0x10;  /* Channel 1 (left) */
-    cs_right[2] = 0x20; /* Channel 2 (right) */
-}
-
-
-/******************************************************************************
-** IEC958 subframe encoding ***************************************************
-******************************************************************************/
-
-/*
- * Compute even parity for bits 4..30 of an IEC958 subframe.
- */
-static inline ULONG iec958_parity(ULONG subframe)
-{
-    ULONG v = (subframe >> 4) & 0x07FFFFFF;
-    v ^= v >> 16;
-    v ^= v >> 8;
-    v ^= v >> 4;
-    v ^= v >> 2;
-    v ^= v >> 1;
-    return v & 1;
-}
-
-/*
- * Encode one IEC958 subframe (matching ALSA IEC958_SUBFRAME_LE format).
- *
- * Layout (32 bits):
- *   Bits 3:0   - Preamble (Z=0x08 block-start left, M=0x02 left, W=0x04 right)
- *   Bits 27:4  - 24-bit audio sample (16-bit left-shifted by 8)
- *   Bit 28     - Validity (0 = valid audio)
- *   Bit 29     - User data (0)
- *   Bit 30     - Channel status bit
- *   Bit 31     - Even parity over bits 4-30
- */
-static inline ULONG encode_iec958_subframe(WORD sample, UBYTE cs_bit, UBYTE preamble)
-{
-    ULONG subframe;
-
-    /* 16-bit sample -> 24-bit at bits 27:4 */
-    subframe = ((ULONG) (UWORD) sample) << 12;
-
-    /* Bits 3:0: preamble */
-    subframe |= (preamble & 0x0F);
-
-    /* Bit 28: validity = 0 (valid audio) */
-    /* Bit 29: user data = 0 */
-
-    /* Bit 30: channel status bit */
-    if (cs_bit)
-        subframe |= (1 << 30);
-
-    /* Bit 31: even parity over bits 4-30 */
-    if (iec958_parity(subframe))
-        subframe |= (1 << 31);
-
-    return subframe;
-}
-
-/*
- * Convert AHI mix buffer (signed 16-bit stereo) to IEC958 subframes.
- * Each stereo frame produces 2 x 32-bit subframes (left, right).
- * Channel status cycles through 192 frames per block.
- *
- * Preamble codes (matching ALSA alsa-lib pcm_iec958.c):
- *   Z = 0x08: block start, left channel (frame 0 of 192)
- *   M = 0x02: left channel (other frames)
- *   W = 0x04: right channel
- */
-void convert_mix_to_iec958(WORD *src, ULONG *dst, ULONG frames, UBYTE *cs_left, UBYTE *cs_right, ULONG *frame_counter)
-{
-    ULONG i;
-    ULONG fc = *frame_counter;
-
-    for (i = 0; i < frames; i++) {
-        WORD left = src[i * 2];
-        WORD right = src[i * 2 + 1];
-        UBYTE cs_bit_l = (cs_left[fc / 8] >> (fc % 8)) & 1;
-        UBYTE cs_bit_r = (cs_right[fc / 8] >> (fc % 8)) & 1;
-        UBYTE preamble_left = (fc == 0) ? 0x08 : 0x02;
-
-        dst[i * 2] = AROS_LONG2LE(encode_iec958_subframe(left, cs_bit_l, preamble_left));
-        dst[i * 2 + 1] = AROS_LONG2LE(encode_iec958_subframe(right, cs_bit_r, 0x04));
-
-        fc++;
-        if (fc >= 192)
-            fc = 0;
-    }
-
-    *frame_counter = fc;
-}
 
 
 /******************************************************************************

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -18,10 +18,13 @@
 
 #include <exec/types.h>
 #include <aros/macros.h>
+#include <aros/debug.h>
 
 #include "DriverData.h"
 #include "rpihdmi-hwaccess.h"
 #include "rpihdmi-iec958.h"
+
+#define RPIHDMI_CHANNEL_MASK 0x03
 
 /*
  * Microsecond delay using a busy loop on the system timer.
@@ -97,9 +100,6 @@ static ULONG srate_to_n(ULONG samplerate)
         return 128 * samplerate / 1000;
     }
 }
-
-
-
 
 /******************************************************************************
 ** HDMI Audio InfoFrame *******************************************************
@@ -208,6 +208,9 @@ static void hdmi_write_audio_infoframe(struct RPiHDMIData *dd)
  */
 void hdmi_mai_init(struct RPiHDMIData *dd)
 {
+    struct DriverBase *AHIsubBase =
+        (struct DriverBase *) dd->ahisubbase;
+
     ULONG pb = dd->periiobase;
     ULONG srate_enum = srate_to_mai_enum(dd->samplerate);
     ULONG n_value = srate_to_n(dd->samplerate);
@@ -227,15 +230,23 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
     wr32le(HDMI_MAI_FMT(dd), MAI_FMT_FORMAT_PCM | MAI_FMT_RATE(srate_enum));
 
     /*
-     * FIFO thresholds (all 0x10).
+     * FIFO thresholds.
      */
-    wr32le(HDMI_MAI_THR(dd), MAI_THR_DREQL(0x10) | MAI_THR_DREQH(0x10) | MAI_THR_PANICL(0x10) | MAI_THR_PANICH(0x10));
+    ULONG dreq_threshold = dd->soc->mai_dreq_threshold;
+    ULONG panic_threshold = dd->soc->mai_panic_threshold;
 
-    /* MAI_CONFIG: BIT_REVERSE | FORMAT_REVERSE | channel_mask=0x03 (stereo) */
-    wr32le(HDMI_MAI_CONFIG(dd), MAI_CONFIG_BIT_REVERSE | MAI_CONFIG_FORMAT_REVERSE | MAI_CONFIG_CHANNEL_MASK(0x03));
+    wr32le(HDMI_MAI_THR(dd), MAI_THR_DREQL(dreq_threshold) | MAI_THR_DREQH(dreq_threshold) | MAI_THR_PANICL(panic_threshold) | MAI_THR_PANICH(panic_threshold));
 
-    /* Channel map for stereo: 3-bit fields at bits 2:0 (ch0) and 6:4 (ch1) */
-    wr32le(HDMI_MAI_CHANNEL_MAP(dd), 0x08);
+    /* MAI_CONFIG: temporarily test one MAI channel at a time. */
+    wr32le(HDMI_MAI_CONFIG(dd),
+           MAI_CONFIG_BIT_REVERSE |
+           MAI_CONFIG_FORMAT_REVERSE |
+           MAI_CONFIG_CHANNEL_MASK(RPIHDMI_CHANNEL_MASK));
+
+    /* Channel map for stereo: bcm283x :3-bit fields at bits 2:0 (ch0) and 6:4 (ch1)
+     *                         bcm2711 :4-bit fields
+     */
+    wr32le(HDMI_MAI_CHANNEL_MAP(dd), dd->soc->hdmi_mai_channel_map);
 
     /*
      * Audio packet config:
@@ -248,6 +259,10 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
            AUDIO_PKT_ZERO_DATA_ON_FLAT | AUDIO_PKT_ZERO_DATA_ON_INACTIVE | AUDIO_PKT_B_FRAME_ID(0x8) |
                AUDIO_PKT_CEA_MASK(0x03));
 
+    bug("[RPiHDMI] channel: MAP=%08lx CONFIG=%08lx AUDIO=%08lx\n",
+        rd32le(HDMI_MAI_CHANNEL_MAP(dd)),
+        rd32le(HDMI_MAI_CONFIG(dd)),
+        rd32le(HDMI_AUDIO_PKT_CFG(dd)));
     /*
      * Sample rate clock divider.
      * MAI_SMP register: bits 31:8 = N (numerator), bits 7:0 = M (denominator-1).

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -18,6 +18,8 @@
 
 #include <exec/types.h>
 #include <aros/macros.h>
+
+#define DEBUG 0
 #include <aros/debug.h>
 
 #include "DriverData.h"
@@ -259,10 +261,10 @@ void hdmi_mai_init(struct RPiHDMIData *dd)
            AUDIO_PKT_ZERO_DATA_ON_FLAT | AUDIO_PKT_ZERO_DATA_ON_INACTIVE | AUDIO_PKT_B_FRAME_ID(0x8) |
                AUDIO_PKT_CEA_MASK(0x03));
 
-    bug("[RPiHDMI] channel: MAP=%08lx CONFIG=%08lx AUDIO=%08lx\n",
+    D(bug("[RPiHDMI] channel: MAP=%08lx CONFIG=%08lx AUDIO=%08lx\n",
         rd32le(HDMI_MAI_CHANNEL_MAP(dd)),
         rd32le(HDMI_MAI_CONFIG(dd)),
-        rd32le(HDMI_AUDIO_PKT_CFG(dd)));
+        rd32le(HDMI_AUDIO_PKT_CFG(dd))));
     /*
      * Sample rate clock divider.
      * MAI_SMP register: bits 31:8 = N (numerator), bits 7:0 = M (denominator-1).

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -143,7 +143,7 @@ static UBYTE srate_to_cea_sf(ULONG samplerate)
 
 static void hdmi_write_audio_infoframe(struct RPiHDMIData *dd)
 {
-    ULONG slot_base = dd->periiobase + dd->soc->hdmi_base + 0x400 + 4 * 0x24;
+    ULONG slot_base = HDMI_RAM_PKT_START(dd) + 4 * 0x24;
     UBYTE infoframe[14];
     UBYTE checksum;
     int i;

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
@@ -163,10 +163,4 @@ void dma_build_control_blocks(struct RPiHDMIData *dd, ULONG peribase);
 /* DMA interrupt handler (called from KrnAddIRQHandler) */
 void dma_irq_handler(struct RPiHDMIData *data, void *data2);
 
-/* IEC958/SPDIF channel status setup (separate L/R per IEC 60958-3) */
-void spdif_setup_channel_status(UBYTE *cs_left, UBYTE *cs_right, ULONG samplerate);
-
-/* IEC958 sample conversion */
-void convert_mix_to_iec958(WORD *src, ULONG *dst, ULONG frames, UBYTE *cs_left, UBYTE *cs_right, ULONG *frame_counter);
-
 #endif /* AHI_Drivers_RPiHDMI_hwaccess_h */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
@@ -43,39 +43,39 @@ static inline void wr32le(ULONG addr, ULONG val)
  * HDMI HD register block (MAI control)
  */
 #define HDMI_MAI_CTL(dd) \
-    ((dd->periiobase) + (dd->soc->mai_base) + 0x14)
+    ((dd->periiobase) + (dd->soc->mai_base) + (dd->soc->regs.mai_ctl))
 #define HDMI_MAI_THR(dd) \
-    ((dd->periiobase) + (dd->soc->mai_base) + 0x18)
+    ((dd->periiobase) + (dd->soc->mai_base) + (dd->soc->regs.mai_thr))
 #define HDMI_MAI_FMT(dd) \
-    ((dd->periiobase) + (dd->soc->mai_base) + 0x1C)
+    ((dd->periiobase) + (dd->soc->mai_base) + (dd->soc->regs.mai_fmt))
 #define HDMI_MAI_DATA(dd) \
-    ((dd->periiobase) + (dd->soc->mai_base) + 0x20)
+    ((dd->periiobase) + (dd->soc->mai_base) + (dd->soc->regs.mai_data))
 #define HDMI_MAI_SMP(dd) \
-    ((dd->periiobase) + (dd->soc->mai_base) + 0x2c)
+    ((dd->periiobase) + (dd->soc->mai_base) + (dd->soc->regs.mai_smp))
 
 /*
  * HDMI register block
  */
 #define HDMI_MAI_CHANNEL_MAP(dd) \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x090)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.mai_channel_map))
 #define HDMI_MAI_CONFIG(dd)      \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x094)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.mai_config))
 #define HDMI_AUDIO_PKT_CFG(dd)   \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x09C)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.audio_packet_cfg))
 #define HDMI_RAM_PKT_CFG(dd)     \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A0)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.ram_packet_cfg))
 #define HDMI_RAM_PKT_STATUS(dd)  \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A4)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.ram_packet_status))
 #define HDMI_CRP_CFG(dd)         \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A8)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.crp_cfg))
 #define HDMI_CTS_0(dd)           \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0AC)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.cts_0))
 #define HDMI_CTS_1(dd)           \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0B0)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.cts_1))
 #define HDMI_SCHEDULER_CONTROL(dd) \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0C0)
+    ((dd->periiobase) + (dd->soc->hdmi_base) + (dd->soc->regs.scheduler_control))
 #define HDMI_RAM_PKT_START(dd)   \
-    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x400)
+    ((dd->periiobase) + (dd->soc->packet_base) + (dd->soc->regs.packet_start))
 
 /* MAI_CTL bits */
 #define MAI_CTL_RESET    (1 << 0)

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.h
@@ -41,30 +41,41 @@ static inline void wr32le(ULONG addr, ULONG val)
 
 /*
  * HDMI HD register block (MAI control)
- * Bus address: 0x7E808000, ARM offset from peribase: 0x808000
  */
-#define HD_OFFSET         0x808000
-#define HDMI_MAI_CTL(pb)  ((pb) + HD_OFFSET + 0x14)
-#define HDMI_MAI_THR(pb)  ((pb) + HD_OFFSET + 0x18)
-#define HDMI_MAI_FMT(pb)  ((pb) + HD_OFFSET + 0x1C)
-#define HDMI_MAI_DATA(pb) ((pb) + HD_OFFSET + 0x20)
-#define HDMI_MAI_SMP(pb)  ((pb) + HD_OFFSET + 0x2C)
+#define HDMI_MAI_CTL(dd) \
+    ((dd->periiobase) + (dd->soc->mai_base) + 0x14)
+#define HDMI_MAI_THR(dd) \
+    ((dd->periiobase) + (dd->soc->mai_base) + 0x18)
+#define HDMI_MAI_FMT(dd) \
+    ((dd->periiobase) + (dd->soc->mai_base) + 0x1C)
+#define HDMI_MAI_DATA(dd) \
+    ((dd->periiobase) + (dd->soc->mai_base) + 0x20)
+#define HDMI_MAI_SMP(dd) \
+    ((dd->periiobase) + (dd->soc->mai_base) + 0x2c)
 
 /*
- * HDMI register block — BCM2835 offsets.
- * Bus address: 0x7E902000, ARM offset from peribase: 0x902000
+ * HDMI register block
  */
-#define HDMI_OFFSET                0x902000
-#define HDMI_MAI_CHANNEL_MAP(pb)   ((pb) + HDMI_OFFSET + 0x090)
-#define HDMI_MAI_CONFIG(pb)        ((pb) + HDMI_OFFSET + 0x094)
-#define HDMI_AUDIO_PKT_CFG(pb)     ((pb) + HDMI_OFFSET + 0x09C)
-#define HDMI_RAM_PKT_CFG(pb)       ((pb) + HDMI_OFFSET + 0x0A0)
-#define HDMI_RAM_PKT_STATUS(pb)    ((pb) + HDMI_OFFSET + 0x0A4)
-#define HDMI_CRP_CFG(pb)           ((pb) + HDMI_OFFSET + 0x0A8)
-#define HDMI_CTS_0(pb)             ((pb) + HDMI_OFFSET + 0x0AC)
-#define HDMI_CTS_1(pb)             ((pb) + HDMI_OFFSET + 0x0B0)
-#define HDMI_SCHEDULER_CONTROL(pb) ((pb) + HDMI_OFFSET + 0x0C0)
-#define HDMI_RAM_PKT_START(pb)     ((pb) + HDMI_OFFSET + 0x400)
+#define HDMI_MAI_CHANNEL_MAP(dd) \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x090)
+#define HDMI_MAI_CONFIG(dd)      \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x094)
+#define HDMI_AUDIO_PKT_CFG(dd)   \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x09C)
+#define HDMI_RAM_PKT_CFG(dd)     \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A0)
+#define HDMI_RAM_PKT_STATUS(dd)  \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A4)
+#define HDMI_CRP_CFG(dd)         \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0A8)
+#define HDMI_CTS_0(dd)           \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0AC)
+#define HDMI_CTS_1(dd)           \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0B0)
+#define HDMI_SCHEDULER_CONTROL(dd) \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x0C0)
+#define HDMI_RAM_PKT_START(dd)   \
+    ((dd->periiobase) + (dd->soc->hdmi_base) + 0x400)
 
 /* MAI_CTL bits */
 #define MAI_CTL_RESET    (1 << 0)
@@ -104,10 +115,6 @@ static inline void wr32le(ULONG addr, ULONG val)
 #define CRP_CFG_EXTERNAL_CTS_EN (1 << 24)
 #define CRP_CFG_N(x)            ((x) & 0xFFFFF)
 
-/* The audio DMA channel is allocated at runtime from dma.resource. */
-
-/* DMA DREQ peripheral map ID for HDMI audio */
-#define DMA_DREQ_HDMI 17
 
 /* Bus address of MAI DATA register (DMA destination) */
 #define HDMI_MAI_DATA_BUS 0x7E808020
@@ -117,24 +124,6 @@ static inline void wr32le(ULONG addr, ULONG val)
  * DMA channel N uses GPU IRQ (16 + N).
  */
 #define BCM_IRQ_DMA0 16
-
-/* DMA control block TI bits */
-#define DMA_TI_INTEN           (1 << 0)
-#define DMA_TI_WAIT_RESP       (1 << 3)
-#define DMA_TI_DEST_DREQ       (1 << 6)
-#define DMA_TI_SRC_INC         (1 << 8)
-#define DMA_TI_BURST_LENGTH(x) (((x) & 0xF) << 12)
-#define DMA_TI_PERMAP(x)       (((x) & 0x1F) << 16)
-#define DMA_TI_NO_WIDE_BURSTS  (1 << 26)
-
-/* DMA CS bits */
-/* Run state and acknowledge live in bcm2708_dma.h, shared with the other
- * DMA-driven AHI driver - they have to agree. */
-#define DMA_CS_ACTIVE          (1 << 0)
-#define DMA_CS_END             (1 << 1)
-#define DMA_CS_INT             (1 << 2)
-#define DMA_CS_ABORT           (1 << 30)
-#define DMA_CS_RESET           (1 << 31)
 
 /* Sample rate enum values for MAI_FMT */
 #define SRATE_8000   1
@@ -154,13 +143,5 @@ static inline void wr32le(ULONG addr, ULONG val)
 /* Hardware setup/teardown functions */
 void hdmi_mai_init(struct RPiHDMIData *dd);
 void hdmi_mai_stop(struct RPiHDMIData *dd);
-
-/* DMA functions */
-void dma_setup(ULONG peribase, ULONG channel, ULONG cb_bus_addr);
-void dma_stop(ULONG peribase, ULONG channel);
-void dma_build_control_blocks(struct RPiHDMIData *dd, ULONG peribase);
-
-/* DMA interrupt handler (called from KrnAddIRQHandler) */
-void dma_irq_handler(struct RPiHDMIData *data, void *data2);
 
 #endif /* AHI_Drivers_RPiHDMI_hwaccess_h */

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-iec958.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-iec958.c
@@ -1,0 +1,156 @@
+#include <config.h>
+
+#include <aros/macros.h>
+
+#include "rpihdmi-iec958.h"
+
+/*
+ * Map sample rate to IEC958 channel status byte 3 value.
+ * IEC 60958-3 Table 3 (sampling frequency).
+ */
+static UBYTE srate_to_iec958_cs3(ULONG samplerate)
+{
+    switch (samplerate) {
+    case 22050:
+        return 0x04;
+    case 44100:
+        return 0x00;
+    case 88200:
+        return 0x08;
+    case 176400:
+        return 0x0C;
+    case 24000:
+        return 0x06;
+    case 48000:
+        return 0x02;
+    case 96000:
+        return 0x0A;
+    case 192000:
+        return 0x0E;
+    case 32000:
+        return 0x03;
+    case 8000:
+        return 0x06;
+    case 11025:
+        return 0x00;
+    case 12000:
+        return 0x02;
+    case 16000:
+        return 0x03;
+    default:
+        return 0x02;
+    }
+}
+
+/******************************************************************************
+** IEC958 channel status setup ************************************************
+******************************************************************************/
+
+/*
+ * Set up IEC 60958-3 channel status for left and right channels.
+ * Byte 2 bits 7:4 = channel number: 1=left, 2=right per IEC 60958-3.
+ */
+void spdif_setup_channel_status(UBYTE *cs_left, UBYTE *cs_right, ULONG samplerate)
+{
+    int i;
+
+    for (i = 0; i < 24; i++)
+        cs_left[i] = cs_right[i] = 0;
+
+    /* Both channels share the same base settings */
+    cs_left[0] = cs_right[0] = 0x04; /* Consumer, PCM, no copyright */
+    cs_left[1] = cs_right[1] = 0x00; /* Category code = general */
+    cs_left[3] = cs_right[3] = srate_to_iec958_cs3(samplerate);
+    cs_left[4] = cs_right[4] = 0x02; /* 16-bit word length */
+
+    /* Byte 2: bits 7:4 = channel number (1=left, 2=right) */
+    cs_left[2] = 0x10;  /* Channel 1 (left) */
+    cs_right[2] = 0x20; /* Channel 2 (right) */
+}
+
+
+/******************************************************************************
+** IEC958 subframe encoding ***************************************************
+******************************************************************************/
+
+/*
+ * Compute even parity for bits 4..30 of an IEC958 subframe.
+ */
+static inline ULONG iec958_parity(ULONG subframe)
+{
+    ULONG v = (subframe >> 4) & 0x07FFFFFF;
+    v ^= v >> 16;
+    v ^= v >> 8;
+    v ^= v >> 4;
+    v ^= v >> 2;
+    v ^= v >> 1;
+    return v & 1;
+}
+
+/*
+ * Encode one IEC958 subframe (matching ALSA IEC958_SUBFRAME_LE format).
+ *
+ * Layout (32 bits):
+ *   Bits 3:0   - Preamble (Z=0x08 block-start left, M=0x02 left, W=0x04 right)
+ *   Bits 27:4  - 24-bit audio sample (16-bit left-shifted by 8)
+ *   Bit 28     - Validity (0 = valid audio)
+ *   Bit 29     - User data (0)
+ *   Bit 30     - Channel status bit
+ *   Bit 31     - Even parity over bits 4-30
+ */
+static inline ULONG encode_iec958_subframe(WORD sample, UBYTE cs_bit, UBYTE preamble)
+{
+    ULONG subframe;
+
+    /* 16-bit sample -> 24-bit at bits 27:4 */
+    subframe = ((ULONG) (UWORD) sample) << 12;
+
+    /* Bits 3:0: preamble */
+    subframe |= (preamble & 0x0F);
+
+    /* Bit 28: validity = 0 (valid audio) */
+    /* Bit 29: user data = 0 */
+
+    /* Bit 30: channel status bit */
+    if (cs_bit)
+        subframe |= (1 << 30);
+
+    /* Bit 31: even parity over bits 4-30 */
+    if (iec958_parity(subframe))
+        subframe |= (1 << 31);
+
+    return subframe;
+}
+
+/*
+ * Convert AHI mix buffer (signed 16-bit stereo) to IEC958 subframes.
+ * Each stereo frame produces 2 x 32-bit subframes (left, right).
+ * Channel status cycles through 192 frames per block.
+ *
+ * Preamble codes (matching ALSA alsa-lib pcm_iec958.c):
+ *   Z = 0x08: block start, left channel (frame 0 of 192)
+ *   M = 0x02: left channel (other frames)
+ *   W = 0x04: right channel
+ */
+void convert_mix_to_iec958(WORD *src, ULONG *dst, ULONG frames, UBYTE *cs_left, UBYTE *cs_right, ULONG *frame_counter)
+{
+    ULONG i;
+    ULONG fc = *frame_counter;
+
+    for (i = 0; i < frames; i++) {
+        WORD left = src[i * 2];
+        WORD right = src[i * 2 + 1];
+        UBYTE cs_bit_l = (cs_left[fc / 8] >> (fc % 8)) & 1;
+        UBYTE cs_bit_r = (cs_right[fc / 8] >> (fc % 8)) & 1;
+        UBYTE preamble_left = (fc == 0) ? 0x08 : 0x02;
+
+        dst[i * 2] = AROS_LONG2LE(encode_iec958_subframe(left, cs_bit_l, preamble_left));
+        dst[i * 2 + 1] = AROS_LONG2LE(encode_iec958_subframe(right, cs_bit_r, 0x04));
+
+        fc++;
+        if (fc >= 192)
+            fc = 0;
+    }
+
+    *frame_counter = fc;
+}

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-iec958.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-iec958.h
@@ -1,0 +1,12 @@
+#ifndef AHI_Drivers_RPiHDMI_iec958_h
+#define AHI_Drivers_RPiHDMI_iec958_h
+
+#include <exec/types.h>
+
+/* IEC958/SPDIF channel status setup (separate L/R per IEC 60958-3) */
+void spdif_setup_channel_status(UBYTE *cs_left, UBYTE *cs_right, ULONG samplerate);
+
+/* IEC958 sample conversion */
+void convert_mix_to_iec958(WORD *src, ULONG *dst, ULONG frames, UBYTE *cs_left, UBYTE *cs_right, ULONG *frame_counter);
+
+#endif

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
@@ -8,9 +8,6 @@
 #include <aros/macros.h>
 #include <string.h>
 
-#include "Drivers/RPiPWM/rpipwm-hwaccess.h"
-#include "inline/exec.h"
-#include "inline/openfirmware.h"
 #include "library.h"
 #include "DriverData.h"
 #include "rpihdmi-soc.h"
@@ -94,56 +91,62 @@ static LONG find_element_index(struct DriverBase *AHIsubBase, void *node, char *
     return -1;
 }
 
+static void fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
+    LONG hdmi_index =
+        find_element_index(AHIsubBase, node, "reg-names", "hdmi");
+    LONG hd_index =
+        find_element_index(AHIsubBase, node, "reg-names", "hd");
+    LONG packet_index =
+        find_element_index(AHIsubBase, node, "reg-names", "packet");
+
+    if (hdmi_index < 0 || hd_index < 0 || packet_index < 0) {
+        bug("[RPiHDMI] Missing HDMI register block, using fallback\n");
+        return;
+    }
+
+    ULONG packet_base =
+        get_device_tree_reg_value(AHIsubBase, node, packet_index);
+    ULONG hdmi_base =
+        get_device_tree_reg_value(AHIsubBase, node, hdmi_index);
+    ULONG mai_base =
+        get_device_tree_reg_value(AHIsubBase, node, hd_index);
+
+    if (hdmi_base == 0 || packet_base == 0 || mai_base == 0) {
+        bug("[RPiHDMI] Missing HDMI register values, using fallback\n");
+        return;
+    }
+
+    soc->hdmi_base = hdmi_base - BCM2711_BUS_PERIIOBASE;
+    soc->mai_base = mai_base - BCM2711_BUS_PERIIOBASE;
+    soc->packet_base = packet_base - BCM2711_BUS_PERIIOBASE;
+
+    D(bug("[RPiHDMI] hdmi_base=%08x mai_base=%08x packet_base=%08x\n",
+        (ULONG)soc->hdmi_base,
+        (ULONG)soc->mai_base,
+        (ULONG)soc->packet_base));
+
+    soc->mai_data_bus = mai_base + soc->regs.mai_data;
+}
+
+static void fill_dreq_value(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
+    ULONG dreq_found = find_dreq(AHIsubBase, node);
+    if (dreq_found > 0) {
+        soc->dma_dreq = dreq_found;
+    } else {
+        bug("[RPiHDMI] Couldn't find DREQ device tree value, using fallback\n");
+    }
+}
+
 static void travers_device_tree_and_fill_soc(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc)
 {
     char *compatible = "brcm,bcm2711-hdmi0";
     void *node = find_hdmi_node(AHIsubBase, compatible);
 
     if (node != NULL) {
-        LONG hdmi_index =
-            find_element_index(AHIsubBase, node, "reg-names", "hdmi");
-        LONG hd_index =
-            find_element_index(AHIsubBase, node, "reg-names", "hd");
-        LONG packet_index =
-            find_element_index(AHIsubBase, node, "reg-names", "packet");
-
-        if (hdmi_index < 0 || hd_index < 0 || packet_index < 0) {
-            bug("[RPiHDMI] Missing required HDMI register block\n");
-            return;
-        }
-
-        ULONG packet_base =
-            get_device_tree_reg_value(AHIsubBase, node, packet_index);
-        ULONG hdmi_base =
-            get_device_tree_reg_value(AHIsubBase, node, hdmi_index);
-        ULONG mai_base =
-            get_device_tree_reg_value(AHIsubBase, node, hd_index);
-
-        if (hdmi_base == 0 || packet_base == 0 || mai_base == 0) {
-            bug("[RPiHDMI] Missing required HDMI register values\n");
-            return;
-        }
-
-        soc->hdmi_base = hdmi_base - BCM2711_BUS_PERIIOBASE;
-        soc->mai_base = mai_base - BCM2711_BUS_PERIIOBASE;
-        soc->packet_base = packet_base - BCM2711_BUS_PERIIOBASE;
-
-        bug("[RPiHDMI] hdmi_base=%08x mai_base=%08x packet_base=%08x\n",
-            (ULONG)soc->hdmi_base,
-            (ULONG)soc->mai_base,
-            (ULONG)soc->packet_base);
-
-        soc->mai_data_bus = BCM2711_BUS_PERIIOBASE + mai_base + 0x20;
+        fill_reg_values(AHIsubBase, soc, node, compatible);
+        fill_dreq_value(AHIsubBase, soc, node, compatible);
     } else {
-        bug("[RPiHDMI] Failed to find hdmi node in device tree for %s\n", compatible);
-    }
-
-    if (node != NULL) {
-        ULONG dreq_found = find_dreq(AHIsubBase, node);
-        if (dreq_found > 0) {
-            bug("[RPiHDMI] Found DREQ for %s: %d\n", compatible, dreq_found);
-            soc->dma_dreq = dreq_found;
-        }
+        bug("[RPiHDMI] Failed to find hdmi node in device tree for %s, using fallback\n", compatible);
     }
 }
 
@@ -197,8 +200,8 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
         RPiHDMIBase->soc = &rpihdmi_bcm2711_hdmi0_soc;
         travers_device_tree_and_fill_soc(AHIsubBase, RPiHDMIBase->soc);
 
-        Req("Unsupported Raspberry Pi HDMI audio hardware. P4 not yet implemented\n");
-        return FALSE;
+        // Req("Unsupported Raspberry Pi HDMI audio hardware. P4 not yet implemented\n");
+        // return FALSE;
     }
     else
     {

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
@@ -7,6 +7,7 @@
 
 #include "library.h"
 #include "DriverData.h"
+#include "rpihdmi-soc.h"
 
 APTR KernelBase = NULL;
 APTR DMABase = NULL;
@@ -21,7 +22,8 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
 
     RPiHDMIBase->dosbase = (struct DosLibrary *) OpenLibrary(DOSNAME, 37);
 
-    if (RPiHDMIBase->dosbase == NULL) {
+    if (RPiHDMIBase->dosbase == NULL)
+    {
         Req("Unable to open 'dos.library' version 37.\n");
         return FALSE;
     }
@@ -35,15 +37,33 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
 
     DMABase = OpenResource("dma.resource");
 
-    if (DMABase == NULL) {
+    if (DMABase == NULL)
+    {
         Req("Unable to open 'dma.resource'.\n");
         return FALSE;
     }
 
     RPiHDMIBase->periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
-    if (RPiHDMIBase->periiobase == 0) {
+    if (RPiHDMIBase->periiobase == 0)
+    {
         Req("No BCM283x peripheral base found.\n");
+        return FALSE;
+    }
+
+    if (RPiHDMIBase->periiobase == BCM2708_DMA_PERIIOBASE_2711)
+    {
+        Req("Unsupported Raspberry Pi HDMI audio hardware. P4 not yet implemented\n");
+        return FALSE;
+        //RPiHDMIBase->soc = &rpihdmi_bcm2711_soc;
+    }
+    else
+    {
+        RPiHDMIBase->soc = &rpihdmi_bcm283x_soc;
+    }
+
+    if (RPiHDMIBase->soc == NULL) {
+        Req("Unsupported Raspberry Pi HDMI audio hardware.\n");
         return FALSE;
     }
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
@@ -1,16 +1,151 @@
-
+#include <aros/debug.h>
 #include <config.h>
 
+#include <proto/openfirmware.h>
 #include <proto/exec.h>
 #include <proto/kernel.h>
 #include <proto/dma.h>
+#include <aros/macros.h>
+#include <string.h>
 
+#include "Drivers/RPiPWM/rpipwm-hwaccess.h"
+#include "inline/exec.h"
+#include "inline/openfirmware.h"
 #include "library.h"
 #include "DriverData.h"
 #include "rpihdmi-soc.h"
 
 APTR KernelBase = NULL;
 APTR DMABase = NULL;
+APTR OpenFirmwareBase = NULL;
+
+static void *find_hdmi_node(struct DriverBase *AHIsubBase, char *compatible)
+{
+    if (OpenFirmwareBase == NULL)
+        return NULL;
+
+    return OF_FindNodeByCompatible(NULL, compatible);
+}
+
+static ULONG get_device_tree_reg_value(struct DriverBase *AHIsubBase, void *node, LONG index)
+{
+    void *prop = OF_FindProperty(node, "reg");
+
+    if (index < 0 || prop == NULL) {
+       return 0;
+    }
+
+    const ULONG *cells = OF_GetPropValue(prop);
+    ULONG len = OF_GetPropLen(prop) / sizeof(ULONG);
+
+    if ((ULONG)(index * 2) >= len)
+        return 0;
+
+    return AROS_BE2LONG(cells[(size_t)(index * 2)]);
+}
+
+static ULONG find_dreq(struct DriverBase *AHIsubBase, void *node)
+{
+    void *prop = OF_FindProperty(node, "dmas");
+    const ULONG *cells;
+    ULONG len;
+
+    if (prop != NULL) {
+        cells = OF_GetPropValue(prop);
+        len = OF_GetPropLen(prop) / sizeof(ULONG);
+
+        if (len > 1) {
+            ULONG dma_spec = AROS_BE2LONG(cells[1]);
+            return dma_spec & 0xff;
+        }
+    }
+
+    return 0;
+}
+
+/* "hdmi\0dvp\0phy\0rm\0packet\0..." */
+static LONG find_element_index(struct DriverBase *AHIsubBase, void *node, char *name, char *element)
+{
+    void *prop = OF_FindProperty(node, name);
+    if (prop == NULL) {
+        bug("[RPiHDMI] Failed to find device tree property: %s\n", name);
+        return -1;
+    }
+
+    const char *value = OF_GetPropValue(prop);
+    ULONG len = OF_GetPropLen(prop);
+    ULONG element_index = 0;
+
+    for (ULONG i = 0; i < len; ) {
+        if (value[i] != '\0') {
+            if (strcmp(&value[i], element) == 0)
+                return (int)element_index;
+
+            element_index++;
+
+            while (i < len && value[i] != '\0')
+                i++;
+        }
+
+        while (i < len && value[i] == '\0')
+            i++;
+    }
+
+    return -1;
+}
+
+static void travers_device_tree_and_fill_soc(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc)
+{
+    char *compatible = "brcm,bcm2711-hdmi0";
+    void *node = find_hdmi_node(AHIsubBase, compatible);
+
+    if (node != NULL) {
+        LONG hdmi_index =
+            find_element_index(AHIsubBase, node, "reg-names", "hdmi");
+        LONG hd_index =
+            find_element_index(AHIsubBase, node, "reg-names", "hd");
+        LONG packet_index =
+            find_element_index(AHIsubBase, node, "reg-names", "packet");
+
+        if (hdmi_index < 0 || hd_index < 0 || packet_index < 0) {
+            bug("[RPiHDMI] Missing required HDMI register block\n");
+            return;
+        }
+
+        ULONG packet_base =
+            get_device_tree_reg_value(AHIsubBase, node, packet_index);
+        ULONG hdmi_base =
+            get_device_tree_reg_value(AHIsubBase, node, hdmi_index);
+        ULONG mai_base =
+            get_device_tree_reg_value(AHIsubBase, node, hd_index);
+
+        if (hdmi_base == 0 || packet_base == 0 || mai_base == 0) {
+            bug("[RPiHDMI] Missing required HDMI register values\n");
+            return;
+        }
+
+        soc->hdmi_base = hdmi_base - BCM2711_BUS_PERIIOBASE;
+        soc->mai_base = mai_base - BCM2711_BUS_PERIIOBASE;
+        soc->packet_base = packet_base - BCM2711_BUS_PERIIOBASE;
+
+        bug("[RPiHDMI] hdmi_base=%08x mai_base=%08x packet_base=%08x\n",
+            (ULONG)soc->hdmi_base,
+            (ULONG)soc->mai_base,
+            (ULONG)soc->packet_base);
+
+        soc->mai_data_bus = BCM2711_BUS_PERIIOBASE + mai_base + 0x20;
+    } else {
+        bug("[RPiHDMI] Failed to find hdmi node in device tree for %s\n", compatible);
+    }
+
+    if (node != NULL) {
+        ULONG dreq_found = find_dreq(AHIsubBase, node);
+        if (dreq_found > 0) {
+            bug("[RPiHDMI] Found DREQ for %s: %d\n", compatible, dreq_found);
+            soc->dma_dreq = dreq_found;
+        }
+    }
+}
 
 /******************************************************************************
 ** Custom driver init *********************************************************
@@ -53,9 +188,17 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
 
     if (RPiHDMIBase->periiobase == BCM2708_DMA_PERIIOBASE_2711)
     {
+        OpenFirmwareBase = OpenResource("openfirmware.resource");
+
+        if (OpenFirmwareBase == NULL) {
+            Req("Unable to open 'openfirmware.resource'.\n");
+            return FALSE;
+        }
+        RPiHDMIBase->soc = &rpihdmi_bcm2711_hdmi0_soc;
+        travers_device_tree_and_fill_soc(AHIsubBase, RPiHDMIBase->soc);
+
         Req("Unsupported Raspberry Pi HDMI audio hardware. P4 not yet implemented\n");
         return FALSE;
-        //RPiHDMIBase->soc = &rpihdmi_bcm2711_soc;
     }
     else
     {

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
@@ -1,3 +1,4 @@
+#define DEBUG 0
 #include <aros/debug.h>
 #include <config.h>
 
@@ -8,6 +9,7 @@
 #include <aros/macros.h>
 #include <string.h>
 
+#include "hardware/bcm2708.h"
 #include "library.h"
 #include "DriverData.h"
 #include "rpihdmi-soc.h"
@@ -91,7 +93,7 @@ static LONG find_element_index(struct DriverBase *AHIsubBase, void *node, char *
     return -1;
 }
 
-static void fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
+static BOOL fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
     LONG hdmi_index =
         find_element_index(AHIsubBase, node, "reg-names", "hdmi");
     LONG hd_index =
@@ -101,7 +103,7 @@ static void fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *so
 
     if (hdmi_index < 0 || hd_index < 0 || packet_index < 0) {
         bug("[RPiHDMI] Missing HDMI register block, using fallback\n");
-        return;
+        return FALSE;
     }
 
     ULONG packet_base =
@@ -113,7 +115,7 @@ static void fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *so
 
     if (hdmi_base == 0 || packet_base == 0 || mai_base == 0) {
         bug("[RPiHDMI] Missing HDMI register values, using fallback\n");
-        return;
+        return FALSE;
     }
 
     soc->hdmi_base = hdmi_base - BCM2711_BUS_PERIIOBASE;
@@ -126,27 +128,35 @@ static void fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *so
         (ULONG)soc->packet_base));
 
     soc->mai_data_bus = mai_base + soc->regs.mai_data;
+    return TRUE;
 }
 
-static void fill_dreq_value(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
+static BOOL fill_dreq_value(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
     ULONG dreq_found = find_dreq(AHIsubBase, node);
     if (dreq_found > 0) {
         soc->dma_dreq = dreq_found;
     } else {
         bug("[RPiHDMI] Couldn't find DREQ device tree value, using fallback\n");
+        return FALSE;
     }
+    return TRUE;
 }
 
-static void travers_device_tree_and_fill_soc(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc)
+static BOOL travers_device_tree_and_fill_soc(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, char *compatible)
 {
-    char *compatible = "brcm,bcm2711-hdmi0";
     void *node = find_hdmi_node(AHIsubBase, compatible);
 
     if (node != NULL) {
-        fill_reg_values(AHIsubBase, soc, node, compatible);
-        fill_dreq_value(AHIsubBase, soc, node, compatible);
+        if (!fill_reg_values(AHIsubBase, soc, node, compatible)) {
+            return FALSE;
+        }
+        if (!fill_dreq_value(AHIsubBase, soc, node, compatible)) {
+            return FALSE;
+        }
+        return TRUE;
     } else {
         bug("[RPiHDMI] Failed to find hdmi node in device tree for %s, using fallback\n", compatible);
+        return FALSE;
     }
 }
 
@@ -189,7 +199,7 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
         return FALSE;
     }
 
-    if (RPiHDMIBase->periiobase == BCM2708_DMA_PERIIOBASE_2711)
+    if (RPiHDMIBase->periiobase == BCM2711_PERIIOBASE)
     {
         OpenFirmwareBase = OpenResource("openfirmware.resource");
 
@@ -197,18 +207,29 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
             Req("Unable to open 'openfirmware.resource'.\n");
             return FALSE;
         }
-        RPiHDMIBase->soc = &rpihdmi_bcm2711_hdmi0_soc;
-        travers_device_tree_and_fill_soc(AHIsubBase, RPiHDMIBase->soc);
 
-        // Req("Unsupported Raspberry Pi HDMI audio hardware. P4 not yet implemented\n");
-        // return FALSE;
+        UWORD num = 0;
+
+        if (travers_device_tree_and_fill_soc(AHIsubBase, &rpihdmi_bcm2711_hdmi0_soc, "brcm,bcm2711-hdmi0"))
+            RPiHDMIBase->soc[num++] = &rpihdmi_bcm2711_hdmi0_soc;
+
+        if (travers_device_tree_and_fill_soc(AHIsubBase, &rpihdmi_bcm2711_hdmi1_soc, "brcm,bcm2711-hdmi1"))
+            RPiHDMIBase->soc[num++] = &rpihdmi_bcm2711_hdmi1_soc;
+
+        RPiHDMIBase->num_outputs = num;
+
+        if (num == 0) {
+            Req("Unsupported Raspberry Pi HDMI audio hardware.\n");
+            return FALSE;
+        }
+    }
+    else if (RPiHDMIBase->periiobase == BCM2836_PERIPHYSBASE || RPiHDMIBase->periiobase == BCM2835_PERIPHYSBASE)
+    {
+        RPiHDMIBase->soc[0] = &rpihdmi_bcm283x_soc;
+        RPiHDMIBase->num_outputs = 1;
     }
     else
     {
-        RPiHDMIBase->soc = &rpihdmi_bcm283x_soc;
-    }
-
-    if (RPiHDMIBase->soc == NULL) {
         Req("Unsupported Raspberry Pi HDMI audio hardware.\n");
         return FALSE;
     }

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
@@ -8,6 +8,7 @@
 
 #include <config.h>
 
+#define DEBUG 0
 #include <aros/debug.h>
 #include <devices/ahi.h>
 #include <dos/dostags.h>
@@ -24,6 +25,7 @@
 #include <string.h>
 
 #include "DriverData.h"
+#include "hardware/bcm2708.h"
 #include "library.h"
 #include "rpihdmi-hwaccess.h"
 #include "rpihdmi-dma.h"
@@ -71,7 +73,8 @@ _AHIsub_AllocAudio(struct TagItem *taglist, struct AHIAudioCtrlDrv *AudioCtrl, s
         dd->ahisubbase = RPiHDMIBase;
         dd->periiobase = RPiHDMIBase->periiobase;
         dd->dma_channel = DMAAllocChannel(0);
-        dd->soc = RPiHDMIBase->soc;
+        dd->soc = RPiHDMIBase->soc[0];
+        dd->output = 0;
         dd->dma_dreq = dd->soc->dma_dreq;
     } else {
         return AHISF_ERROR;
@@ -140,14 +143,14 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         dd->samplerate = AudioCtrl->ahiac_MixFreq;
 
-        bug("[RPiHDMI] start: rate=%lu frames=%lu dma_channel=%ld\n",
+        D(bug("[RPiHDMI] start: rate=%lu frames=%lu dma_channel=%ld\n",
             dd->samplerate,
             AudioCtrl->ahiac_MaxBuffSamples,
-            dd->dma_channel);
-        bug("[RPiHDMI] start: mai_data_bus=%08lx dreq=%lu hsm=%lu\n",
+            dd->dma_channel));
+        D(bug("[RPiHDMI] start: mai_data_bus=%08lx dreq=%lu hsm=%lu\n",
             dd->soc->mai_data_bus,
             dd->soc->dma_dreq,
-            dd->soc->hsm_clock);
+            dd->soc->hsm_clock));
 
         /*
          * Calculate DMA buffer size.
@@ -190,23 +193,23 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
         /* Initialize HDMI MAI audio */
         dd->soc->init(dd);
 
-        bug("[RPiHDMI] MAI after init: CTL=%08lx THR=%08lx FMT=%08lx\n",
+        D(bug("[RPiHDMI] MAI after init: CTL=%08lx THR=%08lx FMT=%08lx\n",
             rd32le(HDMI_MAI_CTL(dd)),
             rd32le(HDMI_MAI_THR(dd)),
-            rd32le(HDMI_MAI_FMT(dd)));
-        bug("[RPiHDMI] HDMI after init: CFG=%08lx PKT_CFG=%08lx CRP=%08lx\n",
+            rd32le(HDMI_MAI_FMT(dd))));
+        D(bug("[RPiHDMI] HDMI after init: CFG=%08lx PKT_CFG=%08lx CRP=%08lx\n",
             rd32le(HDMI_MAI_CONFIG(dd)),
             rd32le(HDMI_RAM_PKT_CFG(dd)),
-            rd32le(HDMI_CRP_CFG(dd)));
+            rd32le(HDMI_CRP_CFG(dd))));
 
         ULONG expect = AudioCtrl->ahiac_MixFreq * 2 / 100;
 
         dd->dma_dreq = dd->soc->dma_dreq;
 
-        bug("[RPiHDMI] DMA: selected dreq=%lu dest=%08lx bytes=%lu\n",
+        D(bug("[RPiHDMI] DMA: selected dreq=%lu dest=%08lx bytes=%lu\n",
             dd->dma_dreq,
             dd->soc->mai_data_bus,
-            dd->dmabuf_size);
+            dd->dmabuf_size));
 
         /* Build the DMA control block chain */
         dma_build_control_blocks(dd);
@@ -342,6 +345,12 @@ IPTR _AHIsub_GetAttr(ULONG attribute,
     case AHIDB_Frequency:
         return (LONG) frequencies[argument];
 
+    case AHIDB_Outputs:
+        {
+            struct RPiHDMIBase *RPiHDMIBase = (struct RPiHDMIBase *) AHIsubBase;
+            return RPiHDMIBase->num_outputs;
+        }
+
     case AHIDB_Index:
         if (argument <= frequencies[0]) {
             return 0;
@@ -378,11 +387,12 @@ IPTR _AHIsub_GetAttr(ULONG attribute,
     case AHIDB_Realtime:
         return TRUE;
 
-    case AHIDB_Outputs:
-        return 1;
-
-    case AHIDB_Output:
-        return (IPTR) "HDMI Audio";
+    case AHIDB_Output: {
+        struct RPiHDMIBase *RPiHDMIBase = (struct RPiHDMIBase *) AHIsubBase;
+        if (argument >= 0 && argument < RPiHDMIBase->num_outputs)
+            return (IPTR) RPiHDMIBase->soc[argument]->name;
+        return def;
+    }
 
     default:
         return def;
@@ -399,5 +409,22 @@ _AHIsub_HardwareControl(ULONG attribute,
                         struct AHIAudioCtrlDrv *AudioCtrl,
                         struct DriverBase *AHIsubBase)
 {
+    switch(attribute) {
+        case AHIC_Output: {
+            struct RPiHDMIBase *RPiHDMIBase = (struct RPiHDMIBase*) AHIsubBase;
+            if (RPiHDMIBase->num_outputs >= argument && argument < RPiHDMIBase->num_outputs && argument >= 0) {
+                dd->soc = RPiHDMIBase->soc[argument];
+                dd->dma_dreq = RPiHDMIBase->soc[argument]->dma_dreq;
+                dd->output = argument;
+                return TRUE;
+            } else {
+                return FALSE;
+            }
+        }
+
+        case AHIC_Output_Query:
+            return dd->output;
+    }
+
     return 0;
 }

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
@@ -25,6 +25,7 @@
 #include "DriverData.h"
 #include "library.h"
 #include "rpihdmi-hwaccess.h"
+#include "rpihdmi-dma.h"
 
 #define dd ((struct RPiHDMIData *) AudioCtrl->ahiac_DriverData)
 
@@ -69,6 +70,7 @@ _AHIsub_AllocAudio(struct TagItem *taglist, struct AHIAudioCtrlDrv *AudioCtrl, s
         dd->ahisubbase = RPiHDMIBase;
         dd->periiobase = RPiHDMIBase->periiobase;
         dd->dma_channel = DMAAllocChannel(0);
+        dd->soc = RPiHDMIBase->soc;
     } else {
         return AHISF_ERROR;
     }
@@ -174,16 +176,16 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
         dd->cb[0] = (struct BCM2708DMACB *) cb_raw;
         dd->cb[1] = (struct BCM2708DMACB *) (cb_raw + sizeof(struct BCM2708DMACB));
 
+        /* Initialize HDMI MAI audio */
+        dd->soc->init(dd);
+
         /* Build the DMA control block chain */
-        dma_build_control_blocks(dd, dd->periiobase);
+        dma_build_control_blocks(dd);
 
         /* Flush DMA control blocks and buffers from ARM data cache */
         CacheClearE(dd->cb[0], sizeof(struct BCM2708DMACB) * 2, CACRF_ClearD);
         CacheClearE(dd->dmabuf[0], buf_bytes, CACRF_ClearD);
         CacheClearE(dd->dmabuf[1], buf_bytes, CACRF_ClearD);
-
-        /* Initialize HDMI MAI audio */
-        hdmi_mai_init(dd);
 
         /*
          * Start slave task.
@@ -219,9 +221,9 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
          * The slave has allocated slavesignal and pre-filled both
          * DMA buffers, so IRQ signals won't be lost.
          */
-        dd->irq_handle = KrnAddIRQHandler(BCM_IRQ_DMA0 + dd->dma_channel, dma_irq_handler, dd, SysBase);
+        dd->irq_handle = KrnAddIRQHandler(BCM2708_DMA_IRQ(dd->periiobase, dd->dma_channel), dma_irq_handler, dd, SysBase);
 
-        dma_setup(dd->periiobase, dd->dma_channel, GPU_BUS_ADDR(dd->cb[0]));
+        dma_setup(dd);
     }
 
     if (flags & AHISF_RECORD) {
@@ -262,8 +264,9 @@ void _AHIsub_Stop(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverB
         }
 
         /* Stop hardware */
-        dma_stop(dd->periiobase, dd->dma_channel);
-        hdmi_mai_stop(dd);
+        dma_stop(dd);
+
+        dd->soc->stop(dd);
 
         dd->slavesignal = -1;
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
@@ -71,6 +71,7 @@ _AHIsub_AllocAudio(struct TagItem *taglist, struct AHIAudioCtrlDrv *AudioCtrl, s
         dd->periiobase = RPiHDMIBase->periiobase;
         dd->dma_channel = DMAAllocChannel(0);
         dd->soc = RPiHDMIBase->soc;
+        dd->dma_dreq = dd->soc->dma_dreq;
     } else {
         return AHISF_ERROR;
     }
@@ -178,6 +179,11 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         /* Initialize HDMI MAI audio */
         dd->soc->init(dd);
+
+        ULONG expect = AudioCtrl->ahiac_MixFreq * 2 / 100;
+        ULONG dreq = dma_probe_dreq(dd, expect);
+
+        dd->dma_dreq = dreq;
 
         /* Build the DMA control block chain */
         dma_build_control_blocks(dd);

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-main.c
@@ -8,6 +8,7 @@
 
 #include <config.h>
 
+#include <aros/debug.h>
 #include <devices/ahi.h>
 #include <dos/dostags.h>
 #include <exec/memory.h>
@@ -139,6 +140,15 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
 
         dd->samplerate = AudioCtrl->ahiac_MixFreq;
 
+        bug("[RPiHDMI] start: rate=%lu frames=%lu dma_channel=%ld\n",
+            dd->samplerate,
+            AudioCtrl->ahiac_MaxBuffSamples,
+            dd->dma_channel);
+        bug("[RPiHDMI] start: mai_data_bus=%08lx dreq=%lu hsm=%lu\n",
+            dd->soc->mai_data_bus,
+            dd->soc->dma_dreq,
+            dd->soc->hsm_clock);
+
         /*
          * Calculate DMA buffer size.
          * Each frame = 2 channels * 4 bytes (32-bit SPDIF subframes) = 8 bytes.
@@ -180,10 +190,23 @@ _AHIsub_Start(ULONG flags, struct AHIAudioCtrlDrv *AudioCtrl, struct DriverBase 
         /* Initialize HDMI MAI audio */
         dd->soc->init(dd);
 
-        ULONG expect = AudioCtrl->ahiac_MixFreq * 2 / 100;
-        ULONG dreq = dma_probe_dreq(dd, expect);
+        bug("[RPiHDMI] MAI after init: CTL=%08lx THR=%08lx FMT=%08lx\n",
+            rd32le(HDMI_MAI_CTL(dd)),
+            rd32le(HDMI_MAI_THR(dd)),
+            rd32le(HDMI_MAI_FMT(dd)));
+        bug("[RPiHDMI] HDMI after init: CFG=%08lx PKT_CFG=%08lx CRP=%08lx\n",
+            rd32le(HDMI_MAI_CONFIG(dd)),
+            rd32le(HDMI_RAM_PKT_CFG(dd)),
+            rd32le(HDMI_CRP_CFG(dd)));
 
-        dd->dma_dreq = dreq;
+        ULONG expect = AudioCtrl->ahiac_MixFreq * 2 / 100;
+
+        dd->dma_dreq = dd->soc->dma_dreq;
+
+        bug("[RPiHDMI] DMA: selected dreq=%lu dest=%08lx bytes=%lu\n",
+            dd->dma_dreq,
+            dd->soc->mai_data_bus,
+            dd->dmabuf_size);
 
         /* Build the DMA control block chain */
         dma_build_control_blocks(dd);

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
@@ -23,6 +23,7 @@
 #include "DriverData.h"
 #include "library.h"
 #include "rpihdmi-hwaccess.h"
+#include "rpihdmi-iec958.h"
 
 #define dd ((struct RPiHDMIData *) AudioCtrl->ahiac_DriverData)
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
@@ -24,37 +24,11 @@
 #include "library.h"
 #include "rpihdmi-hwaccess.h"
 #include "rpihdmi-iec958.h"
+#include "rpihdmi-dma.h"
 
-#define dd ((struct RPiHDMIData *) AudioCtrl->ahiac_DriverData)
-
-
-/******************************************************************************
-** DMA interrupt handler ******************************************************
-******************************************************************************/
-
-/*
- * This is called from the DMA IRQ context via KrnAddIRQHandler.
- * We acknowledge the DMA interrupt and signal the slave task.
- */
 #undef SysBase
 
-void dma_irq_handler(struct RPiHDMIData *data, void *data2)
-{
-    struct ExecBase *SysBase = (struct ExecBase *) data2;
-    ULONG dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
-    ULONG cs = rd32le(dma_base + 0x00);
-
-    if (cs & DMA_CS_INT) {
-        /* Must carry the run state, not just ACTIVE: the AXI priorities
-         * share the register. See bcm2708_dma.h. */
-        wr32le(dma_base + 0x00, BCM2708_DMA_CS_ACK);
-
-        if (data->slavetask != NULL && data->slavesignal != -1) {
-            Signal((struct Task *) data->slavetask, 1L << data->slavesignal);
-        }
-    }
-}
-
+#define dd ((struct RPiHDMIData *) AudioCtrl->ahiac_DriverData)
 
 /******************************************************************************
 ** The slave process **********************************************************

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-playslave.c
@@ -18,6 +18,8 @@
 #include <exec/execbase.h>
 #include <libraries/ahi_sub.h>
 #include <aros/macros.h>
+
+#define DEBUG 0
 #include <aros/debug.h>
 
 #include "DriverData.h"

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -41,6 +41,8 @@ struct RPiHDMISoc {
 
     struct RPiHDMIRegs regs;
 
+    const char *name;
+
     void (*init)(struct RPiHDMIData *dd);
     void (*stop)(struct RPiHDMIData *dd);
 };

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -35,6 +35,10 @@ struct RPiHDMISoc {
     ULONG dma_dreq;
     ULONG hsm_clock;
 
+    ULONG mai_dreq_threshold;
+    ULONG mai_panic_threshold;
+    ULONG hdmi_mai_channel_map;
+
     struct RPiHDMIRegs regs;
 
     void (*init)(struct RPiHDMIData *dd);

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -5,18 +5,46 @@
 
 struct RPiHDMIData;
 
+struct RPiHDMIRegs {
+    ULONG mai_ctl;
+    ULONG mai_thr;
+    ULONG mai_fmt;
+    ULONG mai_data;
+    ULONG mai_smp;
+
+    ULONG mai_channel_map;
+    ULONG mai_config;
+    ULONG audio_packet_cfg;
+    ULONG ram_packet_cfg;
+    ULONG ram_packet_status;
+
+    ULONG crp_cfg;
+    ULONG cts_0;
+    ULONG cts_1;
+    ULONG scheduler_control;
+
+    ULONG packet_start;
+};
+
 struct RPiHDMISoc {
     IPTR mai_base;
     IPTR hdmi_base;
+    IPTR packet_base;
+
     ULONG mai_data_bus;
     ULONG dma_dreq;
     ULONG hsm_clock;
+
+    struct RPiHDMIRegs regs;
 
     void (*init)(struct RPiHDMIData *dd);
     void (*stop)(struct RPiHDMIData *dd);
 };
 
 extern const struct RPiHDMISoc rpihdmi_bcm283x_soc;
-extern const struct RPiHDMISoc rpihdmi_bcm2711_soc;
+extern struct RPiHDMISoc rpihdmi_bcm2711_hdmi0_soc;
+extern struct RPiHDMISoc rpihdmi_bcm2711_hdmi1_soc;
+
+#define BCM2711_BUS_PERIIOBASE 0x7E000000UL
 
 #endif

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -1,0 +1,13 @@
+
+struct RPiHDMISoc {
+    ULONG mai_base;
+    ULONG hdmi_base;
+    ULONG mai_data_bus;
+    ULONG dma_dreq;
+    ULONG hsm_clock;
+
+    ULONG (*dma_irq)(IPTR peribase, ULONG channel);
+
+    void (*init)(struct RPiHDMIData *dd);
+    void (*stop)(struct RPiHDMIData *dd);
+};

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -1,13 +1,22 @@
+#ifndef AHI_Drivers_RPiHDMI_soc_h
+#define AHI_Drivers_RPiHDMI_soc_h
+
+#include <exec/types.h>
+
+struct RPiHDMIData;
 
 struct RPiHDMISoc {
-    ULONG mai_base;
-    ULONG hdmi_base;
+    IPTR mai_base;
+    IPTR hdmi_base;
     ULONG mai_data_bus;
     ULONG dma_dreq;
     ULONG hsm_clock;
 
-    ULONG (*dma_irq)(IPTR peribase, ULONG channel);
-
     void (*init)(struct RPiHDMIData *dd);
     void (*stop)(struct RPiHDMIData *dd);
 };
+
+extern const struct RPiHDMISoc rpihdmi_bcm283x_soc;
+extern const struct RPiHDMISoc rpihdmi_bcm2711_soc;
+
+#endif


### PR DESCRIPTION
- Added bcm2711 (raspi4) support to RPiHDMI driver
- Made it possible to choose between the two hdmi ports the raspi4 by using the channel selector in AHI prefs