### PR TITLE
CD32: quiet CD boot, cd.device audio fixes, and the lowlevel requester gate

### DIFF
--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -386,9 +386,26 @@ static LONG CD32_Cmd(struct CD32Unit *cu, UBYTE *cmd, LONG cmd_len, UBYTE *resp,
             break;
 
         default:
-            D(bug("%s: Command mismatch: got 0x%02x, expected 0x%02x\n", __func__, cu->cu_Misc->Response[RxHead], cmd[0]));
-            err = CDERR_InvalidState;
-            goto out;
+            /* The drive volunteers play status with the MULTI command
+             * nibble and a zero sequence nibble: byte 1 carries the
+             * CHERR_PLAYING state (play started / play finished).
+             */
+            if (cu->cu_Misc->Response[RxHead] == CHCD_MULTI) {
+                if (cu->cu_Misc->Response[(UBYTE)(RxHead + 1)] & CHERR_PLAYING)
+                    cu->cu_CDInfo.Status |= CDSTSF_PLAYING;
+                else
+                    cu->cu_CDInfo.Status &= ~(CDSTSF_PLAYING | CDSTSF_PAUSED);
+                break;
+            }
+            /* Anything else that passed the checksum is drive chatter
+             * this driver does not know; skip it and keep waiting.
+             * Aborting the in-flight command here desynchronises the
+             * whole exchange one packet late, permanently - every
+             * later command then errors on its predecessor's reply.
+             */
+            D(bug("%s: skipping unexpected packet 0x%02x\n", __func__,
+                  cu->cu_Misc->Response[RxHead]));
+            break;
         }
 
         /* Re-open the receive window and re-enable RXDMA for the next

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -839,8 +839,8 @@ static LONG CD32_DoIO(struct IOStdReq *io, APTR priv)
             cmd[3] = cu->cu_CDTOC[io->io_Offset].Entry.Position.MSF.Frame;
             if (last > cu->cu_CDTOC[0].Summary.LastTrack) {
                 cmd[4] = cu->cu_CDTOC[0].Summary.LeadOut.MSF.Minute;
-                cmd[5] = cu->cu_CDTOC[0].Summary.LeadOut.MSF.Minute;
-                cmd[6] = cu->cu_CDTOC[0].Summary.LeadOut.MSF.Minute;
+                cmd[5] = cu->cu_CDTOC[0].Summary.LeadOut.MSF.Second;
+                cmd[6] = cu->cu_CDTOC[0].Summary.LeadOut.MSF.Frame;
             } else {
                 cmd[4] = cu->cu_CDTOC[last].Entry.Position.MSF.Minute;
                 cmd[5] = cu->cu_CDTOC[last].Entry.Position.MSF.Second;
@@ -889,10 +889,13 @@ static LONG CD32_DoIO(struct IOStdReq *io, APTR priv)
         CD32_Status(cu);
         break;
     case CD_ATTENUATE:
-        io->io_Actual = cu->cu_Muted ? 0 : 0x7fff;
-        if (io->io_Offset > 0 && io->io_Offset < 0x7fff) {
+        /* AudioPrecision is 1 (mute only): 0 mutes, anything above
+         * unmutes, -1 queries. io_Actual returns the resulting volume.
+         * The fade duration in io_Length collapses to a step.
+         */
+        if ((LONG)io->io_Offset >= 0)
             CD32_Mute(cu, io->io_Offset == 0);
-        }
+        io->io_Actual = cu->cu_Muted ? 0 : 0x7fff;
         err = 0;
         break;
     default:

--- a/arch/m68k-amiga/lowlevel/readjoyport.c
+++ b/arch/m68k-amiga/lowlevel/readjoyport.c
@@ -53,7 +53,7 @@ static inline ULONG llPollGameCtrl(int port)
     /* Set Pin 5 as output, shift mode */
     pot = custom->potinp;
     pot &= ~((port == 0) ? (3 << 8) : (3 << 12));
