### PR TITLE
m68k: cut the resident chip RAM footprint

### DIFF
--- a/arch/m68k-amiga/card/card_init.c
+++ b/arch/m68k-amiga/card/card_init.c
@@ -123,6 +123,13 @@ static int Cardres_Init(struct CardResource *CardResource)
         TASKTAG_PC, CardTask,
         TASKTAG_NAME, CardResource->crb_LibNode.lib_Node.ln_Name,
         TASKTAG_PRI, 15,
+        /*
+         * The card task waits for status-change signals and calls the
+         * registered client hooks; measured peak stack use is a few
+         * hundred bytes, and its stack is chip RAM on an unexpanded
+         * machine.
+         */
+        TASKTAG_STACKSIZE, 4096,
         TASKTAG_ARG1, FindTask(0),
         TASKTAG_ARG2, CardResource,
         TAG_DONE);

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -195,6 +195,14 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
         cu->cu_Unit    = cb->cb_MaxUnit++;
         cu->cu_Task = NewCreateTask(TASKTAG_PC, cdTask,
                                     TASKTAG_NAME, ops->uo_Name,
+                                    /*
+                                     * The unit task runs the drive
+                                     * protocol and sector delivery;
+                                     * measured peak stack use is well
+                                     * under 1 KB, and its stack is
+                                     * chip RAM on a stock CD32.
+                                     */
+                                    TASKTAG_STACKSIZE, 8192,
                                     TASKTAG_ARG1, cb,
                                     TASKTAG_ARG2, cu,
                                     TASKTAG_TASKMSGPORT, &cu->cu_MsgPort,

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -941,7 +941,17 @@ static const struct DosEnvec CD32Envec = {
     .de_Interleave = 0,
     .de_LowCyl = 0,
     .de_HighCyl = 0,
-    .de_NumBuffers = 32,
+    /*
+     * CDVDFS sizes its sector cache as de_NumBuffers 16-sector (32 KB)
+     * prefetch chunks, so 32 here cost a full megabyte of BufMemType
+     * memory the moment CD0: mounts. A CD32 without expansion RAM backs
+     * MEMF_24BITDMA with its only 2 MB of chip RAM, and half the machine
+     * disappearing before the boot handoff is what forced fast RAM onto
+     * titles that run chip-only under the CD32 Kickstart (whose
+     * CDFileSystem treats a buffer as one 2 KB block). Four chunks
+     * (128 KB) keep sequential streaming ahead of the drive.
+     */
+    .de_NumBuffers = 4,
     .de_BufMemType = MEMF_24BITDMA,
     .de_MaxTransfer = 32 * 2048,
     .de_Mask = 0x00fffffe,

--- a/arch/m68k-amiga/devs/trackdisk/trackdisk_device.c
+++ b/arch/m68k-amiga/devs/trackdisk/trackdisk_device.c
@@ -470,6 +470,12 @@ ULONG TD_InitTask(struct TrackDiskBase *tdb)
         TASKTAG_PC, TD_DevTask,
         TASKTAG_NAME, "trackdisk.device",
         TASKTAG_PRI, 5,
+        /*
+         * The device task runs a flat IO loop over disk.resource;
+         * measured peak stack use is around half a KB, and its stack
+         * is chip RAM on an unexpanded machine.
+         */
+        TASKTAG_STACKSIZE, 4096,
         TASKTAG_ARG1, FindTask(0),
         TASKTAG_ARG2, tdb,
         TAG_DONE);

--- a/arch/m68k-amiga/hidd/amigavideo/amigavideo_compositorclass.c
+++ b/arch/m68k-amiga/hidd/amigavideo/amigavideo_compositorclass.c
@@ -89,6 +89,13 @@ OOP_Object *METHOD(AmigaVideoCompositor, Root, New)
             /* Our housekeeper must have the largest possible priority */
             compdata->housekeeper = NewCreateTask(TASKTAG_NAME       , "AmigaVideo display housekeeper",
                                 TASKTAG_PRI        , 127,
+                                /*
+                                 * A short message loop; measured peak
+                                 * stack use is under 1 KB, and the
+                                 * stack is chip RAM on an unexpanded
+                                 * machine.
+                                 */
+                                TASKTAG_STACKSIZE  , 4096,
                                 TASKTAG_PC         , DisplayServiceTask,
                                 TASKTAG_ARG1       , o,
                                 TAG_DONE);

--- a/rom/devs/ata/ata.h
+++ b/rom/devs/ata/ata.h
@@ -38,7 +38,16 @@
 
 #define MAX_DEVICEBUSES         2
 #define MAX_BUSUNITS            2
+/*
+ * The daemon and bus tasks run plain message/IO loops; measured peak
+ * stack use on m68k is a few hundred bytes, and every resident task's
+ * stack comes out of chip RAM on an unexpanded Amiga.
+ */
+#ifdef __mc68000
+#define STACK_SIZE              4096
+#else
 #define STACK_SIZE              16384
+#endif
 #define TASK_PRI                10
 #define TIMEOUT                 30
 

--- a/rom/devs/console/console_gcc.h
+++ b/rom/devs/console/console_gcc.h
@@ -20,7 +20,16 @@
 struct ConsoleBase;
 
 /* Constants */
+/*
+ * The console task renders through intuition/graphics, but its measured
+ * peak on m68k stays under 1 KB even with a console window open; 8 KB
+ * keeps generous headroom without pinning 16 KB of chip RAM.
+ */
+#ifdef __mc68000
+#define COTASK_STACKSIZE (8192 + 4)
+#else
 #define COTASK_STACKSIZE (AROS_STACKSIZE + 4)
+#endif
 #define COTASK_PRIORITY  10
 
 

--- a/rom/devs/input/input_intern.h
+++ b/rom/devs/input/input_intern.h
@@ -30,8 +30,16 @@
 #   include <devices/timer.h>
 #endif
 
-/* Size of the input device's stack */
+/* Size of the input device's stack. Input handlers run on it, so it
+ * keeps generous headroom over the measured peak (under 1 KB on m68k);
+ * Kickstart gives its input.device task 4 KB and handlers are expected
+ * to be frugal, so 8 KB is still double the classic budget without
+ * pinning 26 KB of chip RAM. */
+#ifdef __mc68000
+#define IDTASK_STACKSIZE    	    8192
+#else
 #define IDTASK_STACKSIZE    	    (AROS_STACKSIZE + 10240)
+#endif
 
 /* Priority of the input.device task */
 #define IDTASK_PRIORITY     	    20

--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -183,7 +183,18 @@ static void internalSetTimeFromBootVolume(BPTR lock, struct DosLibrary *DOSBase)
         return ERROR_NO_FREE_STORE;
     }
 
