### PR TITLE
Shell: Do not overwrite cli_Background if already configured

### DIFF
--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -164,7 +164,8 @@ LONG interact(ShellState *ss)
             }
 
             cli->cli_CurrentInput = cli->cli_StandardInput;
-            cli->cli_Background = IsInteractive(cli->cli_CurrentInput) ? DOSFALSE : DOSTRUE;
+            if (!cli->cli_Background)
+                cli->cli_Background = IsInteractive(cli->cli_CurrentInput) ? DOSFALSE : DOSTRUE;
 
             setInteractive(cli, ss);
         }


### PR DESCRIPTION
When a script finishes executing, do not unconditionally overwrite cli_Background based on IsInteractive(cli_CurrentInput). If cli_Background was already set to DOSTRUE (such as background tasks spawned via Run or SystemTagList/RunCommand), preserve it so the shell does not mistakenly switch into interactive mode and attempt to read from stdin.