### PR TITLE
Bsek/exec smp taskstate

### DIFF
--- a/rom/exec/cause.c
+++ b/rom/exec/cause.c
@@ -5,6 +5,7 @@
 */
 
 #include <aros/asmcall.h>
+#include <aros/atomic.h>
 #include <exec/execbase.h>
 #include <hardware/intbits.h>
 
@@ -90,12 +91,22 @@
         pri = (softint->is_Node.ln_Pri + 0x20)>>4;
 
         /* We are accessing an Exec list, protect ourselves. */
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&SysBase->SoftInts[pri].sh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         ADDTAIL(&SysBase->SoftInts[pri].sh_List, &softint->is_Node);
         softint->is_Node.ln_Type = NT_SOFTINT;
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&SysBase->SoftInts[pri].sh_SpinLock);
+#endif
     }
 
     /* Signal pending software interrupt condition */
+#if defined(__AROSEXEC_SMP__)
+    __AROS_ATOMIC_OR_W(SysBase->SysFlags, SFF_SoftInt);
+#else
     SysBase->SysFlags |= SFF_SoftInt;
+#endif
 
     /*
      * Quick soft int request. For optimal performance m68k-amiga
@@ -140,7 +151,11 @@ AROS_INTH0(SoftIntDispatch)
     if( SysBase->SysFlags & SFF_SoftInt )
     {
         /* Clear Software interrupt pending flag. */
+#if defined(__AROSEXEC_SMP__)
+        __AROS_ATOMIC_AND_W(SysBase->SysFlags, ~SFF_SoftInt);
+#else
         SysBase->SysFlags &= ~(SFF_SoftInt);
