### PR TITLE
battclock: Add Raspberry Pi 5 hardware RTC support via VideoCore Mailbox

### DIFF
--- a/arch/arm-raspi/battclock/battclock_intern.h
+++ b/arch/arm-raspi/battclock/battclock_intern.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
 
     Desc: Internal definitions for battclock.resource, Raspberry Pi version.
 */
@@ -11,6 +12,14 @@
 
 /* File on the boot volume that persists the clock across reboots. */
 #define BATTCLOCK_FILE "DEVS:battclock"
+
+/* VideoCore Mailbox RTC Property Tags (Raspberry Pi 5 PMIC Hardware RTC) */
+#define PROPTAG_GET_RTC                 0x00030080UL
+#define PROPTAG_SET_RTC                 0x00038080UL
+#define VCMB_PROPCHAN                   8
+
+/* Seconds difference between Amiga Epoch (1978-01-01) and POSIX Epoch (1970-01-01) */
+#define AMIGA_POSIX_EPOCH_DIFF          252460800UL
 
 struct BattClockBase
 {

--- a/arch/arm-raspi/battclock/readbattclock.c
+++ b/arch/arm-raspi/battclock/readbattclock.c
@@ -1,7 +1,8 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
 
-    Desc: ReadBattClock() function, Raspberry Pi file-backed version.
+    Desc: ReadBattClock() function, Raspberry Pi hardware RTC & file-backed fallback.
 */
 
 #define DEBUG 0
@@ -9,6 +10,8 @@
 
 #include <proto/exec.h>
 #include <proto/dos.h>
+#include <proto/kernel.h>
+#include <proto/mbox.h>
 #include <dos/dos.h>
 #include <dos/dosextens.h>
 
@@ -20,13 +23,50 @@ AROS_LH0(ULONG, ReadBattClock,
     AROS_LIBFUNC_INIT
 
     struct DosLibrary *DOSBase;
+    APTR KernelBase;
+    APTR MBoxBase;
     ULONG secs = 0;
 
     /*
-     * The Raspberry Pi has no battery-backed RTC, so the clock is kept in a
-     * plain file on the boot volume (written by WriteBattClock()). The clock
-     * does not tick while the file is at rest; it simply preserves the value
-     * SetClock SAVE last stored.
+     * 1. Query Hardware RTC via VideoCore Mailbox (e.g. Raspberry Pi 5 PMIC).
+     */
+    KernelBase = OpenResource("kernel.resource");
+    MBoxBase = OpenResource("mbox.resource");
+
+    if (KernelBase && MBoxBase)
+    {
+        IPTR peri_base = (IPTR)KrnGetSystemAttr(KATTR_PeripheralBase);
+        if (peri_base)
+        {
+            ULONG *msg = AllocMem(32, MEMF_PUBLIC | MEMF_CLEAR);
+            if (msg)
+            {
+                msg[0] = 7 * sizeof(ULONG);  /* Buffer size */
+                msg[1] = 0;                  /* Request */
+                msg[2] = PROPTAG_GET_RTC;    /* Tag */
+                msg[3] = 4;                  /* Value buffer size */
+                msg[4] = 0;                  /* Request/response flag */
+                msg[5] = 0;                  /* Clock ID (0) / output timestamp */
+                msg[6] = 0;                  /* End tag */
+
+                if (MBoxCall((void *)(peri_base + 0x00b880UL), VCMB_PROPCHAN, msg))
+                {
+                    ULONG posix_secs = msg[5];
+                    if (posix_secs > AMIGA_POSIX_EPOCH_DIFF)
+                    {
+                        secs = posix_secs - AMIGA_POSIX_EPOCH_DIFF;
+                        D(bug("[battclock] ReadBattClock: hardware RTC returned %lu (Amiga %lu)\n", posix_secs, secs));
+                        FreeMem(msg, 32);
+                        return secs;
+                    }
+                }
+                FreeMem(msg, 32);
+            }
+        }
+    }
+
+    /*
+     * 2. Fallback: For older boards without hardware RTC, read from DEVS:battclock.
      */
     DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
     if (DOSBase)

--- a/arch/arm-raspi/battclock/writebattclock.c
+++ b/arch/arm-raspi/battclock/writebattclock.c
@@ -1,7 +1,8 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
 
-    Desc: WriteBattClock() function, Raspberry Pi file-backed version.
+    Desc: WriteBattClock() function, Raspberry Pi hardware RTC & file-backed fallback.
 */
 
 #define DEBUG 0
@@ -9,6 +10,8 @@
 
 #include <proto/exec.h>
 #include <proto/dos.h>
+#include <proto/kernel.h>
+#include <proto/mbox.h>
 #include <dos/dos.h>
 #include <dos/dosextens.h>
 
@@ -21,8 +24,40 @@ AROS_LH1(void, WriteBattClock,
     AROS_LIBFUNC_INIT
 
     struct DosLibrary *DOSBase;
+    APTR KernelBase;
+    APTR MBoxBase;
 
-    /* Persist the time to the boot volume; see ReadBattClock() for rationale. */
+    /*
+     * 1. Write to Hardware RTC via VideoCore Mailbox (Raspberry Pi 5 PMIC).
+     */
+    KernelBase = OpenResource("kernel.resource");
+    MBoxBase = OpenResource("mbox.resource");
+
+    if (KernelBase && MBoxBase)
+    {
+        IPTR peri_base = (IPTR)KrnGetSystemAttr(KATTR_PeripheralBase);
+        if (peri_base)
+        {
+            ULONG *msg = AllocMem(32, MEMF_PUBLIC | MEMF_CLEAR);
+            if (msg)
+            {
+                msg[0] = 7 * sizeof(ULONG);                       /* Buffer size */
+                msg[1] = 0;                                       /* Request */
+                msg[2] = PROPTAG_SET_RTC;                         /* Tag */
+                msg[3] = 4;                                       /* Value buffer size */
+                msg[4] = 0;                                       /* Request flag */
+                msg[5] = time + AMIGA_POSIX_EPOCH_DIFF;          /* POSIX timestamp */
+                msg[6] = 0;                                       /* End tag */
+
+                MBoxCall((void *)(peri_base + 0x00b880UL), VCMB_PROPCHAN, msg);
+                FreeMem(msg, 32);
+            }
+        }
+    }
+
+    /*
+     * 2. Persist the time to the boot volume as fallback; see ReadBattClock().
+     */
     DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
     if (DOSBase)
     {


### PR DESCRIPTION
## Summary
Adds clean-room hardware Real-Time Clock (RTC) support for the Raspberry Pi 5 (Renesas DA9091 PMIC battery-backed RTC) in `battclock.resource`, with graceful fallback to file persistence (`DEVS:battclock`) on legacy models without an onboard RTC.

### Changes
- **`battclock_intern.h`**: Defined `PROPTAG_GET_RTC` (`0x00030080`), `PROPTAG_SET_RTC` (`0x00038080`), and `AMIGA_POSIX_EPOCH_DIFF` (`252460800UL`).
- **`readbattclock.c`**: Queries VideoCore Mailbox for hardware RTC timestamp, converts POSIX epoch to Amiga epoch. Falls back to `DEVS:battclock` if hardware RTC is absent or uninitialized.
- **`writebattclock.c`**: Writes timestamp to PMIC hardware RTC via mailbox and persists to `DEVS:battclock` as fallback.