### PR TITLE
exec: make the memory allocator SMP safe

### DIFF
--- a/rom/exec/addmemlist.c
+++ b/rom/exec/addmemlist.c
@@ -88,6 +88,10 @@
     mh->mh_Upper=(APTR)((UBYTE *)base+size);
     mh->mh_Free=mh->mh_First->mc_Bytes;
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_INIT(&mh->mh_SpinLock);
+#endif
+
     /* Protect the memory list. */
     MEM_LOCK;
 

--- a/rom/exec/allocate.c
+++ b/rom/exec/allocate.c
@@ -47,11 +47,20 @@
         The memory is aligned to sizeof(struct MemChunk). All requests
         are rounded up to a multiple of that size.
 
+        On SMP builds this function serialises through the header's
+        embedded spinlock (mh_SpinLock), so a hand-built MemHeader MUST
+        be fully zeroed before the fields are filled in (allocate it
+        with MEMF_CLEAR, as the example does) - a zeroed lock word is an
+        unlocked lock. Passing a header with garbage in mh_SpinLock
+        makes Allocate()/Deallocate() spin forever; this cannot be
+        detected defensively, since garbage is indistinguishable from
+        "currently locked by another CPU".
+
     EXAMPLE
         #define POOLSIZE 4096
         \* Get a MemHeader structure and some private memory *\
         mh=(struct MemHeader *)
-            AllocMem(sizeof(struct MemHeader)+POOLSIZE,MEMF_ANY);
+            AllocMem(sizeof(struct MemHeader)+POOLSIZE,MEMF_ANY|MEMF_CLEAR);
         if(mh!=NULL)
         {
             \* Build a private pool *\

--- a/rom/exec/deallocate.c
+++ b/rom/exec/deallocate.c
@@ -43,6 +43,12 @@
         The start and end borders of the block are aligned to
         a multiple of sizeof(struct MemChunk) and to include the block.
 
+        On SMP builds this function serialises through the header's
+        embedded spinlock (mh_SpinLock) - see the corresponding note in
+        Allocate(): a hand-built MemHeader must be zeroed before its
+        fields are filled in, or the lock word contains garbage and
+        this call spins forever.
+
     EXAMPLE
 
     BUGS

--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -233,16 +233,60 @@ struct MemHeaderAllocatorCtx * mhac_GetSysCtx(struct MemHeader * mh, struct Exec
 {
     struct MemHeaderAllocatorCtx * mhac = NULL;
 
+    /*
+     * Fast path: AllocatorCtxList is only ever appended to (on first touch of
+     * a MemHeader), never removed from, so a lockless walk is safe.
+     */
     ForeachNode(&PrivExecBase(SysBase)->AllocatorCtxList, mhac)
     {
         if (mhac->mhac_MemHeader == mh)
             return mhac;
     }
 
+#if defined(__AROSEXEC_SMP__)
+    /*
+     * Miss: a new ctx must be created and linked. AddTail is not SMP-safe
+     * against a concurrent first-touch of the same MemHeader, so serialize
+     * creation and re-check under the lock (another core may have just added
+     * it).
+     */
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->AllocatorCtxListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+    ForeachNode(&PrivExecBase(SysBase)->AllocatorCtxList, mhac)
+    {
+        if (mhac->mhac_MemHeader == mh)
+        {
+            EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->AllocatorCtxListSpinLock);
+            return mhac;
+        }
+    }
+#endif
+
     /* New context is needed */
     mhac = Allocate(mh, sizeof(struct MemHeaderAllocatorCtx));
+    if (mhac == NULL)
+    {
+        /* Header too full to hold its own ctx - callers treat the ctx as
+         * an optional accelerator, so just run without one. */
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->AllocatorCtxListSpinLock);
+#endif
+        return NULL;
+    }
     mhac_SetupMemHeaderAllocatorCtx(mh, ALLOCATORCTXINDEXSIZE, mhac);
+    /*
+     * Publish the finished node before linking it: the fast path above
+     * walks this list without the lock, so on a weakly ordered CPU a
+     * reader could otherwise follow the AddTail stores while the node's
+     * own fields (mhac_MemHeader in particular) are not visible yet. The
+     * reader side needs nothing - it reaches those fields through the
+     * node pointer, and address dependencies are respected.
+     */
+    EXEC_MEMORY_BARRIER();
     AddTail(&PrivExecBase(SysBase)->AllocatorCtxList, (struct Node *)mhac);
+
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->AllocatorCtxListSpinLock);
+#endif
 
     return mhac;
 }
