### PR TITLE
arm smp core

### DIFF
--- a/arch/aarch64-native/exec/exec_platform.h
+++ b/arch/aarch64-native/exec/exec_platform.h
@@ -21,12 +21,19 @@ extern void Exec_TaskSpinUnlock(spinlock_t *);
 extern void Kernel_40_KrnSpinInit(spinlock_t *, void *);
 #define EXEC_SPINLOCK_INIT(a) Kernel_40_KrnSpinInit((a), NULL)
 extern spinlock_t *Kernel_43_KrnSpinLock(spinlock_t *, struct Hook *, ULONG, void *);
-#define EXEC_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), NULL, (b), NULL)
+/* (lock, failhook, mode) - rom/exec passes all three. */
+#define EXEC_SPINLOCK_LOCK(a,b,c) Kernel_43_KrnSpinLock((a), (b), (c), NULL)
 #define EXECTASK_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), &Exec_TaskSpinLockFailHook, (b), NULL)
 extern void Kernel_44_KrnSpinUnLock(spinlock_t *, void *);
 #define EXEC_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL)
 #define EXECTASK_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL); \
             Exec_TaskSpinUnlock((a))
+
+/*
+ * Store-store barrier for publishing a freshly built structure to readers
+ * that walk it without taking a lock.
+ */
+#define EXEC_MEMORY_BARRIER()   asm volatile("dmb ishst" ::: "memory")
 
 #endif
 

--- a/arch/all-pc/exec/exec_platform.h
+++ b/arch/all-pc/exec/exec_platform.h
@@ -65,6 +65,13 @@ extern void Kernel_53_KrnSpinUnLock(spinlock_t *, void *);
 #define EXEC_SPINLOCK_LOCK(a,b,c) Kernel_52_KrnSpinLock((a), (b), (c), NULL)
 #define EXEC_SPINLOCK_UNLOCK(a) Kernel_53_KrnSpinUnLock((a), NULL)
 
+/*
+ * Store-store barrier for publishing a freshly built structure to readers
+ * that walk it without taking a lock. x86 does not reorder stores, so
+ * keeping the compiler from doing it is enough.
+ */
+#define EXEC_MEMORY_BARRIER()   asm volatile("" ::: "memory")
+
 #if defined(AROS_NO_ATOMIC_OPERATIONS)
 #define IDNESTCOUNT_INC \
     do { \
@@ -188,6 +195,15 @@ extern void Kernel_53_KrnSpinUnLock(spinlock_t *, void *);
             __AROS_ATOMIC_OR_L(__schd->ScheduleFlags, TLSSF_Dispatch); \
     } while(0)
 #endif /* !AROS_NO_ATOMIC_OPERATIONS */
+/*
+ * Block IRQ-exit dispatch without going through Forbid()/Permit() (Permit's
+ * decrement can trigger Reschedule() which yields - exactly what we don't
+ * want while holding a scheduler list spinlock). Used by the scheduler-list
+ * helpers in rom/exec/exec_intern.h. Maps to the per-CPU task-dispatch nest
+ * count, mirroring arm-native's EXEC_BLOCK_DISPATCH_INC/DEC.
+ */
+#define EXEC_BLOCK_DISPATCH_INC         TDNESTCOUNT_INC
+#define EXEC_BLOCK_DISPATCH_DEC         TDNESTCOUNT_DEC
 #define SCHEDQUANTUM_SET(val) \
     do { \
         struct X86SchedulerPrivate  *__schd = TLS_GET(ScheduleData); \

--- a/arch/arm-native/exec/exec_platform.h
+++ b/arch/arm-native/exec/exec_platform.h
@@ -13,21 +13,47 @@
 #include <aros/types/spinlock_s.h>
 #include <utility/hooks.h>
 
-extern struct Hook Exec_TaskSpinLockFailHook;
-extern void Exec_TaskSpinUnlock(spinlock_t *);
-
 extern void Kernel_49_KrnSpinInit(spinlock_t *, void *);
 #define EXEC_SPINLOCK_INIT(a) Kernel_49_KrnSpinInit((a), NULL)
 extern spinlock_t *Kernel_52_KrnSpinLock(spinlock_t *, struct Hook *, ULONG, void *);
 #define EXEC_SPINLOCK_LOCK(a,b,c) Kernel_52_KrnSpinLock((a), (b), (c), NULL)
-#define EXECTASK_SPINLOCK_LOCK(a,b) Kernel_52_KrnSpinLock((a), &Exec_TaskSpinLockFailHook, (b), NULL)
 extern void Kernel_53_KrnSpinUnLock(spinlock_t *, void *);
 #define EXEC_SPINLOCK_UNLOCK(a) Kernel_53_KrnSpinUnLock((a), NULL)
-#define EXECTASK_SPINLOCK_UNLOCK(a) Kernel_53_KrnSpinUnLock((a), NULL); \
-            Exec_TaskSpinUnlock((a))
 
-/* Stub: arm-native syscall-based reschedule is not yet implemented. */
-#define krnSysCallReschedTask(task, state) do { (void)(task); (void)(state); } while (0)
+/*
+ * Store-store barrier for publishing a freshly built structure to readers
+ * that walk it without taking a lock. DMB is available unprivileged on
+ * ARMv7-A, so this is usable from task context in rom/exec.
+ */
+#define EXEC_MEMORY_BARRIER()   asm volatile("dmb" ::: "memory")
+
+/*
+ * arm-native does not need a syscall for reschedule: the work is just
+ * task-list mutation under spinlocks, no privilege change required.
+ * Exec_ReschedTask is implemented in arch/arm-native/exec/platform_init.c.
+ */
+extern void Exec_ReschedTask(struct Task *, ULONG);
+#define krnSysCallReschedTask(task, state) Exec_ReschedTask((task), (state))
+
+/*
+ * Route RemTask/ServiceTask through the locked reschedule path. Without
+ * this, rom/exec/remtask.c and service.c take their #if !defined branch
+ * and mutate the scheduler lists (Remove/Enqueue) with no spinlock held
+ * - safe single-threaded, but it corrupts the lists once tasks run on
+ * more than one core. all-pc defines this for the same reason.
+ */
+#define EXEC_REMTASK_NEEDSSWITCH
+
+/*
+ * Switch-only primitive for RemTask's self-removal (suicide) path. The
+ * task has already set TS_REMOVED; detach it from TaskRunning under the
+ * list lock and tombstone it for the service task, then RETURN so
+ * RemTask can finish its own teardown and send itself to the service
+ * task before the final KrnDispatch. (KrnSwitch would also dispatch and
+ * never return, which would strand the half-torn-down task.)
+ */
+extern void Exec_SuicideSwitch(void);
+#define krnSysCallSwitch() Exec_SuicideSwitch()
 
 #endif
 
@@ -208,6 +234,83 @@ struct Exec_PlatformData
         BOOL __ret = (__tls->ScheduleFlags & TLSSF_Dispatch); \
         __ret;  \
     })
+/*
+ * Plain (non-atomic) TDNestCnt bumps. TDNestCnt lives in per-CPU TLS,
+ * so concurrent updates from other cores aren't possible. Used by the
+ * scheduler-list helpers in rom/exec/exec_intern.h to block IRQ-exit
+ * dispatch without going through Forbid()/Permit() (Permit's decrement
+ * can trigger Reschedule() which yields - exactly what we don't want
+ * while holding a scheduler list spinlock).
+ */
+#define EXEC_BLOCK_DISPATCH_INC \
+    do { \
+        tls_t *__tls; \
+        asm volatile("mrc p15, 0, %0, c13, c0, 3":"=r"(__tls)); \
+        __tls->TDNestCnt++; \
+    } while(0)
+
+#define EXEC_BLOCK_DISPATCH_DEC \
+    do { \
+        tls_t *__tls; \
+        asm volatile("mrc p15, 0, %0, c13, c0, 3":"=r"(__tls)); \
+        __tls->TDNestCnt--; \
+    } while(0)
+
+/*
+ * Mask FIQ across scheduler-list / tc_SpinLock critical sections. On this
+ * platform the ONLY FIQ source is the inter-core mailbox (the IPI). An IPI
+ * that lands while this CPU holds a scheduler lock re-enters that lock via
+ * bcm2708_fiq_process -> handle_ipi -> signal_hook -> Signal ->
+ * Exec_ReschedTask on the SAME CPU and self-deadlocks (TaskReadySpinLock
+ * read held by core_Schedule vs the IPI's write acquire). EXEC_BLOCK_DISPATCH
+ * stops the dispatcher but not FIQ, so it does not cover this.
+ *
+ * EXEC_FIQ_DISABLE returns the prior F bit and disables FIQ; EXEC_FIQ_RESTORE
+ * re-enables FIQ only if it was enabled on entry, so the pair nests safely
+ * (an already-in-FIQ caller stays masked). The mailbox SET register latches
+ * the pending IPI; bcm2708_fiq_process drains it the moment FIQ is unmasked,
+ * so nothing is lost - delivery is just deferred to the end of the section.
+ */
+#define EXEC_FIQ_DISABLE() \
+    ({ unsigned int __cpsr; \
+       asm volatile("mrs %0, cpsr\n\tcpsid f" : "=r"(__cpsr) :: "memory"); \
+       (__cpsr & 0x40); })
+
+#define EXEC_FIQ_RESTORE(prevF) \
+    do { if (!(prevF)) asm volatile("cpsie f" ::: "memory"); } while(0)
+
+/*
+ * The cross-CPU Signal IPI is delivered as an FIQ on this platform, so its
+ * hook (signal_hook in rom/exec/signal.c) runs in restricted interrupt
+ * context: it must NOT call the full Signal() (Disable()/Enable() issue svc
+ * syscalls that nest on the FIQ SVC stack, and Reschedule() would switch
+ * tasks from inside the handler). signal_hook therefore delivers inline.
+ * Arches whose Signal IPI arrives as an ordinary interrupt leave this
+ * undefined and signal_hook just calls Signal().
+ */
+#define __AROSEXEC_IPI_RESTRICTED_CTX__
+
+/*
+ * Raw IRQ+FIQ mask/restore (privileged only). Used by scheduler primitives
+ * that are reachable from the FIQ/IPI handler (Exec_ReschedTask) where the
+ * exec Disable()/Enable() path is unusable: Disable() always issues a
+ * KrnCli svc, and that svc nests an exception on the FIQ-handler SVC stack.
+ * Raw cpsid avoids the syscall. Saves and restores the prior I|F bits so it
+ * nests and leaves an already-masked caller masked. In USER mode cpsid is a
+ * no-op, but every such caller already holds interrupts off (Signal Disable's
+ * first, the IPI handler runs FIQ/IRQ-masked), so it is safe there too.
+ */
+#define EXEC_IRQFIQ_DISABLE() \
+    ({ unsigned int __cpsr; \
+       asm volatile("mrs %0, cpsr\n\tcpsid if" : "=r"(__cpsr) :: "memory"); \
+       (__cpsr & 0xc0); })
+
+#define EXEC_IRQFIQ_RESTORE(prev) \
+    do { \
+        if (!((prev) & 0x80)) asm volatile("cpsie i" ::: "memory"); \
+        if (!((prev) & 0x40)) asm volatile("cpsie f" ::: "memory"); \
+    } while(0)
+
 #define GET_THIS_TASK           TLS_GET(ThisTask)
 #define SCHEDQUANTUM_SET(val)           TLS_SET(Quantum,(val))
 #define SCHEDQUANTUM_GET                TLS_GET(Quantum)
@@ -216,6 +319,13 @@ struct Exec_PlatformData
 #if !defined(__AROSEXEC_SMP__)
 #define SET_THIS_TASK(x)        TLS_SET(ThisTask,(x))
 #else
+/*
+ * SET_THIS_TASK is invoked from core_Dispatch which runs with IRQs
+ * already masked (IRQ-exit path). The TaskRunningSpinLock acquire here
+ * therefore inherits IRQ-disabled context; no explicit Disable() needed.
+ * Callers from non-dispatch context must Disable() themselves before
+ * invoking SET_THIS_TASK to avoid the scheduler-list self-deadlock.
+ */
 #define SET_THIS_TASK(x)        TLS_SET(ThisTask,(x)); \
     KrnSpinLock(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL, SPINLOCK_MODE_WRITE); \
     AddHead(&PrivExecBase(SysBase)->TaskRunning, (struct Node *)(x)); \

--- a/arch/arm-native/exec/intserver_vblank.c
+++ b/arch/arm-native/exec/intserver_vblank.c
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native VBlankServer.
+
+          On SMP the scheduler quantum is expired per-core by each core's
+          own ARM generic timer (CNTP) heartbeat in the kernel, so the
+          VBlank only runs the registered VERTB interrupt servers here.
+
+          On non-SMP arm-native there is no per-core timer, so the VBlank
+          remains the scheduling heartbeat and expires the quantum here,
+          exactly like generic Exec.
+*/
+
+#define DEBUG 0
+#include <aros/debug.h>
+
+#include <aros/asmcall.h>
+#include <exec/execbase.h>
+#include <exec/lists.h>
+
+#define AROS_NO_ATOMIC_OPERATIONS
+#include <exec_platform.h>
+
+#include "intservers.h"
+
+/* VBlankServer. The same as general purpose IntServer, and on non-SMP it
+ * also counts the task's quantum. */
+AROS_INTH3(VBlankServer, struct List *, intList, intMask, custom)
+{
+    AROS_INTFUNC_INIT
+
+    D(bug("[Exec] %s()\n", __func__));
+
+#if !defined(__AROSEXEC_SMP__)
+    /* Check if it is time for the running task to be switched away */
+    {
+        UWORD current = SCHEDELAPSED_GET;
+        if (current)
+            SCHEDELAPSED_SET(--current);
+
+        if (current == 0)
+        {
+            FLAG_SCHEDQUANTUM_SET;
+            FLAG_SCHEDSWITCH_SET;
+        }
+    }
+#endif
+
+    /* Chain to the generic routine */
+    return AROS_INTC3(IntServer, intList, intMask, custom);
+
+    AROS_INTFUNC_EXIT
+}

--- a/arch/arm-native/exec/mmakefile.src
+++ b/arch/arm-native/exec/mmakefile.src
@@ -30,7 +30,8 @@ PRIV_EXEC_INCLUDES = \
     -I$(SRCDIR)/rom/kernel
 
 CFILES          := \
-        platform_init exec_idle superstate userstate coldreboot cachepredma cachecleare
+        platform_init exec_idle superstate userstate coldreboot cachepredma cachecleare \
+        intserver_vblank
 
 ##exec_init
 

