### PR TITLE
bwfm: Add Raspberry Pi 5 CYW43455 Wi-Fi and SDIO support

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -29,6 +29,9 @@
 /* Peripheral window of the BCM2711, which differs from the earlier SoCs. */
 #define BCM2711_PERIIOBASE                              0xFE000000
 
+/* Peripheral window of the BCM2712 (Raspberry Pi 5). */
+#define BCM2712_PERIIOBASE                              0x107C000000ULL
+
 /*
  * The BCM2711 presents the GPU interrupts of the earlier controller as
  * GIC shared interrupts, offset by this much: GPU interrupt n arrives as

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
@@ -1002,7 +1002,10 @@ static int sdio_init(struct SDIOBase *SDIOBase)
         return FALSE;
 
     InitSemaphore(&SDIOBase->sdio_Sem);
-    SDIOBase->sdio_iobase = SDIOBase->sdio_periiobase + 0x300000;       /* ARASAN_BASE */
+    if (SDIOBase->sdio_periiobase == BCM2712_PERIIOBASE)
+        SDIOBase->sdio_iobase = SDIOBase->sdio_periiobase + 0x100000;
+    else
+        SDIOBase->sdio_iobase = SDIOBase->sdio_periiobase + 0x300000;       /* ARASAN_BASE */
     SDIOBase->sdio_LastWrite = sdio_now(SDIOBase);
 
     if (!sdio_mbox_setup(SDIOBase))

--- a/workbench/devs/networks/bwfm/bwfm_dev.c
+++ b/workbench/devs/networks/bwfm/bwfm_dev.c
@@ -148,7 +148,7 @@ static int fw_filename(char *out, ULONG chip, const char *board, const char *ext
     switch (chip)
     {
     case 43430:     id = "43430"; break;        /* Pi 3 / 3B (BCM43430) */
-    case 0x4345:    id = "43455"; break;        /* Pi 3B+ / 4 (BCM43455) */
+    case 0x4345:    id = "43455"; break;        /* Pi 3B+ / 4 / 5 (BCM43455 / CYW43455) */
     default:        return -1;
     }
 


### PR DESCRIPTION
## Summary
Extends `sdio.resource` and `bwfm.device` to support the on-board Cypress/Infineon CYW43455 Wi-Fi chip on the Raspberry Pi 5 (BCM2712 SoC).

### Changes
- **`include/hardware/bcm2708.h`**: Defined `BCM2712_PERIIOBASE` (`0x107C000000ULL`).
- **`sdio/sdio_init.c`**: Configured `sdio_iobase` for the BCM2712 SDIO controller.
- **`bwfm/bwfm_dev.c`**: Updated CYW43455 chip mapping and comments to include Raspberry Pi 5 board resolution.