### PR TITLE
m68k-amiga: cd.device fixes to make CD32 discs bootable

### DIFF
--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -37,6 +37,14 @@ static VOID cdTask(IPTR base, IPTR unit)
     struct IOStdReq *io;
 
     D(bug("%s.%d Task, Port %p\n", cu->cu_UnitOps->uo_Name, cu->cu_Unit, cu->cu_MsgPort));
+
+    /* Blocking drive probes belong here, not in resident init: a
+     * misbehaving drive must cost a failed mount, not a wedged boot
+     * task. I/O queued by early openers is served after this returns.
+     */
+    if (cu->cu_UnitOps->uo_Init)
+        cu->cu_UnitOps->uo_Init(cu->cu_Private);
+
     do {
         WaitPort(cu->cu_MsgPort);
         io = (struct IOStdReq *)GetMsg(cu->cu_MsgPort);

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -164,7 +164,10 @@ static int cd_Init(LIBBASETYPE *cb)
     NEWLIST(&cb->cb_Units);
     InitSemaphore(&cb->cb_UnitsLock);
 
-    /* Hand-hacked port for timer responses */
+    /* Hand-hacked port for timer responses. ReplyMsg() enqueues on
+     * mp_MsgList before signalling, so it must be a valid empty list.
+     */
+    NEWLIST(&cb->cb_TimerPort.mp_MsgList);
     cb->cb_TimerPort.mp_SigBit = SIGB_SINGLE;
     cb->cb_TimerPort.mp_Flags = PA_SIGNAL;
     cb->cb_TimerPort.mp_SigTask = FindTask(NULL);

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -74,7 +74,8 @@ static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
     {
         IPTR pp[24];
         
-        CopyMem((IPTR *)de, &pp[4], sizeof(IPTR)*de->de_TableSize);
+        /* de_TableSize is the highest valid index, not a count */
+        CopyMem((IPTR *)de, &pp[4], sizeof(IPTR)*(de->de_TableSize + 1));
 
         /* This should be dealt with using some sort of volume manager or such. */
         if (unit->cu_Unit < 10)
@@ -92,6 +93,7 @@ static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
          * to handler-name matching when the DosType is zero.
          */
         pp[DE_DOSTYPE      + 4] = AROS_MAKE_ID('C','D','V','D');
+        pp[DE_BAUD         + 4] = 0;
         pp[DE_CONTROL      + 4] = 0;
         pp[DE_BOOTBLOCKS   + 4] = 0;
     

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -14,6 +14,8 @@
 
 #include <dos/filehandler.h>
 
+#include <resources/filesysres.h>
+
 #include <devices/cd.h>
 
 #include "cd_intern.h"
@@ -26,7 +28,11 @@ struct cdUnit {
     const struct cdUnitOps   *cu_UnitOps;
     struct Task        *cu_Task;
     struct MsgPort     *cu_MsgPort;
+    const struct DosEnvec *cu_Envec;
 };
+
+static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
+                             const struct DosEnvec *de);
 
 /* We have a synchonous task for dispatching IO
  * to each cd.device unit.
@@ -37,6 +43,16 @@ static VOID cdTask(IPTR base, IPTR unit)
     struct IOStdReq *io;
 
     D(bug("%s.%d Task, Port %p\n", cu->cu_UnitOps->uo_Name, cu->cu_Unit, cu->cu_MsgPort));
+
+    /* The boot node registers from here rather than from resident init:
+     * the DosType scan in cdRegisterVolume needs FileSystem.resource
+     * populated, and the filesystem modules init at lower resident
+     * priority than this device does. It must also happen before the
+     * disc probe below - the probe can take seconds with a disc in the
+     * drive, and dosboot expects its boot nodes in place by the time it
+     * runs.
+     */
+    cdRegisterVolume((struct cdBase *)base, cu, cu->cu_Envec);
 
     /* Blocking drive probes belong here, not in resident init: a
      * misbehaving drive must cost a failed mount, not a wedged boot
@@ -68,8 +84,47 @@ static VOID cdTask(IPTR base, IPTR unit)
     /* Terminate by fallthough */
 }
 
