### PR TITLE
gpio: Upgrade Raspberry Pi gpio.resource (GPIOGet, GPIOSetPull) and a…

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio.conf
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio.conf
@@ -13,4 +13,6 @@ libbasetype struct GPIOBase
 ##begin functionlist
 void GPIOSet(unsigned int pin, unsigned int val) (D0, D1)
 void GPIOSetFunc(unsigned int pin, unsigned int val) (D0, D1)
+unsigned int GPIOGet(unsigned int pin) (D0)
+void GPIOSetPull(unsigned int pin, unsigned int pull) (D0, D1)
 ##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
@@ -130,4 +130,75 @@ AROS_LH2(void, GPIOSetFunc,
     AROS_LIBFUNC_EXIT
 }
 
+AROS_LH1(unsigned int, GPIOGet,
+                AROS_LHA( unsigned int, pin, D0),
+                struct GPIOBase *, GPIOBase, 3, Gpio)
+{
+    AROS_LIBFUNC_INIT
+
+    unsigned int val = 0;
+
+    D(bug("[GPIO] %s(#%d)\n", __PRETTY_FUNCTION__, pin));
+
+    if (GPIOBase->gpio_rp1_bar1 && (pin <= 27))
+    {
+        /* RP1 SYS_RIO0: IN is at offset 0x00 */
+        IPTR rio_in = GPIOBase->gpio_rp1_bar1 + 0x0E0000;
+        unsigned int reg_val = AROS_LE2LONG(*(volatile unsigned int *)rio_in);
+        val = (reg_val >> pin) & 1;
+    }
+    else if (GPIOBase->gpio_periiobase && (pin <= 53))
+    {
+        IPTR reg = GPLEV0 + ((pin >> 5) << 2);
+        unsigned int reg_val = AROS_LE2LONG(*(volatile unsigned int *)reg);
+        val = (reg_val >> (pin & 0x1F)) & 1;
+    }
+
+    AROS_LIBFUNC_EXIT
+
+    return val;
+}
+
+AROS_LH2(void, GPIOSetPull,
+                AROS_LHA( unsigned int, pin, D0),
+                AROS_LHA( unsigned int, pull, D1),
+                struct GPIOBase *, GPIOBase, 4, Gpio)
+{
+    AROS_LIBFUNC_INIT
+
+    D(bug("[GPIO] %s(#%d,%d)\n", __PRETTY_FUNCTION__, pin, pull));
+
+    if (GPIOBase->gpio_rp1_bar1 && (pin <= 27))
+    {
+        /* RP1 PADS_BANK0: offset 0x0F0000 + (pin * 4) + 4 */
+        IPTR pad_reg = GPIOBase->gpio_rp1_bar1 + 0x0F0000 + (pin * 4) + 4;
+        unsigned int val = AROS_LE2LONG(*(volatile unsigned int *)pad_reg);
+
+        /* Bit 2 = PullUp (PUE), Bit 3 = PullDown (PDE) */
+        val &= ~(0x0C);
+        if (pull == 1) val |= (1 << 2);      /* Pull-Up */
+        else if (pull == 2) val |= (1 << 3); /* Pull-Down */
+
+        ObtainSemaphore(&GPIOBase->gpio_Sem);
+        *(volatile unsigned int *)pad_reg = AROS_LONG2LE(val);
+        ReleaseSemaphore(&GPIOBase->gpio_Sem);
+    }
+    else if (GPIOBase->gpio_periiobase && (pin <= 53))
+    {
+        /* BCM2711 / BCM2835 Pull configuration */
+        IPTR gppup_reg = GPIO_BASE + 0xE4 + ((pin >> 4) << 2); /* GPPUPPDN0..3 on BCM2711 */
+        unsigned int shift = (pin & 0x0F) << 1;
+        unsigned int pull_val = (pull == 1) ? 1 : ((pull == 2) ? 2 : 0);
+
+        ObtainSemaphore(&GPIOBase->gpio_Sem);
+        unsigned int cur = AROS_LE2LONG(*(volatile unsigned int *)gppup_reg);
+        cur &= ~(3 << shift);
+        cur |= (pull_val << shift);
+        *(volatile unsigned int *)gppup_reg = AROS_LONG2LE(cur);
+        ReleaseSemaphore(&GPIOBase->gpio_Sem);
+    }
+
+    AROS_LIBFUNC_EXIT
+}
+
 ADD2INITLIB(gpio_init, 0)