--- a/arch/arm-native/exec/platform_init.c
+++ b/arch/arm-native/exec/platform_init.c
@@ -86,6 +86,15 @@ int Exec_ARMCPUInit(struct ExecBase *SysBase)
                 bug("[Exec] %s: CPU Affinity : %08x\n", __PRETTY_FUNCTION__, GetIntETask(CPUIdleTask)->iet_CpuAffinity);
 #endif
             )
+#if defined(__AROSEXEC_SMP__)
+            /*
+             * Tell the kernel which task idles this core, so
+             * KrnGetSystemAttr(KATTR_CPULoad + cpu) can derive the core's
+             * load from it. Only exec knows the mapping.
+             */
+            if (cpu < ARM_MAXCPUS)
+                arm_IdleTask[cpu] = CPUIdleTask;
+#endif
         }
 #if defined(__AROSEXEC_SMP__)
     }
@@ -95,60 +104,185 @@ int Exec_ARMCPUInit(struct ExecBase *SysBase)
 }
 
 #if defined(__AROSEXEC_SMP__)
-struct Hook Exec_TaskSpinLockFailHook;
+/*
+ * NOTE: no TS_SPIN / spinlock-failhook machinery here. arm-native's
+ * KrnSpinLock never invokes its failhook parameter, so tasks are never
+ * parked in TS_SPIN on this port - spinners just spin. all-pc has the
+ * wired-up version (its KrnSpinLock calls the hook).
+ */
 
-AROS_UFH3(void, Exec_TaskSpinLockFailFunc,
-    AROS_UFHA(struct Hook *, h, A0),
-    AROS_UFHA(spinlock_t *, thisLock, A1),
-    AROS_UFHA(void *, unused, A2))
+/*
+ * Move task from its current state's list to the list matching newState.
+ * Called by krnSysCallReschedTask from rom/exec (signal.c, newaddtask.c,
+ * remtask.c, service.c). On arm-native this is a direct function call,
+ * not a syscall - the work is just list mutation under spinlocks.
+ *
+ * Callers MUST NOT hold tc_SpinLock - we take it ourselves so the
+ * (state-read -> list-lock-pick -> list-mutate -> state-write) sequence
+ * is atomic from any other observer that takes tc_SpinLock. Without this
+ * a concurrent migrator could see a stale tc_State, acquire the wrong
+ * source list-lock, and Remove from a list the task is not on.
+ *
+ * Lock order: tc_SpinLock outer, list-locks inner. Matches wait.c's
+ * TS_WAIT migration and the exec_TaskRemove / exec_TaskEnqueue helpers.
+ */
+void Exec_ReschedTask(struct Task *task, ULONG newState)
 {
-    AROS_USERFUNC_INIT
+    spinlock_t *fromLock = NULL;
+    /*
+     * Raw IRQ+FIQ off for the whole function. tc_SpinLock is held across it
+     * (plus fromLock and the enqueue lists); an IPI (FIQ) or the IRQ-exit
+     * dispatcher re-entering these on this CPU self-deadlocks. We use raw
+     * masking, not Disable()/Enable(): this runs from the FIQ/IPI handler
+     * too, where Disable()'s KrnCli svc would nest an exception on the
+     * FIQ-handler SVC stack. See EXEC_IRQFIQ_DISABLE in exec_platform.h.
+     */
+    unsigned int __if = EXEC_IRQFIQ_DISABLE();
 
-    struct Task *thisTask = GET_THIS_TASK;
+    Kernel_52_KrnSpinLock(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE, NULL);
 
-    /* tell the scheduler that the task is waiting on a spinlock */
-    thisTask->tc_State = TS_SPIN;
-    GetIntETask(thisTask)->iet_SpinLock = thisLock;
-
-    AROS_USERFUNC_EXIT
-}
-
-void Exec_TaskSpinUnlock(spinlock_t *thisLock)
-{
-    struct Task *curTask, *nxtTask;
-
-    Kernel_52_KrnSpinLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL,
-                SPINLOCK_MODE_WRITE, NULL);
-    ForeachNodeSafe(&PrivExecBase(SysBase)->TaskSpinning, curTask, nxtTask)
+    if (newState == TS_READY)
     {
-        if (GetIntETask(curTask)->iet_SpinLock == thisLock)
+        /*
+         * Wake-up semantics: only migrate a task that is actually parked
+         * (TS_WAIT) or being added (TS_INVALID from TaskLaunch).
+         * Callers check the state under tc_SpinLock but must drop it
+         * before calling us, so by now another CPU may already have won
+         * the wake race and made the task READY - or dispatched it
+         * (TS_RUN), or torn it down (terminal states). Migrating in any
+         * of those cases would double-dispatch a running task or
+         * resurrect a corpse. The signal bits are already set, so a
+         * running/ready task will see them - just do nothing.
+         */
+        switch (task->tc_State)
         {
-            Kernel_52_KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
-                SPINLOCK_MODE_WRITE, NULL);
-            Disable();
-            Remove(&curTask->tc_Node);
-            Enqueue(&SysBase->TaskReady, &curTask->tc_Node);
-            Kernel_53_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL);
-            Enable();
+            case TS_WAIT:
+            case TS_INVALID:
+            case TS_ADDED:
+                break;
+            default:
+                Kernel_53_KrnSpinUnLock(&task->tc_SpinLock, NULL);
+                EXEC_IRQFIQ_RESTORE(__if);
+                return;
         }
     }
-    Kernel_53_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL);
+
+    switch (task->tc_State)
+    {
+        case TS_RUN:
+            fromLock = &PrivExecBase(SysBase)->TaskRunningSpinLock;
+            break;
+        case TS_READY:
+            fromLock = &PrivExecBase(SysBase)->TaskReadySpinLock;
+            break;
+        case TS_WAIT:
+            fromLock = &PrivExecBase(SysBase)->TaskWaitSpinLock;
+            break;
+        default:
+            /* TS_INVALID, TS_ADDED, TS_REMOVED, TS_TOMBSTONED, TS_EXCEPT:
+             * task is not on a standard scheduler list. Caller (Signal)
+             * also pre-filters out terminal states under tc_SpinLock so
+             * we should not normally reach here with such a state. */
+            break;
+    }
+
+    if (fromLock)
+    {
+        /* IRQ+FIQ already masked for the whole function (see top). */
+        Kernel_52_KrnSpinLock(fromLock, NULL, SPINLOCK_MODE_WRITE, NULL);
+        Remove(&task->tc_Node);
+        Kernel_53_KrnSpinUnLock(fromLock, NULL);
+    }
+
+    task->tc_State = newState;
+
+    switch (newState)
+    {
+        case TS_READY:
+            exec_TaskEnqueueReady(task);
+            break;
+        case TS_WAIT:
+            exec_TaskEnqueueWait(task);
+            break;
+        default:
+            /* TS_REMOVED, TS_TOMBSTONED: no enqueue. */
+            break;
+    }
+
+    Kernel_53_KrnSpinUnLock(&task->tc_SpinLock, NULL);
+    EXEC_IRQFIQ_RESTORE(__if);
+}
+
+/*
+ * krnSysCallSwitch() for RemTask's self-removal path. The caller (the
+ * task removing itself) has already set TS_REMOVED. Detach it from the
+ * TaskRunning list under the list lock and mark it TS_TOMBSTONED so the
+ * Exec service task reclaims it, then return - unlike KrnSwitch() this
+ * does NOT dispatch, so RemTask resumes on the same context to post
+ * itself to the service port and only gives up the CPU at its final
+ * KrnDispatch().
+ */
+void Exec_SuicideSwitch(void)
+{
+    struct Task *task = GET_THIS_TASK;
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
+
+    Disable();
+    /*
+     * tc_SpinLock outer, list lock inner (the usual order): the state
+     * write must be atomic with the list removal for observers that
+     * check tc_State under tc_SpinLock (Signal's terminal-state check,
+     * Exec_ReschedTask's wake filter).
+     */
+    Kernel_52_KrnSpinLock(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE, NULL);
+    Kernel_52_KrnSpinLock(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL,
+        SPINLOCK_MODE_WRITE, NULL);
+    Remove(&task->tc_Node);
+    Kernel_53_KrnSpinUnLock(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL);
+    task->tc_State = TS_TOMBSTONED;
+    Kernel_53_KrnSpinUnLock(&task->tc_SpinLock, NULL);
+    Enable();
+    EXEC_FIQ_RESTORE(__fiq);
 }
 
 int Exec_ARMCPUSMPInit(struct ExecBase *SysBase)
 {
-    int cpu, thiscpu = KrnGetCPUNumber();
+    /*
+     * Turn on CPU affinity routing in arch-neutral exec. Without this,
+     * signal.c's cross-CPU paths (KrnScheduleCPU on TS_RUN, the early
+     * core_DoCallIPI tunnel for non-affine CPUs) never fire and remote
+     * task wakes silently fail. The cpumask helpers (alloc/get/in/
+     * clear/free) and core_DoCallIPI must already be functional - this
+     * flag is the gate that exposes them to signal.c and newaddtask.c.
+     */
+    PrivExecBase(SysBase)->IntFlags |= EXECF_CPUAffinity;
 
-    /* set up the task spinning hook */
-    Exec_TaskSpinLockFailHook.h_Entry = (HOOKFUNC)Exec_TaskSpinLockFailFunc;
-
-    D(bug("[Exec] %s: Task SpinLock Fail hook @ 0x%p initialised (func @ 0x%p)\n", __PRETTY_FUNCTION__, &Exec_TaskSpinLockFailHook, Exec_TaskSpinLockFailHook.h_Entry));
-#if (0)
-    for (cpu = 1; cpu < 4; cpu++)
+    /*
+     * Pin the primordial boot/init task to the boot CPU. It was created
+     * (exec_init.c) before EXECF_CPUAffinity was set, so InitETask left it
+     * with a NULL affinity == "run anywhere". That lets a secondary core
+     * dispatch it mid-init, but the single-threaded coldstart sequence is
+     * not migration-safe (it holds boot-CPU/boot-stack-local state, e.g.
+     * stack-resident hooks), so running it elsewhere crashes. Keep it on
+     * the boot CPU (always logical 0); other tasks distribute normally.
+     */
     {
-        __arm_arosintern.ARMI_SendIPI((IPI_SCHEDULE & 0x0fffffff) | (thiscpu << 28), 0, KrnGetCPUMask(cpu));
+        struct Task *bootTask = GET_THIS_TASK;
+        struct IntETask *iet = bootTask ? (struct IntETask *)GetETask(bootTask) : NULL;
+
+        if (iet && !iet->iet_CpuAffinity)
+        {
+            void *aff = KrnAllocCPUMask();
+            if (aff)
+            {
+                KrnGetCPUMask(0, aff);
+                iet->iet_CpuAffinity = aff;
+                iet->iet_CpuNumber = 0;
+            }
+        }
     }
-#endif
+
+    return TRUE;
 }
 
 ADD2INITLIB(Exec_ARMCPUSMPInit, -127)

