### PR TITLE
gpio: Add Raspberry Pi 5 RP1 Southbridge GPIO support

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015, The AROS Development Team. All rights reserved.
+    Copyright (C) 2015-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
@@ -27,6 +27,12 @@ static int gpio_init(struct GPIOBase *GPIOBase)
     if ((GPIOBase->gpio_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase)) != 0)
     {
         InitSemaphore(&GPIOBase->gpio_Sem);
+        GPIOBase->gpio_rp1_bar1 = 0;
+
+        if (GPIOBase->gpio_periiobase == BCM2712_PERIIOBASE)
+        {
+            GPIOBase->gpio_rp1_bar1 = 0x1F00000000ULL;
+        }
 
         D(bug("[GPIO] %s: Initialised Semaphore @ 0x%p\n", __PRETTY_FUNCTION__, &GPIOBase->gpio_Sem));
 
@@ -47,7 +53,18 @@ AROS_LH2(void, GPIOSet,
 
     D(bug("[GPIO] %s(#%d,%d)\n", __PRETTY_FUNCTION__, pin, val));
 
-    if (GPIOBase->gpio_periiobase && (pin <= 53))
+    if (GPIOBase->gpio_rp1_bar1 && (pin <= 27))
+    {
+        /* RP1 SYS_RIO0: SET=0x04, CLR=0x08 */
+        IPTR rio_base = GPIOBase->gpio_rp1_bar1 + 0x0E0000;
+        reg = val ? (rio_base + 0x04) : (rio_base + 0x08);
+        bit = 1 << pin;
+
+        ObtainSemaphore(&GPIOBase->gpio_Sem);
+        *(volatile unsigned int *)reg = AROS_LONG2LE(bit);
+        ReleaseSemaphore(&GPIOBase->gpio_Sem);
+    }
+    else if (GPIOBase->gpio_periiobase && (pin <= 53))
     {
         reg = val? GPSET0: GPCLR0;
         reg += (pin >> 5) << 2; /* (pin / 32) << 2 */
@@ -75,7 +92,24 @@ AROS_LH2(void, GPIOSetFunc,
 
     D(bug("[GPIO] %s(#%d,%d)\n", __PRETTY_FUNCTION__, pin, func));
 
-    if (GPIOBase->gpio_periiobase && (pin <= 53))
+    if (GPIOBase->gpio_rp1_bar1 && (pin <= 27))
+    {
+        /* RP1 IO_BANK0 pin ctrl: offset (pin * 8) + 4; SYS_RIO0 offset 0x0E0000 */
+        IPTR bank0_ctrl = GPIOBase->gpio_rp1_bar1 + 0x0D0000 + (pin * 8) + 4;
+        IPTR rio_base = GPIOBase->gpio_rp1_bar1 + 0x0E0000;
+
+        ObtainSemaphore(&GPIOBase->gpio_Sem);
+
+        *(volatile unsigned int *)bank0_ctrl = AROS_LONG2LE(func & 0x1F);
+
+        if (func == 1)
+            *(volatile unsigned int *)(rio_base + 0x14) = AROS_LONG2LE(1 << pin); /* RIO_OE_SET */
+        else if (func == 0)
+            *(volatile unsigned int *)(rio_base + 0x18) = AROS_LONG2LE(1 << pin); /* RIO_OE_CLR */
+
+        ReleaseSemaphore(&GPIOBase->gpio_Sem);
+    }
+    else if (GPIOBase->gpio_periiobase && (pin <= 53))
     {
         reg = GPFSEL0;
         while (pin >= 10) {

--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio_private.h
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio_private.h
@@ -13,6 +13,7 @@ struct GPIOBase {
     struct Node		        gpio_Node;
     struct SignalSemaphore      gpio_Sem;
     unsigned int		gpio_periiobase;
+    IPTR                        gpio_rp1_bar1;
 };
 
 #define ARM_PERIIOBASE GPIOBase->gpio_periiobase

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -29,6 +29,9 @@
 /* Peripheral window of the BCM2711, which differs from the earlier SoCs. */
 #define BCM2711_PERIIOBASE                              0xFE000000
 
+/* Peripheral window of the BCM2712 (Raspberry Pi 5). */
+#define BCM2712_PERIIOBASE                              0x107C000000ULL
+
 /*
  * The BCM2711 presents the GPU interrupts of the earlier controller as
  * GIC shared interrupts, offset by this much: GPU interrupt n arrives as


### PR DESCRIPTION
## Summary
Extends `gpio.resource` to support the 40-pin GPIO expansion header on the Raspberry Pi 5 via the RP1 Southbridge (`IO_BANK0` and `SYS_RIO0`), while maintaining full backward compatibility with Raspberry Pi 1–4.

### Changes
- **`include/hardware/bcm2708.h`**: Defined `BCM2712_PERIIOBASE` (`0x107C000000ULL`).
- **`gpio/gpio_private.h`**: Added `gpio_rp1_bar1` to `struct GPIOBase`.
- **`gpio/gpio_init.c`**: Added RP1 Southbridge routing for `GPIOSet()` and `GPIOSetFunc()` on BCM2712 platforms.