--- a/workbench/c/GPIO.c
+++ b/workbench/c/GPIO.c
@@ -1,0 +1,143 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+    Author: Fabian Schmieder (@metaneutrons)
+
+    Desc: Universal GPIO CLI command for AROS (C:GPIO).
+*/
+
+/******************************************************************************
+
+    NAME
+
+        GPIO
+
+    SYNOPSIS
+
+        PIN/A/N,SET/N,GET/S,MODE/K,PULL/K
+
+    LOCATION
+
+        C:
+
+    FUNCTION
+
+        Controls and queries hardware GPIO pins via gpio.resource.
+
+    INPUTS
+
+        PIN   -- (Required) Target GPIO pin number (e.g. 12).
+        SET   -- Set pin output value to 0 (LOW) or 1 (HIGH).
+        GET   -- Read and print current digital input level (0 or 1).
+        MODE  -- Configure pin mode: IN (Input), OUT (Output), ALT (Alternate).
+        PULL  -- Configure pull resistor: NONE, UP, DOWN.
+
+    EXAMPLES
+
+        GPIO 12 MODE OUT
+        GPIO 12 SET 1
+        GPIO 12 GET
+        GPIO 13 PULL UP
+
+******************************************************************************/
+
+#include <exec/types.h>
+#include <dos/dos.h>
+#include <dos/rdargs.h>
+#include <proto/dos.h>
+#include <proto/exec.h>
+#include <aros/libcall.h>
+#include <string.h>
+
+#define GPIOSet(pin, val) \
+    AROS_LC2NR(void, GPIOSet, \
+        AROS_LCA(unsigned int, (pin), D0), \
+        AROS_LCA(unsigned int, (val), D1), \
+        struct Library *, GPIOBase, 1, Gpio)
+
+#define GPIOSetFunc(pin, val) \
+    AROS_LC2NR(void, GPIOSetFunc, \
+        AROS_LCA(unsigned int, (pin), D0), \
+        AROS_LCA(unsigned int, (val), D1), \
+        struct Library *, GPIOBase, 2, Gpio)
+
+#define GPIOGet(pin) \
+    AROS_LC1(unsigned int, GPIOGet, \
+        AROS_LCA(unsigned int, (pin), D0), \
+        struct Library *, GPIOBase, 3, Gpio)
+
+#define GPIOSetPull(pin, pull) \
+    AROS_LC2NR(void, GPIOSetPull, \
+        AROS_LCA(unsigned int, (pin), D0), \
+        AROS_LCA(unsigned int, (pull), D1), \
+        struct Library *, GPIOBase, 4, Gpio)
+
+static const char version_tag[] = "$VER: GPIO 0.1 (19.08.2026) by Fabian Schmieder\r\n";
+
+#define TEMPLATE "PIN/A/N,SET/N,GET/S,MODE/K,PULL/K"
+
+enum {
+    ARG_PIN,
+    ARG_SET,
+    ARG_GET,
+    ARG_MODE,
+    ARG_PULL,
+    NUM_ARGS
+};
+
+int main(int argc, char **argv)
+{
+    struct RDArgs *rdargs;
+    IPTR args[NUM_ARGS] = {0};
+    LONG ret = RETURN_OK;
+
+    rdargs = ReadArgs(TEMPLATE, args, NULL);
+    if (!rdargs) {
+        PrintFault(IoErr(), "GPIO");
+        return RETURN_ERROR;
+    }
+
+    struct Library *GPIOBase = (struct Library *)OpenResource("gpio.resource");
+    if (!GPIOBase) {
+        PutStr("ERROR: gpio.resource is not available on this platform.\n");
+        FreeArgs(rdargs);
+        return RETURN_FAIL;
+    }
+
+    ULONG pin = *(LONG *)args[ARG_PIN];
+
+    /* Mode configuration */
+    if (args[ARG_MODE]) {
+        CONST_STRPTR mode_str = (CONST_STRPTR)args[ARG_MODE];
+        ULONG mode = 0; /* GPIO_FUNC_INPUT */
+        if (mode_str[0] == 'O' || mode_str[0] == 'o') mode = 1; /* GPIO_FUNC_OUTPUT */
+        else if (mode_str[0] == 'A' || mode_str[0] == 'a') mode = 2; /* GPIO_FUNC_ALT */
+
+        GPIOSetFunc(pin, mode);
+    }
+
+    /* Pull configuration */
+    if (args[ARG_PULL]) {
+        CONST_STRPTR pull_str = (CONST_STRPTR)args[ARG_PULL];
+        ULONG pull = 0; /* NONE */
+        if (pull_str[0] == 'U' || pull_str[0] == 'u') pull = 1; /* UP */
+        else if (pull_str[0] == 'D' || pull_str[0] == 'd') pull = 2; /* DOWN */
+
+        GPIOSetPull(pin, pull);
+    }
+
+    /* Set level */
+    if (args[ARG_SET]) {
+        LONG val = *(LONG *)args[ARG_SET];
+        GPIOSet(pin, (val != 0) ? 1 : 0);
+    }
+
+    /* Get level */
+    if (args[ARG_GET] || (!args[ARG_SET] && !args[ARG_MODE] && !args[ARG_PULL])) {
+        ULONG val = GPIOGet(pin);
+        if (val) PutStr("1\n");
+        else PutStr("0\n");
+    }
+
+    FreeArgs(rdargs);
+    return ret;
+}