--- a/arch/arm-native/kernel/alloccpumask.c
+++ b/arch/arm-native/kernel/alloccpumask.c
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native KrnAllocCPUMask - allocate a CPU affinity bitmap.
+*/
+
+#include <proto/exec.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+
+#include <kernel_base.h>
+
+/*
+ * raspi tops out at 4 cores, so one uint32_t covers any affinity. If a
+ * future arm-native target needs more, size from __arm_arosintern.
+ */
+#define ARM_CPUMASK_BYTES   sizeof(uint32_t)
+
+AROS_LH0(void *, KrnAllocCPUMask,
+        struct KernelBase *, KernelBase, 42, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    return AllocMem(ARM_CPUMASK_BYTES, MEMF_CLEAR | MEMF_PUBLIC);
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/clearcpumask.c
+++ b/arch/arm-native/kernel/clearcpumask.c
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native KrnClearCPUMask - zero the CPU affinity bitmap.
+*/
+
+#include <exec/tasks.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+
+#include <kernel_base.h>
+
+AROS_LH1(void, KrnClearCPUMask,
+        AROS_LHA(void *, mask, A0),
+        struct KernelBase *, KernelBase, 44, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    if (mask && (IPTR)mask != TASKAFFINITY_ANY)
+        *(uint32_t *)mask = 0;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/cpuinmask.c
+++ b/arch/arm-native/kernel/cpuinmask.c
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native KrnCPUInMask - test whether a CPU is in the mask.
+*/
+
+#include <exec/tasks.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+
+#include <kernel_base.h>
+
+AROS_LH2(BOOL, KrnCPUInMask,
+        AROS_LHA(uint32_t, id, D0),
+        AROS_LHA(void *, mask, A0),
+        struct KernelBase *, KernelBase, 46, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    /* A NULL affinity means none was assigned - treat as unrestricted
+     * (run anywhere) rather than unschedulable. */
+    if (!mask)
+        return TRUE;
+
+    /* TASKAFFINITY_ANY ((IPTR)-1) is a sentinel meaning "any CPU" -
+     * not a buffer pointer. Treat it as a match for every CPU. */
+    if ((IPTR)mask == TASKAFFINITY_ANY)
+        return TRUE;
+
+    return (((uint32_t *)mask)[id >> 5] & (1U << (id & 31))) ? TRUE : FALSE;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/freecpumask.c
+++ b/arch/arm-native/kernel/freecpumask.c
@@ -1,0 +1,29 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native KrnFreeCPUMask - release a CPU affinity bitmap.
+*/
+
+#include <exec/tasks.h>
+
+#include <proto/exec.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+
+#include <kernel_base.h>
+
+AROS_LH1(void *, KrnFreeCPUMask,
+        AROS_LHA(void *, mask, A0),
+        struct KernelBase *, KernelBase, 43, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    /* TASKAFFINITY_ANY is a sentinel, not an allocated buffer. */
+    if (mask && (IPTR)mask != TASKAFFINITY_ANY)
+        FreeMem(mask, sizeof(uint32_t));
+
+    return NULL;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/getcpumask.c
+++ b/arch/arm-native/kernel/getcpumask.c
@@ -1,21 +1,25 @@
 /*
-    Copyright (C) 2015, The AROS Development Team. All rights reserved.
+    Copyright (C) 2015-2026, The AROS Development Team. All rights reserved.
 
-    Desc:
+    Desc: arm-native KrnGetCPUMask - set the bit for a CPU in the mask buffer.
 */
+
+#include <exec/tasks.h>
 
 #include <aros/kernel.h>
 #include <aros/libcall.h>
 
 #include <kernel_base.h>
 
-AROS_LH1(cpumask_t, KrnGetCPUMask,
-        AROS_LHA(cpuid_t, id, D0),
+AROS_LH2(void, KrnGetCPUMask,
+        AROS_LHA(uint32_t, id, D0),
+        AROS_LHA(void *, mask, A0),
         struct KernelBase *, KernelBase, 45, Kernel)
 {
     AROS_LIBFUNC_INIT
 
-    return (1 << id);
+    if (mask && (IPTR)mask != TASKAFFINITY_ANY)
+        ((uint32_t *)mask)[id >> 5] |= (1U << (id & 31));
 
     AROS_LIBFUNC_EXIT
 }

--- a/arch/arm-native/kernel/getcpunumber.c
+++ b/arch/arm-native/kernel/getcpunumber.c
@@ -6,48 +6,42 @@
 #include <aros/libcall.h>
 
 #include "kernel_base.h"
+#include "kernel_cpu.h"
 #include "kernel_intern.h"
+#include "kernel_syscall.h"
 
+/*
+ * Caller's mode matters: MRC to MPIDR (c0,c0,5) is privileged on
+ * ARMv7-A and undefined in user mode. The previous implementation
+ * always took a SC_SUPERSTATE trip, which has the side effect of
+ * leaving the caller in SYSTEM mode and then forcibly cps'ing back
+ * to USER - silently flipping SVC callers to USER and breaking any
+ * subsequent privileged ops (inline GetCPUNumber, etc).
+ *
+ * Branch on the actual mode: in USER, SWI to a dedicated handler
+ * (SC_GETCPUNUMBER) that reads MPIDR in SVC and returns the value.
+ * In any privileged mode, do the MRC inline - no mode change.
+ */
 AROS_LH0(cpuid_t, KrnGetCPUNumber,
          struct KernelBase *, KernelBase, 41, Kernel)
 {
     AROS_LIBFUNC_INIT
 
-    register unsigned int superSP;
-    uint32_t tmp;
+    uint32_t cpsr;
 
-    asm volatile (
-        "       stmfd   sp!, {lr}               \n"
-        "       mov     r1, sp                  \n"
-        "       swi     %[swi_no]               \n"
-        "       mov     %[superSP], sp          \n"
-        "       mov     sp, r1                  \n"
-        "       ldmfd   sp!, {lr}               \n"
-        : [superSP] "=r" (superSP)
-        : [swi_no] "I" (6 /*SC_SUPERSTATE*/) : "r1"
-    );
+    asm volatile ("mrs %0, cpsr" : "=r" (cpsr));
 
-    asm volatile (" mrc p15, 0, %0, c0, c0, 5 " : "=r" (tmp));
-
-    if (superSP)
+    if ((cpsr & 0x1f) == 0x10)
     {
-        asm volatile (
-            "       stmfd   sp!, {lr}               \n"
-            "       mov     r1, sp                  \n"
-            "       mov     sp, %[superSP]          \n"
-            "       cpsie   i, %[mode_user]         \n"
-            "       mov     sp, r1                  \n"
-            "       ldmfd   sp!, {lr}               \n"
-            : : [superSP] "r" (superSP), [mode_user] "I" (CPUMODE_USER) : "r1" );
+        register cpuid_t ret asm("r0");
+        asm volatile ("swi %[swi_no]"
+            : "=r" (ret)
+            : [swi_no] "I" (SC_GETCPUNUMBER)
+            : "lr", "memory");
+        return ret;
     }
 
-    if (tmp & (2 << 30))
-    {
-        return (cpuid_t)(((tmp & 0xF00) >> 4) | (tmp & 0xF));
-    }
-
-    // Uniprocessor System
-    return (cpuid_t)0;
+    return (cpuid_t)GetCPUNumber();
 
     AROS_LIBFUNC_EXIT
 }

--- a/arch/arm-native/kernel/getsystemattr.c
+++ b/arch/arm-native/kernel/getsystemattr.c
@@ -9,14 +9,86 @@
 #include <proto/exec.h>
 
 #include "kernel_intern.h"
+#if defined(__AROSEXEC_SMP__)
+#include "etask.h"
+#include "kernel_cpu.h"
+#endif
 
 #include <proto/kernel.h>
+
+#if defined(__AROSEXEC_SMP__)
+/*
+ * A core's load is whatever share of the window its idle task did NOT
+ * consume. cpu_Switch already accumulates every task's busy microseconds
+ * in iet_private2, so we only need the delta since our last sample.
+ *
+ * Derived on read rather than from a periodic sweep: the alternative
+ * would be a walk of the scheduler lists from the CNTP FIQ handler, with
+ * scheduler locks held and IPI delivery blocked for the duration.
+ *
+ * Everything is kept in 32 bits so it survives the microsecond counter's
+ * ~71 minute wrap. Result is fixed point, 0xffffffff == 100%, matching
+ * what x86 puts in cpu_Load.
+ */
+static intptr_t krnCPULoad(unsigned int cpu)
+{
+    struct Task *idler;
+    struct IntETask *iet;
+    ULONG now, idleNow, window;
+    intptr_t retval = 0;
+
+    if ((cpu >= ARM_MAXCPUS) || !__arm_arosintern.ARMI_GetTime)
+        return 0;
+
+    idler = arm_IdleTask[cpu];
+    if (!idler || !(iet = GetIntETask(idler)))
+        return 0;
+
+    now = (ULONG)__arm_arosintern.ARMI_GetTime();
+    idleNow = (ULONG)iet->iet_private2;
+    window = now - (ULONG)arm_CPULoad[cpu].cpl_LastStamp;
+
+    /* Too soon to measure again - reuse the last answer. */
+    if (arm_CPULoad[cpu].cpl_LastStamp && (window < CPULOAD_MINWINDOW))
+        return (intptr_t)arm_CPULoad[cpu].cpl_LastLoad;
+
+    /*
+     * An idle core is not preempted - nothing else is ready to run - so
+     * its idle task can sit in TS_RUN for many windows without ever
+     * committing its slice to iet_private2. Fold the in-progress part in
+     * or a fully idle core reads as fully loaded.
+     */
+    if (idler->tc_State == TS_RUN)
+        idleNow += now - (ULONG)iet->iet_private1;
+
+    if (arm_CPULoad[cpu].cpl_LastStamp && window)
+    {
+        ULONG idle = idleNow - (ULONG)arm_CPULoad[cpu].cpl_LastIdle;
+
+        if (idle >= window)
+            retval = 0;
+        else
+            retval = (intptr_t)(0xffffffff - (ULONG)(((UQUAD)idle << 32) / window));
+    }
+
+    arm_CPULoad[cpu].cpl_LastIdle = idleNow;
+    arm_CPULoad[cpu].cpl_LastStamp = now;
+    arm_CPULoad[cpu].cpl_LastLoad = (ULONG)retval;
+
+    return retval;
+}
+#endif
 
 AROS_LH1(intptr_t, KrnGetSystemAttr,
     AROS_LHA(uint32_t, id, D0),
     struct KernelBase *, KernelBase, 29, Kernel)
 {
     AROS_LIBFUNC_INIT
+
+#if defined(__AROSEXEC_SMP__)
+    if ((id >= KATTR_CPULoad) && (id < KATTR_CPULoad_END))
+        return krnCPULoad(id - KATTR_CPULoad);
+#endif
 
     switch (id)
     {

--- a/arch/arm-native/kernel/intr.c
+++ b/arch/arm-native/kernel/intr.c
@@ -163,7 +163,30 @@ void handle_irq(regs_t *regs)
     entered in FIQ mode.
 */
 
-__attribute__ ((interrupt ("FIQ"))) void __vectorhand_fiq(void)
+asm (
+    ".set       MODE_SYSTEM, 0x1f              \n"
+
+    ".globl __vectorhand_fiq                   \n"
+    ".type __vectorhand_fiq,%function          \n"
+    "__vectorhand_fiq:                         \n"
+    "           sub     lr, lr, #4             \n" // adjust lr_fiq (FIQ return = lr - 4)
+    VECTCOMMON_START
+    "           bl      handle_fiq             \n"
+    "           mov     r0, sp                 \n"
+    "           ldr     r1, [r0, #16*4]        \n" // saved spsr of interrupted context
+    "           tst     r1, #0x80              \n" // were IRQs disabled (Disable())?
+    "           bne     1f                     \n" // yes - defer; Enable() reschedules later
+    "           and     r1, r1, #31            \n" // mask processor mode
+    "           cmp     r1, #0x10              \n" // returning to user mode?
+    "           cmpne   r1, #0x1f              \n" // or system mode?
+    "           bne     1f                     \n" // no - nested interrupt, don't reschedule
+    "           mov     fp, #0                 \n" // clear fp
+    "           bl      core_ExitInterrupt     \n"
+    "1:                                        \n"
+    VECTCOMMON_END
+    );
+
+void handle_fiq(regs_t *regs)
 {
     DIRQ(bug("[Kernel] ## FIQ ##\n"));
 

--- a/arch/arm-native/kernel/kernel_arm.h
+++ b/arch/arm-native/kernel/kernel_arm.h
@@ -18,8 +18,9 @@ struct ARM_Implementation
     void                (*ARMI_InitCore) (APTR, APTR); // takes pointers to KernelBase & SysBase as input
     void                (*ARMI_SendIPI) (uint32_t, uint32_t, uint32_t); // Sends IPI msg to processors in mask
     APTR                (*ARMI_InitTimer) (APTR); // takes a pointer to KernelBase as input, and returns struct IntrNode
+    void                (*ARMI_InitTimerCore) (void); // arms the calling core's per-core scheduler heartbeat
     void                (*ARMI_Delay) (int);
-    unsigned int        (*ARMI_GetTime) (void);
+    uint64_t            (*ARMI_GetTime) (void); // full 64-bit free-running µs counter, wrap-free
     void                (*ARMI_PutChar) (int);
     void                (*ARMI_SerPutChar) (uint8_t);
     int                 (*ARMI_SerGetChar) (void);

--- a/arch/arm-native/kernel/kernel_cpu.c
+++ b/arch/arm-native/kernel/kernel_cpu.c
@@ -57,14 +57,33 @@ asm(
 "               setend  be                      \n" /* If AROS is big endian set the endianess of cpu here */
 #endif
 "               ldr     r3, mpcore_pde          \n" /* MMU table */
+"               orr     r3, r3, #0x4a           \n" /* SMP: S | RGN_OC_WBWA | IRGN_WBWA */
 "               mcr     p15, 0, r3, c2, c0, 0   \n"
 "               mov     r3, #0                  \n"
 "               mcr     p15, 0, r3, c2, c0, 2   \n"
 "               mov     r3, #1                  \n"
 "               mcr     p15, 0, r3, c3, c0, 0   \n"
+/*
+ * SMP enable bit lives in different registers per part:
+ *   Cortex-A7  (Pi 2):  ACTLR.SMP    (bit 6, EL1)
+ *   Cortex-A53 (Pi 3):  CPUECTLR.SMPEN (bit 6, EL3 only - set in leave_hyper)
+ * Writing ACTLR bit 6 on A53 hits an unrelated implementation-defined
+ * bit (not SMPEN), so gate this on the part number.
+ */
+"               mrc     p15, 0, r5, c0, c0, 0   \n" /* MIDR */
+"               movw    r6, #0xfff0             \n"
+"               and     r5, r5, r6              \n"
+"               movw    r6, #0xc070             \n" /* Cortex-A7 part */
+"               cmp     r5, r6                  \n"
+"               bne     mpcore_smp_done         \n"
+"               mrc     p15, 0, r3, c1, c0, 1   \n" /* ACTLR */
+"               orr     r3, r3, #0x40           \n" /* SMPEN (bit 6) - enable cache snoop */
+"               mcr     p15, 0, r3, c1, c0, 1   \n" /* must be set before MMU enable */
+"mpcore_smp_done:                               \n"
 "               mrc     p15, 0, r4, c1, c0, 0   \n"
 "               mov     r3, #0                  \n"
-"               mcr     p15, 0, r3, c7, c10, 4  \n"
+"               mcr     p15, 0, r3, c7, c10, 4  \n" /* dsb */
+"               mcr     p15, 0, r3, c7, c5, 4   \n" /* isb - serialize SMP enable before MMU enable */
 "               orr     r4, r4, #0x800000       \n" /* v6 page tables */
 "               orr     r4, r4, #1              \n" /* Enable MMU */
 #if AROS_BIG_ENDIAN
@@ -84,6 +103,24 @@ asm(
 "               ldr     pc, mpcore_code         \n"
 
 "leave_hyper:                                   \n" /* Escape hypervisor mode forever */
+/*
+ * Cortex-A53 (Pi 3): set CPUECTLR.SMPEN (bit 6) while still in HYP/EL2.
+ * This is the actual SMP enable on A53 - the Pi armstub sets it for the
+ * boot CPU but secondaries come up here in HYP and need it set before
+ * we drop to EL1 (where CPUECTLR is inaccessible). Cortex-A7 (Pi 2)
+ * uses ACTLR.SMP instead and is handled in mpcore_continue_boot.
+ */
+"               mrc     p15, 0, r5, c0, c0, 0   \n" /* MIDR */
+"               movw    r6, #0xfff0             \n"
+"               and     r5, r5, r6              \n"
+"               movw    r6, #0xd030             \n" /* Cortex-A53 part */
+"               cmp     r5, r6                  \n"
+"               bne     mpcore_hyp_eret         \n"
+"               mrrc    p15, 1, r4, r5, c15     \n" /* CPUECTLR (64-bit) */
+"               orr     r4, r4, #0x40           \n" /* SMPEN (bit 6) */
+"               mcrr    p15, 1, r4, r5, c15     \n"
+"               mcr     p15, 0, r3, c7, c5, 4   \n" /* isb */
+"mpcore_hyp_eret:                               \n"
 "               adr     r4, mpcore_continue_boot\n"
 "               .byte   0x04,0xf3,0x2e,0xe1     \n" /* msr     ELR_hyp, r4             */
 "               mrs     r4, cpsr                \n"
@@ -103,6 +140,12 @@ asm(
 );
 
 spinlock_t startup_lock;
+
+#if defined(__AROSEXEC_SMP__)
+/* See kernel_cpu.h - filled in by exec as it creates the idle tasks. */
+struct Task *arm_IdleTask[ARM_MAXCPUS];
+struct arm_CPULoadData arm_CPULoad[ARM_MAXCPUS];
+#endif
 
 void cpu_Register()
 {
@@ -146,6 +189,15 @@ void cpu_Register()
         __arm_arosintern.ARMI_InitCore(KernelBase, SysBase);
 
     cpu_BootStrap(__tls->ThisTask, SysBase);
+
+    /*
+     * Arm this core's per-core scheduler heartbeat (CNTP). Must run in
+     * privileged mode - CNTP_* are PL1-banked - and after the bootstrap
+     * task exists, so the first FIQ tick (~20ms out) lands on a core that
+     * is already schedulable. core 0 keeps the GPU system timer instead.
+     */
+    if (__arm_arosintern.ARMI_InitTimerCore)
+        __arm_arosintern.ARMI_InitTimerCore();
 #else
     KernelBase = (struct KernelBase *)TLS_GET(KernelBase);
 #endif
@@ -183,6 +235,22 @@ cpu_registerfatal:
     /* We now start up the interrupts */
     Permit();
     Enable();
+
+    /*
+     * Become this core's idle context - do NOT return. cpu_Register was
+     * reached by a jump from the trampoline, so the link register still
+     * holds the firmware mailbox spin-table return address; returning here
+     * drops the core back into that loop, out of the scheduler's reach.
+     *
+     * Mirror IdleTask: switch to a privileged mode (so WFI is permitted)
+     * and enable IRQs, then sleep. A cross-CPU IPI_SCHEDULE arrives as an
+     * FIQ whose exit path (handle_fiq -> core_ExitInterrupt) dispatches
+     * whatever task has become ready for this core.
+     */
+    asm volatile ("swi %[swi_no]" : : [swi_no] "I" (SC_SUPERSTATE) : "lr");
+    asm volatile ("swi %[swi_no]" : : [swi_no] "I" (SC_STI) : "lr");
+    for (;;)
+        asm volatile ("wfi");
 #endif
 }
 
@@ -321,10 +389,49 @@ void cpu_Switch(regs_t *regs)
     /* Cache running task's context */
     STORE_TASKSTATE(task, regs)
 
-    if (__arm_arosintern.ARMI_GetTime)
+#if defined(__AROSEXEC_SMP__)
+    /*
+     * Wait() carries tc_SpinLock across KrnSwitch so no other CPU can
+     * observe (TS_WAIT, on-TaskWait) and dispatch this task before its
+     * context is saved. The context is now stored - release the lock
+     * (see rom/exec/wait.c). Only the Wait path reaches here in TS_WAIT:
+     * interrupts are masked for its whole carry window, so an IRQ/FIQ
+     * entry can never find the current task in TS_WAIT.
+     */
+    if (task->tc_State == TS_WAIT)
+        KrnSpinUnLock(&task->tc_SpinLock);
+#endif
+
+    /*
+     * iet_private1 == 0 means the task never went through cpu_Dispatch:
+     * the boot task and the per-core bootstrap tasks are installed with
+     * SET_THIS_TASK, so their first switch has no launch time and a delta
+     * would charge the whole uptime to them. Skip the slice - the next
+     * dispatch stamps iet_private1 and accounting starts clean. (A task
+     * legitimately dispatched at counter value 0 loses one slice per
+     * ~71 minute wrap - noise.)
+     */
+    if (__arm_arosintern.ARMI_GetTime &&
+        IntETask(task->tc_UnionETask.tc_ETask)->iet_private1)
     {
-        /* Update the task's CPU time */
-        timeCur = __arm_arosintern.ARMI_GetTime() - IntETask(task->tc_UnionETask.tc_ETask)->iet_private1;
+        /*
+         * Update the task's CPU time. ARMI_GetTime is the platform's
+         * free-running MICROsecond counter (BCM system timer, 1MHz), so
+         * scale the delta to nanoseconds - without this every task's
+         * accumulated CPU time came out 1000x too low. The delta is taken
+         * in 32 bits so it stays correct across the counter's ~71 minute
+         * wrap (a scheduling interval is milliseconds at most).
+         */
+        uint32_t deltaUS = (uint32_t)__arm_arosintern.ARMI_GetTime() -
+                           (uint32_t)IntETask(task->tc_UnionETask.tc_ETask)->iet_private1;
+
+        /*
+         * Cumulative busy time in microseconds. task.resource derives the
+         * task's CPU usage percentage from how fast this grows.
+         */
+        IntETask(task->tc_UnionETask.tc_ETask)->iet_private2 += deltaUS;
+
+        timeCur = (UQUAD)deltaUS * 1000;
         timeSpec.tv_sec = timeCur / 1000000000;
         timeSpec.tv_nsec = timeCur % 1000000000;
 
@@ -366,7 +473,18 @@ void cpu_Dispatch(regs_t *regs)
     while (!(task = core_Dispatch()))
     {
         DSCHED(bug("[Kernel:%02d] cpu_Dispatch: Nothing to run - idling\n", cpunum));
+        /*
+         * WFI wakes on pending interrupts even when they are masked (and
+         * they ARE masked here - we are in exception context, and Wait()
+         * paths arrive with FIQ off too). But waking is not enough: the
+         * pending IPI/timer FIQ must be HANDLED to make a task ready, or
+         * this loop spins on a latched mailbox bit forever. Open a brief
+         * IRQ+FIQ window after each wake so the handler runs (the FIQ/IRQ
+         * exit path never dispatches over this SVC-mode context - see
+         * intr.c - it just delivers and returns), then re-mask and rescan.
+         */
         asm volatile("wfi");
+        asm volatile("cpsie if\n\tisb\n\tcpsid if" ::: "memory");
     }
 
     DSCHED(bug("[Kernel:%02d] cpu_Dispatch: 0x%p [R  ] '%s'\n", cpunum, task, task->tc_Node.ln_Name));
@@ -400,6 +518,7 @@ void cpu_Dispatch(regs_t *regs)
         AROS_UFC1(void, task->tc_Launch,
                   AROS_UFCA(struct ExecBase *, SysBase, A6));
     }
+
     /* Leave interrupt and jump to the new task */
 }
 

--- a/arch/arm-native/kernel/kernel_cpu.h
+++ b/arch/arm-native/kernel/kernel_cpu.h
@@ -7,6 +7,7 @@
 
 #include <inttypes.h>
 #include "kernel_arm.h"
+#include "tls.h"
 
 extern uint32_t __arm_affinitymask;
 
@@ -37,10 +38,16 @@ extern uint32_t __arm_affinitymask;
 
 void cpu_DumpRegs(regs_t *regs);
 
+/*
+ * Logical CPU id from per-CPU TLS (TPIDRURO), populated by the boot CPU
+ * when it brings each core up. MPIDR/VMPIDR is not a reliable source on
+ * Pi 3 - some armstub revisions leave a core's EL1 MPIDR view at 0 - so
+ * we do not read c0,c0,5 here.
+ */
 static inline int GetCPUNumber() {
-    int tmp;
-    asm volatile (" mrc p15, 0, %0, c0, c0, 5 " : "=r" (tmp));
-    return tmp & 3;
+    tls_t *__tls;
+    asm volatile ("mrc p15, 0, %0, c13, c0, 3" : "=r" (__tls));
+    return (int)__tls->CPUNumber;
 }
 
 static inline void SendIPISelf(uint32_t ipi, uint32_t ipi_param)
@@ -60,5 +67,37 @@ static inline void SendIPIAll(uint32_t ipi, uint32_t ipi_param)
     int cpu = GetCPUNumber();
     __arm_arosintern.ARMI_SendIPI((ipi & 0x0fffffff) | (cpu << 28), ipi_param, 0xf);
 }
+
+#if defined(__AROSEXEC_SMP__)
+/*
+ * Per-core load accounting for KrnGetSystemAttr(KATTR_CPULoad + cpu),
+ * which processor.resource exposes as GCIT_ProcessorLoad (SysMon's CPU
+ * graphs). A core's load is the inverse of its idle task's share of the
+ * elapsed window; that task's cumulative busy time is already kept in
+ * iet_private2 by cpu_Switch, so all we store here is the previous
+ * sample. exec registers each idle task as it creates them, because only
+ * exec knows which task is which core's idler.
+ */
+#define ARM_MAXCPUS     4
+
+struct arm_CPULoadData
+{
+    UQUAD       cpl_LastIdle;       /* idle busy time at the last sample */
+    UQUAD       cpl_LastStamp;      /* when that sample was taken (us)   */
+    ULONG       cpl_LastLoad;       /* the load that sample produced     */
+};
+
+/*
+ * Shortest window we will measure. SysMon asks for each core's load two
+ * or three times per refresh (graph, label, gauge); measuring a window of
+ * a few microseconds would swing the answer between 0 and 100%, so those
+ * extra reads are served the previous result instead. Well below any UI
+ * refresh interval, so each refresh still gets a fresh sample.
+ */
+#define CPULOAD_MINWINDOW       100000  /* microseconds */
+
+extern struct Task *arm_IdleTask[ARM_MAXCPUS];
+extern struct arm_CPULoadData arm_CPULoad[ARM_MAXCPUS];
+#endif
 
 #endif /* CPU_ARM_H_ */

--- a/arch/arm-native/kernel/kernel_execsmp.c
+++ b/arch/arm-native/kernel/kernel_execsmp.c
@@ -43,8 +43,15 @@ struct Task *cpu_InitBootStrap(struct ExecBase *SysBase)
         return NULL;
     }
 
-    /* allocate some stack space for user mode .. */
-    ml->ml_ME[1].me_Length = 15 + (sizeof(IPTR) * 128);
+    /*
+     * Allocate some stack space for user mode. cpu_Register runs Permit()
+     * and Enable() (library calls) on this stack before parking, and it
+     * stays the core's context until the first real dispatch - so keep
+     * enough headroom that an overflow cannot silently corrupt the
+     * adjacent MemList allocation.
+     */
+#define BOOTSTRAP_STACKWORDS 1024
+    ml->ml_ME[1].me_Length = 15 + (sizeof(IPTR) * BOOTSTRAP_STACKWORDS);
     if ((ml->ml_ME[1].me_Addr = AllocMem(ml->ml_ME[1].me_Length, MEMF_PUBLIC|MEMF_CLEAR)) == NULL)
     {
         bug("[Kernel:%02d] FATAL : Failed to allocate stack for bootstrap task", cpunum);
@@ -53,7 +60,7 @@ struct Task *cpu_InitBootStrap(struct ExecBase *SysBase)
         return NULL;
     }
     bstask->tc_SPLower = (APTR)(((unsigned int )ml->ml_ME[1].me_Addr + 15) & ~0xF);
-    bstask->tc_SPUpper = bstask->tc_SPLower + (sizeof(IPTR) * 128);
+    bstask->tc_SPUpper = bstask->tc_SPLower + (sizeof(IPTR) * BOOTSTRAP_STACKWORDS);
 
     AddHead(&bstask->tc_MemEntry, &ml->ml_Node);
 
@@ -77,7 +84,14 @@ struct Task *cpu_InitBootStrap(struct ExecBase *SysBase)
         sprintf(bstask->tc_Node.ln_Name, "CPU #%02d Bootstrap", cpunum);
     }
     bstask->tc_Node.ln_Type = NT_TASK;
-    bstask->tc_Node.ln_Pri  = 0;
+    /*
+     * Idle priority (below the per-CPU "CPU #xx Idle" task at -127). The
+     * bootstrap task only provides a valid context for this core during
+     * bring-up; once the scheduler runs it must yield to the real idle
+     * task and to any task dispatched here, so it must be the lowest
+     * priority runnable thing on the core.
+     */
+    bstask->tc_Node.ln_Pri  = -128;
     bstask->tc_State        = TS_READY;
     bstask->tc_SigAlloc     = 0xFFFF;
 
@@ -93,9 +107,18 @@ struct Task *cpu_InitBootStrap(struct ExecBase *SysBase)
     }
     bstask->tc_UnionETask.tc_ETask->et_RegFrame = bsctx;
 
-    /* the bootstrap can only run on this CPU */
+    /*
+     * The bootstrap task can only run on this CPU. iet_CpuAffinity is a
+     * cpumask buffer pointer (consumed by KrnCPUInMask / core_Dispatch),
+     * not a raw bitmask - allocate one and set this CPU's bit.
+     */
     IntETask(bstask->tc_UnionETask.tc_ETask)->iet_CpuNumber = cpunum;
-    IntETask(bstask->tc_UnionETask.tc_ETask)->iet_CpuAffinity = (1 << cpunum);
+    {
+        void *aff = KrnAllocCPUMask();
+        if (aff)
+            KrnGetCPUMask(cpunum, aff);
+        IntETask(bstask->tc_UnionETask.tc_ETask)->iet_CpuAffinity = aff;
+    }
 
     bsctx->r[11] = 0;
     bsctx->lr = SysBase->TaskExitCode;

--- a/arch/arm-native/kernel/kernel_ipi.c
+++ b/arch/arm-native/kernel/kernel_ipi.c
@@ -9,7 +9,18 @@
 #include <aros/types/spinlock_s.h>
 #include <aros/arm/cpucontext.h>
 
+#include <exec/lists.h>
+#include <exec/memory.h>
+#include <exec/tasks.h>
+#include <proto/exec.h>
+
 #include "kernel_base.h"
+
+/* Pull in exec_platform.h ahead of etask.h so AROS_NO_ATOMIC_OPERATIONS
+ * selects the non-atomic FLAG_SCHEDSWITCH_SET expansion (atomics aren't
+ * needed for per-CPU TLS state and AROS_ATOMIC_OR isn't declared here). */
+#define AROS_NO_ATOMIC_OPERATIONS
+#include <exec_platform.h>
 
 #include "etask.h"
 
@@ -20,9 +31,296 @@
 
 #if defined(__AROSEXEC_SMP__)
 
-#define D(x) x
+#undef D
+#define D(x)
 
 #include "kernel_ipi.h"
+
+/*
+ * Per-target queue of pending IPIHook calls. Sender pops a CallIPIEntry
+ * from the target's free pool, fills it in, pushes it on the target's
+ * busy queue, and sends an IPI_CALL_HOOK message. The receiver drains
+ * its own queue from handle_ipi(), calls each hook, and returns the
+ * entry to the free pool.
+ *
+ * Entries come from a per-target static pool sized for the worst
+ * concurrent burst. AllocMem cannot be used here: Signal() is
+ * documented as IRQ-callable and reaches core_DoCallIPI on cross-CPU
+ * wakeups; AllocMem would recurse on mh_SpinLock if an interrupted
+ * allocator on this CPU held it.
+ *
+ * raspi has at most 4 cores. Async-only - signal.c is the sole caller
+ * and uses async; the sync path is more involved (would need a lock
+ * dance with the sender waiting for completion) and is left for if
+ * a real consumer appears.
+ */
+struct CallIPIEntry
+{
+    struct MinNode cie_Node;
+    struct IPIHook cie_IPIH;        /* h_Entry + ih_Args - passed as A0 to the hook */
+};
+
+#define IPI_CALL_POOL_PER_CPU   128
+
+static struct CallIPIEntry ipi_call_pool[4][IPI_CALL_POOL_PER_CPU];
+static struct MinList      ipi_call_free[4];
+static struct MinList      ipi_call_queue[4];
+static spinlock_t          ipi_call_queue_lock[4];   /* guards both lists for this target */
+static BOOL                ipi_call_inited = FALSE;
+
+/*
+ * What the drain loop is executing right now, published per CPU so
+ * core_CancelCallIPIs can wait out a call it can no longer find on the
+ * queue. Single writer (the owning CPU's FIQ drain); cross-CPU readers.
+ */
+static volatile APTR       ipi_call_exec_func[4];
+static volatile IPTR       ipi_call_exec_arg1[4];
+
+static void core_HandleCallHookIPI(int cpu);
+
+void core_IPIInit(void)
+{
+    int cpu, i;
+    if (ipi_call_inited)
+        return;
+    for (cpu = 0; cpu < 4; cpu++)
+    {
+        NewMinList(&ipi_call_free[cpu]);
+        NewMinList(&ipi_call_queue[cpu]);
+        for (i = 0; i < IPI_CALL_POOL_PER_CPU; i++)
+            ADDTAIL((struct List *)&ipi_call_free[cpu],
+                    (struct Node *)&ipi_call_pool[cpu][i].cie_Node);
+        /* spinlock_t zero-initialised at link time == SPINLOCK_UNLOCKED */
+    }
+    ipi_call_inited = TRUE;
+}
+
+/*
+ * Claim a free pool entry for the given target. If the pool is
+ * momentarily exhausted, the target already has IPI_CALL_HOOK
+ * entries queued (an IPI was sent for each) and drains them back to
+ * its free list from its FIQ handler. Spin until one frees rather
+ * than dropping the call: the hook is signal_hook, so a dropped IPI
+ * is a lost wakeup that hangs the waiting task forever.
+ *
+ * The claim only runs in task/IRQ context (signal_hook does its work
+ * inline and never calls Signal(), so the FIQ path never re-enters
+ * here). With FIQ unmasked the target always drains promptly. The one
+ * cycle left is Signal() under Disable(): FIQ is masked here, so this
+ * CPU cannot drain its own inbound queue - two Disable()-d CPUs
+ * cross-signalling with exhausted pools would wait on each other's
+ * drains forever. Break it by draining our own queue inline while we
+ * spin: that refills OUR pool, unblocking the peer, whose Enable()
+ * eventually refills the pool we are waiting for. Safe precisely
+ * because FIQ is masked - the FIQ drain cannot run concurrently, so
+ * the executing-slot publication keeps its single writer per CPU.
+ *
+ * Corollary: call this with NO task spinlock held. The drains that
+ * refill pools run hooks that take task spinlocks, so spinning here
+ * while holding one could deadlock.
+ */
+struct CallIPIEntry *core_ClaimCallIPI(int cpu)
+{
+    struct CallIPIEntry *cie;
+    int srcCpu = GetCPUNumber();
+
+    for (;;)
+    {
+        EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+        cie = (struct CallIPIEntry *)REMHEAD((struct List *)&ipi_call_free[cpu]);
+        EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+
+        if (cie)
+            return cie;
+
+        if (IDNESTCOUNT_GET >= 0)
+            core_HandleCallHookIPI(srcCpu);
+    }
+}
+
+void core_CommitCallIPI(struct CallIPIEntry *cie, int cpu,
+                        struct Hook *hook, int nargs, IPTR *args)
+{
+    int srcCpu = GetCPUNumber();
+    int i;
+
+    if (nargs > IPI_CALL_HOOK_MAX_ARGS)
+        nargs = IPI_CALL_HOOK_MAX_ARGS;
+
+    cie->cie_IPIH.ih_Hook = *hook;
+    for (i = 0; i < nargs; i++)
+        cie->cie_IPIH.ih_Args[i] = args[i];
+
+    EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+    ADDTAIL((struct List *)&ipi_call_queue[cpu], (struct Node *)&cie->cie_Node);
+    EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+
+    if (__arm_arosintern.ARMI_SendIPI)
+    {
+        __arm_arosintern.ARMI_SendIPI(
+            (IPI_CALL_HOOK & 0x0fffffff) | (srcCpu << 28),
+            0, 1U << cpu);
+    }
+}
+
+void core_AbortCallIPI(struct CallIPIEntry *cie, int cpu)
+{
+    EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+    ADDTAIL((struct List *)&ipi_call_free[cpu], (struct Node *)&cie->cie_Node);
+    EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+}
+
+/*
+ * Cancel all queued calls matching (h_Entry, ih_Args[1]) on every CPU,
+ * then wait out a matching call that is executing right now. On return
+ * no CPU holds or will touch the object ih_Args[1] points at, PROVIDED
+ * the caller has already made new commits impossible (signal.c re-checks
+ * the target's tc_State under tc_SpinLock before core_CommitCallIPI).
+ *
+ * Must run with FIQ masked (Disable): we take our own CPU's queue lock,
+ * which the local FIQ drain also takes. The executing-call wait only
+ * ever waits on OTHER CPUs (our own drain cannot be mid-hook while we
+ * run), and their hooks are short and non-blocking, so the wait is
+ * bounded even under Disable.
+ */
+void core_CancelCallIPIs(APTR hookEntry, IPTR matchArg)
+{
+    int cpu;
+
+    if (!ipi_call_inited)
+        return;
+
+    for (cpu = 0; cpu < 4; cpu++)
+    {
+        struct MinNode *node, *next;
+
+        EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+        for (node = ipi_call_queue[cpu].mlh_Head; (next = node->mln_Succ) != NULL; node = next)
+        {
+            struct CallIPIEntry *cie = (struct CallIPIEntry *)node;
+
+            if ((APTR)cie->cie_IPIH.ih_Hook.h_Entry == hookEntry &&
+                cie->cie_IPIH.ih_Args[1] == matchArg)
+            {
+                REMOVE((struct Node *)node);
+                ADDTAIL((struct List *)&ipi_call_free[cpu], (struct Node *)node);
+            }
+        }
+        EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+
+        while (ipi_call_exec_func[cpu] == hookEntry &&
+               ipi_call_exec_arg1[cpu] == matchArg)
+        {
+            EXEC_MEMORY_BARRIER();
+        }
+    }
+}
+
+int core_DoCallIPI(struct Hook *hook, void *cpu_mask, int async,
+                   int nargs, IPTR *args, APTR _KB)
+{
+    int cpu;
+    int srcCpu = GetCPUNumber();
+    uint32_t mask;
+
+    (void)_KB;
+
+    if (!hook || !cpu_mask)
+        return 0;
+    if (nargs > IPI_CALL_HOOK_MAX_ARGS)
+        return 0;
+    /* Sync mode not yet supported on arm-native */
+    if (!async)
+    {
+        D(bug("[Kernel:IPI] %s: sync mode not implemented\n", __PRETTY_FUNCTION__));
+        return 0;
+    }
+
+    /*
+     * TASKAFFINITY_ANY / TASKAFFINITY_ALL_BUT_SELF are sentinels, not
+     * buffer pointers - resolve them to bitmaps before dereference.
+     */
+    if ((IPTR)cpu_mask == TASKAFFINITY_ANY)
+        mask = 0xf;
+    else if ((IPTR)cpu_mask == TASKAFFINITY_ALL_BUT_SELF)
+        mask = 0xf & ~(1U << srcCpu);
+    else
+        mask = *(uint32_t *)cpu_mask;
+
+    for (cpu = 0; cpu < 4; cpu++)
+    {
+        struct CallIPIEntry *cie;
+
+        if (!(mask & (1U << cpu)))
+            continue;
+
+        cie = core_ClaimCallIPI(cpu);
+        core_CommitCallIPI(cie, cpu, hook, nargs, args);
+    }
+
+    return 1;
+}
+
+static void core_HandleCallHookIPI(int cpu)
+{
+    /*
+     * Block dispatch across the whole drain. The hooks here (signal_hook ->
+     * Signal()) call Enable()/Reschedule(), which would otherwise switch
+     * tasks *now* - from inside this FIQ handler, on the nested SVC stack -
+     * corrupting the interrupted context. With dispatch blocked, Signal()
+     * only sets FLAG_SCHEDSWITCH; the switch is taken cleanly by
+     * core_ExitInterrupt when this FIQ returns to a task context. (The
+     * scheduler-list lock re-entrancy this used to expose is handled by the
+     * EXEC_FIQ_DISABLE masking in the scheduler critical sections.)
+     */
+    EXEC_BLOCK_DISPATCH_INC;
+
+    for (;;)
+    {
+        struct CallIPIEntry *cie;
+
+        EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+        cie = (struct CallIPIEntry *)REMHEAD((struct List *)&ipi_call_queue[cpu]);
+        if (cie)
+        {
+            /*
+             * Publish what is about to run: once dequeued, the call is
+             * invisible to core_CancelCallIPIs' queue scan, so a canceller
+             * waits on this instead. Published under the queue lock - the
+             * unlock's barrier orders it before the hook runs.
+             */
+            ipi_call_exec_func[cpu] = (APTR)cie->cie_IPIH.ih_Hook.h_Entry;
+            ipi_call_exec_arg1[cpu] = cie->cie_IPIH.ih_Args[1];
+        }
+        EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+
+        if (!cie)
+            break;
+
+        /*
+         * Hook signature matches signal_hook: A0 = IPIHook*, A2/A1 unused.
+         * cie_IPIH starts at the same offset as a struct IPIHook so passing
+         * &cie_IPIH gives the hook direct access to its ih_Args[].
+         */
+        AROS_UFC3NR(void, cie->cie_IPIH.ih_Hook.h_Entry,
+            AROS_UFCA(struct IPIHook *, &cie->cie_IPIH, A0),
+            AROS_UFCA(APTR, NULL, A2),
+            AROS_UFCA(APTR, NULL, A1));
+
+        /*
+         * All hook side effects must be visible before a waiting canceller
+         * is released to free the object ih_Args[1] points at.
+         */
+        EXEC_MEMORY_BARRIER();
+        ipi_call_exec_func[cpu] = NULL;
+
+        EXEC_SPINLOCK_LOCK(&ipi_call_queue_lock[cpu], NULL, SPINLOCK_MODE_WRITE);
+        ADDTAIL((struct List *)&ipi_call_free[cpu], (struct Node *)&cie->cie_Node);
+        EXEC_SPINLOCK_UNLOCK(&ipi_call_queue_lock[cpu]);
+    }
+
+    EXEC_BLOCK_DISPATCH_DEC;
+}
 
 void handle_ipi(uint32_t ipi, uint32_t ipi_data)
 {
@@ -32,53 +330,54 @@ void handle_ipi(uint32_t ipi, uint32_t ipi_data)
 
     D(bug("[Kernel:IPI] %s: Core #%02d IPI Msg %08x:%08x from Core #%02d\n",
         __PRETTY_FUNCTION__, cpu, ipi_msg,  ipi_data, ipi_src));
-    switch (ipi_msg)
+
+    /*
+     * IPI messages are bit flags. The BCM2836 mailbox SET register
+     * OR-coalesces concurrent writes from the same sender, so a single
+     * delivery may carry multiple message types. Test each bit
+     * independently rather than switching on the whole value.
+     */
+    if (ipi_msg & IPI_CAUSE)
+        D(bug("[Kernel:IPI] IPI_CAUSE:\n"));
+    if (ipi_msg & IPI_DISPATCH)
+        D(bug("[Kernel:IPI] IPI_DISPATCH:\n"));
+    if (ipi_msg & IPI_SWITCH)
+        D(bug("[Kernel:IPI] IPI_SWITCH:\n"));
+    if (ipi_msg & IPI_SCHEDULE)
     {
-        case IPI_CAUSE:
-        {
-            D(bug("[Kernel:IPI] IPI_CAUSE:\n"));
-            break;
-        }
-        case IPI_DISPATCH:
-        {
-            D(bug("[Kernel:IPI] IPI_DISPATCH:\n"));
-            break;
-        }
-        case IPI_SWITCH:
-        {
-            D(bug("[Kernel:IPI] IPI_SWITCH:\n"));
-            break;
-        }
-        case IPI_SCHEDULE:
-        {
-            D(bug("[Kernel:IPI] IPI_SCHEDULE:\n"));
-            break;
-        }
-        case IPI_CLI:
-        {
-            D(bug("[Kernel:IPI] IPI_CLI:\n"));
-            break;
-        }
-        case IPI_STI:
-        {
-            D(bug("[Kernel:IPI] IPI_STI:\n"));
-            break;
-        }
-        case IPI_REBOOT:
-        {
-            D(bug("[Kernel:IPI] IPI_REBOOT:\n"));
-            break;
-        }
-        case IPI_ADDTASK:
-        {
-            D(bug("[Kernel:IPI] IPI_ADDTASK:\n"));
-            break;
-        }
-        case IPI_REMTASK:
-        {
-            D(bug("[Kernel:IPI] IPI_REMTASK:\n"));
-            break;
-        }
+        /*
+         * Flag the local CPU for reschedule. The next preemption
+         * opportunity (Permit/Enable, next timer tick on core 0,
+         * or completion of the current FIQ return) will pick this
+         * up. Idle CPUs already wake from WFI on FIQ delivery
+         * and re-check core_Dispatch in their idle loop, so no
+         * extra work is needed for the idle-wake case.
+         */
+        D(bug("[Kernel:IPI] IPI_SCHEDULE:\n"));
+        /*
+         * Also expire the quantum: core_Schedule() only keeps the running
+         * task if the best ready candidate has <= priority AND the quantum
+         * is still unused. Secondary cores have no local timer to expire it,
+         * so without this an equal-priority task IPI'd to an idle core would
+         * never preempt the idle context.
+         */
+        FLAG_SCHEDQUANTUM_SET;
+        FLAG_SCHEDSWITCH_SET;
     }
+    if (ipi_msg & IPI_CALL_HOOK)
+    {
+        D(bug("[Kernel:IPI] IPI_CALL_HOOK:\n"));
+        core_HandleCallHookIPI(cpu);
+    }
+    if (ipi_msg & IPI_CLI)
+        D(bug("[Kernel:IPI] IPI_CLI:\n"));
+    if (ipi_msg & IPI_STI)
+        D(bug("[Kernel:IPI] IPI_STI:\n"));
+    if (ipi_msg & IPI_REBOOT)
+        D(bug("[Kernel:IPI] IPI_REBOOT:\n"));
+    if (ipi_msg & IPI_ADDTASK)
+        D(bug("[Kernel:IPI] IPI_ADDTASK:\n"));
+    if (ipi_msg & IPI_REMTASK)
+        D(bug("[Kernel:IPI] IPI_REMTASK:\n"));
 }
 #endif

--- a/arch/arm-native/kernel/kernel_ipi.h
+++ b/arch/arm-native/kernel/kernel_ipi.h
@@ -6,19 +6,24 @@
 */
 
 /*
- * List of all possible (private) kernal IPI message types.
+ * Private kernel IPI message types. Values are bit flags so the
+ * BCM2836 mailbox SET register (which OR-coalesces concurrent writes
+ * from the same sender) can carry multiple message types in one IPI
+ * delivery without losing any. The receiver dispatches by testing
+ * each bit. Source CPU is encoded in the top 4 bits (see senders).
  */
 
 #define IPI_NOP                 0x000
 #define IPI_CAUSE               0x001
 #define IPI_DISPATCH            0x002
-#define IPI_SWITCH              0x003
-#define IPI_SCHEDULE            0x004
-#define IPI_CLI                 0x005
-#define IPI_STI                 0x006
-#define IPI_ADDTASK	        0x101
-#define IPI_REMTASK	        0x102
-#define IPI_REBOOT	        0x10F
+#define IPI_SWITCH              0x004
+#define IPI_SCHEDULE            0x008
+#define IPI_CLI                 0x010
+#define IPI_STI                 0x020
+#define IPI_CALL_HOOK           0x040
+#define IPI_ADDTASK             0x080
+#define IPI_REMTASK             0x100
+#define IPI_REBOOT              0x200
 
 #include <utility/hooks.h>
 
@@ -30,12 +35,25 @@ struct IPIHook
     IPTR        ih_Args[IPI_CALL_HOOK_MAX_ARGS];
 };
 
-/* Stub: arm-native IPI hook dispatch is not yet implemented. */
-static inline int core_DoCallIPI(struct Hook *hook, void *cpu_mask, int async,
-                                 int nargs, IPTR *args, APTR _KB)
-{
-    (void)hook; (void)cpu_mask; (void)async;
-    (void)nargs; (void)args; (void)_KB;
-    return 0;
-}
+extern void core_IPIInit(void);
+extern int core_DoCallIPI(struct Hook *hook, void *cpu_mask, int async,
+                          int nargs, IPTR *args, APTR _KB);
+
+/*
+ * Split claim/commit API plus cancellation, so exec can validate the
+ * target's lifetime atomically with the enqueue (see rom/exec/signal.c)
+ * and flush stale calls at task teardown (see rom/exec/remtask.c).
+ * KERNEL_IPI_CALL_CANCELABLE keys exec's lifetime-safe path off this
+ * header; platforms without it fall back to plain core_DoCallIPI.
+ */
+struct CallIPIEntry;
+
+extern struct CallIPIEntry *core_ClaimCallIPI(int cpu);
+extern void core_CommitCallIPI(struct CallIPIEntry *cie, int cpu,
+                               struct Hook *hook, int nargs, IPTR *args);
+extern void core_AbortCallIPI(struct CallIPIEntry *cie, int cpu);
+extern void core_CancelCallIPIs(APTR hookEntry, IPTR matchArg);
+
+#define KERNEL_IPI_CALL_CANCELABLE
+
 #endif

--- a/arch/arm-native/kernel/kernel_scheduler.c
+++ b/arch/arm-native/kernel/kernel_scheduler.c
@@ -8,6 +8,8 @@
 #include <proto/exec.h>
 #include <proto/kernel.h>
 
+#include <asm/arm/cpu.h>
+
 //#include <kernel_base.h>
 struct KernelBase;
 #include <kernel_debug.h>
@@ -29,6 +31,56 @@ struct KernelBase;
 
 #define DSCHED(x)
 
+#if defined(__AROSEXEC_SMP__)
+/*
+ * iet_CpuAffinity is a pointer to a cpumask buffer (from KrnAllocCPUMask)
+ * or the TASKAFFINITY_ANY sentinel - never a raw bitmask. A NULL pointer
+ * means no affinity was assigned, which is treated as "run anywhere".
+ * cpunum < 4 so the affinity word index is always 0.
+ */
+static inline BOOL core_AffinityMatch(struct Task *t, uint32_t cpumask)
+{
+    void *aff = (void *)(IPTR)GetIntETask(t)->iet_CpuAffinity;
+
+    if (!aff || (IPTR)aff == TASKAFFINITY_ANY)
+        return TRUE;
+
+    return (((uint32_t *)aff)[0] & cpumask) != 0;
+}
+
+/*
+ * Single-attempt write acquire. The dispatcher scans TaskReady holding
+ * TaskReadySpinLock and must take each candidate's tc_SpinLock before
+ * pulling it off the list - but every other tc_SpinLock user acquires
+ * task-lock FIRST, list-lock second, so a blocking acquire here (list
+ * before task) would be an AB-BA deadlock. Try once and skip the
+ * candidate on contention instead.
+ */
+static inline BOOL core_TrySpinLockWrite(spinlock_t *lock)
+{
+    unsigned long lock_value, result;
+
+    asm volatile(
+            "1:     ldrex   %0, [%2]        \n\t"   // Load the lock value, gaining exclusive access
+            "       teq     %0, #0          \n\t"   // Is the lock free?
+            "       bne     2f              \n\t"   // No - fail without spinning
+            "       strex   %1, %3, [%2]    \n\t"   // Try to exclusively write the lock value
+            "       teq     %1, #0          \n\t"   // Did it succeed?
+            "       bne     1b              \n\t"   // Exclusive access lost - re-examine the lock
+            "2:     clrex                   \n\t"   // Drop any dangling exclusive monitor
+            : "=&r"(lock_value), "=&r"(result)
+            : "r"(&lock->lock), "r"(0x80000000)
+            : "cc"
+    );
+
+    if (lock_value != 0)
+        return FALSE;
+
+    dmb();
+    return TRUE;
+}
+#endif
+
 /* Check if the currently running task on this cpu should be rescheduled */
 BOOL core_Schedule(void)
 {
@@ -47,6 +99,9 @@ BOOL core_Schedule(void)
     if (!(task->tc_Flags & TF_EXCEPT))
     {
 #if defined(__AROSEXEC_SMP__)
+        /* FIQ off: an IPI re-entering this read lock as a write would
+         * self-deadlock this CPU. See EXEC_FIQ_DISABLE in exec_platform.h. */
+        unsigned int __fiq = EXEC_FIQ_DISABLE();
         KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
                     SPINLOCK_MODE_READ);
 #endif
@@ -67,7 +122,7 @@ BOOL core_Schedule(void)
             for (nexttask = (struct Task *)GetHead(&SysBase->TaskReady); nexttask != NULL; nexttask = (struct Task *)GetSucc(nexttask))
             {
 #if defined(__AROSEXEC_SMP__)
-                if (((IPTR)GetIntETask(nexttask)->iet_CpuAffinity & cpumask) == cpumask)
+                if (core_AffinityMatch(nexttask, cpumask))
                 {
 #endif
                     if (nexttask->tc_Node.ln_Pri <= task->tc_Node.ln_Pri)
@@ -84,6 +139,7 @@ BOOL core_Schedule(void)
         }
 #if defined(__AROSEXEC_SMP__)
         KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock);
+        EXEC_FIQ_RESTORE(__fiq);
 #endif
     }
 
@@ -103,6 +159,9 @@ void core_Switch(void)
     int cpunum = GetCPUNumber();
 #endif
     struct Task *task = GET_THIS_TASK;
+#if defined(__AROSEXEC_SMP__)
+    unsigned int __fiq;
+#endif
 
     DSCHED(bug("[Kernel:%02d] core_Switch(%08x)\n", cpunum, task->tc_State));
 
@@ -115,10 +174,18 @@ void core_Switch(void)
     {
         DSCHED(bug("[Kernel:%02d] Switching away from '%s' @ 0x%p\n", cpunum, task->tc_Node.ln_Name, task));
 #if defined(__AROSEXEC_SMP__)
-        KrnSpinLock(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL,
-                    SPINLOCK_MODE_WRITE);
-        Remove(&task->tc_Node);
-        KrnSpinUnLock(&PrivExecBase(SysBase)->TaskRunningSpinLock);
+        /*
+         * Hold tc_SpinLock across the RUN->READY (state, list) transition.
+         * Without it, an observer on another CPU (SetTaskPri, ReschedTask)
+         * that locks tc_SpinLock can see TS_READY while the task is not
+         * yet on TaskReady and Remove() a node that is on no list.
+         * Order: task-lock outer, list-locks inner, as everywhere else.
+         * FIQ masked for the whole hold: the IPI's signal_hook takes this
+         * same tc_SpinLock and would self-deadlock this CPU.
+         */
+        __fiq = EXEC_FIQ_DISABLE();
+        KrnSpinLock(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+        exec_TaskRemoveRunning(task);
 #endif
         task->tc_State = TS_READY;
 
@@ -131,12 +198,9 @@ void core_Switch(void)
             task->tc_SigWait    = 0;
             task->tc_State      = TS_WAIT;
 #if defined(__AROSEXEC_SMP__)
-            KrnSpinLock(&PrivExecBase(SysBase)->TaskWaitSpinLock, NULL,
-                        SPINLOCK_MODE_WRITE);
-#endif
+            exec_TaskEnqueueWait(task);
+#else
             Enqueue(&SysBase->TaskWait, &task->tc_Node);
-#if defined(__AROSEXEC_SMP__)
-            KrnSpinUnLock(&PrivExecBase(SysBase)->TaskWaitSpinLock);
 #endif
 
             Alert(AN_StackProbe);
@@ -149,14 +213,15 @@ void core_Switch(void)
         {
             DSCHED(bug("[Kernel:%02d] Setting '%s' @ 0x%p as ready\n", cpunum, task->tc_Node.ln_Name, task));
 #if defined(__AROSEXEC_SMP__)
-            KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
-                    SPINLOCK_MODE_WRITE);
-#endif
+            exec_TaskEnqueueReady(task);
+#else
             Enqueue(&SysBase->TaskReady, &task->tc_Node);
-#if defined(__AROSEXEC_SMP__)
-            KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock);
 #endif
         }
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&task->tc_SpinLock);
+        EXEC_FIQ_RESTORE(__fiq);
+#endif
     }
 }
 
@@ -165,34 +230,64 @@ struct Task *core_Dispatch(void)
 {
     struct Task *newtask;
     struct Task *task = GET_THIS_TASK;
+    BOOL taskStateLocked = FALSE;
 #if defined(__AROSEXEC_SMP__) || defined(DEBUG)
     int cpunum = GetCPUNumber();
     (void)cpunum;
 #endif
 #if defined(__AROSEXEC_SMP__)
     uint32_t cpumask = (1 << cpunum);
+    BOOL sawContended;
+    /* FIQ off for the whole dispatch: it holds TaskReadySpinLock,
+     * tc_SpinLock, TaskWait/Spinning and (via SET_THIS_TASK) TaskRunning -
+     * an IPI re-entering any of these on this CPU self-deadlocks. Nestable
+     * across the recursive call below. */
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
 #endif
 
     DSCHED(bug("[Kernel:%02d] core_Dispatch()\n", cpunum));
 
 #if defined(__AROSEXEC_SMP__)
+dispatch_rescan:
+    sawContended = FALSE;
     KrnSpinLock(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
                 SPINLOCK_MODE_WRITE);
 #endif
     for (newtask = (struct Task *)GetHead(&SysBase->TaskReady); newtask != NULL; newtask = (struct Task *)GetSucc(newtask))
     {
 #if defined(__AROSEXEC_SMP__)
-        if (((IPTR)GetIntETask(newtask)->iet_CpuAffinity & cpumask) == cpumask)
+        if (core_AffinityMatch(newtask, cpumask))
         {
-#endif
+            /*
+             * Take tc_SpinLock before pulling the task off TaskReady so
+             * the (state, list) transition is atomic to SetTaskPri /
+             * Exec_ReschedTask, which trust tc_State under tc_SpinLock.
+             * See core_TrySpinLockWrite for why this must be a trylock.
+             */
+            if (!core_TrySpinLockWrite(&newtask->tc_SpinLock))
+            {
+                sawContended = TRUE;
+                continue;
+            }
+            taskStateLocked = TRUE;
             Remove(&newtask->tc_Node);
             break;
-#if defined(__AROSEXEC_SMP__)
         }
+#else
+        Remove(&newtask->tc_Node);
+        break;
 #endif
     }
 #if defined(__AROSEXEC_SMP__)
     KrnSpinUnLock(&PrivExecBase(SysBase)->TaskReadySpinLock);
+
+    /*
+     * Every candidate we saw was locked by another CPU (Signal /
+     * SetTaskPri hold it only for a few instructions). Rescan rather
+     * than going idle with runnable work on the list.
+     */
+    if (!newtask && sawContended)
+        goto dispatch_rescan;
 #endif
 
     if ((!newtask) && (task) && (task->tc_State != TS_WAIT))
@@ -214,35 +309,52 @@ struct Task *core_Dispatch(void)
             /* Check the stack of the task we are about to launch. */
             if ((newtask->tc_SPReg <= newtask->tc_SPLower) ||
                 (newtask->tc_SPReg > newtask->tc_SPUpper))
+            {
+#if defined(__AROSEXEC_SMP__)
+                if (!taskStateLocked)
+                {
+                    KrnSpinLock(&newtask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                    taskStateLocked = TRUE;
+                }
+#endif
                 newtask->tc_State     = TS_WAIT;
+            }
             else
                 newtask->tc_State     = TS_RUN;
         }
 
         BOOL launchtask = TRUE;
-#if defined(__AROSEXEC_SMP__)
-        if (newtask->tc_State == TS_SPIN)
-        {
-            /* move it to the spinning list */
-            KrnSpinLock(&PrivExecBase(SysBase)->TaskSpinningLock, NULL,
-                SPINLOCK_MODE_WRITE);
-            AddHead(&PrivExecBase(SysBase)->TaskSpinning, &newtask->tc_Node);
-            KrnSpinUnLock(&PrivExecBase(SysBase)->TaskSpinningLock);
-            launchtask = FALSE;
-        }
-#endif
         if (newtask->tc_State == TS_WAIT)
         {
+#if defined(__AROSEXEC_SMP__)
+            if (!taskStateLocked)
+            {
+                KrnSpinLock(&newtask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                taskStateLocked = TRUE;
+            }
+#endif
 #if defined(__AROSEXEC_SMP__)
             KrnSpinLock(&PrivExecBase(SysBase)->TaskWaitSpinLock, NULL,
                         SPINLOCK_MODE_WRITE);
 #endif
-            Enqueue(&SysBase->TaskWait, &task->tc_Node);
+            Enqueue(&SysBase->TaskWait, &newtask->tc_Node);
 #if defined(__AROSEXEC_SMP__)
             KrnSpinUnLock(&PrivExecBase(SysBase)->TaskWaitSpinLock);
+            KrnSpinUnLock(&newtask->tc_SpinLock);
+            taskStateLocked = FALSE;
 #endif
             launchtask = FALSE;
         }
+
+#if defined(__AROSEXEC_SMP__)
+        /* Covers the launch path; the TS_WAIT block has already dropped
+         * the lock itself. */
+        if (taskStateLocked)
+        {
+            KrnSpinUnLock(&newtask->tc_SpinLock);
+            taskStateLocked = FALSE;
+        }
+#endif
 
         if (!launchtask)
         {
@@ -270,5 +382,8 @@ struct Task *core_Dispatch(void)
         FLAG_SCHEDSWITCH_SET;
     }
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_FIQ_RESTORE(__fiq);
+#endif
     return newtask;
 }

--- a/arch/arm-native/kernel/kernel_startup.c
+++ b/arch/arm-native/kernel/kernel_startup.c
@@ -29,12 +29,15 @@
 
 #include "kernel_intern.h"
 #include "kernel_debug.h"
+#include "kernel_fb.h"
 #include "kernel_romtags.h"
 
 #include "exec_platform.h"
 
 #undef KernelBase
 #include "tls.h"
+
+extern struct MemHeader *krnCreateROMHeader(CONST_STRPTR name, APTR start, APTR end);
 
 extern struct TagItem *BootMsg;
 
@@ -180,24 +183,18 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
         __arm_arosintern.ARMI_LED_Toggle(ARM_LED_POWER, ARM_LED_OFF);
     }
 
-    cpu_Init(&__arm_arosintern, msg);
-
-    if (__arm_arosintern.ARMI_LED_Toggle)
-    {
-        if (__arm_arosintern.ARMI_Delay)
-            __arm_arosintern.ARMI_Delay(100000);
-        __arm_arosintern.ARMI_LED_Toggle(ARM_LED_POWER, ARM_LED_ON);
-    }
-
-    /* NB: the bootstrap has conveniently setup the framebuffer
-            and initialised the serial port and led for us */
-
+    /*
+     * Parse memory ranges and allocate per-CPU TLS before cpu_Init.
+     * cpu_Init -> GetCPUNumber() reads TPIDRURO and dereferences it as
+     * a tls_t *, so TPIDRURO must point at a valid tls_t with CPUNumber
+     * set before any code inside cpu_Init runs. On real silicon TPIDRURO
+     * is 0 out of reset, so calling cpu_Init first faults silently.
+     */
     while(msg->ti_Tag != TAG_DONE)
     {
         switch (msg->ti_Tag)
         {
         case KRN_CmdLine:
-//            RelocateStringData(tag);
             cmdline = (char *)msg->ti_Data;
             break;
         case KRN_MEMLower:
@@ -210,18 +207,7 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
             protlower = msg->ti_Data;
             break;
         case KRN_ProtAreaEnd:
-            // Page align
             protupper = (msg->ti_Data + 4095) & ~4095;
-            break;
-        case KRN_KernelBase:
-            /*
-             * KRN_KernelBase is actually a border between read-only
-             * (code) and read-write (data) sections of the kickstart.
-             * read-write section goes to lower addresses from this one,
-             * so we align it upwards in order not to make part of RW data
-             * read-only.
-             */
-//            addr = AROS_ROUNDUP2(msg->ti_Data, PAGE_SIZE);
             break;
         }
         msg++;
@@ -234,6 +220,21 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
     __tls->KernelBase = NULL;
     __tls->SysBase = NULL;
     __tls->ThisTask = NULL;
+    __tls->CPUNumber = 0;               /* boot CPU is always logical 0 */
+
+    asm volatile("mcr p15, 0, %0, c13, c0, 3" : : "r"(__tls));
+
+    cpu_Init(&__arm_arosintern, msg);
+
+    if (__arm_arosintern.ARMI_LED_Toggle)
+    {
+        if (__arm_arosintern.ARMI_Delay)
+            __arm_arosintern.ARMI_Delay(100000);
+        __arm_arosintern.ARMI_LED_Toggle(ARM_LED_POWER, ARM_LED_ON);
+    }
+
+    /* NB: the bootstrap has conveniently setup the framebuffer
+            and initialised the serial port and led for us */
 
     D(bug("[Kernel] AROS ARM Native Kernel built on %s\n", __DATE__));
     if (dt_find_node("/")) {
@@ -241,8 +242,6 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
     }
 
     D(bug("[Kernel] Entered kernel_cstart @ 0x%p, BootMsg @ 0x%p\n", kernel_cstart, BootMsg));
-
-    asm volatile("mcr p15, 0, %0, c13, c0, 3" : : "r"(__tls));
 
     D(
         if (__arm_arosintern.ARMI_PutChar)
@@ -306,6 +305,14 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
 
     __tls->SysBase = SysBase;
     D(bug("[Kernel] SysBase @ 0x%p\n", SysBase));
+
+    /*
+     * Register the kickstart ROM region so TypeOfMem() recognizes pointers
+     * to ROM-resident static data (attrLists, IORequest templates, etc.).
+     * Without this, ASSERT_VALID_PTR fires on every such pointer when ADEBUG
+     * is enabled, storming Alert() through hot I/O paths.
+     */
+    krnCreateROMHeader("Kickstart ROM", ranges[0], ranges[1]);
 
     /*
      * Make kickstart code area read-only.

--- a/arch/arm-native/kernel/mmakefile.src
+++ b/arch/arm-native/kernel/mmakefile.src
@@ -35,9 +35,15 @@ CFILES := \
         platform_init \
         kernel_debug \
         getsystemattr \
+        timestamp \
         getcpucount \
+        alloccpumask \
+        clearcpumask \
+        cpuinmask \
+        freecpumask \
         getcpumask \
         getcpunumber \
+        schedulecpu \
         maygetchar \
         tags \
         intr \

--- a/arch/arm-native/kernel/schedulecpu.c
+++ b/arch/arm-native/kernel/schedulecpu.c
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: arm-native KrnScheduleCPU - send IPI_SCHEDULE to a CPU mask.
+*/
+
+#include <exec/tasks.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+
+#include "kernel_base.h"
+#include "kernel_cpu.h"
+#include "kernel_ipi.h"
+
+AROS_LH1(void, KrnScheduleCPU,
+        AROS_LHA(void *, cpu_mask, A0),
+        struct KernelBase *, KernelBase, 47, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+#if defined(__AROSEXEC_SMP__)
+    if (cpu_mask && __arm_arosintern.ARMI_SendIPI)
+    {
+        /*
+         * On arm-native cpumask_t is unsigned int, so the affinity buffer
+         * is a small bitmap with the lowest 32 bits indexing CPUs 0-31.
+         * Pi 2/3/4 have at most 4 cores - one word is plenty.
+         *
+         * TASKAFFINITY_ANY / TASKAFFINITY_ALL_BUT_SELF are sentinels
+         * (not buffer pointers) and must not be dereferenced.
+         */
+        int srcCpu = GetCPUNumber();
+        uint32_t mask;
+
+        if ((IPTR)cpu_mask == TASKAFFINITY_ANY)
+            mask = 0xf;
+        else if ((IPTR)cpu_mask == TASKAFFINITY_ALL_BUT_SELF)
+            mask = 0xf & ~(1U << srcCpu);
+        else
+            mask = *(uint32_t *)cpu_mask;
+
+        __arm_arosintern.ARMI_SendIPI((IPI_SCHEDULE & 0x0fffffff) | (srcCpu << 28),
+                                      0, mask);
+    }
+#else
+    (void)cpu_mask;
+#endif
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/spinlock.c
+++ b/arch/arm-native/kernel/spinlock.c
@@ -56,6 +56,7 @@ AROS_LH3(spinlock_t *, KrnSpinLock,
     }
 
     dmb();
+
     return lock;
 
     AROS_LIBFUNC_EXIT

--- a/arch/arm-native/kernel/spinunlock.c
+++ b/arch/arm-native/kernel/spinunlock.c
@@ -6,6 +6,8 @@
 #include <aros/kernel.h>
 #include <aros/libcall.h>
 
+#include <asm/arm/cpu.h>
+
 #include <kernel_base.h>
 
 #include <proto/kernel.h>
@@ -20,12 +22,29 @@ AROS_LH1(void, KrnSpinUnLock,
         return;
 
     /*
+     * Release fence: prior critical-section stores must be globally
+     * observable before the lock-clear store. Without this dmb, a
+     * subsequent acquirer on another core can take the lock and read
+     * stale data because ARMv7-A allows the lock-release store to be
+     * reordered ahead of earlier stores. Pairs with the acquire dmb
+     * in KrnSpinLock.
+     */
+    dmb();
+
+    /*
      * Are we releasing a write lock? Just zero out the value. Also send event so that other cores waiting for lock
      * wake up.
      */
     if (lock->lock & 0x80000000)
     {
         lock->lock = 0;
+        /*
+         * dsb before sev: the event must not overtake the lock-clear
+         * store, or a wfe-parked waiter wakes, re-reads the still-locked
+         * value and parks again (recovery then depends on the global
+         * monitor generating another event).
+         */
+        dsb();
         asm volatile("sev");
     }
     else
@@ -45,7 +64,10 @@ AROS_LH1(void, KrnSpinUnLock,
 
         /* Send event to other cores if lock is free */
         if (lock_value == 0)
+        {
+            dsb();
             asm volatile("sev");
+        }
     }
 
     AROS_LIBFUNC_EXIT

--- a/arch/arm-native/kernel/syscall.c
+++ b/arch/arm-native/kernel/syscall.c
@@ -160,7 +160,7 @@ void handle_syscall(void *regs)
         D(bug("[Kernel] ## SWI : ILLEGAL ACCESS!\n"));
         return;
     }
-    if (swi_no <= 0x0b || swi_no == 0x100)
+    if (swi_no <= SC_GETCPUNUMBER || swi_no == SC_REBOOT)
     {
         DREGS(cpu_DumpRegs(regs));
 
@@ -169,14 +169,25 @@ void handle_syscall(void *regs)
             case SC_CLI:
             {
                 D(bug("[Kernel] ## CLI...\n"));
-                ((uint32_t *)regs)[16] |= (1 << 7);
+                /*
+                 * Mask BOTH IRQ (bit 7) and FIQ (bit 6). Tasks run
+                 * unprivileged, so Disable() must come through this syscall
+                 * to touch the interrupt bits - a raw cpsid in task context
+                 * is ignored. The cross-CPU IPI is delivered as an FIQ and
+                 * takes tc_SpinLock / scheduler-list locks via signal_hook;
+                 * if it could fire while a Disable()'d task holds one of
+                 * those it would self-deadlock that CPU. Disabling FIQ here
+                 * keeps the IPI pending (the BCM2836 mailbox latches it) until
+                 * the matching Enable() re-opens both.
+                 */
+                ((uint32_t *)regs)[16] |= (1 << 7) | (1 << 6);
                 break;
             }
 
             case SC_STI:
             {
                 D(bug("[Kernel] ## STI...\n"));
-                ((uint32_t *)regs)[16] &= ~(1 << 7);
+                ((uint32_t *)regs)[16] &= ~((1 << 7) | (1 << 6));
                 break;
             }
 

--- a/arch/arm-native/kernel/timestamp.c
+++ b/arch/arm-native/kernel/timestamp.c
@@ -1,0 +1,29 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: KrnTimeStamp() - architecture-specific monotonic timestamp.
+*/
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+#include <exec/execbase.h>
+
+#include "kernel_intern.h"
+
+#include <proto/kernel.h>
+
+/* See rom/kernel/timestamp.c for documentation. On arm-native this returns
+ * the platform free-running timer in microseconds (BCM System Timer). */
+
+AROS_LH0(UQUAD, KrnTimeStamp,
+        struct KernelBase *, KernelBase, 64, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    if (__arm_arosintern.ARMI_GetTime)
+        return (UQUAD)__arm_arosintern.ARMI_GetTime();
+
+    return 0;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/kernel/tls.h
+++ b/arch/arm-native/kernel/tls.h
@@ -11,6 +11,10 @@ typedef struct tls
     BYTE                TDNestCnt;
     UWORD               Quantum;
     UWORD               Elapsed;
+    ULONG               CPUNumber;      /* Logical CPU id, set by boot CPU. The
+                                         * BCM2836 MPIDR/VMPIDR view is unreliable
+                                         * across cores on some Pi 3 armstubs, so
+                                         * GetCPUNumber() reads this instead. */
 } tls_t;
 
 #define TLSSF_Quantum   (1 << 0)

--- a/arch/riscv-native/exec/exec_platform.h
+++ b/arch/riscv-native/exec/exec_platform.h
@@ -19,12 +19,19 @@ extern void Exec_TaskSpinUnlock(spinlock_t *);
 extern void Kernel_40_KrnSpinInit(spinlock_t *, void *);
 #define EXEC_SPINLOCK_INIT(a) Kernel_40_KrnSpinInit((a), NULL)
 extern spinlock_t *Kernel_43_KrnSpinLock(spinlock_t *, struct Hook *, ULONG, void *);
-#define EXEC_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), NULL, (b), NULL)
+/* (lock, failhook, mode) - rom/exec passes all three. */
+#define EXEC_SPINLOCK_LOCK(a,b,c) Kernel_43_KrnSpinLock((a), (b), (c), NULL)
 #define EXECTASK_SPINLOCK_LOCK(a,b) Kernel_43_KrnSpinLock((a), &Exec_TaskSpinLockFailHook, (b), NULL)
 extern void Kernel_44_KrnSpinUnLock(spinlock_t *, void *);
 #define EXEC_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL)
 #define EXECTASK_SPINLOCK_UNLOCK(a) Kernel_44_KrnSpinUnLock((a), NULL); \
             Exec_TaskSpinUnlock((a))
+
+/*
+ * Store-store barrier for publishing a freshly built structure to readers
+ * that walk it without taking a lock.
+ */
+#define EXEC_MEMORY_BARRIER()   asm volatile("fence w,w" ::: "memory")
 
 #endif
 

--- a/rom/exec/exec_intern.h
+++ b/rom/exec/exec_intern.h
@@ -16,6 +16,26 @@
 
 #include <exec_platform.h>
 
+/*
+ * Mask the IPI's FIQ around tc_SpinLock / scheduler-list critical sections.
+ * arm-native defines real versions in exec_platform.h (the IPI that delivers
+ * cross-CPU Signal arrives as an FIQ and would re-enter these locks on the
+ * same CPU via signal_hook). Arches without an FIQ-delivered IPI get no-ops.
+ */
+#ifndef EXEC_FIQ_DISABLE
+#define EXEC_FIQ_DISABLE()      (0)
+#define EXEC_FIQ_RESTORE(x)     do { (void)(x); } while (0)
+#endif
+
+/*
+ * Store-store barrier, for publishing a freshly built structure to a reader
+ * that walks it lock-free. SMP arches define a real one in exec_platform.h;
+ * on single-CPU builds there is no other observer, so a no-op is correct.
+ */
+#ifndef EXEC_MEMORY_BARRIER
+#define EXEC_MEMORY_BARRIER()   do { } while (0)
+#endif
+
 #if defined(__AROSEXEC_SMP__)
 #include <aros/types/spinlock_s.h>
 #endif
@@ -81,6 +101,8 @@ struct IntExecBase
     void                       *ExecLockBase;
     cpumask_t                   *CPUMask;                       /* bitmap of online core                                        */
     spinlock_t                  MemListSpinLock;
+    spinlock_t                  AllocMemListSpinLock;           /* mungwall AllocMemList (SMP-safe replacement for Forbid)       */
+    spinlock_t                  AllocatorCtxListSpinLock;       /* AllocatorCtxList lazy-create serialization                   */
     /* First the locks for arbitration of public resources ... */
     spinlock_t                  ResourceListSpinLock;
     spinlock_t                  DeviceListSpinLock;
@@ -138,5 +160,81 @@ BOOL IsSysBaseValid(struct ExecBase *sysbase);
 IPTR cpu_SuperState();
 
 void ServiceTask(struct ExecBase *SysBase);
+
+#if defined(__AROSEXEC_SMP__)
+
+/*
+ * Task list migration helpers. Single source of truth for "atomically
+ * move task on or off a SysBase task list under the matching spinlock."
+ * Caller is responsible for tc_State semantics and (if needed) the
+ * per-task tc_SpinLock around the (state, list-membership) tuple.
+ *
+ * Used by rom/exec/wait.c and by core_Switch on both x86_64 and
+ * arm-native.
+ */
+
+/*
+ * Scheduler-list spinlocks must be held with IRQ/FIQ-driven dispatch
+ * blocked: arm-native's core_ExitInterrupt runs core_Dispatch which
+ * itself acquires TaskReadySpinLock - if a dispatch fires while we
+ * hold the lock, the dispatcher self-deadlocks (same CPU) or leaks
+ * the lock to whoever runs next.
+ *
+ * EXEC_BLOCK_DISPATCH_INC/DEC bump TDNestCnt directly (per-CPU TLS,
+ * no atomics needed) without going through Forbid()/Permit(). Permit's
+ * decrement-to-fully-permitted path triggers Reschedule() if
+ * FLAG_SCHEDSWITCH is set, yielding the CPU - the LAST thing we want
+ * while holding a scheduler lock. The macros are defined per-arch in
+ * exec_platform.h.
+ */
+static inline void exec_TaskRemoveRunning(struct Task *task)
+{
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
+    EXEC_BLOCK_DISPATCH_INC;
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL,
+                       SPINLOCK_MODE_WRITE);
+    Remove(&task->tc_Node);
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskRunningSpinLock);
+    EXEC_BLOCK_DISPATCH_DEC;
+    EXEC_FIQ_RESTORE(__fiq);
+}
+
+static inline void exec_TaskEnqueueReady(struct Task *task)
+{
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
+    EXEC_BLOCK_DISPATCH_INC;
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL,
+                       SPINLOCK_MODE_WRITE);
+    Enqueue(&SysBase->TaskReady, &task->tc_Node);
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskReadySpinLock);
+    EXEC_BLOCK_DISPATCH_DEC;
+    EXEC_FIQ_RESTORE(__fiq);
+}
+
+static inline void exec_TaskEnqueueWait(struct Task *task)
+{
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
+    EXEC_BLOCK_DISPATCH_INC;
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock, NULL,
+                       SPINLOCK_MODE_WRITE);
+    Enqueue(&SysBase->TaskWait, &task->tc_Node);
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock);
+    EXEC_BLOCK_DISPATCH_DEC;
+    EXEC_FIQ_RESTORE(__fiq);
+}
+
+static inline void exec_TaskEnqueueSpinning(struct Task *task)
+{
+    unsigned int __fiq = EXEC_FIQ_DISABLE();
+    EXEC_BLOCK_DISPATCH_INC;
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskSpinningLock, NULL,
+                       SPINLOCK_MODE_WRITE);
+    Enqueue(&PrivExecBase(SysBase)->TaskSpinning, &task->tc_Node);
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskSpinningLock);
+    EXEC_BLOCK_DISPATCH_DEC;
+    EXEC_FIQ_RESTORE(__fiq);
+}
+
+#endif /* __AROSEXEC_SMP__ */
 
 #endif /* __EXEC_INTERN_H__ */