+#endif
 
         for(;;)
         {
@@ -151,7 +166,13 @@ AROS_INTH0(SoftIntDispatch)
                  * been executed. In this case interrupts have been enabled before calling the handler.
                  */
                 KrnCli();
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_LOCK(&SysBase->SoftInts[i].sh_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
                 intr = (struct Interrupt *)RemHead(&SysBase->SoftInts[i].sh_List);
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_UNLOCK(&SysBase->SoftInts[i].sh_SpinLock);
+#endif
 
                 if (intr)
                 {

--- a/rom/exec/childfree.c
+++ b/rom/exec/childfree.c
@@ -49,16 +49,50 @@
 {
     AROS_LIBFUNC_INIT
 
-    struct ETask *et;
+    struct Task *ThisTask = GET_THIS_TASK;
+    struct ETask *parent, *et = NULL, *child;
 
     Forbid();
-    et = FindChild(tid);
-    if(et != NULL)
+    parent = ThisTask ? GetETask(ThisTask) : NULL;
+    if (parent)
     {
-        Remove((struct Node *)et);
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&IntETask(parent)->iet_TaskLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        ForeachNode(&parent->et_Children, child)
+        {
+            if (child->et_UniqueID == tid)
+            {
+                et = child;
+                Remove((struct Node *)et);
+                break;
+            }
+        }
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&IntETask(parent)->iet_TaskLock);
+#endif
 
-        ExpungeETask(et);
+        if (et == NULL)
+        {
+#if defined(__AROSEXEC_SMP__)
+            EXEC_SPINLOCK_LOCK(&parent->et_TaskMsgPort.mp_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+            ForeachNode(&parent->et_TaskMsgPort.mp_MsgList, child)
+            {
+                if (child->et_UniqueID == tid)
+                {
+                    et = child;
+                    Remove((struct Node *)et);
+                    break;
+                }
+            }
+#if defined(__AROSEXEC_SMP__)
+            EXEC_SPINLOCK_UNLOCK(&parent->et_TaskMsgPort.mp_SpinLock);
+#endif
+        }
     }
+    if(et != NULL)
+        ExpungeETask(et);
     Permit();
     
     AROS_LIBFUNC_EXIT

--- a/rom/exec/childorphan.c
+++ b/rom/exec/childorphan.c
@@ -5,6 +5,7 @@
 */
 #include "exec_intern.h"
 #include "exec_util.h"
+#include "etask.h"
 #include <proto/exec.h>
 
 /*****************************************************************************
@@ -54,6 +55,7 @@
 
     struct Task *ThisTask = GET_THIS_TASK;
     struct ETask *et, *child;
+    BOOL found;
 
         if (ThisTask)
         {
@@ -64,6 +66,9 @@
                 if (tid == 0L)
                 {
                         Forbid();
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_LOCK(&IntETask(et)->iet_TaskLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
                 ForeachNode(&et->et_Children, child)
                 {
                         /*
@@ -73,23 +78,40 @@
                         child->et_Parent = NULL;
                 }
                 NEWLIST(&et->et_Children);
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_UNLOCK(&IntETask(et)->iet_TaskLock);
+#endif
                         Permit();
                 }
                 else
                 {
                         Forbid();
-                child = FindChild(tid);
-                if (child != NULL)
+                found = FALSE;
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_LOCK(&IntETask(et)->iet_TaskLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+                ForeachNode(&et->et_Children, child)
                 {
-                        child->et_Parent = NULL;
-                        Remove((struct Node *)child);
+                        if (child->et_UniqueID == tid)
+                        {
+                                child->et_Parent = NULL;
+                                Remove((struct Node *)child);
+                                found = TRUE;
+                                break;
+                        }
+                }
+#if defined(__AROSEXEC_SMP__)
+                EXEC_SPINLOCK_UNLOCK(&IntETask(et)->iet_TaskLock);
+#endif
+                if (!found)
+                {
+                        Permit();
+                        return CHILD_NOTFOUND;
                 }
                 else
                 {
-                                Permit();
-                        return CHILD_NOTFOUND;
+                        Permit();
                 }
-                Permit();
                 }
         }
     return 0;

--- a/rom/exec/etask.h
+++ b/rom/exec/etask.h
@@ -63,6 +63,9 @@ struct IntETask
     cpumask_t           *iet_CpuAffinity;        /* bitmap of cores this task can run on    */
     spinlock_t          *iet_SpinLock;          /* pointer to spinlock task is spinning on */
 #endif
+    /* Last CPU-usage sample, for arches that derive iet_CpuUsage on read. */
+    UQUAD               iet_LastBusy;           /* iet_private2 at the last sample         */
+    UQUAD               iet_LastUsageStamp;     /* when that sample was taken              */
 #ifdef DEBUG_ETASK
     STRPTR              iet_Me;
 #endif

--- a/rom/exec/exec_util.c
+++ b/rom/exec/exec_util.c
@@ -270,21 +270,41 @@ Exec_CleanupETask(struct Task *task, struct ExecBase *SysBase)
            to TRUE */
         if(parent != NULL)
         {
+            BOOL notify = (((struct Task *)task)->tc_Node.ln_Type == NT_PROCESS) &&
+                          (((struct Process*) task)->pr_Flags & PRF_NOTIFYONDEATH);
+
 #if defined(__AROSEXEC_SMP__)
+            /*
+             * Move the child from et_Children to the parent's message
+             * port in one step, so a concurrent ChildStatus/ChildFree
+             * scan cannot find it on neither list. Signal() afterwards,
+             * since it must not run under a spinlock.
+             */
             EXEC_SPINLOCK_LOCK(&IntETask(parent)->iet_TaskLock, NULL, SPINLOCK_MODE_WRITE);
-#endif
             REMOVE(et);
-#if defined(__AROSEXEC_SMP__)
+            if (notify)
+            {
+                EXEC_SPINLOCK_LOCK(&parent->et_TaskMsgPort.mp_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+                ADDTAIL(&parent->et_TaskMsgPort.mp_MsgList, (struct Node *)et);
+                EXEC_SPINLOCK_UNLOCK(&parent->et_TaskMsgPort.mp_SpinLock);
+            }
             EXEC_SPINLOCK_UNLOCK(&IntETask(parent)->iet_TaskLock);
-#endif
-            if(
-               (((struct Task *)task)->tc_Node.ln_Type == NT_PROCESS) &&
-               (((struct Process*) task)->pr_Flags & PRF_NOTIFYONDEATH)
-            )
+
+            if (notify)
+            {
+                if (parent->et_TaskMsgPort.mp_SigTask)
+                    Signal((struct Task *)parent->et_TaskMsgPort.mp_SigTask,
+                           1UL << parent->et_TaskMsgPort.mp_SigBit);
+                expunge = FALSE;
+            }
+#else
+            REMOVE(et);
+            if (notify)
             {
                 PutMsg(&parent->et_TaskMsgPort, (struct Message *)et);
                 expunge = FALSE;
             }
+#endif
         }
     }
     else
@@ -325,75 +345,92 @@ BOOL Exec_CheckTask(struct Task *task, struct ExecBase *SysBase)
     if (!task)
         return FALSE;
 
-    Forbid();
 #if defined(__AROSEXEC_SMP__)
+    /*
+     * Disable(), not Forbid(): the FIQ-delivered IPI takes these same
+     * locks for writing, and a writer spins while a reader holds them.
+     * Only Disable() masks that FIQ.
+     */
+    Disable();
     EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskRunningSpinLock, NULL, SPINLOCK_MODE_READ);
     ForeachNode(&PrivExecBase(SysBase)->TaskRunning, t)
     {
         if (task == t)
         {
             EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskRunningSpinLock);
-            Permit();
+            Enable();
             return TRUE;
         }
     }
     EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskRunningSpinLock);
-    Permit();
-    Forbid();
+    Enable();
+    Disable();
     EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskSpinningLock, NULL, SPINLOCK_MODE_READ);
     ForeachNode(&PrivExecBase(SysBase)->TaskSpinning, t)
     {
         if (task == t)
         {
             EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskSpinningLock);
-            Permit();
+            Enable();
             return TRUE;
         }
     }
     EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskSpinningLock);
