### PR TITLE
muimaster: capture window positions on exit and guard against corrupted prefs

### DIFF
--- a/workbench/libs/muimaster/classes/application.c
+++ b/workbench/libs/muimaster/classes/application.c
@@ -791,22 +791,47 @@ static IPTR Application__OM_DISPOSE(struct IClass *cl, Object *obj,
         positionmode = data->app_GlobalInfo.mgi_Prefs->window_position;
         if (positionmode >= 1)
         {
-            snprintf(filename, 255, "ENV:zune/%s.prefs", data->app_Base);
             /*
-             * The config window (sys:prefs/Zune) is launched asynchronously,
-             * so we may not have refreshed our in-memory Configdata when it
-             * was opened. Reload the latest settings it has written before
-             * saving, so we don't overwrite the user's changes with our
-             * stale copy. Window positions are still persisted by Save.
+             * Capture the final window positions. Windows that are closed
+             * by the application before disposing it (e.g. FryingPan) are
+             * already snapshotted in UndisplayWindow, but apps that just
+             * dispose the application with its windows still open (e.g.
+             * iGame) would otherwise lose their position. MUIM_Window_
+             * Snapshot stores the position in the app's winpos array,
+             * which Configdata_SetWindowPos re-adds during Save.
              */
-            DoMethod(data->app_GlobalInfo.mgi_Configdata,
-                MUIM_Configdata_Load, (IPTR) filename);
+            {
+                struct MinList *children = NULL;
+                Object *cstate;
+                Object *child;
+
+                get(data->app_WindowFamily, MUIA_Family_List, &children);
+                if (children)
+                {
+                    cstate = (Object *) children->mlh_Head;
+                    while ((child = NextObject(&cstate)))
+                        DoMethod(child, MUIM_Window_Snapshot, 1);
+                }
+            }
+
+            snprintf(filename, 255, "ENV:zune/%s.prefs", data->app_Base);
             DoMethod(data->app_GlobalInfo.mgi_Configdata,
                 MUIM_Configdata_Save, (IPTR) filename);
         }
         if (positionmode == 2)
         {
+            /*
+             * ENVARC holds the settings that survive a reboot, i.e. the
+             * ones from the last "Save" in the config window. "Use" only
+             * applies the settings for the current session, so do not
+             * write the session settings here. Reload the persistent
+             * ENVARC content and save it again, which updates only the
+             * window positions (Configdata_SetWindowPos re-adds them
+             * during Save).
+             */
             snprintf(filename, 255, "ENVARC:zune/%s.prefs", data->app_Base);
+            DoMethod(data->app_GlobalInfo.mgi_Configdata,
+                MUIM_Configdata_Load, (IPTR) filename);
             DoMethod(data->app_GlobalInfo.mgi_Configdata,
                 MUIM_Configdata_Save, (IPTR) filename);
         }

--- a/workbench/libs/muimaster/classes/dataspace.c
+++ b/workbench/libs/muimaster/classes/dataspace.c
@@ -218,7 +218,7 @@ IPTR Dataspace__MUIM_ReadIFF(struct IClass *cl, Object *obj,
 
     p = buffer;
 
-    while (p < buffer + read)
+    while (p + 8 <= buffer + read)
     {
         /* Since data can be stored on uneven addresses we must read
          ** them byte by byte as MC68000 doesn't like this
@@ -229,6 +229,11 @@ IPTR Dataspace__MUIM_ReadIFF(struct IClass *cl, Object *obj,
         p += 4;
 
         /* p might be uneven but MUIM_Dataspace_Add use CopyMem() */
+
+        /* Guard against a corrupted/truncated file - do not read past
+         ** the chunk if the length field is bogus */
+        if (len > (ULONG)(buffer + read - p))
+            break;
 
         /* Now add the data */
         DoMethod(obj, MUIM_Dataspace_Add, (IPTR) p, len, id);


### PR DESCRIPTION
Fix two issues in muimaster related to saving prefs on application exit.

### 1. Capture window positions before saving prefs on application exit
### 2. Dataspace: guard against corrupted prefs files when reading IFF