--- a/rom/kernel/addexceptionhandler.c
+++ b/rom/kernel/addexceptionhandler.c
@@ -113,7 +113,13 @@ void *krnAddExceptionHandler(UBYTE num, APTR handler,  APTR handlerData, APTR ha
             handle->in_nr = num;
 
             Disable();
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
             ADDHEAD(&KernelBase->kb_Exceptions[num], &handle->in_Node);
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+#endif
             Enable();
         }
     }
@@ -131,6 +137,50 @@ int krnRunExceptionHandlers(struct KernelBase *KernelBase, uint8_t exception, vo
     if (!KernelBase || (EXCEPTIONS_COUNT < exception))
         return 0;
 
+#if defined(__AROSEXEC_SMP__)
+    /*
+     * Snapshot the chain under the lock and call the handlers OUTSIDE it.
+     * On x86-64 the syscall vector is dispatched through here
+     * (core_SysCallHandler), and a scheduling syscall ends in
+     * cpu_Dispatch, which never returns to this frame: holding the read
+     * lock across the call leaked one hold per task switch, so the
+     * count could never drain and the next KrnAddIRQHandler (WRITE
+     * acquire on the same lock) spun forever. The walk itself stays
+     * protected against concurrent Add/Rem; a handler torn down between
+     * snapshot and call is the remover's lifetime problem, exactly as
+     * it already was with the lock held across the call.
+     */
+    {
+        struct
+        {
+            exhandler_t h;
+            void *d1, *d2;
+        } snap[8];
+        unsigned int n = 0, i;
+
+        KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_READ);
+        ForeachNodeSafe(&KernelBase->kb_Exceptions[exception], in, in2)
+        {
+            if (in->in_Handler)
+            {
+                if (n < sizeof(snap) / sizeof(snap[0]))
+                {
+                    snap[n].h  = in->in_Handler;
+                    snap[n].d1 = in->in_HandlerData;
+                    snap[n].d2 = in->in_HandlerData2;
+                    n++;
+                }
+                else
+                    bug("[KRN] %s: exception #%u handler chain exceeds snapshot (%u), handler dropped!\n",
+                        __func__, exception, n);
+            }
+        }
+        KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+
+        for (i = 0; i < n; i++)
+            ret |= snap[i].h(ctx, snap[i].d1, snap[i].d2);
+    }
+#else
     ForeachNodeSafe(&KernelBase->kb_Exceptions[exception], in, in2)
     {
         exhandler_t h = in->in_Handler;
@@ -138,6 +188,7 @@ int krnRunExceptionHandlers(struct KernelBase *KernelBase, uint8_t exception, vo
         if (h)
             ret |= h(ctx, in->in_HandlerData, in->in_HandlerData2);
     }
+#endif
 
     return ret;
 }

