### PR TITLE
hidds/v3d: Add VideoCore VI (V3D 4.2) GPU driver with Mesa OpenGL

### DIFF
--- a/workbench/hidds/v3d/drm-stubs/drm-uapi/drm_fourcc.h
+++ b/workbench/hidds/v3d/drm-stubs/drm-uapi/drm_fourcc.h
@@ -1,0 +1,15 @@
+/* DRM fourcc stub for AROS */
+#ifndef DRM_FOURCC_H
+#define DRM_FOURCC_H
+#include <stdint.h>
+#define fourcc_code(a, b, c, d) ((uint32_t)(a) | ((uint32_t)(b) << 8) | ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24))
+#define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL
+#define DRM_FORMAT_MOD_LINEAR 0
+#define DRM_FORMAT_MOD_BROADCOM_UIF (((uint64_t)0x09) << 56 | 2)
+#define DRM_FORMAT_MOD_BROADCOM_SAND128 (((uint64_t)0x09) << 56 | 3)
+#define DRM_FORMAT_ARGB8888 fourcc_code('A','R','2','4')
+#define DRM_FORMAT_XRGB8888 fourcc_code('X','R','2','4')
+#define DRM_FORMAT_ABGR8888 fourcc_code('A','B','2','4')
+#define DRM_FORMAT_XBGR8888 fourcc_code('X','B','2','4')
+#define DRM_FORMAT_RGB565 fourcc_code('R','G','1','6')
+#endif