@@ -493,6 +537,24 @@ APTR stdAlloc(struct MemHeader *mh, struct MemHeaderAllocatorCtx *mhac, IPTR siz
 
         if (mhe->mhe_Alloc)
         {
+#if defined(__AROSEXEC_SMP__)
+            /*
+             * Managed headers without MEMF_SEM_PROTECTED do not serialise
+             * themselves - take the header lock, as the plain path below
+             * does. SEM_PROTECTED ones obtain a semaphore internally and
+             * may Wait(), so they must not be entered with a spinlock held.
+             */
+            if (!((IPTR)mh->mh_First & MEMF_SEM_PROTECTED))
+            {
+                APTR ret;
+
+                EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                ret = mhe->mhe_Alloc(mhe, size, &requirements);
+                EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+
+                return ret;
+            }
+#endif
             return mhe->mhe_Alloc(mhe, size, &requirements);
         }
         else
@@ -504,13 +566,24 @@ APTR stdAlloc(struct MemHeader *mh, struct MemHeaderAllocatorCtx *mhac, IPTR siz
         IPTR byteSize = AROS_ROUNDUP2(size, MEMCHUNK_TOTAL);
         struct MemChunk *mc=NULL, *p1, *p2;
 
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+
+retry_alloc:
         /* Validate MemHeader before doing anything. */
         if (!validateHeader(mh, MM_ALLOC, NULL, size, tp, SysBase))
-            return NULL;
+        {
+            mc = NULL;
+            goto stdalloc_done;
+        }
 
         /* Validate if there is even enough total free memory */
         if (mh->mh_Free < byteSize)
-            return NULL;
+        {
+            mc = NULL;
+            goto stdalloc_done;
+        }
 
 
         /*
@@ -526,11 +599,15 @@ APTR stdAlloc(struct MemHeader *mh, struct MemHeaderAllocatorCtx *mhac, IPTR siz
          * On 1st pass p1 points to mh->mh_First, so that changing p1->mc_Next actually
          * changes mh->mh_First.
          */
+        mc = NULL;
         while (p2 != NULL)
         {
             /* Validate the current chunk */
             if (!validateChunk(p2, p1, mh, MM_ALLOC, NULL, size, tp, SysBase))
-                return NULL;
+            {
+                mc = NULL;
+                goto stdalloc_done;
+            }
 
             /* Check if the current block is large enough */
             if (p2->mc_Bytes>=byteSize)
@@ -601,13 +678,18 @@ APTR stdAlloc(struct MemHeader *mh, struct MemHeaderAllocatorCtx *mhac, IPTR siz
             {
                 /*
                  * Since chunks created during deallocation are not returned to index,
-                 * retry with cleared index.
+                 * retry with cleared index. Loop instead of recursing so we keep
+                 * holding mh_SpinLock across the retry (the index is per-mh state).
                  */
                 mhac_ClearIndex(mhac);
-                mc = stdAlloc(mh, mhac, size, requirements, tp, SysBase);
+                goto retry_alloc;
             }
         }
 
+stdalloc_done:
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+#endif
         return mc;
     }
 }
@@ -627,15 +709,31 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
     if ((freeList->mh_Node.ln_Type == NT_MEMORY) && IsManagedMem(freeList))
     {
         struct MemHeaderExt *mhe = (struct MemHeaderExt *)freeList;
-        
+
         if (mhe->mhe_Free)
+        {
+#if defined(__AROSEXEC_SMP__)
+            /* See stdAlloc: unprotected managed headers are serialised here. */
+            if (!((IPTR)freeList->mh_First & MEMF_SEM_PROTECTED))
+            {
+                EXEC_SPINLOCK_LOCK(&freeList->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                mhe->mhe_Free(mhe, addr, size);
+                EXEC_SPINLOCK_UNLOCK(&freeList->mh_SpinLock);
+            }
+            else
+#endif
             mhe->mhe_Free(mhe, addr, size);
+        }
     }
     else
     {
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&freeList->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+
         /* Make sure the MemHeader is OK */
         if (!validateHeader(freeList, MM_FREE, addr, size, tp, SysBase))
-            return;
+            goto stddealloc_done;
 
         /* Align size to the requirements */
         byteSize = size + ((IPTR)addr & (MEMCHUNK_TOTAL - 1));
@@ -664,7 +762,7 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
             p3->mc_Next = NULL;
             p1->mc_Next = p3;
             freeList->mh_Free += byteSize;
-            return;
+            goto stddealloc_done;
         }
 
         /* Find closer chunk */
@@ -675,7 +773,7 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
         do
         {
             if (!validateChunk(p2, p1, freeList, MM_FREE, addr, size, tp, SysBase))
-                return;
+                goto stddealloc_done;
 
             /* Found a block with a higher address? */
             if (p2 >= p3)
@@ -695,7 +793,7 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
                         FindTask(NULL)->tc_Node.ln_Name);
 
                     Alert(AN_FreeTwice);
-                    return;
+                    goto stddealloc_done;
                 }
 #endif
                 /* End the loop with p2 non-zero */
@@ -723,7 +821,7 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
                     FindTask(NULL)->tc_Node.ln_Name);
 
                 Alert(AN_FreeTwice);