--- a/rom/kernel/addirqhandler.c
+++ b/rom/kernel/addirqhandler.c
@@ -93,11 +93,19 @@
             handle->in_nr = irq;
 
             Disable();
-
+#if defined(__AROSEXEC_SMP__)
+            /*
+             * Disable() only stops this CPU; another core may be walking
+             * this chain in krnRunIRQHandlers() right now.
+             */
+            KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
             ADDHEAD(&KERNELIRQ_LIST(irq), &handle->in_Node);
 
             ictl_enable_irq(irq, KernelBase);
-
+#if defined(__AROSEXEC_SMP__)
+            KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+#endif
             Enable();
         }
 
@@ -114,10 +122,22 @@ void krnRunIRQHandlers(struct KernelBase *KernelBase, irqid_t irq)
 {
     struct IntrNode *in, *in2;
 
+#if defined(__AROSEXEC_SMP__)
+    /*
+     * Hold the chain in READ mode so a concurrent KrnAdd/RemIRQHandler()
+     * on another CPU cannot mutate it mid-walk. Consequence: a handler
+     * must not add/remove IRQ handlers from within itself - that would
+     * self-deadlock on the WRITE acquire.
+     */
+    KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_READ);
+#endif
     ForeachNodeSafe(&KERNELIRQ_LIST(irq), in, in2)
     {
         irqhandler_t h = in->in_Handler;
 
         h(in->in_HandlerData, in->in_HandlerData2);
     }