--- a/workbench/hidds/v3d/drm-stubs/drm-uapi/v3d_drm.h
+++ b/workbench/hidds/v3d/drm-stubs/drm-uapi/v3d_drm.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2014-2018 Broadcom
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef _V3D_DRM_H_
+#define _V3D_DRM_H_
+
+/* drm.h stub */
+#include <stdint.h>
+typedef unsigned int __u32;
+typedef unsigned long long __u64;
+typedef int __s32;
+typedef long long __s64;
+#define DRM_COMMAND_BASE 0x40
+#define DRM_IOWR(nr, type) (DRM_COMMAND_BASE + (nr))
+#define DRM_IOW(nr, type) (DRM_COMMAND_BASE + (nr))
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define DRM_V3D_SUBMIT_CL                         0x00
+#define DRM_V3D_WAIT_BO                           0x01
+#define DRM_V3D_CREATE_BO                         0x02
+#define DRM_V3D_MMAP_BO                           0x03
+#define DRM_V3D_GET_PARAM                         0x04
+#define DRM_V3D_GET_BO_OFFSET                     0x05
+#define DRM_V3D_SUBMIT_TFU                        0x06
+#define DRM_V3D_SUBMIT_CSD                        0x07
+
+#define DRM_IOCTL_V3D_SUBMIT_CL           DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_CL, struct drm_v3d_submit_cl)
+#define DRM_IOCTL_V3D_WAIT_BO             DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_WAIT_BO, struct drm_v3d_wait_bo)
+#define DRM_IOCTL_V3D_CREATE_BO           DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_CREATE_BO, struct drm_v3d_create_bo)
+#define DRM_IOCTL_V3D_MMAP_BO             DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_MMAP_BO, struct drm_v3d_mmap_bo)
+#define DRM_IOCTL_V3D_GET_PARAM           DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_GET_PARAM, struct drm_v3d_get_param)
+#define DRM_IOCTL_V3D_GET_BO_OFFSET       DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_GET_BO_OFFSET, struct drm_v3d_get_bo_offset)
+#define DRM_IOCTL_V3D_SUBMIT_TFU          DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_TFU, struct drm_v3d_submit_tfu)
+#define DRM_IOCTL_V3D_SUBMIT_CSD          DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_CSD, struct drm_v3d_submit_csd)
+
+#define DRM_V3D_SUBMIT_CL_FLUSH_CACHE             0x01
+
+/**
+ * struct drm_v3d_submit_cl - ioctl argument for submitting commands to the 3D
+ * engine.
+ *
+ * This asks the kernel to have the GPU execute an optional binner
+ * command list, and a render command list.
+ *
+ * The L1T, slice, L2C, L2T, and GCA caches will be flushed before
+ * each CL executes.  The VCD cache should be flushed (if necessary)
+ * by the submitted CLs.  The TLB writes are guaranteed to have been
+ * flushed by the time the render done IRQ happens, which is the
+ * trigger for out_sync.  Any dirtying of cachelines by the job (only
+ * possible using TMU writes) must be flushed by the caller using the
+ * DRM_V3D_SUBMIT_CL_FLUSH_CACHE_FLAG flag.
+ */
+struct drm_v3d_submit_cl {
+	/* Pointer to the binner command list.
+	 *
+	 * This is the first set of commands executed, which runs the
+	 * coordinate shader to determine where primitives land on the screen,
+	 * then writes out the state updates and draw calls necessary per tile
+	 * to the tile allocation BO.
+	 *
+	 * This BCL will block on any previous BCL submitted on the
+	 * same FD, but not on any RCL or BCLs submitted by other
+	 * clients -- that is left up to the submitter to control
+	 * using in_sync_bcl if necessary.
+	 */
+	__u32 bcl_start;
+
+	/** End address of the BCL (first byte after the BCL) */
+	__u32 bcl_end;
+
+	/* Offset of the render command list.
+	 *
+	 * This is the second set of commands executed, which will either
+	 * execute the tiles that have been set up by the BCL, or a fixed set
+	 * of tiles (in the case of RCL-only blits).
+	 *
+	 * This RCL will block on this submit's BCL, and any previous
+	 * RCL submitted on the same FD, but not on any RCL or BCLs
+	 * submitted by other clients -- that is left up to the
+	 * submitter to control using in_sync_rcl if necessary.
+	 */
+	__u32 rcl_start;
+
+	/** End address of the RCL (first byte after the RCL) */
+	__u32 rcl_end;
+
+	/** An optional sync object to wait on before starting the BCL. */
+	__u32 in_sync_bcl;
+	/** An optional sync object to wait on before starting the RCL. */
+	__u32 in_sync_rcl;
+	/** An optional sync object to place the completion fence in. */
+	__u32 out_sync;
+
+	/* Offset of the tile alloc memory
+	 *
+	 * This is optional on V3D 3.3 (where the CL can set the value) but
+	 * required on V3D 4.1.
+	 */
+	__u32 qma;
+
+	/** Size of the tile alloc memory. */
+	__u32 qms;
+
+	/** Offset of the tile state data array. */
+	__u32 qts;
+
+	/* Pointer to a u32 array of the BOs that are referenced by the job.
+	 */
+	__u64 bo_handles;
+
+	/* Number of BO handles passed in (size is that times 4). */
+	__u32 bo_handle_count;
+
+	__u32 flags;
+};
+
+/**
+ * struct drm_v3d_wait_bo - ioctl argument for waiting for
+ * completion of the last DRM_V3D_SUBMIT_CL on a BO.
+ *
+ * This is useful for cases where multiple processes might be
+ * rendering to a BO and you want to wait for all rendering to be
+ * completed.
+ */
+struct drm_v3d_wait_bo {
+	__u32 handle;
+	__u32 pad;
+	__u64 timeout_ns;
+};
+
+/**
+ * struct drm_v3d_create_bo - ioctl argument for creating V3D BOs.
+ *
+ * There are currently no values for the flags argument, but it may be
+ * used in a future extension.
+ */
+struct drm_v3d_create_bo {
+	__u32 size;
+	__u32 flags;
+	/** Returned GEM handle for the BO. */
+	__u32 handle;
+	/**
+	 * Returned offset for the BO in the V3D address space.  This offset
+	 * is private to the DRM fd and is valid for the lifetime of the GEM
+	 * handle.
+	 *
+	 * This offset value will always be nonzero, since various HW
+	 * units treat 0 specially.
+	 */
+	__u32 offset;
+};
+
+/**
+ * struct drm_v3d_mmap_bo - ioctl argument for mapping V3D BOs.
+ *
+ * This doesn't actually perform an mmap.  Instead, it returns the
+ * offset you need to use in an mmap on the DRM device node.  This
+ * means that tools like valgrind end up knowing about the mapped
+ * memory.
+ *
+ * There are currently no values for the flags argument, but it may be
+ * used in a future extension.
+ */
+struct drm_v3d_mmap_bo {
+	/** Handle for the object being mapped. */
+	__u32 handle;
+	__u32 flags;
+	/** offset into the drm node to use for subsequent mmap call. */
+	__u64 offset;
+};
+
+enum drm_v3d_param {
+	DRM_V3D_PARAM_V3D_UIFCFG,
+	DRM_V3D_PARAM_V3D_HUB_IDENT1,
+	DRM_V3D_PARAM_V3D_HUB_IDENT2,
+	DRM_V3D_PARAM_V3D_HUB_IDENT3,
+	DRM_V3D_PARAM_V3D_CORE0_IDENT0,
+	DRM_V3D_PARAM_V3D_CORE0_IDENT1,
+	DRM_V3D_PARAM_V3D_CORE0_IDENT2,
+	DRM_V3D_PARAM_SUPPORTS_TFU,
+	DRM_V3D_PARAM_SUPPORTS_CSD,
+	DRM_V3D_PARAM_SUPPORTS_CACHE_FLUSH,
+};
+
+struct drm_v3d_get_param {
+	__u32 param;
+	__u32 pad;
+	__u64 value;
+};
+
+/**
+ * Returns the offset for the BO in the V3D address space for this DRM fd.
+ * This is the same value returned by drm_v3d_create_bo, if that was called
+ * from this DRM fd.
+ */
+struct drm_v3d_get_bo_offset {
+	__u32 handle;
+	__u32 offset;
+};
+
+struct drm_v3d_submit_tfu {
+	__u32 icfg;
+	__u32 iia;
+	__u32 iis;
+	__u32 ica;
+	__u32 iua;
+	__u32 ioa;
+	__u32 ios;
+	__u32 coef[4];
+	/* First handle is the output BO, following are other inputs.
+	 * 0 for unused.
+	 */
+	__u32 bo_handles[4];
+	/* sync object to block on before running the TFU job.  Each TFU
+	 * job will execute in the order submitted to its FD.  Synchronization
+	 * against rendering jobs requires using sync objects.
+	 */
+	__u32 in_sync;
+	/* Sync object to signal when the TFU job is done. */
+	__u32 out_sync;
+};
+
+/* Submits a compute shader for dispatch.  This job will block on any
+ * previous compute shaders submitted on this fd, and any other
+ * synchronization must be performed with in_sync/out_sync.
+ */
+struct drm_v3d_submit_csd {
+	__u32 cfg[7];
+	__u32 coef[4];
+
+	/* Pointer to a u32 array of the BOs that are referenced by the job.
+	 */
+	__u64 bo_handles;
+
+	/* Number of BO handles passed in (size is that times 4). */
+	__u32 bo_handle_count;
+
+	/* sync object to block on before running the CSD job.  Each
+	 * CSD job will execute in the order submitted to its FD.
+	 * Synchronization against rendering/TFU jobs or CSD from
+	 * other fds requires using sync objects.
+	 */
+	__u32 in_sync;
+	/* Sync object to signal when the CSD job is done. */
+	__u32 out_sync;
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* _V3D_DRM_H_ */

--- a/workbench/hidds/v3d/drm-stubs/drm.h
+++ b/workbench/hidds/v3d/drm-stubs/drm.h
@@ -1,0 +1,9 @@
+/* DRM base stub for AROS */
+#ifndef DRM_H
+#define DRM_H
+#include <stdint.h>
+typedef unsigned int __u32;
+typedef unsigned long long __u64;
+typedef int __s32;
+typedef long long __s64;
+#endif

--- a/workbench/hidds/v3d/drm-stubs/valgrind.h
+++ b/workbench/hidds/v3d/drm-stubs/valgrind.h
@@ -1,0 +1,6 @@
+/* Valgrind stub for AROS */
+#ifndef VALGRIND_H
+#define VALGRIND_H
+#define VG_USERREQ_TOOL_BASE(a,b) 0
+#define VALGRIND_DO_CLIENT_REQUEST_EXPR(a,b,c,d,e,f,g) 0
+#endif

--- a/workbench/hidds/v3d/drm-stubs/valgrind/memcheck.h
+++ b/workbench/hidds/v3d/drm-stubs/valgrind/memcheck.h
@@ -1,0 +1,7 @@
+#ifndef MEMCHECK_H
+#define MEMCHECK_H
+#define VALGRIND_MAKE_MEM_DEFINED(a,b)
+#define VALGRIND_MAKE_MEM_UNDEFINED(a,b)
+#define VALGRIND_MALLOCLIKE_BLOCK(a,b,c,d)
+#define VALGRIND_FREELIKE_BLOCK(a,b)
+#endif

--- a/workbench/hidds/v3d/drm-stubs/xf86drm.h
+++ b/workbench/hidds/v3d/drm-stubs/xf86drm.h
@@ -1,0 +1,20 @@
+/* DRM stub for AROS — V3D uses v3d_ioctl_aros() instead */
+#ifndef XF86DRM_H
+#define XF86DRM_H
+
+#include <stdint.h>
+
+#define DRM_SYNCOBJ_CREATE_SIGNALED 0x01
+#define DRM_COMMAND_BASE 0x40
+
+#define DRM_IOWR(nr, type) (nr)
+#define DRM_IOW(nr, type) (nr)
+
+static inline int drmIoctl(int fd, unsigned long request, void *arg) { return -1; }
+static inline int drmSyncobjCreate(int fd, uint32_t flags, uint32_t *handle) { *handle = 1; return 0; }
+static inline int drmSyncobjWait(int fd, uint32_t *handles, uint32_t count, int64_t timeout, uint32_t flags, uint32_t *first) { return 0; }
+static inline int drmSyncobjDestroy(int fd, uint32_t handle) { return 0; }
+static inline int drmPrimeHandleToFD(int fd, uint32_t handle, uint32_t flags, int *prime_fd) { *prime_fd = -1; return -1; }
+static inline int drmCloseBufferHandle(int fd, uint32_t handle) { return 0; }
+
+#endif

--- a/workbench/hidds/v3d/drm-stubs/xf86drmMode.h
+++ b/workbench/hidds/v3d/drm-stubs/xf86drmMode.h
@@ -1,0 +1,4 @@
+/* DRM Mode stub for AROS */
+#ifndef XF86DRMMODE_H
+#define XF86DRMMODE_H
+#endif

--- a/workbench/hidds/v3d/mmakefile.src
+++ b/workbench/hidds/v3d/mmakefile.src
@@ -1,0 +1,113 @@
+
+include $(SRCDIR)/config/aros.cfg
+include $(SRCDIR)/workbench/libs/mesa/mesa.cfg
+
+MESA_V3D_DIR = $(top_srcdir)/src/gallium/drivers/v3d
+MESA_BROADCOM_DIR = $(top_srcdir)/src/broadcom
+MESA_GALLIUM_DIR = $(top_srcdir)/src/gallium
+
+# V3D Gallium driver sources (excluding simulator)
+V3D_SOURCES := \
+    $(MESA_V3D_DIR)/v3d_blit \
+    $(MESA_V3D_DIR)/v3d_bufmgr \
+    $(MESA_V3D_DIR)/v3d_cl \
+    $(MESA_V3D_DIR)/v3d_context \
+    $(MESA_V3D_DIR)/v3d_fence \
+    $(MESA_V3D_DIR)/v3d_formats \
+    $(MESA_V3D_DIR)/v3d_job \
+    $(MESA_V3D_DIR)/v3d_program \
+    $(MESA_V3D_DIR)/v3d_query \
+    $(MESA_V3D_DIR)/v3d_resource \
+    $(MESA_V3D_DIR)/v3d_screen \
+    $(MESA_V3D_DIR)/v3d_tiling \
+    $(MESA_V3D_DIR)/v3d_uniforms
+
+# V3D per-version sources (v42 for BCM2711)
+V3DX_SOURCES := \
+    $(MESA_V3D_DIR)/v3dx_draw \
+    $(MESA_V3D_DIR)/v3dx_emit \
+    $(MESA_V3D_DIR)/v3dx_format_table \
+    $(MESA_V3D_DIR)/v3dx_job \
+    $(MESA_V3D_DIR)/v3dx_rcl \
+    $(MESA_V3D_DIR)/v3dx_state
+
+# Broadcom compiler sources
+BROADCOM_COMPILER_SOURCES := \
+    $(MESA_BROADCOM_DIR)/compiler/nir_to_vir \
+    $(MESA_BROADCOM_DIR)/compiler/vir \
+    $(MESA_BROADCOM_DIR)/compiler/vir_dump \
+    $(MESA_BROADCOM_DIR)/compiler/vir_live_variables \
+    $(MESA_BROADCOM_DIR)/compiler/vir_opt_copy_propagate \
+    $(MESA_BROADCOM_DIR)/compiler/vir_opt_dead_code \
+    $(MESA_BROADCOM_DIR)/compiler/vir_opt_redundant_flags \
+    $(MESA_BROADCOM_DIR)/compiler/vir_opt_small_immediates \
+    $(MESA_BROADCOM_DIR)/compiler/vir_register_allocate \
+    $(MESA_BROADCOM_DIR)/compiler/vir_to_qpu \
+    $(MESA_BROADCOM_DIR)/compiler/qpu_schedule \
+    $(MESA_BROADCOM_DIR)/compiler/qpu_validate \
+    $(MESA_BROADCOM_DIR)/compiler/v3d40_tex \
+    $(MESA_BROADCOM_DIR)/compiler/v3d33_tex \
+    $(MESA_BROADCOM_DIR)/compiler/v3d33_vpm_setup \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_io \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_image_load_store \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_logic_ops \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_scratch \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_txf_ms
+
+# Broadcom common sources
+BROADCOM_COMMON_SOURCES := \
+    $(MESA_BROADCOM_DIR)/common/v3d_debug \
+    $(MESA_BROADCOM_DIR)/common/v3d_device_info
+
+# V3D HIDD sources (our code)
+V3D_HIDD_SOURCES := \
+    v3d_init \
+    v3d_hw \
+    v3d_galliumclass \
+    v3d_drm_shim
+
+USER_INCLUDES := \
+    $(USER_INCLUDES) \
+    -iquote $(SRCDIR)/$(CURDIR) \
+    -iquote $(SRCDIR)/$(CURDIR)/drm-stubs \
+    -isystem $(top_srcdir)/include \
+    -isystem $(MESA_BROADCOM_DIR)/cle \
+    -isystem $(MESA_BROADCOM_DIR) \
+    -isystem $(MESA_V3D_DIR) \
+    -I $(MESA_GALLIUM_DIR)/include \
+    -I $(MESA_GALLIUM_DIR)/auxiliary \
+    -I $(MESA_GALLIUM_DIR)/drivers \
+    -I $(top_srcdir)/src \
+    -I $(top_srcdir)/src/compiler/nir \
+    -I $(top_builddir)/src/compiler/nir
+
+USER_CPPFLAGS += \
+    -DV3D_VERSION=41 \
+    -DUSING_V3D_SIMULATOR=0 \
+    -Dusing_v3d_simulator=0 \
+    -UHAVE_VALGRIND \
+    -include $(SRCDIR)/$(CURDIR)/v3d_aros_override.h
+
+NOWARN_CFLAGS := $(NOWARN_MAYBE_UNINITIALIZED) $(NOWARN_MISSING_FIELD_INITIALIZERS)
+USER_CFLAGS += $(NOWARN_CFLAGS)
+
+USER_LDFLAGS := \
+    -L$(top_libdir) \
+    -Wl,--start-group -lgallium_v3d -lbroadcom_compiler -lcompiler -lgalliumauxiliary -lmesautil \
+    -lpthread -lposixc_rel -lstdc_rel \
+    -Wl,--end-group
+
+#MM hidd-v3d: includes hidd-gallium mesa3dgl-linklibs linklibs-gallium_v3d linklibs-broadcom_compiler
+#MM linklibs-gallium_v3d : mesa3dgl-linklibs
+#MM linklibs-broadcom_compiler : mesa3dgl-linklibs
+
+%build_module mmake=hidd-v3d modname=v3d modtype=hidd \
+    files="$(V3D_HIDD_SOURCES)" alwayscxxlink=yes uselibs="" objdir="$(OBJDIR)/$(MESAGLVERSION)"
+
+%build_linklib mmake=linklibs-gallium_v3d libname=gallium_v3d libdir=$(top_libdir) \
+    objdir=$(top_builddir)/gallium_v3d files="$(V3D_SOURCES) $(V3DX_SOURCES)"
+
+%build_linklib mmake=linklibs-broadcom_compiler libname=broadcom_compiler libdir=$(top_libdir) \
+    objdir=$(top_builddir)/broadcom_compiler files="$(BROADCOM_COMPILER_SOURCES) $(BROADCOM_COMMON_SOURCES)"
+
+%common

--- a/workbench/hidds/v3d/mmakefile.src
+++ b/workbench/hidds/v3d/mmakefile.src
@@ -59,15 +59,17 @@ BROADCOM_COMMON_SOURCES := \
     $(MESA_BROADCOM_DIR)/common/v3d_debug \
     $(MESA_BROADCOM_DIR)/common/v3d_device_info
 
-# V3D HIDD sources (our code)
+# V3D HIDD sources
 V3D_HIDD_SOURCES := \
     v3d_init \
     v3d_hw \
     v3d_galliumclass \
-    v3d_drm_shim
+    v3d_drm_shim \
+    $(SRCDIR)/workbench/libs/mesa/emul_arosc
 
 USER_INCLUDES := \
     $(USER_INCLUDES) \
+    -I$(top_builddir)/galliumglue \
     -iquote $(SRCDIR)/$(CURDIR) \
     -iquote $(SRCDIR)/$(CURDIR)/drm-stubs \
     -isystem $(top_srcdir)/include \
@@ -82,32 +84,62 @@ USER_INCLUDES := \
     -I $(top_builddir)/src/compiler/nir
 
 USER_CPPFLAGS += \
-    -DV3D_VERSION=41 \
+    -DV3D_VERSION=42 \
     -DUSING_V3D_SIMULATOR=0 \
     -Dusing_v3d_simulator=0 \
     -UHAVE_VALGRIND \
+    -DGCA_CONSUMER_MODULE \
     -include $(SRCDIR)/$(CURDIR)/v3d_aros_override.h
 
 NOWARN_CFLAGS := $(NOWARN_MAYBE_UNINITIALIZED) $(NOWARN_MISSING_FIELD_INITIALIZERS)
 USER_CFLAGS += $(NOWARN_CFLAGS)
 
-USER_LDFLAGS := \
-    -L$(top_libdir) \
-    -Wl,--start-group -lgallium_v3d -lbroadcom_compiler -lcompiler -lgalliumauxiliary -lmesautil \
-    -lpthread -lposixc_rel -lstdc_rel \
-    -Wl,--end-group
-
-#MM hidd-v3d: includes hidd-gallium mesa3dgl-linklibs linklibs-gallium_v3d linklibs-broadcom_compiler
-#MM linklibs-gallium_v3d : mesa3dgl-linklibs
-#MM linklibs-broadcom_compiler : mesa3dgl-linklibs
-
-%build_module mmake=hidd-v3d modname=v3d modtype=hidd \
-    files="$(V3D_HIDD_SOURCES)" alwayscxxlink=yes uselibs="" objdir="$(OBJDIR)/$(MESAGLVERSION)"
+# Build combined Mesa V3D driver archive
+COMBINED_V3D_SOURCES := $(V3D_SOURCES) $(V3DX_SOURCES) $(BROADCOM_COMPILER_SOURCES) $(BROADCOM_COMMON_SOURCES)
 
 %build_linklib mmake=linklibs-gallium_v3d libname=gallium_v3d libdir=$(top_libdir) \
-    objdir=$(top_builddir)/gallium_v3d files="$(V3D_SOURCES) $(V3DX_SOURCES)"
+    objdir=$(top_builddir)/gallium_v3d files="$(COMBINED_V3D_SOURCES)"
 
-%build_linklib mmake=linklibs-broadcom_compiler libname=broadcom_compiler libdir=$(top_libdir) \
-    objdir=$(top_builddir)/broadcom_compiler files="$(BROADCOM_COMPILER_SOURCES) $(BROADCOM_COMMON_SOURCES)"
+# GalliumCoreAPI runtime binding
+GCA_GENDIR   := $(top_builddir)/galliumglue
+GCA_TOOL     := $(SRCDIR)/workbench/libs/mesa/galliumglue.py
+GCA_NM       := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-nm
+GCA_OBJCOPY  := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-objcopy
+GCA_AR       := $(TOOLDIR)/$(AROS_TARGET_CPU)-$(AROS_TARGET_ARCH)-aros-ar
+GCA_CORELIBS := $(addprefix $(top_libdir)/lib, \
+    compiler.a galliumauxiliary.a mesautil.a mesa.a glapi.a mesadevutil.a)
+GCA_ABI_FLAGS := $(TARGET_ISA_CFLAGS) $(USER_CPPFLAGS)
+
+$(GCA_GENDIR)/.gca_v3d.stamp : $(top_libdir)/libgallium_v3d.a $(GCA_CORELIBS) $(GCA_TOOL)
+	%mkdir_q dir="$(GCA_GENDIR)"
+	$(Q)$(ECHO) "Generating GalliumCoreAPI glue for V3D"
+	$(Q)$(PYTHON) $(GCA_TOOL) --nm $(GCA_NM) --ar $(GCA_AR) \
+		--consumer $(top_libdir)/libgallium_v3d.a \
+		--providers $(GCA_CORELIBS) \
+		--private-data nir_intrinsic_infos nir_op_infos util_cpu_caps \
+		--mesa-version $(MESAGLVERSION) --arch $(AROS_TARGET_CPU) \
+		--abi-flags "$(strip $(GCA_ABI_FLAGS))" \
+		--abi-files $(SRCDIR)/workbench/libs/mesa/mesa-$(MESAGLVERSION)-aros.diff \
+		--outdir $(GCA_GENDIR)
+	$(Q)touch $@
+
+$(top_libdir)/libgallium_v3d_gca.a : $(top_libdir)/libgallium_v3d.a $(GCA_GENDIR)/.gca_v3d.stamp
+	$(Q)$(ECHO) "Rewriting gallium_v3d through GalliumCoreAPI table"
+	$(Q)$(GCA_OBJCOPY) --redefine-syms=$(GCA_GENDIR)/gca_redefs.txt \
+		$(top_libdir)/libgallium_v3d.a $@
+	$(Q)$(GCA_AR) rs $@ $(GCA_GENDIR)/gca_bind.o $(GCA_GENDIR)/gca_glue.o
+	$(Q)cat $(GCA_GENDIR)/gca_private.list | xargs $(GCA_AR) rs $@
+
+#MM
+linklibs-gallium_v3d-gca : $(top_libdir)/libgallium_v3d_gca.a
+
+USER_LDFLAGS := -L$(top_libdir) -lstdcio -lstdc
+
+#MM hidd-v3d: includes hidd-gallium mesa3dgl-linklibs linklibs-gallium_v3d linklibs-gallium_v3d-gca
+
+%build_module mmake=hidd-v3d modname=v3d modtype=hidd \
+    files="$(V3D_HIDD_SOURCES)" alwayscxxlink=yes \
+    uselibs="gallium_v3d_gca pthread" \
+    objdir="$(OBJDIR)/$(MESAGLVERSION)"
 
 %common

--- a/workbench/hidds/v3d/v3d.conf
+++ b/workbench/hidds/v3d/v3d.conf
@@ -1,0 +1,23 @@
+##begin config
+version         1.0
+residentpri     90
+libbasetype     struct IntHiddV3DBase
+basename        HiddV3D
+classid         "hidd.gallium.v3d"
+superclass      CLID_Hidd_Gallium
+classptr_field  sd.galliumclass
+classdatatype   struct V3DData
+##end config
+
+##begin cdefprivate
+#include <hidd/gallium.h>
+#include "v3d_intern.h"
+##end cdefprivate
+
+##begin methodlist
+.interface Root
+New
+.interface Hidd_Gallium
+CreatePipeScreen
+DisplayResource
+##end methodlist

--- a/workbench/hidds/v3d/v3d_aros_override.h
+++ b/workbench/hidds/v3d/v3d_aros_override.h
@@ -6,7 +6,6 @@
  */
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     V3D Mesa AROS DRM Override
 */

--- a/workbench/hidds/v3d/v3d_aros_override.h
+++ b/workbench/hidds/v3d/v3d_aros_override.h
@@ -1,0 +1,28 @@
+/*
+ * v3d_ioctl override for AROS
+ *
+ * This header is force-included (-include) before all Mesa V3D source files.
+ * It redefines v3d_ioctl to route through our DRM shim instead of drmIoctl.
+ */
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    V3D Mesa AROS DRM Override
+*/
+
+#ifndef V3D_AROS_OVERRIDE_H
+#define V3D_AROS_OVERRIDE_H
+
+/* Forward declaration of our shim */
+struct V3DData;
+extern struct V3DData *g_v3d_data;
+extern int v3d_ioctl_aros(struct V3DData *sd, unsigned long request, void *arg);
+
+/* Override the inline v3d_ioctl that Mesa defines in v3d_context.h */
+#define drmIoctl(fd, request, arg) v3d_ioctl_aros(g_v3d_data, request, arg)
+
+/* Suppress the simulator path */
+#define using_v3d_simulator 0
+
+#endif /* V3D_AROS_OVERRIDE_H */

--- a/workbench/hidds/v3d/v3d_drm_shim.c
+++ b/workbench/hidds/v3d/v3d_drm_shim.c
@@ -1,0 +1,241 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    V3D DRM ioctl shim for AROS
+*/
+
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <aros/debug.h>
+#include <proto/exec.h>
+
+#include "v3d_intern.h"
+
+/* DRM ioctl numbers used by Mesa V3D driver */
+#define DRM_IOCTL_V3D_SUBMIT_CL    0x00
+#define DRM_IOCTL_V3D_WAIT_BO      0x01
+#define DRM_IOCTL_V3D_CREATE_BO    0x02
+#define DRM_IOCTL_V3D_MMAP_BO      0x03
+#define DRM_IOCTL_V3D_GET_PARAM    0x04
+#define DRM_IOCTL_V3D_GET_BO_OFFSET 0x05
+#define DRM_IOCTL_V3D_SUBMIT_TFU   0x06
+#define DRM_IOCTL_GEM_CLOSE        0x09
+#define DRM_IOCTL_GEM_OPEN         0x0A
+#define DRM_IOCTL_GEM_FLINK        0x0B
+
+/* Structures matching Linux DRM V3D ioctls */
+struct drm_v3d_submit_cl {
+    ULONG bcl_start;
+    ULONG bcl_end;
+    ULONG rcl_start;
+    ULONG rcl_end;
+    ULONG qma;          /* Query memory address */
+    ULONG qms;          /* Query memory size */
+    ULONG qts;          /* Query timestamp */
+    ULONG flags;
+    /* BO handles array follows */
+};
+
+struct drm_v3d_create_bo {
+    ULONG size;
+    ULONG flags;
+    ULONG handle;       /* Output */
+    ULONG offset;       /* Output: GPU address */
+};
+
+struct drm_v3d_mmap_bo {
+    ULONG handle;
+    ULONG flags;
+    UQUAD offset;     /* Output: mmap offset (we return vaddr) */
+};
+
+struct drm_v3d_wait_bo {
+    ULONG handle;
+    ULONG pad;
+    UQUAD timeout_ns;
+};
+
+struct drm_v3d_get_param {
+    ULONG param;
+    ULONG pad;
+    UQUAD value;      /* Output */
+};
+
+struct drm_v3d_get_bo_offset {
+    ULONG handle;
+    ULONG offset;       /* Output */
+};
+
+struct drm_gem_close {
+    ULONG handle;
+    ULONG pad;
+};
+
+/* V3D_GET_PARAM parameter IDs */
+#define DRM_V3D_PARAM_V3D_UIFCFG    0
+#define DRM_V3D_PARAM_V3D_HUB_IDENT1 1
+#define DRM_V3D_PARAM_V3D_HUB_IDENT2 2
+#define DRM_V3D_PARAM_V3D_HUB_IDENT3 3
+#define DRM_V3D_PARAM_V3D_CORE0_IDENT0 4
+#define DRM_V3D_PARAM_V3D_CORE0_IDENT1 5
+#define DRM_V3D_PARAM_V3D_CORE0_IDENT2 6
+#define DRM_V3D_PARAM_SUPPORTS_TFU  7
+#define DRM_V3D_PARAM_SUPPORTS_CSD  8
+
+/*
+ * Simple handle table — maps integer handles to V3DBO pointers.
+ * Max 256 concurrent BOs should be plenty for AROS usage.
+ */
+#define MAX_BO_HANDLES 256
+static struct V3DBO *bo_table[MAX_BO_HANDLES];
+static ULONG next_handle = 1;
+
+static ULONG alloc_handle(struct V3DBO *bo)
+{
+    ULONG h = next_handle++;
+    if (h >= MAX_BO_HANDLES)
+        return 0;
+    bo_table[h] = bo;
+    return h;
+}
+
+static struct V3DBO *lookup_handle(ULONG handle)
+{
+    if (handle >= MAX_BO_HANDLES)
+        return NULL;
+    return bo_table[handle];
+}
+
+static void free_handle(ULONG handle)
+{
+    if (handle < MAX_BO_HANDLES)
+        bo_table[handle] = NULL;
+}
+
+/*
+ * v3d_ioctl_aros — replacement for drmIoctl/v3d_ioctl.
+ *
+ * This function is called by the Mesa V3D driver instead of the
+ * Linux DRM ioctl interface.
+ */
+int v3d_ioctl_aros(struct V3DData *sd, unsigned long request, void *arg)
+{
+    switch (request) {
+    case DRM_IOCTL_V3D_CREATE_BO:
+    {
+        struct drm_v3d_create_bo *create = arg;
+        struct V3DBO *bo = v3d_aros_bo_alloc(sd, create->size);
+        if (!bo)
+            return -1;
+        create->handle = alloc_handle(bo);
+        create->offset = bo->paddr;
+        return 0;
+    }
+
+    case DRM_IOCTL_GEM_CLOSE:
+    {
+        struct drm_gem_close *close = arg;
+        struct V3DBO *bo = lookup_handle(close->handle);
+        if (bo) {
+            free_handle(close->handle);
+            v3d_aros_bo_free(sd, bo);
+        }
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_MMAP_BO:
+    {
+        struct drm_v3d_mmap_bo *map = arg;
+        struct V3DBO *bo = lookup_handle(map->handle);
+        if (!bo)
+            return -1;
+        /* On AROS, vaddr IS the usable pointer (no mmap needed) */
+        map->offset = (IPTR)bo->vaddr;
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_GET_BO_OFFSET:
+    {
+        struct drm_v3d_get_bo_offset *get = arg;
+        struct V3DBO *bo = lookup_handle(get->handle);
+        if (!bo)
+            return -1;
+        get->offset = bo->paddr;
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_WAIT_BO:
+    {
+        /* All our submissions are synchronous for now */
+        v3d_wait_idle(sd);
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_SUBMIT_CL:
+    {
+        struct drm_v3d_submit_cl *submit = arg;
+
+        /* Submit binning CL */
+        if (submit->bcl_start != submit->bcl_end) {
+            v3d_submit_cl(sd, submit->bcl_start, submit->bcl_end, FALSE);
+            v3d_wait_idle(sd);
+        }
+
+        /* Submit rendering CL */
+        if (submit->rcl_start != submit->rcl_end) {
+            v3d_submit_cl(sd, submit->rcl_start, submit->rcl_end, TRUE);
+            v3d_wait_idle(sd);
+        }
+
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_GET_PARAM:
+    {
+        struct drm_v3d_get_param *p = arg;
+        ULONG val;
+
+        switch (p->param) {
+        case DRM_V3D_PARAM_V3D_HUB_IDENT1:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->hub_base + V3D_HUB_IDENT1));
+            break;
+        case DRM_V3D_PARAM_V3D_HUB_IDENT2:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->hub_base + V3D_HUB_IDENT2));
+            break;
+        case DRM_V3D_PARAM_V3D_HUB_IDENT3:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->hub_base + V3D_HUB_IDENT3));
+            break;
+        case DRM_V3D_PARAM_V3D_CORE0_IDENT0:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->core0_base + V3D_CTL_IDENT0));
+            break;
+        case DRM_V3D_PARAM_V3D_CORE0_IDENT1:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->core0_base + V3D_CTL_IDENT1));
+            break;
+        case DRM_V3D_PARAM_V3D_CORE0_IDENT2:
+            val = AROS_LE2LONG(*(volatile ULONG *)(sd->core0_base + V3D_CTL_IDENT2));
+            break;
+        case DRM_V3D_PARAM_SUPPORTS_TFU:
+            val = 1; /* BCM2711 V3D 4.2 has TFU */
+            break;
+        case DRM_V3D_PARAM_SUPPORTS_CSD:
+            val = 1; /* BCM2711 V3D 4.2 has CSD */
+            break;
+        default:
+            val = 0;
+            break;
+        }
+        p->value = val;
+        return 0;
+    }
+
+    case DRM_IOCTL_V3D_SUBMIT_TFU:
+        /* TFU (Texture Formatting Unit) — not yet implemented */
+        D(bug("[V3D] TFU submit not yet implemented\n"));
+        return -1;
+
+    default:
+        D(bug("[V3D] Unknown ioctl 0x%lx\n", request));
+        return -1;
+    }
+}