-    Permit();
-    Forbid();
+    Enable();
+    Disable();
     EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskReadySpinLock, NULL, SPINLOCK_MODE_READ);
+    ForeachNode(&SysBase->TaskReady, t)
+    {
+        if (task == t)
+        {
+            EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskReadySpinLock);
+            Enable();
+            return TRUE;
+        }
+    }
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskReadySpinLock);
+    Enable();
+    Disable();
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock, NULL, SPINLOCK_MODE_READ);
+    ForeachNode(&SysBase->TaskWait, t)
+    {
+        if (task == t)
+        {
+            EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock);
+            Enable();
+            return TRUE;
+        }
+    }
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock);
+    Enable();
+
+    return FALSE;
 #else
+    Forbid();
     if (task == GET_THIS_TASK)
     {
         Permit();
         return TRUE;
     }
-#endif
 
     ForeachNode(&SysBase->TaskReady, t)
     {
         if (task == t)
         {
-#if defined(__AROSEXEC_SMP__)
-            EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskReadySpinLock);
-#endif
             Permit();
             return TRUE;
         }
     }
-#if defined(__AROSEXEC_SMP__)
-    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskReadySpinLock);
-    Permit();
-    Forbid();
-    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock, NULL, SPINLOCK_MODE_READ);
-#endif
     ForeachNode(&SysBase->TaskWait, t)
     {
         if (task == t)
         {
-#if defined(__AROSEXEC_SMP__)
-            EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock);
-#endif
             Permit();
             return TRUE;
         }
     }
-#if defined(__AROSEXEC_SMP__)
-    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->TaskWaitSpinLock);
-#endif
     Permit();
 
     return FALSE;
+#endif
 }

--- a/rom/exec/exec_util.h
+++ b/rom/exec/exec_util.h
@@ -113,6 +113,11 @@ struct IntETask *FindETask(struct List *, ULONG id, struct ExecBase *SysBase);
 
 BOOL Exec_CheckTask(struct Task *task, struct ExecBase *SysBase);
 
+#if defined(__AROSEXEC_SMP__)
+void Exec_CancelSignalIPIs(struct Task *task, struct ExecBase *SysBase);
+#define CancelSignalIPIs(t) Exec_CancelSignalIPIs(t,SysBase)
+#endif
+
 STRPTR Alert_AddString(STRPTR dest, CONST_STRPTR src);
 STRPTR Alert_GetTitle(ULONG alertNum);
 STRPTR Alert_GetString(ULONG alertnum, STRPTR buf);

