### PR TITLE
aarch64: end the .aros.init directive so its attributes survive

### DIFF
--- a/arch/aarch64-native/kernel/kernel_startup.c
+++ b/arch/aarch64-native/kernel/kernel_startup.c
@@ -42,6 +42,21 @@
 extern struct TagItem *BootMsg;
 
 void __attribute__((used)) kernel_cstart(struct TagItem *msg);
+/*
+ * .aros.init is declared twice: "ax" by the asm below that carries
+ * start:, and again by the section attribute on the stack pointers. The
+ * second declaration must not bring attributes of its own, which is what
+ * the section comment ends the directive for.
+ *
+ * AROS_SECTION_COMMENT arrives empty because config/features only probes
+ * for it when AROS_TARGET_CPU is arm, so the compiler's flags come
+ * through and the assembler rejects the second declaration.
+ * riscv-native works around it the same way; the fix belongs in that
+ * probe.
+ */
+#undef TARGET_SECTION_COMMENT
+#define TARGET_SECTION_COMMENT "\n#"
+
 static void __attribute__((used, noreturn, noinline)) kernel_cstart_user(void);
 
 uint64_t stack[AROS_STACKSIZE] __attribute__((used,aligned(16)));


### PR DESCRIPTION
`.aros.init` holds two things: the entry point, which has to be executable, and a pair of stack pointers, which do not. The section is therefore declared twice — once as `"ax"` by the inline asm carrying `start:`, and once through a section attribute on the pointers — and the second declaration must not carry attributes of its own.

`TARGET_SECTION_COMMENT` exists for exactly that: it ends the directive, so whatever flags the compiler appends become a comment and the section keeps what the entry point asked for. It reaches this file from the mmakefile as

```make
USER_CPPFLAGS := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"
```

and arrives empty. The compiler's flags come through, the second declaration says `"aw"` where the first said `"ax"`, and the assembler refuses it:

```
Error: changed section attributes for .aros.init
```

### Why it arrives empty

Worth stating precisely, because it decides where the real fix goes — and it is **not** `configure.in`. The value belongs to `config/features`, which does probe for it and picks `"#"`, `"@"`, or falls back to `"//"`. The probe never runs here, because the whole block sits inside

```sh
if test "$AROS_TARGET_CPU" = "arm"; then
```

so every target that is not arm skips it and gets the empty string. A riscv build shows the same from the other side: `gen/config/compiler.cfg` has `AROS_SECTION_COMMENT` empty and the features log has no "comment style" line at all.

### And widening that test alone would not be enough

There is a second fault in the same probe. Its test program assembles

```
ldr sp, section_ptr
```

which is an ARM instruction. On any other target both the `"#"` and the `"@"` attempt fail on the instruction rather than on the section attribute, so the probe lands on its `"//"` fallback whatever the assembler would actually accept — and `arch/arm-native/kernel/kernel_startup.c` already records that `"//"` is not a comment for clang's integrated assembler.

Doing this properly therefore means widening the CPU test **and** making the test program target-neutral, so the assembler decides. That is a change across targets I cannot test, so it is deliberately not attempted here.

### This is a workaround

Defined locally, exactly as `arch/riscv-native/sifive_u` already does in its own `kernel_startup.c`. sifive_u also has a third variant in `boot/mmakefile.src`, which passes the `-D` directly, and the mmakefile line in `kernel/mmakefile.src` is commented out — which is the clearest evidence that the configure value has been unusable for some time.

**I am happy to be told to do it properly instead of this.** If the preference is a `config/features` fix, say so and I will close this in favour of one — it just needs someone who can test the other targets.

### Why now

It takes a strict enough assembler to reject this and a toolchain new enough to build at all on a current host. Neither condition held for the aarch64 target until recently.

### Testing

Tested on `darwin-aarch64` building `raspi-aarch64`. Not run on hardware, hence draft.