+#if defined(__AROSEXEC_SMP__)
+    KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+#endif
 }

--- a/rom/kernel/kernel_base.h
+++ b/rom/kernel/kernel_base.h
@@ -25,6 +25,10 @@
 #include <aros/kernel.h>
 #endif
 
+#if defined(__AROSEXEC_SMP__)
+#include <aros/types/spinlock_s.h>
+#endif
+
 /* Early declaration for ictl functions */
 struct KernelBase;
 
@@ -90,6 +94,9 @@ struct KernelBase
 #endif
     struct MinList      kb_Exceptions[EXCEPTIONS_COUNT];
     struct KernelInt    kb_Interrupts[HW_IRQ_COUNT];
+#if defined(__AROSEXEC_SMP__)
+    spinlock_t          kb_IntrSpinLock;            /* guards kb_Exceptions/kb_Interrupts chains */
+#endif
     ULONG               kb_ContextFlags;            /* Hints for KrnCreateContext()         */
     ULONG               kb_ContextSize;	                /* Total length of CPU context          */
     ULONG               kb_PageSize;                /* Physical memory page size            */

--- a/rom/kernel/kernel_init.c
+++ b/rom/kernel/kernel_init.c
@@ -110,6 +110,11 @@ AROS_UFH3S(struct KernelBase *, Kernel_Init,
     for (i=0; i < HW_IRQ_COUNT; i++)
         NEWLIST(&KERNELIRQ_LIST(i));
 
+#if defined(__AROSEXEC_SMP__)
+    KernelBase->kb_IntrSpinLock.lock    = SPINLOCK_UNLOCKED;
+    KernelBase->kb_IntrSpinLock.s_Owner = NULL;
+#endif
+
     /*
      * Everything is ok, add our resource.
      * exec.library catches this call and sets up its memory management.

--- a/rom/kernel/kernel_memory.c
+++ b/rom/kernel/kernel_memory.c
@@ -67,6 +67,11 @@ void krnCreateMemHeader(CONST_STRPTR name, BYTE pri, APTR start, IPTR size, ULON
     mh->mh_Lower           = start;
     mh->mh_Upper           = start + size;
     mh->mh_Free            = mh->mh_First->mc_Bytes;
+
+#if defined(__AROSEXEC_SMP__)
+    mh->mh_SpinLock.lock    = SPINLOCK_UNLOCKED;
+    mh->mh_SpinLock.s_Owner = NULL;
+#endif
 }
 
 /*
@@ -91,6 +96,10 @@ struct MemHeader *krnCreateROMHeader(CONST_STRPTR name, APTR start, APTR end)
         mh->mh_Lower = start;
         mh->mh_Upper = end + 1;                 /* end is the last valid address of the region */
         mh->mh_Free = 0;                        /* Never allocate from this chunk! */
+#if defined(__AROSEXEC_SMP__)
+        mh->mh_SpinLock.lock    = SPINLOCK_UNLOCKED;
+        mh->mh_SpinLock.s_Owner = NULL;
+#endif
         Enqueue(&SysBase->MemList, &mh->mh_Node);
     }
 