--- a/rom/exec/newaddtask.c
+++ b/rom/exec/newaddtask.c
@@ -36,7 +36,10 @@ static void TaskLaunch(struct Task *parent, struct Task *task, struct Hook *plHo
     Enqueue(&SysBase->TaskReady, &task->tc_Node);
 #else
     task->tc_State = TS_INVALID;
+    /* Disable() masks the FIQ that would re-enter the scheduler locks. */
+    Disable();
     krnSysCallReschedTask(task, TS_READY);
+    Enable();
 #endif
 
     /*
@@ -103,7 +106,9 @@ static void TaskLaunch(struct Task *parent, struct Task *task, struct Hook *plHo
     {
        bug("[Exec] TaskLaunch: Unable to Launch on the selected CPU\n");
         // TODO: Free up all the task data ..
+        Disable();
         krnSysCallReschedTask(task, TS_REMOVED);
+        Enable();
         if (GetETask(task))
             KrnDeleteContext(GetETask(task)->et_RegFrame);
         CleanupETask(task);
@@ -236,6 +241,10 @@ static void TaskLaunch(struct Task *parent, struct Task *task, struct Hook *plHo
     task->tc_SigWait = 0;
     task->tc_SigRecvd = 0;
     task->tc_SigExcept = 0;
+
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_INIT(&task->tc_SpinLock);
+#endif
 
     /* Signals default to all system signals allocated. */
     if (task->tc_SigAlloc == 0)

--- a/rom/exec/prepareexecbase.c
+++ b/rom/exec/prepareexecbase.c
@@ -220,6 +220,7 @@ struct ExecBase *PrepareExecBase(struct MemHeader *mh, struct TagItem *msg)
     SysBase->LibNode.lib_Flags        = LIBF_CHANGED | LIBF_SUMUSED;
 
 #if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_INIT(&SysBase->LibNode.lib_SpinLock);
     EXEC_SPINLOCK_INIT(&PrivExecBase(SysBase)->MemListSpinLock);
 #endif
     NEWLIST(&SysBase->MemList);
@@ -290,11 +291,18 @@ struct ExecBase *PrepareExecBase(struct MemHeader *mh, struct TagItem *msg)
     {
         NEWLIST(&SysBase->SoftInts[i].sh_List);
         SysBase->SoftInts[i].sh_List.lh_Type = NT_INTERRUPT;
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_INIT(&SysBase->SoftInts[i].sh_SpinLock);
+#endif
     }
 
     NEWLIST(&PrivExecBase(SysBase)->ResetHandlers);
     NEWLIST(&PrivExecBase(SysBase)->AllocMemList);
     NEWLIST(&PrivExecBase(SysBase)->AllocatorCtxList);
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_INIT(&PrivExecBase(SysBase)->AllocMemListSpinLock);
+    EXEC_SPINLOCK_INIT(&PrivExecBase(SysBase)->AllocatorCtxListSpinLock);
+#endif
 
 #if defined(__AROSEXEC_BROKENMEMLOCK__)
     InitSemaphore(&PrivExecBase(SysBase)->MemListSem);

--- a/rom/exec/remtask.c
+++ b/rom/exec/remtask.c
@@ -55,7 +55,7 @@
 {
     AROS_LIBFUNC_INIT
 
-    struct MemList *mb;
+    struct MemList *mb, *mbnext;
     struct ETask *et;
     struct Task *suicide = GET_THIS_TASK;
 
@@ -98,9 +98,19 @@
             task->tc_State = TS_REMOVED;
             Remove(&task->tc_Node);
 #else
+            /* Disable(), not Forbid(): only it masks the FIQ whose
+             * signal_hook would re-enter these same locks. */
+            Disable();
             krnSysCallReschedTask(task, TS_REMOVED);
+            Enable();
 #endif
         }
+
+#if defined(__AROSEXEC_SMP__)
+        /* Terminal now, so no new IPIs can be queued - flush the ones
+         * already in flight before any memory is freed. */
+        CancelSignalIPIs(task);
+#endif
 
         /* Delete context */
         et = GetETask(task);
@@ -159,9 +169,16 @@
              * We do this here because it's unsafe to send it to the service task:
              * by the time the service task processes it, the task structure may
              * have been freed following the return of this function.
+             *
+             * The list header may itself live in one of these MemLists, so
+             * detach the chain first rather than walking with RemHead.
              */
-            while((mb = (struct MemList *) RemHead(&task->tc_MemEntry)) != NULL)
+            task->tc_MemEntry.lh_TailPred->ln_Succ = NULL;
+            for (mb = (struct MemList *)task->tc_MemEntry.lh_Head; mb; mb = mbnext)
+            {
+                mbnext = (struct MemList *)mb->ml_Node.ln_Succ;
                 FreeEntry(mb);
+            }
         }
     }
 

--- a/rom/exec/service.c
+++ b/rom/exec/service.c
@@ -104,7 +104,11 @@ void ServiceTask(struct ExecBase *SysBase)
                     task->tc_State = TS_READY;
                     Enqueue(&SysBase->TaskReady, &task->tc_Node);
 #else
+                    /* Disable() masks the FIQ that would re-enter the
+                     * scheduler locks taken below. */
+                    Disable();
                     krnSysCallReschedTask(task, TS_READY);
+                    Enable();
 #endif
                 }
                 else

--- a/rom/exec/setexcept.c
+++ b/rom/exec/setexcept.c
@@ -60,10 +60,10 @@
     struct Task *thisTask = GET_THIS_TASK;
     ULONG old;
 
-    /* Protect mask of sent signals and task lists */
+    /* Disable() also masks the FIQ that would re-enter tc_SpinLock. */
     Disable();
 #if defined(__AROSEXEC_SMP__)
-    EXEC_LOCK_WRITE(&IntETask(thisTask->tc_UnionETask.tc_ETask)->iet_TaskLock);
+    EXEC_SPINLOCK_LOCK(&thisTask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
 #endif
 
     /* Get returncode */
@@ -82,7 +82,7 @@
         Reschedule();
     }
 #if defined(__AROSEXEC_SMP__)
-    EXEC_UNLOCK(&IntETask(thisTask->tc_UnionETask.tc_ETask)->iet_TaskLock);
+    EXEC_SPINLOCK_UNLOCK(&thisTask->tc_SpinLock);
 #endif
     Enable();
 

--- a/rom/exec/setsignal.c
+++ b/rom/exec/setsignal.c
@@ -59,8 +59,11 @@
 
     if (thisTask)
     {
-        /* Protect the signal mask against access by other tasks. */
+        /* Disable() also masks the FIQ that would re-enter tc_SpinLock. */
         Disable();
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&thisTask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
         /* Get address */
         sig = &thisTask->tc_SigRecvd;
@@ -69,6 +72,9 @@
         old = *sig;
         *sig = (old & ~signalSet) | (newSignals & signalSet);
 
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&thisTask->tc_SpinLock);
+#endif
         Enable();
     }
 

