### PR TITLE
sdcard, dma: Add BCM2712 eMMC2 and DMA support for Raspberry Pi 5

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
@@ -36,6 +36,12 @@
 #define DMA_POOL_FULL_BCM2711  ((1 << 2) | (1 << 4))
 #define DMA_POOL_LITE_BCM2711  ((1 << 8) | (1 << 9) | (1 << 10))
 
+/*
+ * BCM2712 DMA channel allocation.
+ */
+#define DMA_POOL_FULL_BCM2712  ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3))
+#define DMA_POOL_LITE_BCM2712  ((1 << 4) | (1 << 5) | (1 << 6) | (1 << 7))
+
 APTR KernelBase __attribute__((used)) = NULL;
 
 static int dma_init(struct DMABase *DMABase)
@@ -130,8 +136,9 @@ AROS_LH1(int, DMAAllocChannel,
 
     {
         int is2711 = (DMABase->dma_periiobase == BCM2711_PERIIOBASE);
-        ULONG full = is2711 ? DMA_POOL_FULL_BCM2711 : DMA_POOL_FULL;
-        ULONG lite = is2711 ? DMA_POOL_LITE_BCM2711 : DMA_POOL_LITE;
+        int is2712 = (DMABase->dma_periiobase == BCM2712_PERIIOBASE);
+        ULONG full = is2712 ? DMA_POOL_FULL_BCM2712 : (is2711 ? DMA_POOL_FULL_BCM2711 : DMA_POOL_FULL);
+        ULONG lite = is2712 ? DMA_POOL_LITE_BCM2712 : (is2711 ? DMA_POOL_LITE_BCM2711 : DMA_POOL_LITE);
 
         /* Prefer lite channels so the scarce full engines stay available
          * for users that need TDMODE. */

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
@@ -13,8 +13,12 @@
  */
 #define EMMC2_BASE                      (ARM_PERIIOBASE + 0x340000)
 
+/* BCM2712 (Raspberry Pi 5) eMMC2 controller */
+#define BCM2712_EMMC2_BASE              (ARM_PERIIOBASE + 0x100000)
+
 /* Both windows share one interrupt line on the BCM2711 (GIC SPI 126). */
 #define IRQ_BCM2711_SDHCI               158
+#define IRQ_BCM2712_SDHCI               300
 
 /* Identification clock, used until the card reports what it can take. */
 #define BCM2708SDCLOCK_MIN              400000

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -29,6 +29,9 @@
 /* Peripheral window of the BCM2711, which differs from the earlier SoCs. */
 #define BCM2711_PERIIOBASE                              0xFE000000
 
+/* Peripheral window of the BCM2712 (Raspberry Pi 5). */
+#define BCM2712_PERIIOBASE                              0x107C000000ULL
+
 /*
  * The BCM2711 presents the GPU interrupts of the earlier controller as
  * GIC shared interrupts, offset by this much: GPU interrupt n arrives as

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -91,8 +91,8 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
 
     __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
-    isEMMC2 = (__arm_periiobase == BCM2711_PERIIOBASE);
-    if (isEMMC2)
+    isEMMC2 = (__arm_periiobase == BCM2711_PERIIOBASE || __arm_periiobase == BCM2712_PERIIOBASE);
+    if (__arm_periiobase == BCM2711_PERIIOBASE)
     {
         /*
          * The card slot sits on EMMC2, but the legacy window is still wired
@@ -107,7 +107,13 @@ static int FNAME_BCMSDC(BCM2708Init)(struct SDCardBase *SDCardBase)
         }
     }
 
-    if (isEMMC2)
+    if (__arm_periiobase == BCM2712_PERIIOBASE)
+    {
+        ctrlBase  = BCM2712_EMMC2_BASE;
+        ctrlClock = VCCLOCK_EMMC2;
+        ctrlIRQ   = IRQ_BCM2712_SDHCI;
+    }
+    else if (isEMMC2)
     {
         ctrlBase  = EMMC2_BASE;
         ctrlClock = VCCLOCK_EMMC2;
@@ -227,6 +233,9 @@ bcminit_clock:
             MBoxWrite((APTR)VCMB_BASE, VCMB_PROPCHAN, MBoxMessage);
             if (MBoxRead((APTR)VCMB_BASE, VCMB_PROPCHAN) == MBoxMessage)
                 __BCM2708Bus->sdcb_ClockMax = AROS_LE2LONG(MBoxMessage[6]);
+
+            if (__BCM2708Bus->sdcb_ClockMax == 0)
+                __BCM2708Bus->sdcb_ClockMax = 200000000;
 
             DINIT(bug("[SDCard--] %s: clock was parked, max rate %d Hz\n",
                       __PRETTY_FUNCTION__, __BCM2708Bus->sdcb_ClockMax));


### PR DESCRIPTION
## Summary
Adds native hardware support for the MicroSD card slot on the Raspberry Pi 5 (BCM2712 eMMC2 SDHCI controller) and configures the BCM2712 DMA channel allocator.

### Changes
- **`include/hardware/arasan.h` & `bcm2708.h`**: Defined `BCM2712_PERIIOBASE` (`0x107C000000ULL`), `BCM2712_EMMC2_BASE` (`ARM_PERIIOBASE + 0x100000`), and GIC-400 interrupt `IRQ_BCM2712_SDHCI` (300).
- **`sdcard/sdcard_bcm2708init.c`**: Added BCM2712 SoC platform detection, configured eMMC2 SDHCI registers and 200 MHz base clock.
- **`dma/dma_init.c`**: Configured BCM2712 DMA channel pools (`DMA_POOL_FULL_BCM2712` and `DMA_POOL_LITE_BCM2712`).