-                return;
+                goto stddealloc_done;
             }
 #endif
             /* Merge if possible */
@@ -762,6 +860,12 @@ void stdDealloc(struct MemHeader *freeList, struct MemHeaderAllocatorCtx *mhac, 
         p3->mc_Bytes = p4 - (UBYTE *)p3;
         freeList->mh_Free += byteSize;
         if (p1->mc_Next==p3) mhac_MemChunkCreated(p3, p1, mhac);
+
+stddealloc_done:
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&freeList->mh_SpinLock);
+#endif
+        ;
     }
 }
 
@@ -801,6 +905,12 @@ APTR AllocMemHeader(IPTR size, ULONG flags, struct TraceLocation *loc, struct Ex
     if (mh)
     {
         struct MemHeader *orig = FindMem(mh, SysBase);
+
+#if defined(__AROSEXEC_SMP__)
+        /* nommu_AllocMem() does not clear memory, and stdAlloc()/stdDealloc()
+         * lock mh_SpinLock unconditionally - garbage here spins forever. */
+        EXEC_SPINLOCK_INIT(&mh->mh_SpinLock);
+#endif
 
         if (IsManagedMem(orig))
         {

--- a/rom/exec/memory_nommu.c
+++ b/rom/exec/memory_nommu.c
@@ -23,8 +23,12 @@ APTR nommu_AllocMem(IPTR byteSize, ULONG flags, struct TraceLocation *loc, struc
     struct MemHeader *mh;
     ULONG requirements = flags & MEMF_PHYSICAL_MASK;
 
-    /* Protect memory list against other tasks */
-    MEM_LOCK;
+    /*
+     * Hold MemListSpinLock in shared mode for the list walk. Per-MemHeader
+     * mutations are serialized by mh_SpinLock inside stdAlloc.
+     * AddMemList still takes the exclusive lock.
+     */
+    MEM_LOCK_SHARED;
 
     /* Loop over MemHeader structures */
     ForeachNode(&SysBase->MemList, mh)
@@ -43,7 +47,30 @@ APTR nommu_AllocMem(IPTR byteSize, ULONG flags, struct TraceLocation *loc, struc
             struct MemHeaderExt *mhe = (struct MemHeaderExt *)mh;
 
             if (mhe->mhe_Alloc)
+            {
+                /*
+                 * The managed allocator (e.g. TLSF) only serialises itself
+                 * when the header is MEMF_SEM_PROTECTED. The system heap is
+                 * not, so take the per-MemHeader spinlock here - exactly as
+                 * stdAlloc does for the plain path below - otherwise
+                 * concurrent AllocMem/FreeMem from other cores corrupt the
+                 * free list. MemListSpinLock is held shared, so the list walk
+                 * stays parallel; this only serialises this one header.
+                 * SEM_PROTECTED headers obtain a semaphore internally and
+                 * may Wait(), so they must NOT be entered with a spinlock
+                 * held (also as stdAlloc does).
+                 */
+#if defined(__AROSEXEC_SMP__)
+                if (!((IPTR)mh->mh_First & MEMF_SEM_PROTECTED))
+                {
+                    EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                    res = mhe->mhe_Alloc(mhe, byteSize, &flags);
+                    EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+                }
+                else
+#endif
                 res = mhe->mhe_Alloc(mhe, byteSize, &flags);
+            }
         }
         else
         {
@@ -77,7 +104,26 @@ APTR nommu_AllocAbs(APTR location, IPTR byteSize, struct ExecBase *SysBase)
             {
                 if (mhe->mhe_AllocAbs)
                 {
-                    APTR ret = mhe->mhe_AllocAbs(mhe, byteSize, location);
+                    APTR ret;
+
+                    /*
+                     * Same rule as nommu_Alloc above: the managed allocator
+                     * only serialises itself when MEMF_SEM_PROTECTED, which
+                     * the system heap is not. MEM_LOCK alone does not help -
+                     * the alloc/free paths hold MemListSpinLock shared only.
+                     * SEM_PROTECTED headers may Wait() internally - never
+                     * enter them with the spinlock held.
+                     */
+#if defined(__AROSEXEC_SMP__)
+                    if (!((IPTR)mh->mh_First & MEMF_SEM_PROTECTED))
+                    {
+                        EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                        ret = mhe->mhe_AllocAbs(mhe, byteSize, location);
+                        EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+                    }
+                    else
+#endif
+                    ret = mhe->mhe_AllocAbs(mhe, byteSize, location);
 
                     MEM_UNLOCK;
 
@@ -204,8 +250,11 @@ void nommu_FreeMem(APTR memoryBlock, IPTR byteSize, struct TraceLocation *loc, s
 
     blockEnd = memoryBlock + byteSize;
 
-    /* Protect the memory list from access by other tasks. */
-    MEM_LOCK;
+    /*
+     * Shared lock for the list walk; stdDealloc serializes the per-mh write
+     * via mh_SpinLock.
+     */
+    MEM_LOCK_SHARED;
 
     ForeachNode(&SysBase->MemList, mh)
     {
@@ -218,7 +267,22 @@ void nommu_FreeMem(APTR memoryBlock, IPTR byteSize, struct TraceLocation *loc, s
                 continue;
 
             if (mhe->mhe_Free)
+            {
+                /* See nommu_AllocMem: serialise the unprotected managed
+                 * heap against concurrent alloc/free on other cores.
+                 * SEM_PROTECTED headers serialise themselves and may
+                 * Wait() - never enter them with the spinlock held. */
+#if defined(__AROSEXEC_SMP__)
+                if (!((IPTR)mh->mh_First & MEMF_SEM_PROTECTED))
+                {
+                    EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                    mhe->mhe_Free(mhe, memoryBlock, byteSize);
+                    EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+                }
+                else
+#endif
                 mhe->mhe_Free(mhe, memoryBlock, byteSize);
+            }
 
         }
         else
@@ -277,6 +341,23 @@ IPTR nommu_AvailMem(ULONG attributes, struct ExecBase *SysBase)
             continue;
         }
 
+#if defined(__AROSEXEC_SMP__)
+        /*
+         * Read this header's free list / managed state under its spinlock
+         * in shared mode (we don't mutate) so a concurrent alloc/free on
+         * another core can't change the chunk list mid-walk. This is the
+         * reader counterpart to the WRITE-mode lock nommu_AllocMem and
+         * stdAlloc take around mutations. SEM_PROTECTED managed headers
+         * serialise themselves and may Wait() in mhe_Avail - do not hold
+         * the spinlock around them.
+         */
+        BOOL lockmh = !(IsManagedMem(mh) &&
+                        ((IPTR)mh->mh_First & MEMF_SEM_PROTECTED));
+
+        if (lockmh)
+            EXEC_SPINLOCK_LOCK(&mh->mh_SpinLock, NULL, SPINLOCK_MODE_READ);
+#endif
+
         if (IsManagedMem(mh))
         {
             struct MemHeaderExt *mhe = (struct MemHeaderExt *)mh;
@@ -293,6 +374,10 @@ IPTR nommu_AvailMem(ULONG attributes, struct ExecBase *SysBase)
                 else
                     ret += val;
 
+#if defined(__AROSEXEC_SMP__)
+                if (lockmh)
+                    EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+#endif
                 continue;
             }
         }
@@ -339,6 +424,11 @@ IPTR nommu_AvailMem(ULONG attributes, struct ExecBase *SysBase)
         else
             /* Sum up free memory. */
             ret += mh->mh_Free;
+
+#if defined(__AROSEXEC_SMP__)
+        if (lockmh)
+            EXEC_SPINLOCK_UNLOCK(&mh->mh_SpinLock);
+#endif
     }
 
     /* All done */

--- a/rom/exec/mungwall.c
+++ b/rom/exec/mungwall.c
@@ -67,7 +67,13 @@ APTR MungWall_Build(APTR res, APTR pool, IPTR origSize, ULONG requirements, stru
         memset(res + origSize, 0xDB, MUNGWALL_SIZE);
 
         Forbid();
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->AllocMemListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         AddHead((struct List *)&PrivExecBase(SysBase)->AllocMemList, (struct Node *)&header->mwh_node);
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->AllocMemListSpinLock);
+#endif
         Permit();
     }
     return res;
@@ -211,7 +217,13 @@ APTR MungWall_Check(APTR memoryBlock, IPTR byteSize, struct TraceLocation *loc, 
          * while the alert is displayed.
          */
         Forbid();
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->AllocMemListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         Remove((struct Node *)header);
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->AllocMemListSpinLock);
+#endif
         Permit();
 
         /* Reset fault state in order to see who is freeing the bad entry */
@@ -260,6 +272,9 @@ void MungWall_Scan(APTR pool, struct TraceLocation *loc, struct ExecBase *SysBas
         DSCAN(bug("[Mungwall] Scan(), caller %s, SysBase 0x%p\n", function, SysBase);)
 
         Forbid();
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&sysBase->AllocMemListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
         ForeachNodeSafe(&sysBase->AllocMemList, allocnode, tmp)
         {
@@ -281,6 +296,9 @@ void MungWall_Scan(APTR pool, struct TraceLocation *loc, struct ExecBase *SysBas
             CheckHeader(allocnode, 0, loc, SysBase);
         }
 
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&sysBase->AllocMemListSpinLock);
+#endif
         Permit();
     }
 }


### PR DESCRIPTION
Each memory header is now locked individually while its free list is changed, and the walk over the list of headers takes the list lock in shared mode instead of exclusive. Before this, all allocation on all cores queued behind one lock; now two cores allocating from different headers do not wait for each other. Headers that are marked `MEMF_SEM_PROTECTED` handle their own locking and may sleep, so they are never entered while a spinlock is held.

The mungwall allocation list and the lazy-created allocator contexts get their own locks as well, since both were previously protected by `Forbid()` alone, which only holds off the calling core.