--- a/rom/kernel/remexceptionhandler.c
+++ b/rom/kernel/remexceptionhandler.c
@@ -61,7 +61,13 @@
         (void)goSuper();
 
         Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         REMOVE(h);
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+#endif
         Enable();
 
         krnFreeIntrNode(h);

--- a/rom/kernel/remirqhandler.c
+++ b/rom/kernel/remirqhandler.c
@@ -57,11 +57,17 @@
         (void)goSuper();
 
         Disable();
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         REMOVE(h);
         if (IsListEmpty(&KERNELIRQ_LIST(irq)))
         {
                 ictl_disable_irq(irq, KernelBase);
         }
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
+#endif
         Enable();
 
         krnFreeIntrNode(h);

--- a/rom/kernel/tlsf.c
+++ b/rom/kernel/tlsf.c
@@ -1499,6 +1499,11 @@ void krnCreateTLSFMemHeader(CONST_STRPTR name, BYTE pri, APTR start, IPTR size, 
     mhe->mhe_MemHeader.mh_Upper           = start + size;
     mhe->mhe_MemHeader.mh_Free            = size;
 
+#if defined(__AROSEXEC_SMP__)
+    mhe->mhe_MemHeader.mh_SpinLock.lock    = SPINLOCK_UNLOCKED;
+    mhe->mhe_MemHeader.mh_SpinLock.s_Owner = NULL;
+#endif
+
     D(nbug("[Kernel:TLSF] %s: 0x%p -> 0x%p\n", __PRETTY_FUNCTION__, mhe->mhe_MemHeader.mh_Lower, mhe->mhe_MemHeader.mh_Upper));
 
     tlsf_init(mhe);


### PR DESCRIPTION
**arm: SMP infrastructure for the kernel and exec**

- The lock and memory-barrier helpers the rest of exec builds on, for arm, aarch64, riscv and x86.
- Locking for the kernel's interrupt and exception handler lists, so they cannot be changed while another core is walking them.
- CPU mask calls, spinlocks and a 64-bit timestamp for arm.
- Messages between cores, so one core can wake a task that belongs to another.
- A scheduler that each core runs for itself, rather than one core scheduling for all of them.
- The arm side of exec that ties those together, including moving a task between the scheduler lists without going through a syscall.

**Why this is one pull request**

The six commits refer to each other: helpers in the first expand into functions added in the last, and those need symbols from the arm scheduler. Splitting them further breaks the build. 

The secondary cores are not started here — that comes with the raspi bring-up commit — so the system still runs on one core and behaves as before. That makes this a safe point to land the groundwork.