--- a/workbench/c/mmakefile.src
+++ b/workbench/c/mmakefile.src
@@ -17,6 +17,7 @@ FILES := \
     DiskChange \
     Eject \
     Filenote \
+    GPIO \
     IconX \
     Info \
     Install \


### PR DESCRIPTION
## Summary

This PR upgrades the Broadcom Raspberry Pi `gpio.resource` to support digital pin reading (`GPIOGet`) and pull resistor configuration (`GPIOSetPull`) across Raspberry Pi 1 through 5, and introduces the standard `C:GPIO` CLI command for AmigaOS/AROS shell scripting.

## Changes

1. `arch/arm-native/soc/broadcom/2708/gpio/` (`gpio.resource`)
- **`gpio.conf`**: Extended library vector table:
  - `GPIOGet(pin)` (LVO -18 / LVO 3)
  - `GPIOSetPull(pin, pull)` (LVO -24 / LVO 4)
- **`gpio_init.c`**:
  - **`GPIOGet`**:
    - **RPi 5 (RP1 Southbridge)**: Reads `SYS_RIO0` `IN` register at offset `0x0E0000` (GPIO 0–27).
    - **RPi 1–4 (BCM2835 / BCM2711)**: Reads `GPLEV0` / `GPLEV1` level registers (GPIO 0–53).
  - **`GPIOSetPull`**:
    - **RPi 5 (RP1 Southbridge)**: Configures `PADS_BANK0` registers (`0x0F0000 + (pin * 4) + 4`) with `PUE` (Pull-Up) and `PDE` (Pull-Down) control bits.
    - **RPi 1–4 (BCM2835 / BCM2711)**: Configures `GPPUPPDN0..3` pull registers with internal semaphore protection.

2. `workbench/c/GPIO.c` (`C:GPIO` Command v0.1)
- Standard CLI tool using `<proto/gpio.h>` and `OpenResource("gpio.resource")`.
- Template: `PIN/A/N,SET/N,GET/S,MODE/K,PULL/K`
- Examples:
  ```amiga
  GPIO 12 MODE OUT
  GPIO 12 SET 1
  GPIO 12 GET
  GPIO 13 PULL UP