--- a/workbench/hidds/v3d/v3d_drm_shim.c
+++ b/workbench/hidds/v3d/v3d_drm_shim.c
@@ -1,6 +1,5 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     V3D DRM ioctl shim for AROS
 */

--- a/workbench/hidds/v3d/v3d_galliumclass.c
+++ b/workbench/hidds/v3d/v3d_galliumclass.c
@@ -1,0 +1,85 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    VideoCore VI (V3D) — Gallium HIDD class
+*/
+
+#include <aros/debug.h>
+#include <proto/oop.h>
+#include <proto/utility.h>
+
+#include <hidd/gallium.h>
+
+#include "v3d_intern.h"
+
+#undef HiddGalliumAttrBase
+#define HiddGalliumAttrBase (SD(cl)->hiddGalliumAB)
+
+/* Forward declaration — from Mesa V3D driver */
+struct pipe_screen;
+struct pipe_screen_config;
+struct renderonly;
+extern struct pipe_screen *v3d_screen_create(int fd,
+    const struct pipe_screen_config *config, struct renderonly *ro);
+
+/* Global V3DData pointer for the DRM shim to access */
+struct V3DData *g_v3d_data = NULL;
+
+/*
+ * New — create instance of V3D Gallium HIDD.
+ */
+OOP_Object *HiddV3D__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
+{
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    return o;
+}
+
+/*
+ * CreatePipeScreen — create the Gallium pipe_screen for V3D.
+ *
+ * This is called by mesa3dgl.library when an OpenGL context is created.
+ * We return a real V3D pipe_screen backed by hardware.
+ */
+OOP_Object *HiddV3D__Hidd_Gallium__CreatePipeScreen(OOP_Class *cl, OOP_Object *o,
+                                                     struct pHidd_Gallium_CreatePipeScreen *msg)
+{
+    struct V3DData *sd = SD(cl);
+
+    D(bug("[V3D] CreatePipeScreen\n"));
+
+    if (!sd->powered) {
+        D(bug("[V3D] GPU not powered\n"));
+        return NULL;
+    }
+
+    /* Set global pointer for DRM shim */
+    g_v3d_data = sd;
+
+    /*
+     * Create the Mesa V3D pipe_screen.
+     * fd=0 is a dummy — our v3d_ioctl override doesn't use it.
+     * config=NULL — no driconf on AROS.
+     * ro=NULL — no renderonly (we own the display).
+     */
+    struct pipe_screen *screen = v3d_screen_create(0, NULL, NULL);
+
+    if (!screen) {
+        D(bug("[V3D] v3d_screen_create failed\n"));
+        return NULL;
+    }
+
+    D(bug("[V3D] pipe_screen created at %p\n", screen));
+
+    return (OOP_Object *)screen;
+}
+
+/*
+ * DisplayResource — present a rendered frame to the screen.
+ */
+VOID HiddV3D__Hidd_Gallium__DisplayResource(OOP_Class *cl, OOP_Object *o,
+                                             struct pHidd_Gallium_DisplayResource *msg)
+{
+    /* TODO: Blit from V3D render target to vc4gfx framebuffer */
+    D(bug("[V3D] DisplayResource\n"));
+}