+#ifdef __mc68000
+    /*
+     * This process mounts the boot volume and then becomes the initial
+     * shell; commands it launches run on their own cli_DefaultStack
+     * stacks, so its own stack only carries mount packets and script
+     * parsing. 8 KB is double the classic shell budget, and the block
+     * is chip RAM on an unexpanded machine.
+     */
+    mp = CreateProc("Boot Mount", 0, seg, 8192);
+#else
     mp = CreateProc("Boot Mount", 0, seg, AROS_STACKSIZE);
+#endif
     if (mp == NULL) {
         DeleteMsgPort(reply_mp);
         if (my_dp)

--- a/rom/dos/newcliproc.c
+++ b/rom/dos/newcliproc.c
@@ -279,8 +279,19 @@ ULONG internal_CliInitAny(struct DosPacket *dp, APTR DOSBase)
            NP_StackSize tag */
         cli->cli_DefaultStack = (me->pr_StackSize + CLI_DEFAULTSTACK_UNIT - 1) / CLI_DEFAULTSTACK_UNIT;
 
+#ifdef __mc68000
+        /*
+         * The command stack is chip RAM on an unexpanded Amiga and is
+         * held for as long as a launched program runs. AmigaOS shells
+         * default to 4000 bytes here; 8 KB is double that for AROS's
+         * heavier C commands without pinning a full 16 KB.
+         */
+        if (cli->cli_DefaultStack < (LONG)(8192 / CLI_DEFAULTSTACK_UNIT))
+            cli->cli_DefaultStack = (LONG)(8192 / CLI_DEFAULTSTACK_UNIT);
+#else
         if (cli->cli_DefaultStack < (LONG)(AROS_STACKSIZE / CLI_DEFAULTSTACK_UNIT))
             cli->cli_DefaultStack = (LONG)(AROS_STACKSIZE / CLI_DEFAULTSTACK_UNIT);
+#endif
     }
 
     AROS_BSTR_setstrlen(cli->cli_CommandFile, 0);