+/* Ask FileSystem.resource which CD filesystem the ROM actually carries
+ * rather than hard-coding one: the boot node's DosType must match a
+ * registered filesystem or CliInit never finds a handler for CD0:,
+ * which is how the 2019 switch from cdfs to CDVDFS broke CD boot.
+ * Registration order is not guaranteed against this unit task, so poll
+ * briefly before falling back to CDVDFS's type.
+ */
+static IPTR cdSelectDosType(struct cdBase *cb)
+{
+    static const ULONG types[] = {
+        AROS_MAKE_ID('C','D','V','D'),  /* CDVDFS */
+        AROS_MAKE_ID('C','D','F','S'),  /* the older cdfs handler */
+    };
+    int attempt, i;
+
+    for (attempt = 0; attempt < 20; attempt++) {
+        struct FileSysResource *fsr = OpenResource(FSRNAME);
+        if (fsr) {
+            for (i = 0; i < (int)(sizeof(types) / sizeof(types[0])); i++) {
+                struct FileSysEntry *fse;
+                IPTR found = 0;
+                Forbid();
+                ForeachNode(&fsr->fsr_FileSysEntries, fse) {
+                    if (fse->fse_DosType == types[i]) {
+                        found = types[i];
+                        break;
+                    }
+                }
+                Permit();
+                if (found)
+                    return found;
+            }
+        }
+        cdDelayMS(cb, 100);
+    }
+    return types[0];
+}
+
 /* Add a bootnode using expansion.library */