--- a/workbench/hidds/v3d/v3d_galliumclass.c
+++ b/workbench/hidds/v3d/v3d_galliumclass.c
@@ -1,6 +1,5 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     VideoCore VI (V3D) — Gallium HIDD class
 */
@@ -23,6 +22,11 @@ struct renderonly;
 extern struct pipe_screen *v3d_screen_create(int fd,
     const struct pipe_screen_config *config, struct renderonly *ro);
 
+/* Forward declaration — from GalliumCoreAPI */
+struct GalliumCoreAPI;
+extern int gca_bind(const struct GalliumCoreAPI *api);
+extern const char *gca_slot_name(unsigned int slot);
+
 /* Global V3DData pointer for the DRM shim to access */
 struct V3DData *g_v3d_data = NULL;
 
@@ -32,6 +36,10 @@ struct V3DData *g_v3d_data = NULL;
 OOP_Object *HiddV3D__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 {
     o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+    if (o)
+    {
+        SD(cl)->coreapi = (APTR)GetTagData(aHidd_Gallium_CoreAPI, 0, msg->attrList);
+    }
     return o;
 }
 
@@ -50,6 +58,26 @@ OOP_Object *HiddV3D__Hidd_Gallium__CreatePipeScreen(OOP_Class *cl, OOP_Object *o
 
     if (!sd->powered) {
         D(bug("[V3D] GPU not powered\n"));
+        return NULL;
+    }
+
+    /*
+     * Bind the driver's Mesa-core trampolines to mesa3dgl's
+     * GalliumCoreAPI table before any driver code runs.
+     */
+    if (!sd->coreapi) {
+        bug("[V3D] GalliumCoreAPI table missing (old mesa3dgl?)\n");
+        return NULL;
+    }
+
+    int bres = gca_bind((const struct GalliumCoreAPI *)sd->coreapi);
+    if (bres > 0) {
+        bug("[V3D] GalliumCoreAPI bind refused: slot %d is not '%s'\n",
+            bres - 1, gca_slot_name((unsigned int)(bres - 1)));
+        return NULL;
+    }
+    if (bres < 0) {
+        bug("[V3D] GalliumCoreAPI bind refused (code %d)\n", bres);
         return NULL;
     }
 

--- a/workbench/hidds/v3d/v3d_hw.c
+++ b/workbench/hidds/v3d/v3d_hw.c
@@ -1,0 +1,198 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    VideoCore VI (V3D 4.2) GPU — Hardware initialization and job submission
+*/
+
+#include <exec/types.h>
+#include <exec/memory.h>
+#include <aros/debug.h>
+#include <aros/macros.h>
+#include <proto/exec.h>
+#include <proto/kernel.h>
+
+#include "v3d_intern.h"
+
+/* Register access */
+static inline ULONG v3d_hub_rd(struct V3DData *sd, ULONG off)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)(sd->hub_base + off));
+}
+
+static inline void v3d_hub_wr(struct V3DData *sd, ULONG off, ULONG val)
+{
+    *(volatile ULONG *)(sd->hub_base + off) = AROS_LONG2LE(val);
+}
+
+static inline ULONG v3d_core_rd(struct V3DData *sd, ULONG off)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)(sd->core0_base + off));
+}
+
+static inline void v3d_core_wr(struct V3DData *sd, ULONG off, ULONG val)
+{
+    *(volatile ULONG *)(sd->core0_base + off) = AROS_LONG2LE(val);
+}
+
+/*
+ * Power on the V3D block via VideoCore mailbox.
+ */
+static BOOL v3d_power_on(struct V3DData *sd)
+{
+    /* The V3D power domain should already be enabled by the firmware
+     * if the GPU is in use for the framebuffer. If not, we'd need
+     * to send a mailbox message to power it on.
+     * For now, assume it's powered (firmware enables it at boot). */
+    D(bug("[V3D] Assuming V3D is powered on by firmware\n"));
+    return TRUE;
+}
+
+/*
+ * Initialize V3D hardware — identify the GPU and verify it's alive.
+ */
+BOOL v3d_hw_init(struct V3DData *sd)
+{
+    ULONG ident0, ident1, ident2;
+
+    sd->hub_base = V3D_HUB_BASE;
+    sd->core0_base = V3D_CORE0_BASE;
+
+    /* Power on */
+    if (!v3d_power_on(sd))
+        return FALSE;
+
+    /* Read identification registers */
+    ident0 = v3d_hub_rd(sd, V3D_HUB_IDENT0);
+    ident1 = v3d_hub_rd(sd, V3D_HUB_IDENT1);
+    ident2 = v3d_hub_rd(sd, V3D_HUB_IDENT2);
+
+    sd->ver = (ident0 >> V3D_IDENT0_VER_SHIFT) & 0xFF;
+
+    if (sd->ver == 0 || sd->ver == 0xFF) {
+        D(bug("[V3D] V3D not responding (ident0=0x%08lx) — not powered?\n", ident0));
+        return FALSE;
+    }
+
+    /* Extract core info from ident1 */
+    sd->nslc = (ident1 >> 4) & 0xF;
+    sd->qpus_per_slice = (ident1 >> 8) & 0xF;
+
+    D(bug("[V3D] V3D %ld.%ld identified: %ld slices, %ld QPUs/slice\n",
+          sd->ver / 10, sd->ver % 10, sd->nslc, sd->qpus_per_slice));
+    D(bug("[V3D] IDENT0=0x%08lx IDENT1=0x%08lx IDENT2=0x%08lx\n",
+          ident0, ident1, ident2));
+
+    /* Mask all interrupts initially */
+    v3d_hub_wr(sd, V3D_HUB_INT_MSK_SET, 0xFFFFFFFF);
+    v3d_hub_wr(sd, V3D_HUB_INT_CLR, 0xFFFFFFFF);
+
+    /* Initialize buffer and job lists */
+    NEWLIST(&sd->bo_list);
+    NEWLIST(&sd->job_list);
+    InitSemaphore(&sd->bo_lock);
+    InitSemaphore(&sd->job_lock);
+
+    sd->powered = TRUE;
+
+    return TRUE;
+}
+
+void v3d_hw_shutdown(struct V3DData *sd)
+{
+    /* Mask all interrupts */
+    v3d_hub_wr(sd, V3D_HUB_INT_MSK_SET, 0xFFFFFFFF);
+    sd->powered = FALSE;
+}
+
+/*
+ * Allocate a GPU buffer object (physically contiguous).
+ * The V3D GPU on BCM2711 without IOMMU sees physical addresses directly.
+ */
+struct V3DBO *v3d_aros_bo_alloc(struct V3DData *sd, ULONG size)
+{
+    struct V3DBO *bo;
+
+    bo = AllocVec(sizeof(struct V3DBO), MEMF_CLEAR | MEMF_PUBLIC);
+    if (!bo)
+        return NULL;
+
+    /* Allocate physically contiguous memory in the low 1GB
+     * (V3D can address full 4GB but we keep it simple) */
+    bo->vaddr = AllocVec(size, MEMF_CLEAR | MEMF_PUBLIC | MEMF_31BIT);
+    if (!bo->vaddr) {
+        FreeVec(bo);
+        return NULL;
+    }
+
+    /* On AROS without MMU for userspace, virtual = physical */
+    bo->paddr = (ULONG)(IPTR)bo->vaddr;
+    bo->size = size;
+    bo->refcount = 1;
+
+    ObtainSemaphore(&sd->bo_lock);
+    AddTail((struct List *)&sd->bo_list, (struct Node *)bo);
+    ReleaseSemaphore(&sd->bo_lock);
+
+    return bo;
+}
+
+void v3d_aros_bo_free(struct V3DData *sd, struct V3DBO *bo)
+{
+    if (--bo->refcount > 0)
+        return;
+
+    ObtainSemaphore(&sd->bo_lock);
+    Remove((struct Node *)bo);
+    ReleaseSemaphore(&sd->bo_lock);
+
+    FreeVec(bo->vaddr);
+    FreeVec(bo);
+}
+
+/*
+ * Submit a control list to the V3D CLE (Control List Executor).
+ *
+ * Thread 0 = Binning (geometry processing)
+ * Thread 1 = Rendering (fragment processing)
+ *
+ * The CLE starts executing when we write the end address.
+ */
+BOOL v3d_submit_cl(struct V3DData *sd, ULONG start, ULONG end, BOOL is_render)
+{
+    if (!sd->powered)
+        return FALSE;
+
+    /* Flush data cache so GPU sees the control list */
+    CacheClearE((APTR)(IPTR)start, end - start, CACRF_ClearD);
+
+    if (is_render) {
+        /* Thread 1: Rendering */
+        v3d_core_wr(sd, V3D_CLE_CT1CA, start);
+        v3d_core_wr(sd, V3D_CLE_CT1EA, end);
+    } else {
+        /* Thread 0: Binning */
+        v3d_core_wr(sd, V3D_CLE_CT0CA, start);
+        v3d_core_wr(sd, V3D_CLE_CT0EA, end);
+    }
+
+    return TRUE;
+}
+
+/*
+ * Wait for both CLE threads to become idle.
+ */
+void v3d_wait_idle(struct V3DData *sd)
+{
+    int tries = 1000000;
+
+    while (--tries) {
+        ULONG ct0cs = v3d_core_rd(sd, V3D_CLE_CT0CS);
+        ULONG ct1cs = v3d_core_rd(sd, V3D_CLE_CT1CS);
+
+        if (!(ct0cs & V3D_CLE_CTCS_RUN) && !(ct1cs & V3D_CLE_CTCS_RUN))
+            return;
+    }
+
+    D(bug("[V3D] WARNING: Timeout waiting for CLE idle\n"));
+}

