### PR TITLE
crosstools: add an aarch64-aros case to libgcc's config.host

### DIFF
--- a/tools/crosstools/gnu/gcc-16.2.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.2.0-aros.diff
@@ -1739,10 +1739,19 @@ diff -ruN gcc-16.2.0/libgcc/config.host gcc-16.2.0.aros/libgcc/config.host
  m68k-*-elf* | fido-*-elf)
  	tmake_file="$tmake_file m68k/t-floatlib"
  	;;
-@@ -1574,6 +1583,9 @@
+@@ -1574,6 +1583,18 @@
  	tmake_file="$tmake_file nvptx/t-nvptx"
  	extra_parts="crt0.o"
  	;;
++aarch64*-*-aros*)
++	# AROS has no signal frames; the generic aarch64 unwinder is the
++	# one declaring the helpers unwind-dw2-execute_cfa.h calls.
++	md_unwind_def_header=aarch64/aarch64-unwind-def.h
++	md_unwind_header=aarch64/aarch64-unwind.h
++	# Out-of-line atomics and TFmode soft float. The generic aros case
++	# below leaves tmake_file empty, which is not enough on aarch64.
++	tmake_file="${tmake_file} ${cpu_type}/t-lse ${cpu_type}/t-softfp t-softfp"
++	;;
 +*-*-aros*)
 +	tmake_file=
 +	;;


### PR DESCRIPTION
`libgcc/config.host` has cases for `arm*-*-aros*` and `m68k-*-aros*`, plus a generic `*-*-aros*` that sets `tmake_file` empty and nothing else. aarch64 falls into that generic case, which is wrong for it twice over: it needs the unwinder headers, and it needs routines the compiler emits calls to.

### Without the unwind headers, libgcc does not build at all

With gcc 15 or newer, `unwind-dw2-execute_cfa.h` calls into the return-address signing helpers and nothing declares them:

```
unwind-dw2-execute_cfa.h:289: error: implicit declaration of
function 'aarch64_fs_ra_state_toggle'
```

`aarch64/aarch64-unwind.h` is named rather than `aarch64/linux-unwind.h` on purpose: the linux one exists to read signal frames, which AROS has not got, and pulls in the generic aarch64 header only for these helpers.

### Without the tmake files, libgcc is incomplete

Three entries are added, all plain code with no OS dependency, and all three are what gcc's own `aarch64*-*-elf` and `aarch64*-*-linux*` cases use:

| | |
|---|---|
| `aarch64/t-lse` | Out-of-line atomics. Without them libgcc lacks `__aarch64_cas*` and `__aarch64_swp*`, which anything not built `-mno-outline-atomics` calls — AROS's own `libpthread.a` among them. libatomic's configure then cannot link its pthread probe and reports the misleading *"Pthreads are required to build libatomic"*. |
| `aarch64/t-softfp` + `t-softfp` | Soft float for TFmode, and it takes both the cpu-specific and the generic file. `long double` is binary128 here and its arithmetic is done in software, so without them `stdc.library` comes out missing `__addtf3`, `__multf3`, `__extenddftf2` and the rest of that set. |

`tmake_file` is appended to rather than assigned, matching the neighbouring arm and m68k aros cases. Nothing sets it for an aros host before this point, so the two are equivalent today.

### Five that the linux case carries are left out on purpose

- `t-slibgcc-libgcc` — for a shared libgcc, where AROS links static
- `t-crtfm` — builds a `crtfastmath.o` no `extra_parts` asks for
- `t-heap-trampoline` — wants OS support this port has not got
- `t-dfprules` — decimal float, not enabled here
- `t-aarch64` — would close the one remaining gap, `__aarch64_sync_cache_range`, but it also turns `-Werror` on for libgcc, which then fails on an incomplete initialiser reached through AROS's own `pthread.h`. That symbol was already undefined before this change, so nothing regresses by leaving it until the header is fixed. Reported separately.

### Scope

Only the gcc 16.2.0 patch is touched, so nothing changes for anyone on another version.

Found by building the whole distribution rather than a single module — a module target links none of this and gives no hint it is missing.

### Testing

Tested on `darwin-aarch64` building `raspi-aarch64` with binutils 2.47. After the in-patch comments were cut back, the hunk was dry-run against pristine gcc 16.2.0 sources to confirm it still applies and lands where intended.