-static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
+static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
+                             const struct DosEnvec *de)
 {
     struct ExpansionBase *ExpansionBase;
     struct DeviceNode *devnode;
@@ -96,11 +151,7 @@ static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
         pp[2]                   = unit->cu_Unit;
         pp[DE_TABLESIZE    + 4] = DE_BOOTBLOCKS;
         pp[DE_BOOTPRI      + 4] = -10;
-        /* Must match the DosType the ROM's CD filesystem registers in
-         * FileSystem.resource (CDVDFS, 'CDVD'); CliInit only falls back
-         * to handler-name matching when the DosType is zero.
-         */
-        pp[DE_DOSTYPE      + 4] = AROS_MAKE_ID('C','D','V','D');
+        pp[DE_DOSTYPE      + 4] = cdSelectDosType(cb);
         pp[DE_BAUD         + 4] = 0;
         pp[DE_CONTROL      + 4] = 0;
         pp[DE_BOOTBLOCKS   + 4] = 0;
@@ -139,6 +190,9 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
     if (cu) {
         cu->cu_Private = priv;
         cu->cu_UnitOps = ops;
+        cu->cu_Envec   = de;
+        /* Assigned before the task starts: it names the boot node */
+        cu->cu_Unit    = cb->cb_MaxUnit++;
         cu->cu_Task = NewCreateTask(TASKTAG_PC, cdTask,
                                     TASKTAG_NAME, ops->uo_Name,
                                     TASKTAG_ARG1, cb,
@@ -146,11 +200,9 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
                                     TASKTAG_TASKMSGPORT, &cu->cu_MsgPort,
                                     TAG_END);
         if (cu->cu_Task) {
-            cu->cu_Unit = cb->cb_MaxUnit++;
             ObtainSemaphore(&cb->cb_UnitsLock);
             ADDTAIL(&cb->cb_Units, &cu->cu_Node);
             ReleaseSemaphore(&cb->cb_UnitsLock);
-            cdRegisterVolume(cu, de);
             return cu->cu_Unit;
         }
         FreeVec(cu);

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -87,7 +87,11 @@ static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
         pp[2]                   = unit->cu_Unit;
         pp[DE_TABLESIZE    + 4] = DE_BOOTBLOCKS;
         pp[DE_BOOTPRI      + 4] = -10;
-        pp[DE_DOSTYPE      + 4] = AROS_MAKE_ID('C','D','F','S');
+        /* Must match the DosType the ROM's CD filesystem registers in
+         * FileSystem.resource (CDVDFS, 'CDVD'); CliInit only falls back
+         * to handler-name matching when the DosType is zero.
+         */
+        pp[DE_DOSTYPE      + 4] = AROS_MAKE_ID('C','D','V','D');
         pp[DE_CONTROL      + 4] = 0;
         pp[DE_BOOTBLOCKS   + 4] = 0;
     

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -157,6 +157,7 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
 
     if (status & AKIKO_CDINT_TXDMA) {
         CD32_IntDisable(cu, AKIKO_CDINT_TXDMA);
+        claimed = TRUE;
     }
 
     if (status & AKIKO_CDINT_RXDMA) {
@@ -189,6 +190,7 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
         writew(0, AKIKO_CDPBX);
         if (pbx < 0x000f && cu->cu_Task)
             Signal(cu->cu_Task, SIGF_SINGLE);
+        claimed = TRUE;
     }
 
     return claimed;
@@ -245,6 +247,11 @@ static VOID CD32_UpdateTOC(struct CD32Unit *cu)
  * interrupt handler uses - so a drive that stops answering turns
  * into a normal wakeup with an empty response ring, which the
  * checksum paths already reject, instead of an eternal Wait().
+ *
+ * The request lives in the device base and is deliberately shared
+ * without locking: every user - these timeouts and cdDelayMS() in the
+ * TOC loop - runs on the one unit task, which owns all drive I/O. A
+ * second backend with its own unit task would need a per-unit request.
  */
 static VOID cd32TimeoutStart(struct CD32Unit *cu, ULONG ms)
 {
@@ -473,6 +480,10 @@ static LONG CD32_CmdRead(struct CD32Unit *cu, LONG sect_start, LONG sectors, voi
         cd32TimeoutStart(cu, CD32_CMD_TIMEOUT_MS);
         Wait(SIGF_SINGLE);
         cd32TimeoutEnd(cu);
+        /* Nobody waits for sectors past this point: a late PBX
+         * interrupt must not signal the task under some later Wait().
+         */
+        CD32_IntDisable(cu, AKIKO_CDINT_PBX);
 
         CD32_Cmd(cu, cmd_pause, 1, resp, sizeof(resp));
         CD32_Led(cu, FALSE);

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -147,12 +147,17 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
     };
     ULONG status;
     UBYTE rxtail;
+    BOOL claimed = FALSE;
 
     AROS_INTFUNC_INIT
 
     status = readl(AKIKO_CDINTREQ);
     if (!status)
         return FALSE;
+
+    if (status & AKIKO_CDINT_TXDMA) {
+        CD32_IntDisable(cu, AKIKO_CDINT_TXDMA);
+    }
 
     if (status & AKIKO_CDINT_RXDMA) {
         rxtail = readb(AKIKO_CDRXINX);
@@ -163,15 +168,13 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
                 D(bug("%s: Insane response byte 0x%02x\n", cu->cu_Misc->Response[cu->cu_RxHead]));
             }
             writeb(cu->cu_RxHead+len+1, AKIKO_CDRXCMP);
-            return TRUE;
+            claimed = TRUE;
+        } else {
+            CD32_IntDisable(cu, AKIKO_CDINT_RXDMA);
+            D(bug("%s: Signal %p\n", __func__, cu->cu_Task));
+            if (cu->cu_Task)
+                Signal(cu->cu_Task, SIGF_SINGLE);
         }
-        CD32_IntDisable(cu, AKIKO_CDINT_RXDMA);
-        D(bug("%s: Signal %p\n", __func__, cu->cu_Task));
-        Signal(cu->cu_Task, SIGF_SINGLE);
-    }
-
-    if (status & AKIKO_CDINT_TXDMA) {
-        CD32_IntDisable(cu, AKIKO_CDINT_TXDMA);
     }
 
 #if 0
@@ -184,11 +187,11 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
     if (status & AKIKO_CDINT_PBX) {
         UWORD pbx = readw(AKIKO_CDPBX);
         writew(0, AKIKO_CDPBX);
-        if (pbx < 0x000f)
+        if (pbx < 0x000f && cu->cu_Task)
             Signal(cu->cu_Task, SIGF_SINGLE);
     }
 
-    return FALSE;
+    return claimed;
 
     AROS_INTFUNC_EXIT
 }
