### PR TITLE
exec: Fix mismatched list lock and Permit in OpenLibrary/OpenDevice

### DIFF
--- a/rom/exec/opendevice.c
+++ b/rom/exec/opendevice.c
@@ -97,7 +97,7 @@
 
     iORequest->io_Device = (struct Device *)FindName(&SysBase->DeviceList, devName);
 
-    EXEC_UNLOCK_LIST(&SysBase->DeviceList);
+    EXEC_UNLOCK_LIST_AND_PERMIT(&SysBase->DeviceList);
 
     D(bug("[OpenDevice] Found resident 0x%p\n", iORequest->io_Device));
 

--- a/rom/exec/openlibrary.c
+++ b/rom/exec/openlibrary.c
@@ -67,7 +67,7 @@
     /* Look for the library in our list */
     library = (struct Library *) FindName (&SysBase->LibList, libName);
 
-    EXEC_UNLOCK_LIST(&SysBase->LibList);
+    EXEC_UNLOCK_LIST_AND_PERMIT(&SysBase->LibList);
 
     /* Something found ? */
     if(library!=NULL)


### PR DESCRIPTION
Use EXEC_UNLOCK_LIST_AND_PERMIT instead of EXEC_UNLOCK_LIST to properly decrement the Forbid counter initiated by EXEC_LOCK_LIST_READ_AND_FORBID. Without this, tasks were left in an unintended Forbid state, leading to multitasking stalls and potential deadlocks on SMP systems.