--- a/rom/exec/settaskpri.c
+++ b/rom/exec/settaskpri.c
@@ -61,14 +61,22 @@
     struct Task *thisTask = GET_THIS_TASK;
 #if defined(__AROSEXEC_SMP__)
     spinlock_t *task_listlock = NULL;
+    BOOL doResched = FALSE, doRemote = FALSE;
     int cpunum = KrnGetCPUNumber();
+    void *remoteCpuAffinity = NULL;
 #endif
     BYTE old;
 
     D(bug("[Exec] SetTaskPri(0x%p, %d)\n", task, priority);)
 
     /* Always Disable() when doing something with task lists. */
+    Disable();
 #if defined(__AROSEXEC_SMP__)
+    /*
+     * Take the task lock before picking the list lock: tc_State tells us
+     * which list the task is on, and only the task lock keeps it still.
+     */
+    EXEC_SPINLOCK_LOCK(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
     switch (task->tc_State)
     {
         case TS_RUN:
@@ -81,9 +89,6 @@
             task_listlock = &PrivExecBase(SysBase)->TaskReadySpinLock;
             break;
     }
-#endif
-    Disable();
-#if defined(__AROSEXEC_SMP__)
     if (task->tc_State == TS_READY)
         EXEC_LOCK_WRITE(task_listlock);
     else
@@ -107,31 +112,39 @@
         }
 
 #if defined(__AROSEXEC_SMP__)
-        EXEC_UNLOCK(task_listlock);
-
-        task_listlock = NULL;
-        if (IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber == cpunum) {
-#endif
+        if (IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber == cpunum)
+            doResched = (task->tc_Node.ln_Pri > thisTask->tc_Node.ln_Pri);
+        else if (task->tc_State == TS_RUN)
+        {
+            /* Read the affinity while still locked - the ETask can be
+             * freed the moment we let go. */
+            remoteCpuAffinity = IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity;
+            doRemote = TRUE;
+        }
+#else
         if ( task->tc_Node.ln_Pri > thisTask->tc_Node.ln_Pri)
         {
             D(bug("[Exec] SetTaskPri: Task needs reschedule...\n");)
             Reschedule();
-        }
-#if defined(__AROSEXEC_SMP__)
-        }
-        else if (task->tc_State == TS_RUN)
-        {
-            D(bug("[Exec] SetTaskPri: changing priority of task running on another cpu (%03u)\n", IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber);)
-            KrnScheduleCPU(IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity);
         }
 #endif
     }
 
     /* All done. */
 #if defined(__AROSEXEC_SMP__)
-    if (task_listlock)
+    /* Drop both locks before kicking any scheduler path. */
+    EXEC_UNLOCK(task_listlock);
+    EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+
+    if (doResched)
     {
-        EXEC_UNLOCK(task_listlock);
+        D(bug("[Exec] SetTaskPri: Task needs reschedule...\n");)
+        Reschedule();
+    }
+    else if (doRemote)
+    {
+        D(bug("[Exec] SetTaskPri: changing priority of task running on another cpu (%03u)\n", remoteCpuNumber);)
+        KrnScheduleCPU(remoteCpuAffinity);
     }
 #endif
     Enable();

