### PR TITLE
m68k-amiga: survive a chip-RAM-starved boot console

### DIFF
--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_bitmapclass.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <proto/exec.h>
 #include <proto/oop.h>
 #include <proto/utility.h>
 #include <exec/alerts.h>
@@ -82,6 +83,9 @@ OOP_Object *AmigaVideoBM__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_N
     {
         struct TagItem  *tag, *tstate;
         bug("[AmigaVideo:Bitmap] %s: superclass failed to instantiate a suitable bitmap...!!\n", __func__);
+        bug("[AmigaVideo:Bitmap] %s: chip free %lu, largest %lu\n", __func__,
+            (unsigned long)AvailMem(MEMF_CHIP),
+            (unsigned long)AvailMem(MEMF_CHIP | MEMF_LARGEST));
         bug("[AmigaVideo:Bitmap] %s: tags @ 0x%p\n", __func__, msg->attrList);
         tstate = msg->attrList;
         while((tag = NextTagItem(&tstate)))

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -351,7 +351,22 @@ static BOOL MakeSureWinIsOpen(struct filehandle *fh)
         return TRUE;
     if (fh->window)
         return TRUE;
-    return MakeConWindow(fh) == 0;
+    if (fh->flags & FHFLG_NOWINDOW)
+        return FALSE;
+    if (MakeConWindow(fh) == 0)
+        return TRUE;
+    if (fh->flags & FHFLG_BOOTCON) {
+        /* The boot console could not get its window - typically the
+         * screen's bitmap allocation failing on a chip-RAM-only machine
+         * whose memory the booted program already owns. Latch it:
+         * without this every packet re-attempts the whole screen open
+         * (40 KB of chip for a Workbench screen) forever. The callers
+         * turn a latched boot console into a sink: writes are
+         * swallowed, reads see end-of-file.
+         */
+        fh->flags |= FHFLG_NOWINDOW;
+    }
+    return FALSE;
 }
 
 static void close_con(struct filehandle *fh)
@@ -1022,7 +1037,10 @@ LONG CONMain(struct ExecBase *SysBase)
                 case ACTION_READ:
                     DACTION(bug("[con:handler] ACTION_READ\n"));
                     if (!MakeSureWinIsOpen(fh)) {
-                        replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
+                        if (fh->flags & FHFLG_NOWINDOW)
+                            replypkt(dp, 0); /* sink: end-of-file */
+                        else
+                            replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
                         break;
                     }
                     fh->breaktask = dp->dp_Port->mp_SigTask;
@@ -1039,7 +1057,10 @@ LONG CONMain(struct ExecBase *SysBase)
                 case ACTION_WRITE:
                     DACTION(bug("[con:handler] ACTION_WRITE\n"));
                     if (!MakeSureWinIsOpen(fh)) {
-                        replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
+                        if (fh->flags & FHFLG_NOWINDOW)
+                            replypkt(dp, dp->dp_Arg3); /* sink: swallowed */
+                        else
+                            replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
                         break;
                     }
                     fh->breaktask = dp->dp_Port->mp_SigTask;
@@ -1078,7 +1099,10 @@ LONG CONMain(struct ExecBase *SysBase)
                     {
                         DACTION(bug("[con:handler] ACTION_WAIT_CHAR\n"));
                         if (!MakeSureWinIsOpen(fh)) {
-                            replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
+                            if (fh->flags & FHFLG_NOWINDOW)
+                                replypkt(dp, DOSFALSE); /* sink: never a char */
+                            else
+                                replypkt2(dp, DOSFALSE, ERROR_NO_FREE_STORE);
                             break;
                         }
                         if (fh->inputsize > 0) {

--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -293,7 +293,15 @@ static LONG MakeConWindow(struct filehandle *fh)
         else
             err = ERROR_INVALID_RESIDENT_LIBRARY;
         if (err)
+        {
+            /* The pointer must not survive the close: MakeSureWinIsOpen
+             * treats a non-NULL window as an open one, so a stale pointer
+             * both bypasses the FHFLG_NOWINDOW latch and hands console
+             * I/O a freed window.
+             */
             CloseWindow(fh->window);
+            fh->window = NULL;
+        }
 
     } /* if (fh->window) */
     else {

--- a/rom/filesys/console_handler/con_handler_intern.h
+++ b/rom/filesys/console_handler/con_handler_intern.h
@@ -123,6 +123,7 @@ struct filehandle
 #define FHFLG_WAITFORCLOSE      512 /* Console with WAIT is waiting to be closed */
 #define FHFLG_BOOTCON           1024/* Special marker for boot console */
 #define FHFLG_DEVICEMODE        2048/* Driving a plain device, no window */
+#define FHFLG_NOWINDOW          4096/* Boot console failed to get a window: act as a sink */
 
 #undef InputBase
 #undef IntuitionBase

--- a/rom/hidds/gfx/gfx_planarbitmapclass.c
+++ b/rom/hidds/gfx/gfx_planarbitmapclass.c
@@ -187,6 +187,9 @@ OOP_Object *PBM__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
             if (NULL == data->bitmap->Planes[i])
             {
+                D(bug("[PlanarBM] %s: plane %d allocation failed (%lu bytes, flags 0x%lx)\n",
+                      __func__, i, (unsigned long)(height * bytesperrow),
+                      (unsigned long)planeflags));
                 ok = FALSE;
                 break;
             }


### PR DESCRIPTION
Follow-up to #1018. With CD32 discs booting, the next thing a commercial title hits is this, looping forever at packet rate:

```
[AmigaVideo:Bitmap] AmigaVideoBM__Root__New: superclass failed to instantiate a suitable bitmap...!!
```

Decoding the tags shows it is not the game's screen at all: 640x256 depth-2 PAL:HighRes with no friend bitmap is the Workbench screen (NominalDimensions hardcodes depth 2), dragged in lazily by the boot CON: window. The game has filled the 2 MB of a stock CD32 by then, so the screen's two contiguous 20 KB chip plane allocations can never succeed - and MakeSureWinIsOpen re-attempted the entire screen open on every ACTION_READ/WRITE/WAIT_CHAR, forever. Making it worse, every one of the eight distinct failure exits in the bitmap class chain produces that identical log line, so the cause was invisible in the field.

Three small commits:

* The planar bitmap class logs (in debug builds) which plane allocation failed, how big it was, and with what MEMF flags - it previously had no failure logging at all.
* The amigavideo failure message, which is already unconditional, now prints AvailMem(MEMF_CHIP) and the largest contiguous chunk beside it. From the failing machine: `chip free 41576, largest 21608` - a one-line diagnosis when the screen needs two contiguous 20 KB planes.
* A boot console that cannot get its window latches the failure and degrades to a sink: writes are swallowed, reads return end-of-file, WaitForChar never sees a character. Programs that only write status text keep running and the machine stops thrashing. Non-boot consoles keep the old per-request behaviour.

Verified under emulation on the CD32 profile: a chip-only machine booting Pinball Fantasies now makes exactly two window attempts (one per console handle) and stops, with the memory line telling the story; with 8 MB of fast RAM the same disc boots through to the game running attract mode; the no-media boot screen path is unchanged.