-    custom->potgo = pot | (port == 0) ? (2 << 8) : (2 << 12);
+    custom->potgo = pot | ((port == 0) ? (2 << 8) : (2 << 12));
     cia->ciapra  &= ~cmask;
     /*
      * Clocking the buttons out means driving pin 5, so the line has to

--- a/rom/dos/boot.c
+++ b/rom/dos/boot.c
@@ -138,8 +138,16 @@ void __dos_Boot(struct DosLibrary *DOSBase, ULONG BootFlags, UBYTE Flags)
         cis = Open("ECON:", MODE_OLDFILE);
     }
 
-    if (cis == BNULL)
-        cis = Open("CON:////AROS/AUTO/CLOSE/SMART/BOOT", MODE_OLDFILE);
+    if (cis == BNULL) {
+        if (BootFlags & BF_NO_BOOT_REQUESTERS) {
+            /* Appliance boot (CD): no boot console window either - the
+             * CD32 Kickstart never opens one, and the console's window
+             * is what would drag in a Workbench screen.
+             */
+            cis = Open("NIL:", MODE_OLDFILE);
+        } else
+            cis = Open("CON:////AROS/AUTO/CLOSE/SMART/BOOT", MODE_OLDFILE);
+    }
 
     if (cis) {
         BPTR cos = OpenFromLock(DupLockFromFH(cis));
@@ -167,6 +175,9 @@ void __dos_Boot(struct DosLibrary *DOSBase, ULONG BootFlags, UBYTE Flags)
 
             if (SystemTags(NULL,
                            NP_Name, "Initial CLI",
+                           NP_WindowPtr,
+                               (BootFlags & BF_NO_BOOT_REQUESTERS)
+                                   ? (IPTR)-1 : (IPTR)0,
                            SYS_Background, FALSE,
                            SYS_Asynch, FALSE,
                            SYS_Input, cis,

--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -718,7 +718,7 @@ static LONG internalBootCliHandler(void)
      * execute with this pr_WindowPtr, and on a CD boot it must stay -1
      * for the whole run, like the CD32 Kickstart behaves.
      */
-    if (!(IntExpBase(ExpansionBase)->BootFlags & BF_NO_BOOT_REQUESTERS))
+    if (!(BootFlags & BF_NO_BOOT_REQUESTERS))
         bootProc->pr_WindowPtr = bootWin;
 
     /* Init all the RTF_AFTERDOS code, since we now have SYS:, the dos devices, and all the other assigns */

--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "dos_intern.h"
+#include "../dosboot/bootflags.h"
 #include "../expansion/expansion_intern.h"
 
 #ifdef DEBUG_DOSTYPE
@@ -657,6 +658,41 @@ static LONG internalBootCliHandler(void)
      */
     D(bug("Dos/CliInit: Assigns done, mount remaining handlers...\n"));
 
+    /* A CD-booted system runs its startup like an appliance: the CD32
+     * Kickstart suppresses DOS requesters for the entire boot (there may
+     * be no pointing device to answer one), and titles rely on it - for
+     * example probing for their harddisk-install volume by name and
+     * expecting the lookup to fail silently on CD. Mirror that when the
+     * boot device is cd.device: the boot shell (and thus everything the
+     * Startup-Sequence runs in it) gets pr_WindowPtr = -1.
+     */
+    ObtainSemaphore(&IntExpBase(ExpansionBase)->BootSemaphore);
+    bn = (struct BootNode *)GetHead(&ExpansionBase->MountList);
+    if (bn != NULL && bn->bn_DeviceNode != NULL)
+    {
+        struct DeviceNode *bootdn = bn->bn_DeviceNode;
+        struct FileSysStartupMsg *fssm = BADDR(bootdn->dn_Startup);
+
+        /* dn_Startup may hold a small integer instead of a BPTR for some
+         * handlers; require a plausible pointer before dereferencing.
+         * The device name is a BSTR and need not be NUL-terminated, so
+         * compare by length.
+         */
+        if ((IPTR)fssm > 0x1000 && fssm->fssm_Device != BNULL)
+        {
+            CONST_STRPTR dev = AROS_BSTR_ADDR(fssm->fssm_Device);
+            int devlen = AROS_BSTR_strlen(fssm->fssm_Device);
+            D(bug("CliInit: boot device '%s' len %d\n", dev, devlen));
+            if (devlen >= 9 && memcmp(dev, "cd.device", 9) == 0 &&
+                (devlen == 9 || dev[9] == '\0'))
+            {
+                D(bug("CliInit: appliance boot (requesters off)\n"));
+                IntExpBase(ExpansionBase)->BootFlags |= BF_NO_BOOT_REQUESTERS;
+            }
+        }
+    }
+    ReleaseSemaphore(&IntExpBase(ExpansionBase)->BootSemaphore);
+
     BootFlags = IntExpBase(ExpansionBase)->BootFlags;
     Flags = ExpansionBase->Flags;
     D(bug("Dos/CliInit: BootFlags 0x%lx Flags 0x%x\n", BootFlags, Flags));
@@ -676,8 +712,14 @@ static LONG internalBootCliHandler(void)
 
     CloseLibrary((APTR)ExpansionBase);
 
-    /* Enable prompts to insert missing volumes again .. */
-    bootProc->pr_WindowPtr = bootWin;
+    /* Enable prompts to insert missing volumes again - unless this is an
+     * appliance boot: __dos_Boot runs the Initial CLI synchronously in
+     * THIS process, so the Startup-Sequence and whatever it starts
+     * execute with this pr_WindowPtr, and on a CD boot it must stay -1
+     * for the whole run, like the CD32 Kickstart behaves.
+     */
+    if (!(IntExpBase(ExpansionBase)->BootFlags & BF_NO_BOOT_REQUESTERS))
+        bootProc->pr_WindowPtr = bootWin;
 
     /* Init all the RTF_AFTERDOS code, since we now have SYS:, the dos devices, and all the other assigns */
     D(bug("Dos/CliInit: Calling InitCode(RTF_AFTERDOS, 0)\n"));

--- a/rom/dosboot/bootflags.h
+++ b/rom/dosboot/bootflags.h
@@ -14,5 +14,7 @@
 #define BF_NO_DISPLAY_DRIVERS  0x0002
 #define BF_NO_COMPOSITION      0x0004
 #define BF_EMERGENCY_CONSOLE   0x0008    /* Use emergency console */
+#define BF_NO_BOOT_REQUESTERS  0x0010    /* Boot shell runs with DOS requesters
+                                            suppressed (pr_WindowPtr = -1) */
 
 #endif /* DOSBOOT_BOOTFLAGS_H */

--- a/workbench/libs/lowlevel/lowlevel.conf
+++ b/workbench/libs/lowlevel/lowlevel.conf
@@ -29,8 +29,8 @@ void StartTimerInt(APTR intHandle, ULONG timeInterval, BOOL continuous) (A1, D0,
 ULONG ElapsedTime(struct EClockVal *context) (A0)
 APTR AddVBlankInt(APTR intRoutine, APTR intData) (A0, A1)
 void RemVBlankInt(APTR intHandle) (A1)
-.skip 1
-.skip 1
+void DisableSystemRequesters() ()
+void EnableSystemRequesters() ()
 .version 41 # Actually 40.27, but, just to be on the safe side..
-BOOL SetJoyPortAttrsA(ULONG portNumber, struct TagItem *taglist) (D0,A1) 
+BOOL SetJoyPortAttrsA(ULONG portNumber, struct TagItem *taglist) (D0,A1)
 ##end functionlist

--- a/workbench/libs/lowlevel/lowlevel_init.c
+++ b/workbench/libs/lowlevel/lowlevel_init.c
@@ -230,6 +230,7 @@ static int Init(LIBBASETYPEPTR LowLevelBase)
 
     NEWLIST(&LowLevelBase->ll_KBInterrupts);
     LowLevelBase->ll_LastKey = 0xFF;
+    LowLevelBase->ll_SysReqNest = -1;
 
     if ((LowLevelBase->ll_UtilityBase = OpenLibrary("utility.library", 0)))
     {

--- a/workbench/libs/lowlevel/lowlevel_init.c
+++ b/workbench/libs/lowlevel/lowlevel_init.c
@@ -259,10 +259,12 @@ static int Init(LIBBASETYPEPTR LowLevelBase)
 static int Expunge(LIBBASETYPEPTR LowLevelBase)
 {
     D(bug("[lowlevel] %s()\n", __func__);)
+    llSysReq_Cleanup(LowLevelBase);
     LowLevelTimerClose(LowLevelBase);
     LowLevelInputClose(LowLevelBase);
     if (LowLevelBase->ll_UtilityBase)
         CloseLibrary(LowLevelBase->ll_UtilityBase);
+    return TRUE;
 }
 
 ADD2INITLIB(Init, 0);

--- a/workbench/libs/lowlevel/lowlevel_intern.h
+++ b/workbench/libs/lowlevel/lowlevel_intern.h
@@ -71,6 +71,10 @@ struct LowLevelBase
     struct llArchData           ll_Arch;
 };
 
+/* systemrequesters.c: restore the EasyRequestArgs() vector and close
+ * intuition on expunge. */
+VOID llSysReq_Cleanup(struct LowLevelBase *LowLevelBase);
+
 /*
  * Defintion of internal structures.
  */

--- a/workbench/libs/lowlevel/lowlevel_intern.h
+++ b/workbench/libs/lowlevel/lowlevel_intern.h
@@ -61,6 +61,13 @@ struct LowLevelBase
     struct MsgPort          	*ll_TimerMP;
     struct IOStdReq         	*ll_TimerIO;
 
+    /* System requester gate (private LVOs -120/-126, see
+     * systemrequesters.c). ll_SysReqNest is -1 when requesters are
+     * allowed; each DisableSystemRequesters() raises it. */
+    struct Library              *ll_IntuitionBase;
+    APTR                        ll_EasyRequestOrig;
+    LONG                        ll_SysReqNest;
+
     struct llArchData           ll_Arch;
 };
 

--- a/workbench/libs/lowlevel/mmakefile.src
+++ b/workbench/libs/lowlevel/mmakefile.src
@@ -21,7 +21,8 @@ FUNCS	:= \
 	setjoyportattrsa \
 	starttimerint \
 	stoptimerint \
-	systemcontrola
+	systemcontrola \
+	systemrequesters
 
 #MM workbench-libs-lowlevel-includes : \
 #MM     kernel-exec-includes \

--- a/workbench/libs/lowlevel/systemrequesters.c
+++ b/workbench/libs/lowlevel/systemrequesters.c
@@ -1,0 +1,171 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: System requester gate - private LVOs -120/-126
+*/
+#include "lowlevel_intern.h"
+
+#include <aros/libcall.h>
+#include <exec/types.h>
+#include <exec/libraries.h>
+#include <libraries/lowlevel.h>
+#include <intuition/intuition.h>
+#include <proto/exec.h>
+
+/* EasyRequestArgs() is vector 98 in intuition.library */
+#define EASYREQUESTARGS_SLOT 98
+#define EASYREQUESTARGS_LVO  (-(EASYREQUESTARGS_SLOT) * LIB_VECTSIZE)
+
+/* Replacement for intuition.library/EasyRequestArgs(), installed with
+ * SetFunction() the first time requesters are disabled. While the disable
+ * count is held it answers every requester immediately with 0 (the
+ * rightmost gadget, normally "Cancel"), without any display; otherwise it
+ * passes through to the original vector.
+ *
+ * The gate runs with A6 = IntuitionBase, and ROM modules cannot carry
+ * writable globals, so the library base is looked up per call. Requesters
+ * are rare enough that the lookup cost does not matter.
+ */
+AROS_LH4(LONG, llEasyRequestGate,
+      AROS_LHA(struct Window *, window, A0),
+      AROS_LHA(struct EasyStruct *, easyStruct, A1),
+      AROS_LHA(ULONG *, idcmpPtr, A2),
+      AROS_LHA(APTR, args, A3),
+      struct IntuitionBase *, IntuitionBase, EASYREQUESTARGS_SLOT, LowLevel)
+{
+    AROS_LIBFUNC_INIT
+
+    struct LowLevelBase *LowLevelBase;
+
+    Forbid();
+    LowLevelBase = (struct LowLevelBase *)FindName(&SysBase->LibList,
+                                                   "lowlevel.library");
+    Permit();
+
+    if (LowLevelBase == NULL || LowLevelBase->ll_SysReqNest >= 0 ||
+        LowLevelBase->ll_EasyRequestOrig == NULL)
+        return 0;
+
+    return AROS_CALL4(LONG, LowLevelBase->ll_EasyRequestOrig,
+        AROS_LCA(struct Window *, window, A0),
+        AROS_LCA(struct EasyStruct *, easyStruct, A1),
+        AROS_LCA(ULONG *, idcmpPtr, A2),
+        AROS_LCA(APTR, args, A3),
+        struct IntuitionBase *, IntuitionBase);
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+
+      AROS_LH0(VOID, DisableSystemRequesters,
+
+/*  SYNOPSIS */
+
+/*  LOCATION */
+      struct LowLevelBase *, LowLevelBase, 20, LowLevel)
+
+/*  FUNCTION
+
+    Stop intuition system requesters from being displayed. While disabled,
+    any EasyRequestArgs() call returns 0 immediately (as if the rightmost
+    gadget, normally "Cancel", had been selected) instead of opening a
+    requester and waiting for input. Calls nest; each one must be balanced
+    by EnableSystemRequesters().
+
+    This is the private vector at LVO -120 of the Kickstart 40 (CD32)
+    lowlevel.library, which patches EasyRequestArgs() the same way. CD32
+    titles call it during startup so that error requesters cannot block a
+    pad-only machine, so it must exist and be callable here.
+
+    INPUTS
+
+    RESULT
+
+    BUGS
+
+    SEE ALSO
+
+    EnableSystemRequesters()
+
+    INTERNALS
+
+    The first call opens intuition.library and diverts the
+    EasyRequestArgs() vector through a gate with SetFunction(); the gate
+    stays installed for the library's lifetime and later calls only flip
+    the nest count it tests.
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&LowLevelBase->ll_Lock);
+
+    if (LowLevelBase->ll_SysReqNest++ == -1 &&
+        LowLevelBase->ll_EasyRequestOrig == NULL)
+    {
+        if (LowLevelBase->ll_IntuitionBase == NULL)
+            LowLevelBase->ll_IntuitionBase = OpenLibrary("intuition.library", 0);
+
+        if (LowLevelBase->ll_IntuitionBase != NULL)
+        {
+            LowLevelBase->ll_EasyRequestOrig =
+                SetFunction(LowLevelBase->ll_IntuitionBase,
+                            EASYREQUESTARGS_LVO,
+                            (APTR)AROS_SLIB_ENTRY(llEasyRequestGate,
+                                                  LowLevel,
+                                                  EASYREQUESTARGS_SLOT));
+        }
+    }
+
+    ReleaseSemaphore(&LowLevelBase->ll_Lock);
+
+    AROS_LIBFUNC_EXIT
+} /* DisableSystemRequesters */
+
+/*****************************************************************************
+
+    NAME */
+
+      AROS_LH0(VOID, EnableSystemRequesters,
+
+/*  SYNOPSIS */
+
+/*  LOCATION */
+      struct LowLevelBase *, LowLevelBase, 21, LowLevel)
+
+/*  FUNCTION
+
+    Balance one DisableSystemRequesters() call. When the outermost disable
+    is released, EasyRequestArgs() behaves normally again.
+
+    This is the private vector at LVO -126 of the Kickstart 40 (CD32)
+    lowlevel.library.
+
+    INPUTS
+
+    RESULT
+
+    BUGS
+
+    SEE ALSO
+
+    DisableSystemRequesters()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&LowLevelBase->ll_Lock);
+
+    if (LowLevelBase->ll_SysReqNest >= 0)
+        LowLevelBase->ll_SysReqNest--;
+
+    ReleaseSemaphore(&LowLevelBase->ll_Lock);
+
+    AROS_LIBFUNC_EXIT
+} /* EnableSystemRequesters */

--- a/workbench/libs/lowlevel/systemrequesters.c
+++ b/workbench/libs/lowlevel/systemrequesters.c
@@ -56,6 +56,26 @@ AROS_LH4(LONG, llEasyRequestGate,
     AROS_LIBFUNC_EXIT
 }
 
+/* Expunge-time cleanup: put intuition's vector back and drop our
+ * reference. If something else SetFunction()ed EasyRequestArgs() after
+ * us this un-hooks it too, but leaving the vector pointing into an
+ * expunged library would be worse.
+ */
+VOID llSysReq_Cleanup(struct LowLevelBase *LowLevelBase)
+{
+    if (LowLevelBase->ll_EasyRequestOrig != NULL)
+    {
+        SetFunction(LowLevelBase->ll_IntuitionBase, EASYREQUESTARGS_LVO,
+                    LowLevelBase->ll_EasyRequestOrig);
+        LowLevelBase->ll_EasyRequestOrig = NULL;
+    }
+    if (LowLevelBase->ll_IntuitionBase != NULL)
+    {
+        CloseLibrary(LowLevelBase->ll_IntuitionBase);
+        LowLevelBase->ll_IntuitionBase = NULL;
+    }
+}
+
 /*****************************************************************************
 
     NAME */
@@ -92,10 +112,11 @@ AROS_LH4(LONG, llEasyRequestGate,
 
     INTERNALS
 
-    The first call opens intuition.library and diverts the
-    EasyRequestArgs() vector through a gate with SetFunction(); the gate
-    stays installed for the library's lifetime and later calls only flip
-    the nest count it tests.
+    The first successful call opens intuition.library and diverts the
+    EasyRequestArgs() vector through a gate with SetFunction(); a failed
+    installation is retried on the next call. Once in, the gate stays
+    for the library's lifetime (expunge restores the vector) and further
+    calls only move the nest count it tests.
 
 *****************************************************************************/
 {
@@ -103,8 +124,13 @@ AROS_LH4(LONG, llEasyRequestGate,
 
     ObtainSemaphore(&LowLevelBase->ll_Lock);
 
-    if (LowLevelBase->ll_SysReqNest++ == -1 &&
-        LowLevelBase->ll_EasyRequestOrig == NULL)
+    LowLevelBase->ll_SysReqNest++;
+
+    /* Keep trying until the gate is in: a failed first attempt (say,
+     * intuition was not openable yet) must not block the feature for
+     * the rest of the session while the nest count is already raised.
+     */
+    if (LowLevelBase->ll_EasyRequestOrig == NULL)
     {
         if (LowLevelBase->ll_IntuitionBase == NULL)
             LowLevelBase->ll_IntuitionBase = OpenLibrary("intuition.library", 0);


### PR DESCRIPTION
This continues the CD32 work from #1018 with the fixes needed to take two commercial CD32 titles (Pinball Fantasies and Pinball Illusions) from "boots" to "playable", plus two small bugs found along the way.

**dos: appliance-quiet CD boot.** When the boot device is `cd.device`, keep the boot process's `pr_WindowPtr` at -1 through `__dos_Boot` and give the initial CLI `NIL:` instead of a console window. A CD32 has no mouse or keyboard to answer a requester with, and Kickstart boots CDs appliance-quiet the same way. (Pinball Illusions probes its HD-install volume `PIN3001:` at startup; on AROS that raised a "Please insert volume" requester that Kickstart never shows.)

**m68k-amiga/cd: unsolicited drive status must not abort the exchange.** The CR-563 volunteers a status packet when audio play starts and again when it finishes. `CD32_Cmd` treated any packet that did not echo the in-flight command as a failed exchange, which leaves the reply in the ring and desynchronises every later command by one packet, permanently. Pinball Fantasies starts a music track when a table is picked and the table read that follows fails: it drops back to the shell. Recognise the play status packet, skip any other checksummed chatter.

**m68k-amiga/cd: CD_PLAYTRACK / CD_ATTENUATE.** The play-to-lead-out branch filled all three MSF bytes of the end position with the lead-out minute, and CD_ATTENUATE only acted for offsets strictly between 0 and 0x7fff - ignoring exactly the two values that matter on a mute-only drive.

**m68k-amiga/lowlevel: ReadJoyPort probe precedence.** `pot | (port == 0) ? a : b` parses as `(pot | (port == 0)) ? a : b`, so probing a controller on either port always drove port 0's POTGO output bits.

**lowlevel: the private requester-gate vectors.** The V40 CD32 lowlevel.library has two undocumented private vectors at -120/-126 that the NDK FD skips over, and `lowlevel.conf` skipped them too, leaving genmodule's poison vectors there. CD32 titles call -120 during startup without checking anything; Pinball Illusions jumps into the poison from its support library's `lib_Open` and dies on its loading screen, leaving a suspend requester a pad-only machine cannot answer. I disassembled the 40.34 ROM to recover what they actually do: they are a nested disable/enable pair for intuition system requesters, implemented as a SetFunction gate on `EasyRequestArgs()` that answers 0 (the rightmost gadget, normally Cancel) without any display while the disable count is held - i.e. how a CD32 title guarantees a disk error can never block the machine. This implements the same contract portably; the function names are mine, since Commodore never published any.

Verified on an emulated CD32 (2MB chip + 8MB fast, AROS ROMs only, no Kickstart): both titles cold-boot from CD to their tables and play. No-CD boot and Workbench boot are unchanged.