--- a/rom/exec/signal.c
+++ b/rom/exec/signal.c
@@ -36,14 +36,74 @@ AROS_UFH3(IPTR, signal_hook,
     D(
         struct KernelBase *KernelBase = __kernelBase;
         int cpunum = KrnGetCPUNumber();
-        bug("[Exec] CPU%03d: Using IPI to do Signal(%p, %08x), SysBase=%p\n", cpunum, msg->target, msg->sigset, SysBase);
+        bug("[Exec] CPU%03d: Using IPI to do Signal(%p, %08x), SysBase=%p\n", cpunum, target, sigset, SysBase);
     );
-    
+
+#if defined(__AROSEXEC_IPI_RESTRICTED_CTX__)
+    /*
+     * Delivered as an FIQ here, so the full Signal() is out: it needs
+     * Disable()/Enable() syscalls and may reschedule from inside this
+     * handler. Deliver locally instead and let core_ExitInterrupt take
+     * the switch on return.
+     */
+    EXEC_SPINLOCK_LOCK(&target->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+
+    if (target->tc_State == TS_INVALID ||
+        target->tc_State == TS_REMOVED ||
+        target->tc_State == TS_TOMBSTONED)
+    {
+        __AROS_ATOMIC_OR_L(target->tc_SigRecvd, sigset);
+        EXEC_SPINLOCK_UNLOCK(&target->tc_SpinLock);
+        return 0;
+    }
+
+    __AROS_ATOMIC_OR_L(target->tc_SigRecvd, sigset);
+
+    if (target->tc_SigRecvd & target->tc_SigExcept)
+        __AROS_ATOMIC_OR_B(target->tc_Flags, TF_EXCEPT);
+
+    if (target->tc_SigRecvd & (target->tc_SigWait | target->tc_SigExcept))
+    {
+        if (target->tc_State == TS_WAIT)
+        {
+            EXEC_SPINLOCK_UNLOCK(&target->tc_SpinLock);
+            krnSysCallReschedTask(target, TS_READY);
+            FLAG_SCHEDSWITCH_SET;
+            return 0;
+        }
+        /* TS_RUN / TS_READY: let the FIQ-exit dispatcher pick it up. */
+        FLAG_SCHEDSWITCH_SET;
+    }
+
+    EXEC_SPINLOCK_UNLOCK(&target->tc_SpinLock);
+#else
+    /* Ordinary interrupt here, so the full Signal() is safe. */
     Signal(target, sigset);
+#endif
 
     return 0;
 
     AROS_USERFUNC_EXIT
+}
+
+/*
+ * Called from RemTask() once the task is terminal, before its memory can
+ * go away, so no core drains a queued Signal-IPI naming a freed task.
+ */
+void Exec_CancelSignalIPIs(struct Task *task, struct ExecBase *SysBase)
+{
+#if defined(KERNEL_IPI_CALL_CANCELABLE)
+    /*
+     * Disable() masks the FIQ hook and the local drain. The empty
+     * lock/unlock waits out a sender mid-commit; later ones see the
+     * terminal state and refuse.
+     */
+    Disable();
+    EXEC_SPINLOCK_LOCK(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+    EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+    core_CancelCallIPIs((APTR)signal_hook, (IPTR)task);
+    Enable();
+#endif
 }
 #endif
 
@@ -113,10 +173,7 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
     {
         struct Hook h;
         IPTR args[3];
-        // We cannot use KrnAllocCPUMask() since this function uses AllocMem
-        // And we cannot use AllocMem from interrupts (where Signal() is allowed)...
-        ULONG mask[8] = { 0, 0, 0, 0, 0, 0, 0, 0 }; // CPU mask large enough for 256 CPUs...
-        void *cpu_mask = &mask;
+        int targetcpu;
 
         args[0] = (IPTR)SysBase;
         args[1] = (IPTR)task;
@@ -125,7 +182,7 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
         /* Task is running *now* on another CPU, send signal there */
         if (task->tc_State == TS_RUN)
         {
-            KrnGetCPUMask(IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber, cpu_mask);
+            targetcpu = IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber;
         }
         else
         {
@@ -133,22 +190,62 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
             int cpumax = KrnGetCPUCount();
 
             /* Task is not running now, find first cpu suitable to run this task. Use CPU balancing some day... */
+            targetcpu = 0;
             for (i=0; i < cpumax; i++)
             {
                 if (KrnCPUInMask(i, IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity))
                 {
-                    KrnGetCPUMask(i, cpu_mask);
+                    targetcpu = i;
                     break;
                 }
             }
         }
 
-        D(bug("[Exec] %s: Signaling from CPU%03d -> CPU%03d using IPI...\n", __func__, cpunum, IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber));
+        D(bug("[Exec] %s: Signaling from CPU%03d -> CPU%03d using IPI...\n", __func__, cpunum, targetcpu));
 
         h.h_Entry = signal_hook;
 
-        D(bug("[Exec] %s: Sending IPI...\n", __func__));
-        core_DoCallIPI(&h, cpu_mask, 1, 3, args, (void *)KernelBase);
+#if defined(KERNEL_IPI_CALL_CANCELABLE)
+        {
+            struct CallIPIEntry *cie;
+
+            /*
+             * The queued call outlives this function, so claim and commit
+             * are split: claim first (it may spin, and must not hold a
+             * task lock), then commit under tc_SpinLock once tc_State is
+             * re-checked, so teardown's sweep cannot miss it.
+             */
+            cie = core_ClaimCallIPI(targetcpu);
+
+            Disable();
+            EXEC_SPINLOCK_LOCK(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+            if (task->tc_State == TS_INVALID ||
+                task->tc_State == TS_REMOVED ||
+                task->tc_State == TS_TOMBSTONED)
+            {
+                __AROS_ATOMIC_OR_L(task->tc_SigRecvd, signalSet);
+                EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+                Enable();
+                core_AbortCallIPI(cie, targetcpu);
+                return;
+            }
+            core_CommitCallIPI(cie, targetcpu, &h, 3, args);
+            EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+            Enable();
+        }
+#else
+        {
+            // We cannot use KrnAllocCPUMask() since this function uses AllocMem
+            // And we cannot use AllocMem from interrupts (where Signal() is allowed)...
+            ULONG mask[8] = { 0, 0, 0, 0, 0, 0, 0, 0 }; // CPU mask large enough for 256 CPUs...
+            void *cpu_mask = &mask;
+
+            KrnGetCPUMask(targetcpu, cpu_mask);
+
+            D(bug("[Exec] %s: Sending IPI...\n", __func__));
+            core_DoCallIPI(&h, cpu_mask, 1, 3, args, (void *)KernelBase);
+        }
+#endif
         D(bug("[Exec] %s: IPI Sent\n", __func__));
     }
     else
@@ -163,6 +260,29 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
 #endif
 
         Disable();
+#if defined(__AROSEXEC_SMP__)
+        /*
+         * tc_SpinLock covers the state and signal fields as a group.
+         * Release it before any scheduler call - those take it again.
+         * Lock order is task lock, then list lock.
+         */
+        EXEC_SPINLOCK_LOCK(&task->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+
+        /*
+         * A task mid-teardown may be on no scheduler list, so
+         * rescheduling it would Remove() from the wrong one. Record the
+         * signal and leave.
+         */
+        if (task->tc_State == TS_INVALID ||
+            task->tc_State == TS_REMOVED ||
+            task->tc_State == TS_TOMBSTONED)
+        {
+            __AROS_ATOMIC_OR_L(task->tc_SigRecvd, signalSet);
+            EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+            Enable();
+            return;
+        }
+#endif
         D(
             bug("[Exec] %s: Signaling 0x%p '%s', state = %08x\n", __func__, task, task->tc_Node.ln_Name, task->tc_State);
 #if (0)
@@ -200,20 +320,25 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
             if (task->tc_State == TS_RUN)
             {
 #if defined(__AROSEXEC_SMP__)
-                if (!(PrivExecBase(SysBase)->IntFlags & EXECF_CPUAffinity) ||
-                    (IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber == cpunum))
+                BOOL sameCpu = (!(PrivExecBase(SysBase)->IntFlags & EXECF_CPUAffinity) ||
+                                (IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber == cpunum));
+                void *targetCpuAffinity = IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity;
+                EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+                if (sameCpu)
                 {
-#endif
-                D(bug("[Exec] %s: calling Reschedule to raise Exception for RUN Task\n", __func__);)
-                /* Order a reschedule */
-                Reschedule();
-#if defined(__AROSEXEC_SMP__)
+                    D(bug("[Exec] %s: calling Reschedule to raise Exception for RUN Task\n", __func__);)
+                    Reschedule();
                 }
                 else
                 {
-                    D(bug("[Exec] %s: Raising Exception for RUN Task on CPU %03u\n", __func__, IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuNumber));
-                    KrnScheduleCPU(IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity);
+                    /* Use the cached affinity - the ETask may be gone. */
+                    D(bug("[Exec] %s: Raising Exception for RUN Task on another CPU\n", __func__));
+                    KrnScheduleCPU(targetCpuAffinity);
                 }
+#else
+                D(bug("[Exec] %s: calling Reschedule to raise Exception for RUN Task\n", __func__);)
+                /* Order a reschedule */
+                Reschedule();
 #endif
                 Enable();
 
@@ -232,7 +357,34 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
                 )
                 /* Yes. Move it to the ready list. */
 #if defined(__AROSEXEC_SMP__)
-                krnSysCallReschedTask(task, TS_READY);
+                /*
+                 * Once the task is made READY another core can run and
+                 * even free it, so read what we need first and do not
+                 * touch *task afterwards.
+                 */
+                {
+                    BYTE targetPri = task->tc_Node.ln_Pri;
+                    BOOL onThisCpu = (!(PrivExecBase(SysBase)->IntFlags & EXECF_CPUAffinity) ||
+                                      KrnCPUInMask(cpunum, IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity));
+                    void *targetCpuAffinity = IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity;
+
+                    EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+                    krnSysCallReschedTask(task, TS_READY);
+
+                    if (!onThisCpu)
+                    {
+                        D(bug("[Exec] %s: Signaling task on another CPU\n", __func__));
+                        KrnScheduleCPU(targetCpuAffinity);
+                    }
+                    else if ((targetPri > thisTask->tc_Node.ln_Pri) &&
+                             (thisTask->tc_State == TS_RUN))
+                    {
+                        D(bug("[Exec] %s: Task has higher priority ...\n", __func__);)
+                        Reschedule();
+                    }
+                    Enable();
+                    return;
+                }
 #else
                 Remove(&task->tc_Node);
                 task->tc_State = TS_READY;
@@ -260,25 +412,41 @@ void Exec_SignalSlow(struct Task *task, ULONG signalSet, struct ExecBase *SysBas
                         D(
                             bug("[Exec] %s: Rescheduling RUN Task 0x%p '%s' pri %d,  to let 0x%p '%s' process the signal...\n", __func__, thisTask, thisTask->tc_Node.ln_Name, thisTask->tc_Node.ln_Pri, task, task->tc_Node.ln_Name);
                         )
+#if defined(__AROSEXEC_SMP__)
+                        /* Do not re-lock: another core may have freed it. */
+                        EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+                        Reschedule();
+                        Enable();
+                        return;
+#else
                         Reschedule();
                         D(
                             bug("[Exec] %s: returned to task 0x%p '%s' pri %d\n", __func__, thisTask, thisTask->tc_Node.ln_Name, thisTask->tc_Node.ln_Pri);
                         )
+#endif
                     }
                 }
 #if defined(__AROSEXEC_SMP__)
                 else if ((PrivExecBase(SysBase)->IntFlags & EXECF_CPUAffinity) &&
                     !(KrnCPUInMask(cpunum, IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity)))
                 {
+                    void *targetCpuAffinity = IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity;
                     D(bug("[Exec] %s: Signaling task on another CPU\n", __func__));
+                    /* Do not re-lock: the target core may have freed it. */
+                    EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
                     krnSysCallReschedTask(task, TS_READY);
-                    KrnScheduleCPU(IntETask(task->tc_UnionETask.tc_ETask)->iet_CpuAffinity);
+                    KrnScheduleCPU(targetCpuAffinity);
+                    Enable();
+                    return;
                 }
 #endif
                 D(else bug("[Exec] %s: Letting Task process signal when next scheduled to run...\n", __func__);)
             }
         }
 
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&task->tc_SpinLock);
+#endif
         Enable();
 
         D(

--- a/rom/exec/wait.c
+++ b/rom/exec/wait.c
@@ -66,7 +66,11 @@
     ULONG rcvd;
 
     D(bug("[Exec] Wait(%08lX)\n", signalSet);)
+    /* Disable() also masks the FIQ that would re-enter tc_SpinLock. */
     Disable();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&thisTask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /* If at least one of the signals is already set do not wait. */
     while (!(thisTask->tc_SigRecvd & signalSet))
@@ -86,11 +90,24 @@
         TDNESTCOUNT_SET(-1);
 
         thisTask->tc_State = TS_WAIT;
-        // nb: on smp builds switch will move us.
-#if !defined(__AROSEXEC_SMP__)
+
+#if defined(__AROSEXEC_SMP__)
+        /*
+         * Move lists and set the state under tc_SpinLock, so an observer
+         * always sees TS_WAIT together with being on TaskWait.
+         */
+        exec_TaskRemoveRunning(thisTask);
+        exec_TaskEnqueueWait(thisTask);
+#else
         /* Move current task to the waiting list. */
         Enqueue(&SysBase->TaskWait, &thisTask->tc_Node);
 #endif
+
+        /*
+         * Keep tc_SpinLock held across KrnSwitch; cpu_Switch drops it
+         * once the context is saved. Releasing it here would let another
+         * core wake and dispatch the task with a stale register frame.
+         */
 
         /* And switch to the next ready task. */
         KrnSwitch();
@@ -102,6 +119,9 @@
         */
         D(bug("[Exec] Wait: Awoken...\n");)
 
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_LOCK(&thisTask->tc_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
         /* Restore TDNestCnt. */
         TDNESTCOUNT_SET(thisTask->tc_TDNestCnt);
     }
@@ -111,6 +131,7 @@
     /* And clear them. */
 #if defined(__AROSEXEC_SMP__)
     __AROS_ATOMIC_AND_L(thisTask->tc_SigRecvd, ~signalSet);
+    EXEC_SPINLOCK_UNLOCK(&thisTask->tc_SpinLock);
 #else
     thisTask->tc_SigRecvd &= ~signalSet;
 #endif


### PR DESCRIPTION
**exec: lock task state and the ETask lifetime**

A task's state and its signal fields are changed as a group — read the state, decide, write it back — by `Signal()`, `Wait()`, `SetSignal()`, `RemTask()` and the scheduler. Until now that group was only held together by `Disable()`, which stops interrupts on the calling core but not on any other. Each task's own lock is now held across the group, and released before anything calls into the scheduler, since the scheduler takes the same lock itself.

Cross-core signalling goes with it: when a task belongs to another core, the signal is handed to that core rather than delivered locally, and any such message still in flight is cancelled when the task is torn down, so a core cannot wake a task that has already been freed.

The second commit covers the parent and child bookkeeping. A dying child is moved from its parent's child list to its message port in one step, so a `ChildStatus()` or `ChildFree()` running at the same time cannot see it on neither list.

**Why two commits together**

`RemTask()` in the first one calls the cancel helper that the second one declares. Splitting them does not compile. They are separate steps to review.