### PR TITLE
crosstools: Fix host GCC char8_t bootstrap issue in libcody and clean binutils 2.32 patch

### DIFF
--- a/tools/crosstools/gnu/binutils-2.32-aros.diff
+++ b/tools/crosstools/gnu/binutils-2.32-aros.diff
@@ -619,14 +619,6 @@ diff -ruN binutils-2.32/ld/emulparams/armelf_aros.sh binutils-2.32.aros/ld/emulp
 +
 +TEXT_START_ADDR=0x80000000
 +SEPARATE_CODE=yes
-diff -ruN binutils-2.32/ld/emulparams/armelfb_aros.sh binutils-2.32.aros/ld/emulparams/armelfb_aros.sh
---- binutils-2.32/ld/emulparams/armelfb_aros.sh	1970-01-01 01:00:00.000000000 +0100
-+++ binutils-2.32.aros/ld/emulparams/armelfb_aros.sh	2026-07-31 15:55:51.208078555 +0100
-@@ -0,0 +1,4 @@
-+. ${srcdir}/emulparams/armelf_aros.sh
-+OUTPUT_FORMAT="elf32-bigarm-aros"
-+BIG_OUTPUT_FORMAT="elf32-bigarm-aros"
-+LITTLE_OUTPUT_FORMAT="elf32-littlearm-aros"
 diff -ruN binutils-2.32/ld/emulparams/riscv64elf_aros.sh binutils-2.32.aros/ld/emulparams/riscv64elf_aros.sh
 --- binutils-2.32/ld/emulparams/riscv64elf_aros.sh	1970-01-01 01:00:00.000000000 +0100
 +++ binutils-2.32.aros/ld/emulparams/riscv64elf_aros.sh	2026-07-31 15:56:21.846911176 +0100

--- a/tools/crosstools/gnu/gcc-15.2.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-15.2.0-aros.diff
@@ -2787,3 +2787,16 @@ diff -ruN gcc-15.2.0/libstdc++-v3/include/std/ratio gcc-15.2.0.aros/libstdc++-v3
        static constexpr int __shift = __builtin_clzll(__d);
        static constexpr int __coshift_ = sizeof(uintmax_t) * 8 - __shift;
        static constexpr int __coshift = (__shift != 0) ? __coshift_ : 0;
+diff -ruN gcc-15.2.0/libcody/buffer.cc gcc-15.2.0.aros/libcody/buffer.cc
+--- gcc-15.2.0/libcody/buffer.cc	2025-08-08 06:51:45.000000000 +0000
++++ gcc-15.2.0.aros/libcody/buffer.cc	2026-05-10 20:00:00.000000000 +0000
+@@ -1,5 +1,9 @@
+ // CODYlib		-*- mode:c++ -*-
+ // Copyright (C) 2020 Nathan Sidwell, nathan@acm.org
++#if __cpp_char8_t >= 201811L
++// Fix for host GCC with char8_t enabled: provide conversion
++inline char S2C(char8_t c) { return static_cast<char>(c); }
++#endif
+ // License: Apache v2.0
+ 
+ #include "cody.hh"

--- a/tools/crosstools/gnu/gcc-16.2.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.2.0-aros.diff
@@ -2823,3 +2823,16 @@ diff -ruN gcc-16.2.0/libstdc++-v3/include/std/ratio gcc-16.2.0.aros/libstdc++-v3
        static constexpr int __shift = __builtin_clzll(__d);
        static constexpr int __coshift_ = sizeof(uintmax_t) * 8 - __shift;
        static constexpr int __coshift = (__shift != 0) ? __coshift_ : 0;
+diff -ruN gcc-16.2.0/libcody/buffer.cc gcc-16.2.0.aros/libcody/buffer.cc
+--- gcc-16.2.0/libcody/buffer.cc	2026-08-07 07:46:10.000000000 +0000
++++ gcc-16.2.0.aros/libcody/buffer.cc	2026-05-10 20:00:00.000000000 +0000
+@@ -1,5 +1,9 @@
+ // CODYlib		-*- mode:c++ -*-
+ // Copyright (C) 2020 Nathan Sidwell, nathan@acm.org
++#if __cpp_char8_t >= 201811L
++// Fix for host GCC with char8_t enabled: provide conversion
++inline char S2C(char8_t c) { return static_cast<char>(c); }
++#endif
+ // License: Apache v2.0
+ 
+ #include "cody.hh"


### PR DESCRIPTION
## Summary
Fixes cross-compiler bootstrap build failures when compiling AROS on modern Linux/macOS host systems equipped with recent compilers (GCC 14/15/16, modern Clang) where C++20 `char8_t` strict typing is enabled by default.

## Details
- **libcody char8_t conversion:** Adds `#if __cpp_char8_t >= 201811L inline char S2C(char8_t c) { return static_cast<char>(c); }` to `gcc-15.2.0-aros.diff` and `gcc-16.2.0-aros.diff`. This resolves type mismatch errors in `libcody/buffer.cc` during the host stage of the toolchain build.
- **Binutils 2.32 patch cleanup:** Removes a duplicate file creation hunk (`ld/emulparams/armelfb_aros.sh`) in `binutils-2.32-aros.diff` which caused patch application failures with modern `patch` utilities.

## Testing
- Verified clean patch application and build on modern host compilers.