@@ -253,14 +256,20 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
 
     cu->cu_Misc->Command[cu->cu_TxHead++] = ~csum;
 
-    /* Just wait for the RX to complete of the status */
-    CD32_IntEnable(cu, AKIKO_CDINT_RXDMA | AKIKO_CDINT_TXDMA);
-    writel(AKIKO_CDFLAG_TXD | AKIKO_CDFLAG_RXD | AKIKO_CDFLAG_CAS | AKIKO_CDFLAG_PBX | AKIKO_CDFLAG_MSB, AKIKO_CDFLAG);
-
-    /* Trigger the command by updating AKIKO_CDTXCMP */
+    /* CDINTREQ completion bits stay latched until the matching index
+     * register is written: CDRXCMP clears RXDMADONE, CDTXCMP clears
+     * TXDMADONE. Clear the previous command's stale latches before
+     * enabling their interrupts - enabling on top of a stale latch
+     * fires the handler at once, which disables RXDMA again and
+     * consumes the completion signal before this command has run.
+     */
     SetSignal(0, SIGF_SINGLE);
     writeb((cu->cu_RxHead + 1) & 0xff, AKIKO_CDRXCMP);
     writeb(cu->cu_TxHead, AKIKO_CDTXCMP);
+    CD32_IntEnable(cu, AKIKO_CDINT_RXDMA | AKIKO_CDINT_TXDMA);
+
+    /* Let the transfers run; this triggers the command */
+    writel(AKIKO_CDFLAG_TXD | AKIKO_CDFLAG_RXD | AKIKO_CDFLAG_CAS | AKIKO_CDFLAG_PBX | AKIKO_CDFLAG_MSB, AKIKO_CDFLAG);
 
     for (;;) {
         UBYTE RxHead = cu->cu_RxHead;
@@ -337,7 +346,12 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
             return CDERR_InvalidState;
         }
 
+        /* Re-open the receive window and re-enable RXDMA for the next
+         * response; the interrupt handler disabled RXDMA when it
+         * signalled this one.
+         */
         writeb((RxTail + 1) & 0xff, AKIKO_CDRXCMP);
+        CD32_IntEnable(cu, AKIKO_CDINT_RXDMA);
     }
 
     D(bug("%s: Found expected: 0x%02x (%d)\n", __func__, cu->cu_Misc->Response[cu->cu_RxHead], (RxTail + 256 - cu->cu_RxHead) & 0xff));

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -234,9 +234,43 @@ static VOID CD32_UpdateTOC(struct CD32Unit *cu)
     }
 }
 
