### PR TITLE
AHI/RPiHDMI: Add Raspberry Pi 5 (BCM2712) HDMI audio support

### DIFF
--- a/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/DriverData.h
@@ -18,7 +18,7 @@
 struct RPiHDMIBase {
     struct DriverBase driverbase;
     struct DosLibrary *dosbase;
-    ULONG periiobase;
+    IPTR periiobase;
 
     struct RPiHDMISoc *soc[2]; /* Pointers to underlaying SOC implementation */
     UBYTE num_outputs;
@@ -42,7 +42,7 @@ struct RPiHDMIData {
     struct RPiHDMIBase *ahisubbase;
 
     /* Hardware state */
-    ULONG periiobase;
+    IPTR periiobase;
     LONG dma_channel;     /* Allocated from dma.resource, -1 = none */
     ULONG dma_dreq;
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/Makefile.in
@@ -9,6 +9,6 @@ srcdir		= @srcdir@
 DRIVER		= rpihdmi.audio
 MODEFILE	= RPIHDMI
 
-OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o rpihdmi-iec958.o rpihdmi-dma.o rpihdmi-bcm283x.o rpihdmi-bcm2711.o
+OBJECTS		= rpihdmi-init.o rpihdmi-main.o rpihdmi-playslave.o rpihdmi-accel.o rpihdmi-hwaccess.o rpihdmi-iec958.o rpihdmi-dma.o rpihdmi-bcm283x.o rpihdmi-bcm2711.o rpihdmi-bcm2712.o
 
 include ../Common/Makefile.common

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2712.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-bcm2712.c
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    BCM2712 (VC6) HDMI audio register map for Raspberry Pi 5.
+*/
+
+#include "DriverData.h"
+#include "rpihdmi-soc.h"
+#include "rpihdmi-hwaccess.h"
+
+struct RPiHDMISoc rpihdmi_bcm2712_hdmi0_soc = {
+    .dma_dreq = 10,
+    .hsm_clock = 108000000,
+
+    .regs = {
+        /* HD block, HDMI0 set */
+        .mai_ctl            = 0x010,
+        .mai_thr            = 0x014,
+        .mai_fmt            = 0x018,
+        .mai_data           = 0x01C,
+        .mai_smp            = 0x020,
+
+        /* HDMI block */
+        .mai_channel_map    = 0x09C,
+        .mai_config         = 0x0A0,
+        .audio_packet_cfg   = 0x0B8,
+        .ram_packet_cfg     = 0x0BC,
+        .ram_packet_status  = 0x0C4,
+        .crp_cfg            = 0x0C8,
+        .cts_0              = 0x0CC,
+        .cts_1              = 0x0D0,
+        .scheduler_control  = 0x0E0,
+
+        /* Packet block */
+        .packet_start       = 0x000,
+    },
+
+    .mai_dreq_threshold   = 0x1C,
+    .mai_panic_threshold  = 0x10,
+    .hdmi_mai_channel_map = 0x10,
+    .name = "HDMI 0",
+
+    .init         = hdmi_mai_init,
+    .stop         = hdmi_mai_stop
+};
+
+struct RPiHDMISoc rpihdmi_bcm2712_hdmi1_soc = {
+    .dma_dreq = 17,
+    .hsm_clock = 108000000,
+
+    .regs = {
+        /* HD block, HDMI1 set */
+        .mai_ctl            = 0x030,
+        .mai_thr            = 0x034,
+        .mai_fmt            = 0x038,
+        .mai_data           = 0x03C,
+        .mai_smp            = 0x040,
+
+        /* HDMI block */
+        .mai_channel_map    = 0x09C,
+        .mai_config         = 0x0A0,
+        .audio_packet_cfg   = 0x0B8,
+        .ram_packet_cfg     = 0x0BC,
+        .ram_packet_status  = 0x0C4,
+        .crp_cfg            = 0x0C8,
+        .cts_0              = 0x0CC,
+        .cts_1              = 0x0D0,
+        .scheduler_control  = 0x0E0,
+
+        /* Packet block */
+        .packet_start       = 0x000,
+    },
+
+    .mai_dreq_threshold  = 0x1C,
+    .mai_panic_threshold = 0x10,
+    .hdmi_mai_channel_map = 0x10,
+    .name = "HDMI 1",
+
+    .init         = hdmi_mai_init,
+    .stop         = hdmi_mai_stop
+};

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-dma.c
@@ -11,9 +11,9 @@
 /*
  * Microsecond delay using a busy loop on the system timer.
  */
-static void udelay(ULONG peribase, ULONG us)
+static void udelay(IPTR peribase, ULONG us)
 {
-    volatile ULONG *clo = (volatile ULONG *) (ULONG) (peribase + 0x003004);
+    volatile ULONG *clo = (volatile ULONG *) (peribase + 0x003004);
     ULONG start = AROS_LE2LONG(*clo);
 
     while ((AROS_LE2LONG(*clo) - start) < us)
@@ -50,10 +50,10 @@ void dma_setup(struct RPiHDMIData *dd)
 {
     struct DriverBase *AHIsubBase =
         (struct DriverBase *) dd->ahisubbase;
-    ULONG peribase = dd->periiobase;
+    IPTR peribase = dd->periiobase;
     ULONG channel = dd->dma_channel;
     ULONG cb_bus_addr = GPU_BUS_ADDR(dd->cb[0]);
-    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
+    IPTR dma_base = peribase + 0x007000 + channel * 0x100;
     /* The channel is already enabled by dma.resource at allocation. */
     wr32le(dma_base + 0x00, DMA_CS_RESET);
     udelay(peribase, 10);
@@ -72,9 +72,9 @@ void dma_setup(struct RPiHDMIData *dd)
 
 void dma_stop(struct RPiHDMIData *dd)
 {
-    ULONG peribase = dd->periiobase;
+    IPTR peribase = dd->periiobase;
     ULONG channel = dd->dma_channel;
-    ULONG dma_base = peribase + 0x007000 + channel * 0x100;
+    IPTR dma_base = peribase + 0x007000 + channel * 0x100;
 
     wr32le(dma_base + 0x00, 0);
     udelay(peribase, 50);
@@ -97,7 +97,7 @@ void dma_stop(struct RPiHDMIData *dd)
 void dma_irq_handler(struct RPiHDMIData *data, void *data2)
 {
     struct ExecBase *SysBase = (struct ExecBase *) data2;
-    ULONG dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
+    IPTR dma_base = data->periiobase + 0x007000 + data->dma_channel * 0x100;
     ULONG cs = rd32le(dma_base + 0x00);
 
     if (cs & DMA_CS_INT) {

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-hwaccess.c
@@ -31,9 +31,9 @@
 /*
  * Microsecond delay using a busy loop on the system timer.
  */
-static void udelay(ULONG peribase, ULONG us)
+static void udelay(IPTR peribase, ULONG us)
 {
-    volatile ULONG *clo = (volatile ULONG *) (ULONG) (peribase + 0x003004);
+    volatile ULONG *clo = (volatile ULONG *) (peribase + 0x003004);
     ULONG start = AROS_LE2LONG(*clo);
 
     while ((AROS_LE2LONG(*clo) - start) < us)

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-init.c
@@ -94,6 +94,8 @@ static LONG find_element_index(struct DriverBase *AHIsubBase, void *node, char *
 }
 
 static BOOL fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *soc, void *node, char *compatible) {
+    struct RPiHDMIBase *RPiHDMIBase = (struct RPiHDMIBase *) AHIsubBase;
+    ULONG bus_peribase = (RPiHDMIBase->periiobase == BCM2712_PERIIOBASE) ? BCM2712_BUS_PERIIOBASE : BCM2711_BUS_PERIIOBASE;
     LONG hdmi_index =
         find_element_index(AHIsubBase, node, "reg-names", "hdmi");
     LONG hd_index =
@@ -118,9 +120,9 @@ static BOOL fill_reg_values(struct DriverBase *AHIsubBase, struct RPiHDMISoc *so
         return FALSE;
     }
 
-    soc->hdmi_base = hdmi_base - BCM2711_BUS_PERIIOBASE;
-    soc->mai_base = mai_base - BCM2711_BUS_PERIIOBASE;
-    soc->packet_base = packet_base - BCM2711_BUS_PERIIOBASE;
+    soc->hdmi_base = hdmi_base - bus_peribase;
+    soc->mai_base = mai_base - bus_peribase;
+    soc->packet_base = packet_base - bus_peribase;
 
     D(bug("[RPiHDMI] hdmi_base=%08x mai_base=%08x packet_base=%08x\n",
         (ULONG)soc->hdmi_base,
@@ -199,7 +201,31 @@ BOOL DriverInit(struct DriverBase *AHIsubBase)
         return FALSE;
     }
 
-    if (RPiHDMIBase->periiobase == BCM2711_PERIIOBASE)
+    if (RPiHDMIBase->periiobase == BCM2712_PERIIOBASE)
+    {
+        OpenFirmwareBase = OpenResource("openfirmware.resource");
+
+        if (OpenFirmwareBase == NULL) {
+            Req("Unable to open 'openfirmware.resource'.\n");
+            return FALSE;
+        }
+
+        UWORD num = 0;
+
+        if (travers_device_tree_and_fill_soc(AHIsubBase, &rpihdmi_bcm2712_hdmi0_soc, "brcm,bcm2712-hdmi0"))
+            RPiHDMIBase->soc[num++] = &rpihdmi_bcm2712_hdmi0_soc;
+
+        if (travers_device_tree_and_fill_soc(AHIsubBase, &rpihdmi_bcm2712_hdmi1_soc, "brcm,bcm2712-hdmi1"))
+            RPiHDMIBase->soc[num++] = &rpihdmi_bcm2712_hdmi1_soc;
+
+        RPiHDMIBase->num_outputs = num;
+
+        if (num == 0) {
+            Req("Unsupported Raspberry Pi HDMI audio hardware.\n");
+            return FALSE;
+        }
+    }
+    else if (RPiHDMIBase->periiobase == BCM2711_PERIIOBASE)
     {
         OpenFirmwareBase = OpenResource("openfirmware.resource");
 

--- a/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
+++ b/workbench/devs/AHI/Drivers/RPiHDMI/rpihdmi-soc.h
@@ -50,7 +50,10 @@ struct RPiHDMISoc {
 extern const struct RPiHDMISoc rpihdmi_bcm283x_soc;
 extern struct RPiHDMISoc rpihdmi_bcm2711_hdmi0_soc;
 extern struct RPiHDMISoc rpihdmi_bcm2711_hdmi1_soc;
+extern struct RPiHDMISoc rpihdmi_bcm2712_hdmi0_soc;
+extern struct RPiHDMISoc rpihdmi_bcm2712_hdmi1_soc;
 
 #define BCM2711_BUS_PERIIOBASE 0x7E000000UL
+#define BCM2712_BUS_PERIIOBASE 0x7C000000UL
 
 #endif


### PR DESCRIPTION
Extend the RPiHDMI AHI sub-driver to support the BCM2712 (VC6) HDMI audio controllers on the Raspberry Pi 5.

- Add rpihdmi-bcm2712.c with register maps for HDMI0 and HDMI1
- Detect BCM2712 peripheral base (0x107C000000) and query OpenFirmware device tree nodes 'brcm,bcm2712-hdmi0' and 'brcm,bcm2712-hdmi1'
- Calculate dynamic bus offsets for VC6 register and packet blocks