--- a/workbench/hidds/v3d/v3d_hw.c
+++ b/workbench/hidds/v3d/v3d_hw.c
@@ -1,6 +1,5 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     VideoCore VI (V3D 4.2) GPU — Hardware initialization and job submission
 */

--- a/workbench/hidds/v3d/v3d_init.c
+++ b/workbench/hidds/v3d/v3d_init.c
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    VideoCore VI (V3D) — HIDD initialization
+*/
+
+#include <aros/debug.h>
+#include <aros/symbolsets.h>
+#include <proto/exec.h>
+#include <proto/oop.h>
+#include <proto/kernel.h>
+
+#include <hidd/gallium.h>
+
+#include "v3d_intern.h"
+
+#include LC_LIBDEFS_FILE
+
+APTR KernelBase = NULL;
+
+static int V3D_Init(LIBBASETYPEPTR LIBBASE)
+{
+    struct V3DData *sd = &LIBBASE->sd;
+
+    D(bug("[V3D] Init\n"));
+
+    KernelBase = OpenResource("kernel.resource");
+
+    if (!v3d_hw_init(sd)) {
+        D(bug("[V3D] Hardware init failed — V3D not available\n"));
+        /* Not fatal: system works without 3D acceleration */
+        return TRUE;
+    }
+
+    D(bug("[V3D] Hardware initialized successfully\n"));
+
+    return TRUE;
+}
+
+static int V3D_Expunge(LIBBASETYPEPTR LIBBASE)
+{
+    struct V3DData *sd = &LIBBASE->sd;
+
+    if (sd->powered)
+        v3d_hw_shutdown(sd);
+
+    return TRUE;
+}
+
+ADD2INITLIB(V3D_Init, 0)
+ADD2EXPUNGELIB(V3D_Expunge, 0)