+/* Command/response timeout, in milliseconds. Unsolicited traffic
+ * (media change, SUBQ streams) arrives interleaved, so this bounds
+ * one response, not a whole TOC read.
+ */
+#define CD32_CMD_TIMEOUT_MS 3000
+
+/* Arm the device timerequest as a wait bound. Its hand-built reply
+ * port signals SIGF_SINGLE on this task - the same signal the
+ * interrupt handler uses - so a drive that stops answering turns
+ * into a normal wakeup with an empty response ring, which the
+ * checksum paths already reject, instead of an eternal Wait().
+ */
+static VOID cd32TimeoutStart(struct CD32Unit *cu, ULONG ms)
+{
+    LIBBASETYPE *cb = cu->cu_CDBase;
+
+    cb->cb_TimerPort.mp_SigTask = FindTask(NULL);
+    cb->cb_TimerRequest.tr_node.io_Command = TR_ADDREQUEST;
+    cb->cb_TimerRequest.tr_time.tv_secs = ms / 1000;
+    cb->cb_TimerRequest.tr_time.tv_micro = (ms * 1000) % 1000000;
+    SendIO((struct IORequest *)&cb->cb_TimerRequest);
+}
+
+static VOID cd32TimeoutEnd(struct CD32Unit *cu)
+{
+    LIBBASETYPE *cb = cu->cu_CDBase;
+
+    if (!CheckIO((struct IORequest *)&cb->cb_TimerRequest))
+        AbortIO((struct IORequest *)&cb->cb_TimerRequest);
+    WaitIO((struct IORequest *)&cb->cb_TimerRequest);
+    SetSignal(0, SIGF_SINGLE);
+}
+
 static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp, LONG resp_len)
 {
     UBYTE csum, RxTail;
+    LONG err;
     int i;
 
     cu->cu_Sequence++;
@@ -271,6 +305,8 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
     /* Let the transfers run; this triggers the command */
     writel(AKIKO_CDFLAG_TXD | AKIKO_CDFLAG_RXD | AKIKO_CDFLAG_CAS | AKIKO_CDFLAG_PBX | AKIKO_CDFLAG_MSB, AKIKO_CDFLAG);
 
+    cd32TimeoutStart(cu, CD32_CMD_TIMEOUT_MS);
+
     for (;;) {
         UBYTE RxHead = cu->cu_RxHead;
 
@@ -299,7 +335,8 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
 
         if (csum != 0xff) {
             D(bug("%s: Checksum failed on RX\n", __func__));
-            return CDERR_NotSpecified;
+            err = CDERR_NotSpecified;
+            goto out;
         }
 
         RxHead = cu->cu_RxHead;
@@ -343,7 +380,8 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
 
         default:
             D(bug("%s: Command mismatch: got 0x%02x, expected 0x%02x\n", __func__, cu->cu_Misc->Response[RxHead], cmd[0]));
-            return CDERR_InvalidState;
+            err = CDERR_InvalidState;
+            goto out;
         }
 
         /* Re-open the receive window and re-enable RXDMA for the next
@@ -373,12 +411,16 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
 
     if (csum != 0xff) {
         D(bug("%s: Checksum failed on RX\n", __func__));
-        return CDERR_NotSpecified;
+        err = CDERR_NotSpecified;
+        goto out;
     }
 
     D(bug("%s:  -- RXHead %2x --\n", __func__, cu->cu_RxHead));
 
-    return 0;
+    err = 0;
+out:
+    cd32TimeoutEnd(cu);
+    return err;
 }
 
 static VOID CD32_Led(struct CD32Unit *cu, BOOL led_on)
@@ -428,7 +470,9 @@ static LONG CD32_CmdRead(struct CD32Unit *cu, LONG sect_start, LONG sectors, voi
         CD32_IntEnable(cu, AKIKO_CDINT_PBX);
 
         writel(readl(AKIKO_CDFLAG) | AKIKO_CDFLAG_ENABLE, AKIKO_CDFLAG);
+        cd32TimeoutStart(cu, CD32_CMD_TIMEOUT_MS);
         Wait(SIGF_SINGLE);
+        cd32TimeoutEnd(cu);
 
         CD32_Cmd(cu, cmd_pause, 1, resp, sizeof(resp));
         CD32_Led(cu, FALSE);
@@ -437,6 +481,12 @@ static LONG CD32_CmdRead(struct CD32Unit *cu, LONG sect_start, LONG sectors, voi
         if (pbx == 0) {
             D(bug("%s: Overflow during read\n", __func__));
             break;
+        }
+
+        if (pbx == 0xffff) {
+            /* Not a single sector arrived before the timeout */
+            D(bug("%s: No sectors delivered\n", __func__));
+            return CDERR_NotSpecified;
         }
 
         for (i = 15; i >= 0; i--) {

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -834,10 +834,19 @@ static VOID CD32_Expunge(APTR priv)
     FreeVec(cu);
 }
 
