### PR TITLE
build: fix host toolchain detection on a host whose CC carries flags

### DIFF
--- a/config/make-autotools.tmpl
+++ b/config/make-autotools.tmpl
@@ -236,7 +236,7 @@ ifeq (%(compiler),host)
     # the "plain" host compiler.
     %(mmake)-cfg-env := %(config_env_extra) \
         CPP="$(HOST_CPP)" \
-        CXXCPP="$(HOST_CPP)" \
+        CXXCPP="$(strip $(%(mmake)-HOST_CXX) -E)" \
         CC="$(strip $(%(mmake)-HOST_CC) $(%(mmake)-HOST_CFLAGS) -I$(CROSSTOOLSDIR)/include)" \
         CXX="$(strip $(%(mmake)-HOST_CXX) $(%(mmake)-HOST_CXXFLAGS) -I$(CROSSTOOLSDIR)/include)" \
         LDFLAGS="-L$(CROSSTOOLSDIR)/lib $(USER_LDFLAGS)"

--- a/configure
+++ b/configure
@@ -5187,13 +5187,15 @@ if test "$IS_SUN_COMPILER" -ne "0"; then
     HOST_TOOLCHAIN_SUFFIX=
     HOST_TOOLCHAIN_FAMILY=sun
 fi
+CC_PROG=`echo $CC_BASE | sed -e 's| .*||' -e 's|.*/||'`
+
 IS_LLVM_COMPILER=`echo $HOST_COMPILER_VERSION | grep -i -c -E 'LLVM|clang'`
 if test "$IS_LLVM_COMPILER" -ne "0"; then
-    if test "$CC_BASE" != "gcc"; then
+    if test "$CC_PROG" != "gcc"; then
         HOST_TOOLCHAIN_CC=clang
         HOST_TOOLCHAIN_CXX=clang++
         HOST_TOOLCHAIN_PREFIX=llvm-
-        HOST_TOOLCHAIN_SUFFIX="`echo $CC_BASE | sed -e \"s|clang||g\"`"
+        HOST_TOOLCHAIN_SUFFIX="`echo $CC_PROG | sed -e \"s|clang||g\"`"
         HOST_TOOLCHAIN_FAMILY=llvm
     else
         IS_GNU_COMPILER=1

--- a/configure.in
+++ b/configure.in
@@ -172,13 +172,18 @@ if test "$IS_SUN_COMPILER" -ne "0"; then
     HOST_TOOLCHAIN_SUFFIX=
     HOST_TOOLCHAIN_FAMILY=sun
 fi
+dnl AC_PROG_CC leaves the standard flag it picked in CC, so CC_BASE is a
+dnl command line ("gcc -std=gnu23"). The guard and the derived binutils
+dnl names below want the program name.
+CC_PROG=`echo $CC_BASE | sed -e 's| .*||' -e 's|.*/||'`
+
 IS_LLVM_COMPILER=`echo $HOST_COMPILER_VERSION | grep -i -c -E 'LLVM|clang'`
 if test "$IS_LLVM_COMPILER" -ne "0"; then
-    if test "$CC_BASE" != "gcc"; then
+    if test "$CC_PROG" != "gcc"; then
         HOST_TOOLCHAIN_CC=clang
         HOST_TOOLCHAIN_CXX=clang++
         HOST_TOOLCHAIN_PREFIX=llvm-
-        HOST_TOOLCHAIN_SUFFIX="`echo $CC_BASE | sed -e \"s|clang||g\"`"
+        HOST_TOOLCHAIN_SUFFIX="`echo $CC_PROG | sed -e \"s|clang||g\"`"
         HOST_TOOLCHAIN_FAMILY=llvm
     else
         IS_GNU_COMPILER=1


### PR DESCRIPTION
Two independent faults stop the host side of the build on a current macOS/clang host. Both derive a tool name or flag from another variable, and both are silent — configure reports success and the failure surfaces much later as a missing program.

**`configure.in`** derives the host binutils names from `$CC_BASE` and guards that with a test against `"gcc"`. `CC_BASE` is a whole command line rather than a program name, because `AC_PROG_CC` leaves the standard flag it selected in `CC` (`gcc -std=gnu23`). Reading `configure.in` alone makes that look impossible, since `CC_BASE=$CC` comes *before* the `AC_PROG_CC_STDC` call; the generated `configure` shows why it is not:

```
4549:     CC="$CC $ac_cv_prog_cc_c23" ;;
4711: CC_BASE=$CC
5192:     if test "$CC_BASE" != "gcc"; then
```

`AC_PROG_CC_STDC` has been obsolete since autoconf 2.70 and does nothing here; `AC_PROG_CC` does the standard detection itself, well before `CC_BASE` captures the value.

So the guard always takes the non-gcc path, the names come from the command line rather than the program, `HOST_AR` becomes `cr` — which is `ar`'s flags — and the build later dies with

```
gmake[3]: cr: No such file or directory
```

while configure had reported nothing wrong. Fixed by deriving the program name first, then testing and substituting that.

**`config/make-autotools.tmpl`** passes `CXXCPP="$(HOST_CPP)"` to the autotools ports built for the host. `HOST_CPP` is the *C* preprocessor, and a port probing for a C++ one rejects it:

```
checking how to run the C++ preprocessor... gcc -std=gnu23 -E
configure: error: C++ preprocessor "gcc -std=gnu23 -E" fails sanity check
```

gmp is the first to hit it. Fixed by deriving `CXXCPP` from `HOST_CXX`.

### Testing

Tested on `darwin-aarch64` building `raspi-aarch64`.

What decides whether the first fault appears is not the host OS but whether the compiler needs an explicit `-std=` flag to reach the standard autoconf asks for. clang does, so the flag lands in `CC`. gcc 15 and newer already default to gnu23, so `$ac_cv_prog_cc_c23` stays empty and `CC` keeps its bare name. That predicts the fault on Linux with an older gcc too, and a second pair of eyes there would be welcome before this is merged. Draft because of that gap, not because the change is unfinished.

### Not fixed here

The same pattern sits in three more places, where a tool prefix is prepended to what may be a whole command line rather than a program name:

```
configure.in:3225   aros_kernel_cpp=${kernel_tool_prefix}${CPP_BASE}
configure.in:3232   aros_kernel_cc=${kernel_tool_prefix}${CC_BASE}
configure.in:3240   aros_kernel_cxx=${kernel_tool_prefix}${CXX_BASE}
```

With `gcc -std=gnu23` those happen to produce a working command. With a path in `CC` they produce `arm-aros-/usr/bin/gcc-13`. Left alone deliberately, to keep this change to the two faults that actually break the build.

### Note on squashing

The two fixes are logically separate and were developed as separate commits. They are squashed here as one "make the host build work" change; happy to split them if a reviewer prefers one bug per commit.