--- a/workbench/hidds/v3d/v3d_init.c
+++ b/workbench/hidds/v3d/v3d_init.c
@@ -1,6 +1,5 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     VideoCore VI (V3D) — HIDD initialization
 */

--- a/workbench/hidds/v3d/v3d_intern.h
+++ b/workbench/hidds/v3d/v3d_intern.h
@@ -1,6 +1,5 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
-    Author: Fabian Schmieder (@metaneutrons)
 
     VideoCore VI (V3D 4.2) GPU Internal Definitions
 */
@@ -139,6 +138,7 @@ struct V3DData {
     struct Task     *irq_task;
     ULONG           irq_signal;
 
+    APTR            coreapi;        /* GalliumCoreAPI table from mesa3dgl */
     BOOL            powered;
 };
 

--- a/workbench/hidds/v3d/v3d_intern.h
+++ b/workbench/hidds/v3d/v3d_intern.h
@@ -1,0 +1,161 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    VideoCore VI (V3D 4.2) GPU Internal Definitions
+*/
+
+#ifndef V3D_INTERN_H
+#define V3D_INTERN_H
+
+#include <exec/types.h>
+#include <exec/libraries.h>
+#include <exec/semaphores.h>
+#include <oop/oop.h>
+#include <hidd/gallium.h>
+
+/*
+ * VideoCore VI (V3D 4.2) GPU driver for BCM2711 (Raspberry Pi 4)
+ *
+ * Register blocks:
+ *   Hub:   0xFEC00000 (V3D_HUB) — top-level control, MMU, cache
+ *   Core0: 0xFEC04000 (V3D_CORE0) — rendering core
+ *
+ * The V3D GPU is a tile-based deferred renderer:
+ *   1. Binning pass: geometry → per-tile command lists
+ *   2. Rendering pass: per-tile rasterization + fragment shading
+ *
+ * Jobs are submitted by writing Control List addresses to the
+ * CLE (Control List Executor) registers.
+ */
+
+/* V3D Hub register base (ARM physical) */
+#define V3D_HUB_BASE        0xFEC00000
+#define V3D_CORE0_BASE      0xFEC04000
+
+/* Hub registers */
+#define V3D_HUB_IDENT0      0x0000  /* V3D Identification 0 */
+#define V3D_HUB_IDENT1      0x0004  /* V3D Identification 1 */
+#define V3D_HUB_IDENT2      0x0008  /* V3D Identification 2 */
+#define V3D_HUB_IDENT3      0x000C  /* V3D Identification 3 */
+#define V3D_HUB_INT_STS     0x0050  /* Hub interrupt status */
+#define V3D_HUB_INT_SET     0x0054  /* Hub interrupt set */
+#define V3D_HUB_INT_CLR     0x0058  /* Hub interrupt clear */
+#define V3D_HUB_INT_MSK_STS 0x005C  /* Hub interrupt mask status */
+#define V3D_HUB_INT_MSK_SET 0x0060  /* Hub interrupt mask set */
+#define V3D_HUB_INT_MSK_CLR 0x0064  /* Hub interrupt mask clear */
+
+/* Core registers (offset from V3D_CORE0_BASE) */
+#define V3D_CTL_IDENT0      0x0000  /* Core identification */
+#define V3D_CTL_IDENT1      0x0004
+#define V3D_CTL_IDENT2      0x0008
+#define V3D_CLE_CT0CS       0x0100  /* Control List Executor Thread 0 Control/Status */
+#define V3D_CLE_CT0CA       0x0104  /* Thread 0 Current Address */
+#define V3D_CLE_CT0EA       0x0108  /* Thread 0 End Address */
+#define V3D_CLE_CT1CS       0x010C  /* Thread 1 Control/Status */
+#define V3D_CLE_CT1CA       0x0110  /* Thread 1 Current Address */
+#define V3D_CLE_CT1EA       0x0114  /* Thread 1 End Address */
+#define V3D_CLE_CT0QTS      0x0118  /* Thread 0 Queue Total Submitted */
+#define V3D_CLE_CT0QBA      0x011C  /* Thread 0 Queue Branch Address */
+#define V3D_CLE_CT1QTS      0x0120  /* Thread 1 Queue Total Submitted */
+#define V3D_CLE_CT1QBA      0x0124  /* Thread 1 Queue Branch Address */
+
+/* CLE status bits */
+#define V3D_CLE_CTCS_RUN    (1 << 5)  /* CLE is running */
+
+/* V3D_CTL_IDENT0 fields */
+#define V3D_IDENT0_VER_SHIFT 24
+
+/* GCA (GPU Cache Allocator) */
+#define V3D_GCA_CACHE_CTRL  0x0C00
+#define V3D_GCA_SAFE_SHUTDOWN (1 << 19)
+#define V3D_GCA_SAFE_SHUTDOWN_ACK (1 << 20)
+
+/* MMU registers */
+#define V3D_MMU_CTL         0x1000
+#define V3D_MMU_PT_PA_BASE  0x1004
+#define V3D_MMU_ILLEGAL_ADDR 0x1030
+
+/* IRQ number (GIC SPI 74) */
+#define V3D_IRQ             (32 + 74)
+
+/* Power management via VideoCore mailbox */
+#define VCPOWER_V3D         10  /* V3D power domain ID for mailbox */
+
+/*
+ * Buffer Object — represents a GPU-accessible memory allocation.
+ * On RPi4 without IOMMU, we use physically-contiguous memory
+ * (the GPU sees physical addresses directly).
+ */
+struct V3DBO {
+    struct MinNode  node;
+    APTR            vaddr;      /* CPU virtual address */
+    ULONG           paddr;      /* Physical address (for GPU) */
+    ULONG           size;
+    ULONG           refcount;
+};
+
+/*
+ * Job — a binning or rendering submission to the GPU.
+ */
+struct V3DJob {
+    struct MinNode  node;
+    struct V3DBO    *start;     /* Control list BO */
+    ULONG           cl_start;   /* CL start address (physical) */
+    ULONG           cl_end;     /* CL end address (physical) */
+    BOOL            is_render;  /* FALSE=bin, TRUE=render */
+    volatile BOOL   done;       /* Set by IRQ handler */
+};
+
+/*
+ * Driver static data
+ */
+struct V3DData {
+    OOP_Class       *galliumclass;  /* Our Gallium class pointer */
+
+    OOP_AttrBase    hiddGalliumAB;
+    OOP_AttrBase    hiddAttrBase;
+
+    struct Library  *CyberGfxBase;
+    struct Library  *UtilityBase;
+
+    IPTR            hub_base;       /* V3D Hub MMIO */
+    IPTR            core0_base;     /* V3D Core0 MMIO */
+
+    ULONG           ver;            /* V3D version (42 for RPi4) */
+    ULONG           nslc;           /* Number of slices */
+    ULONG           qpus_per_slice; /* QPUs per slice */
+
+    /* Buffer management */
+    struct MinList  bo_list;
+    struct SignalSemaphore bo_lock;
+
+    /* Job queue */
+    struct MinList  job_list;
+    struct SignalSemaphore job_lock;
+
+    /* IRQ */
+    APTR            irq_handle;
+    struct Task     *irq_task;
+    ULONG           irq_signal;
+
+    BOOL            powered;
+};
+
+struct IntHiddV3DBase {
+    struct Library  lib;
+    struct V3DData  sd;
+};
+
+#define BASE(lib) ((struct IntHiddV3DBase *)(lib))
+#define SD(cl)    (&BASE(cl->UserData)->sd)
+
+/* Hardware functions */
+BOOL v3d_hw_init(struct V3DData *sd);
+void v3d_hw_shutdown(struct V3DData *sd);
+struct V3DBO *v3d_aros_bo_alloc(struct V3DData *sd, ULONG size);
+void v3d_aros_bo_free(struct V3DData *sd, struct V3DBO *bo);
+BOOL v3d_submit_cl(struct V3DData *sd, ULONG start, ULONG end, BOOL is_render);
+void v3d_wait_idle(struct V3DData *sd);
+
+#endif /* V3D_INTERN_H */


### PR DESCRIPTION
## Summary
Adds an experimental native Gallium GPU driver (`hidd.gallium.v3d`) for the Broadcom VideoCore VI (V3D 4.2) GPU on BCM2711 (Raspberry Pi 4), providing hardware-accelerated OpenGL 3.3 and OpenGL ES 3.1 via Mesa.

## Architecture
- **Hardware Layer (`v3d_hw.c`)**: Direct MMIO register access (`0xFEC00000` / `0xFEC04000`), Buffer Object management in contiguous memory (`MEMF_31BIT`), and Control List Executor (CLE) job submission for binning and rendering.
- **DRM Ioctl Shim (`v3d_drm_shim.c`)**: User-space DRM interface shim bridging Mesa V3D driver calls directly to hardware without Linux kernel DRM.
- **Gallium HIDD (`v3d_galliumclass.c`)**: Integrates with AROS Gallium state tracker to instantiate `v3d_screen_create()`.