--- a/rom/exec/createpool.c
+++ b/rom/exec/createpool.c
@@ -80,6 +80,8 @@
     struct TraceLocation tp = CURRENT_LOCATION("CreatePool");
     struct MemHeader *firstPuddle = NULL;
     IPTR align = PrivExecBase(SysBase)->PageSize - 1;
+    ULONG poolstruct_size;
+    IPTR headerSize;
 
     if (align < 4095)
         align = 4095;
@@ -105,14 +107,59 @@
     puddleSize = (puddleSize + align) & ~align;
     D(bug("[CreatePool] Aligned puddle size: %u (0x%08X)\n", puddleSize, puddleSize);)
 
-    /* Allocate the first puddle. It will contain pool header. */
-    firstPuddle = AllocMemHeader(puddleSize, requirements & ~MEMF_SEM_PROTECTED, &tp, SysBase);
-    D(bug("[CreatePool] Initial puddle 0x%p\n", firstPuddle);)
+    poolstruct_size = (requirements & MEMF_SEM_PROTECTED) ? sizeof(struct ProtectedPool) :
+                                      sizeof(struct Pool);
+
+    /*
+     * The pool handle is the address of a MemHeader whose first allocation
+     * is the pool structure (see AllocPooled()). Historically that
+     * MemHeader was a full puddle, which made every pool cost puddleSize
+     * bytes up front even when nothing was ever allocated from it - and
+     * pools are created eagerly all over the system. Instead, size the
+     * handle's block for the pool structure (plus its allocator context)
+     * alone and leave the rest of the puddle list empty: the first
+     * AllocPooled() brings in the first real puddle. The block is laid
+     * out exactly like a puddle and sits on the puddle list as before,
+     * so nothing downstream changes; with zero free bytes it can never
+     * satisfy an allocation nor be reclaimed as an empty puddle.
+     */
+    headerSize = MEMHEADER_TOTAL + mhac_GetCtxSize()
+        + ((poolstruct_size + MEMCHUNK_TOTAL - 1) & ~(MEMCHUNK_TOTAL - 1));
+
+    firstPuddle = nommu_AllocMem(headerSize, requirements & ~MEMF_SEM_PROTECTED, &tp, SysBase);
+    if (firstPuddle)
+    {
+        struct MemHeader *orig = FindMem(firstPuddle, SysBase);
+
+        if (IsManagedMem(orig))
+        {
+            /*
+             * In managed memory the block itself becomes the managed pool
+             * and needs real capacity behind the header, so managed pools
+             * keep the historical eager full-size block.
+             */
+            nommu_FreeMem(firstPuddle, headerSize, &tp, SysBase);
+            firstPuddle = AllocMemHeader(puddleSize, requirements & ~MEMF_SEM_PROTECTED, &tp, SysBase);
+        }
+        else
+        {
+            /* Initialize the handle's MemHeader like AllocMemHeader() would */
+            firstPuddle->mh_Node.ln_Type = NT_MEMORY;
+            firstPuddle->mh_Node.ln_Pri  = orig->mh_Node.ln_Pri;
+            firstPuddle->mh_Attributes   = orig->mh_Attributes;
+            firstPuddle->mh_Lower        = (APTR)firstPuddle + MEMHEADER_TOTAL;
+            firstPuddle->mh_Upper        = (APTR)firstPuddle + headerSize;
+            firstPuddle->mh_First        = firstPuddle->mh_Lower;
+            firstPuddle->mh_Free         = headerSize - MEMHEADER_TOTAL;
+
+            firstPuddle->mh_First->mc_Next  = NULL;
+            firstPuddle->mh_First->mc_Bytes = firstPuddle->mh_Free;
+        }
+    }
+    D(bug("[CreatePool] Pool header block 0x%p\n", firstPuddle);)
 
     if (firstPuddle)
     {
-        ULONG poolstruct_size = (requirements & MEMF_SEM_PROTECTED) ? sizeof(struct ProtectedPool) :
-                                          sizeof(struct Pool);
         struct ProtectedPool *pool;
 
         /*

--- a/rom/exec/exec_init.c
+++ b/rom/exec/exec_init.c
@@ -312,6 +312,17 @@ int Exec_InitServices(struct ExecBase *SysBase)
 #if defined(__AROSEXEC_SMP__)
                         TASKTAG_AFFINITY, TASKAFFINITY_ANY,
 #endif
+#ifdef __mc68000
+                        /*
+                         * The service loop only disposes tasks and answers
+                         * ServicePort messages; measured peak stack use is
+                         * a few hundred bytes, and resident-task stacks
+                         * come out of chip RAM on an unexpanded Amiga.
+                         * The guru task below keeps the default: it runs
+                         * the alert display path.
+                         */
+                        TASKTAG_STACKSIZE  , 4096,
+#endif
                         TASKTAG_PC         , ServiceTask,
                         TASKTAG_TASKMSGPORT, &((struct IntExecBase *)SysBase)->ServicePort,
                         TASKTAG_ARG1       , SysBase,
@@ -326,6 +337,14 @@ int Exec_InitServices(struct ExecBase *SysBase)
     /* Create task for handling supervisor level errors */
     NewCreateTask(TASKTAG_NAME       , "Exec Guru Task",
                   TASKTAG_PRI        , 126,
+#ifdef __mc68000
+                  /*
+                   * Idle until an alert fires; the alert display path
+                   * runs well within 8 KB and the stack is chip RAM on
+                   * an unexpanded machine.
+                   */
+                  TASKTAG_STACKSIZE  , 8192,
+#endif
                   TASKTAG_PC         , SupervisorAlertTask,
                   TASKTAG_ARG1       , SysBase,
                   TAG_DONE);

--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -985,6 +985,7 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
              * allocator ctx size in any case.
              */
             IPTR puddleSize = pool->pool.PuddleSize;
+            struct Node *head = (struct Node *)pool->pool.PuddleList.mlh_Head;
 
             if (memSize > puddleSize - (MEMHEADER_TOTAL + mhac_GetCtxSize()))
             {
@@ -993,6 +994,20 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
                 puddleSize = memSize + MEMHEADER_TOTAL + mhac_GetCtxSize();
                 /* Align the size up to page boundary */
                 puddleSize = (puddleSize + align) & ~align;
+            }
+            else if (head->ln_Succ && head->ln_Succ->ln_Succ == NULL)
+            {
+                /*
+                 * Slow start: the only list entry is the pool's header
+                 * block, so this is the pool's first data puddle. Many
+                 * pools only ever hold a handful of small allocations;
+                 * size the first puddle for the request instead of
+                 * committing a full puddleSize up front. Pools that
+                 * keep allocating get full-size puddles from the
+                 * second one on.
+                 */
+                puddleSize = memSize + MEMHEADER_TOTAL + mhac_GetCtxSize();
+                puddleSize = (puddleSize + MEMCHUNK_TOTAL - 1) & ~(MEMCHUNK_TOTAL - 1);
             }
 
             mh = AllocMemHeader(puddleSize, flags, loc, SysBase);

--- a/rom/exec/newcreatetaska.c
+++ b/rom/exec/newcreatetaska.c
@@ -163,10 +163,26 @@ static const struct newMemList MemTemplate =
 
     /* We need a minimum stack to handle interrupt contexts. Additionally confirned on MorphOS that
        it sets a minimum fixed size of stack */
+#ifdef __mc68000
+    /*
+     * On m68k interrupts and exceptions run on the supervisor stack, so
+     * the floor only guards the task's own calls. AmigaOS never floored
+     * CreateTask() stacks at all; flooring at AROS_STACKSIZE (16 KB)
+     * silently pinned 16 KB of chip RAM for every task on machines that
+     * may only have 512 KB. 4 KB still covers several times the
+     * measured peak of the system's own service tasks while letting
+     * explicitly sized stacks take effect.
+     */
+    if (nml.nml_ME[1].me_Length < 4096)
+    {
+        nml.nml_ME[1].me_Length = 4096;
+    }
+#else
     if (nml.nml_ME[1].me_Length < AROS_STACKSIZE)
     {
         nml.nml_ME[1].me_Length = AROS_STACKSIZE;
     }
+#endif
 
 
     DADDTASK("NewCreateTaskA: name %s", taskname ? taskname : "<NULL>");

--- a/rom/intuition/menutask.c
+++ b/rom/intuition/menutask.c
@@ -223,6 +223,15 @@ BOOL InitDefaultMenuHandler(struct IntuitionBase *IntuitionBase)
 
     task = NewCreateTask(TASKTAG_NAME, "Intuition menu handler",
                  TASKTAG_PC  , DefaultMenuHandler,
+#ifdef __mc68000
+                 /*
+                  * Menu rendering peaks well under 1 KB of stack on
+                  * m68k; 4 KB keeps several times that in headroom
+                  * without pinning 16 KB of chip RAM for the machine's
+                  * whole lifetime.
+                  */
+                 TASKTAG_STACKSIZE, 4096,
+#endif
                  TASKTAG_ARG1, &params,
                  TAG_DONE);
 

--- a/rom/intuition/screennotifytask.h
+++ b/rom/intuition/screennotifytask.h
@@ -7,7 +7,16 @@
 */
 
 #define SCREENNOTIFYTASK_NAME 	    	"\xAB Screennotify Handler \xBB"
+/*
+ * The handler only replies notification messages; measured peak stack
+ * use on m68k is under 400 bytes, and 16 KB of chip RAM is a real cost
+ * on small Amigas.
+ */
+#ifdef __mc68000
+#define SCREENNOTIFYTASK_STACKSIZE  	4096
+#else
 #define SCREENNOTIFYTASK_STACKSIZE  	AROS_STACKSIZE
+#endif
 #define SCREENNOTIFYTASK_PRIORITY   	0
 
 /* Structure passed to the DefaultMenuHandler task when it's initialized */


### PR DESCRIPTION
While chasing why CD32 discs that run chip-only under Kickstart needed expansion RAM under AROS, I measured where the RAM actually goes on an unexpanded machine. At the point where dosboot hands off to a bootable disc's startup-sequence, Kickstart has around 180KB of the 2MB allocated. AROS had 1.93MB, leaving the game 164KB.

Three things dominated, fixed here in order:

1. **CDVDFS's cache.** `de_NumBuffers = 32` on the CD32 boot node becomes 32 x 16 x 2048 bytes, exactly 1MB, allocated the moment CD0: mounts. With no expansion fitted, MEMF_24BITDMA is chip RAM. Now 4 chunks (128KB).

2. **Pools.** 45 pools are alive after boot, and CreatePool() committed a full puddle to each up front: 323KB of puddles, 313KB of it never touched. The pool header now lives in a block of its own size and the first real puddle arrives with the first AllocPooled(), sized to the request. The handle ABI is unchanged and managed memory keeps the old path. The same 45 pools now cost 7.8KB.

3. **Task stacks.** NewCreateTaskA() floors every stack at AROS_STACKSIZE (16KB on m68k), so the dozen resident tasks pin about 200KB while ten of them peak under 1KB (stacks are MEMF_CLEAR, so the high-water mark is measurable). It also means the TASKTAG_STACKSIZE values already in the tree were being silently ignored. On m68k interrupts run on the supervisor stack, and AmigaOS never floored CreateTask() at all, so the m68k floor drops to 4KB and the resident tasks get explicit sizes with 4-8x margin over the measurements. The CLI default command stack (what a booted game runs on; 4000 bytes on a Kickstart shell) goes from 16KB to 8KB.

Results, measured on stock machines under Copperline, no expansion:

|                                          | before | after  |
|------------------------------------------|--------|--------|
| CD32, free chip at CD boot handoff       | 164KB  | 1.4MB  |
| A1200, free chip at floppy boot handoff  | 1.24MB | 1.64MB |
| A500 (1MB), OS footprint at insert screen | 898KB | 518KB  |

Pinball Fantasies now cold boots to table select on a chip-only CD32, and still does with fast RAM attached. A 512K+512K A500 goes from 64 bytes of free slow RAM to 236KB.

Everything m68k-specific is behind `#ifdef __mc68000` or in m68k-amiga files; other architectures are untouched, and tasks created without an explicit stack size still get the 16KB default. One honest caveat: I have not soak-tested heavy Workbench sessions or the guru display path at the new stack sizes, which is why the alert task deliberately keeps 8KB.