+static VOID CD32_UnitInit(APTR priv)
+{
+    struct CD32Unit *cu = priv;
+
+    cu->cu_Task = FindTask(NULL);
+    CD32_IsCDROM(cu);
+}
+
 static const struct cdUnitOps CD32Ops = {
     .uo_Name = "CD32 (Akiko)",
     .uo_Expunge = CD32_Expunge,
     .uo_DoIO = CD32_DoIO,
+    .uo_Init = CD32_UnitInit,
 };
 
 static const struct DosEnvec CD32Envec = {
@@ -900,7 +909,6 @@ static int CD32_InitLib(LIBBASETYPE *cb)
                 priv->cu_CDInfo.ReadSpeed = 150;
                 priv->cu_CDInfo.ReadXLSpeed = 150;
                 priv->cu_CDInfo.AudioPrecision = 1;
-                CD32_IsCDROM(priv);
 
                 unit = cdAddUnit(cb, &CD32Ops, priv, &CD32Envec);
                 if (unit >= 0) {

--- a/arch/m68k-amiga/devs/cd/cd_intern.h
+++ b/arch/m68k-amiga/devs/cd/cd_intern.h
@@ -33,6 +33,8 @@ struct cdUnitOps {
     CONST_STRPTR  uo_Name;
     LONG        (*uo_DoIO)(struct IOStdReq *io, APTR priv);
     VOID        (*uo_Expunge)(APTR priv);
+    VOID        (*uo_Init)(APTR priv);  /* optional; runs on the unit task
+                                         * before any I/O is served */
 };
 
 LONG cdAddUnit(LIBBASETYPE *cb, const struct cdUnitOps *ops, APTR priv, const struct DosEnvec *de);


### PR DESCRIPTION
While working on CD32 support in the Copperline emulator I found that the AROS ROM can no longer boot CD32 discs, and traced it to a chain of problems in cd.device. This series fixes them.

The headline bug is a one-liner: 34d67c894690 switched the m68k ROM's CD filesystem from the cdfs handler to CDVDFS back in 2019, but cd.device still registers its boot node with DosType 'CDFS'. CDVDFS registers itself as 'CDVD', and CliInit only falls back to handler-name matching when the DosType is zero, so CD0: has been unmountable ever since.

Behind that were a few driver bugs in the Akiko command path:

* CD32_Cmd enables RXDMA/TXDMA before clearing the previous command's latched completion bits, so the stale latches fire the interrupt handler immediately, which disables the enables again and steals the completion signal. The retry loop also never re-enables RXDMA after consuming an unsolicited response (media change, SUBQ), which can park the unit task in an untimed Wait() forever.
* The initial media/TOC probe runs from InitCode(RTF_COLDSTART) at residentpri 5, so any drive misbehaviour wedges the boot task on the boot splash with no diagnostic. The series moves it onto the unit task via a new optional uo_Init hook.
* Neither drive wait had a timeout.
* The published DosEnvec carried stack garbage in de_Mask and de_Baud (the copy was off by one, de_TableSize being the highest valid index rather than a count), and the hand-built timer reply port never had its message list initialised even though ReplyMsg() enqueues on it.

With the series applied a CD32 disc mounts through CDVDFS and boots - real CD32 discs have no boot block, just an ISO9660 volume with an S/Startup-Sequence, so nothing in dosboot needed to change. Verified under Copperline against Pinball Fantasies, which now loads from CD and runs. Where this driver and the CD32 Kickstart cd.device disagreed about the wire protocol I checked both against the Kickstart ROM's parsing (for example the media-status byte: KS masks it with 3, this driver compares the whole byte against 0x83 - the real drive sends 0x83, and the emulator now does too). This is all under emulation, so a test on real hardware would be very welcome.

Two things I noticed nearby but did not touch, in case anyone wants them: the m68k level-2 wrapper acks INTF_PORTS whether or not any server claimed it (Amiga_Level_6 similarly handles INTF_EXTER|INTF_INTEN but only ever acks INTF_EXTER), and once discs mount, Pinball Fantasies gets as far as opening its screen and then loops on AmigaVideoBM__Root__New failing to instantiate a 640x256 depth-2 bitmap, which looks like a separate amigavideo issue.
