### PR TITLE
test/smp: add semaphore, scheduler and device I/O tests

### DIFF
--- a/developer/debug/test/smp/mmakefile.src
+++ b/developer/debug/test/smp/mmakefile.src
@@ -2,8 +2,8 @@
 #MM- test : test-smp
 #MM- test-quick : test-smp-quick
 #
-#MM- test-smp : test-smp-stress test-smp-trace test-smp-smp test-smp-smp-smallpt test-smp-preempt test-smp-sigrace
-#MM- test-smp-quick : test-smp-stress-quick test-smp-trace-quick test-smp-smp-quick test-smp-smp-smallpt-quick test-smp-preempt-quick test-smp-sigrace-quick
+#MM- test-smp : test-smp-stress test-smp-trace test-smp-smp test-smp-smp-smallpt test-smp-preempt test-smp-sigrace test-smp-sem test-smp-sched test-smp-doio
+#MM- test-smp-quick : test-smp-stress-quick test-smp-trace-quick test-smp-smp-quick test-smp-smp-smallpt-quick test-smp-preempt-quick test-smp-sigrace-quick test-smp-sem-quick test-smp-sched-quick test-smp-doio-quick
 
 include $(SRCDIR)/config/aros.cfg
 
@@ -26,5 +26,17 @@ USER_CFLAGS := $(PARANOIA_CFLAGS)
 %build_prog mmake=test-smp-sigrace \
     files=smpsigrace targetdir=$(EXEDIR) \
     progname=SMP-SigRace
+
+%build_prog mmake=test-smp-sem \
+    files=smpsem targetdir=$(EXEDIR) \
+    progname=SMP-Sem
+
+%build_prog mmake=test-smp-sched \
+    files=smpsched targetdir=$(EXEDIR) \
+    progname=SMP-Sched
+
+%build_prog mmake=test-smp-doio \
+    files=smpdoio targetdir=$(EXEDIR) \
+    progname=SMP-DoIO
 
 %common

--- a/developer/debug/test/smp/smpdoio.c
+++ b/developer/debug/test/smp/smpdoio.c
@@ -1,0 +1,317 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP coverage for device I/O round trips. One worker per core
+          drives its own timer.device requests with DoIO, then with a
+          SendIO/AbortIO/WaitIO mix. The completions arrive from the
+          timer interrupt on another core, so the reply path (PutMsg,
+          Signal, port arbitration) is exercised across cores.
+*/
+
+#include <exec/memory.h>
+#include <exec/tasks.h>
+#include <exec/io.h>
+#include <exec/errors.h>
+#include <devices/timer.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <clib/alib_protos.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+static int g_NumCPUs = 1;
+
+#define STACKSIZE       16384
+#define WAIT_TICKS      750         /* 15s bound: many timer round trips */
+#define DOIO_ITERS      200
+#define SENDIO_ITERS    100
+
+struct IOWorker
+{
+    volatile ULONG  w_Started;
+    volatile ULONG  w_Done;
+    volatile ULONG  w_Errors;
+    volatile ULONG  w_Completed;
+    volatile ULONG  w_Aborted;
+};
+
+static struct IOWorker *myworker(void)
+{
+    return (struct IOWorker *)FindTask(NULL)->tc_UserData;
+}
+
+static struct Task *spawn_pinned(const char *name, APTR pc, int cpu,
+                                 struct IOWorker *w)
+{
+    cpumask_t *mask = KrnAllocCPUMask();
+
+    if (!mask)
+        return NULL;
+    KrnClearCPUMask(mask);
+    KrnGetCPUMask(cpu % g_NumCPUs, mask);
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       0,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TASKTAG_AFFINITY,  (IPTR)mask,
+                         TAG_DONE);
+}
+
+static int wait_all(const char *phase, struct IOWorker *w, int n)
+{
+    int i, t;
+
+    for (t = 0; t < WAIT_TICKS; t++)
+    {
+        int done = 0;
+
+        for (i = 0; i < n; i++)
+            if (w[i].w_Done)
+                done++;
+        if (done == n)
+            return 1;
+        Delay(1);
+    }
+    bug("[smpdoio] %s: *** TIMEOUT *** (workers stuck)\n", phase);
+    return 0;
+}
+
+/* Open a private timer.device unit for this task. */
+static struct timerequest *open_timer(struct MsgPort **portp)
+{
+    struct MsgPort *port;
+    struct timerequest *tr;
+
+    port = CreateMsgPort();
+    if (!port)
+        return NULL;
+    tr = (struct timerequest *)CreateIORequest(port, sizeof(struct timerequest));
+    if (!tr)
+    {
+        DeleteMsgPort(port);
+        return NULL;
+    }
+    if (OpenDevice("timer.device", UNIT_MICROHZ, (struct IORequest *)tr, 0))
+    {
+        DeleteIORequest((struct IORequest *)tr);
+        DeleteMsgPort(port);
+        return NULL;
+    }
+    *portp = port;
+    return tr;
+}
+
+static void close_timer(struct timerequest *tr, struct MsgPort *port)
+{
+    CloseDevice((struct IORequest *)tr);
+    DeleteIORequest((struct IORequest *)tr);
+    DeleteMsgPort(port);
+}
+
+/******************************************************************************/
+/*  Phase 1: synchronous DoIO round trips from every core                     */
+/******************************************************************************/
+
+static void DoIOWorker(void)
+{
+    struct IOWorker *w = myworker();
+    struct MsgPort *port;
+    struct timerequest *tr;
+    ULONG i;
+
+    tr = open_timer(&port);
+    if (!tr)
+    {
+        w->w_Errors = 1;
+        w->w_Started = 1;
+        w->w_Done = 1;
+        Wait(0);
+    }
+
+    w->w_Started = 1;
+
+    for (i = 0; i < DOIO_ITERS; i++)
+    {
+        tr->tr_node.io_Command = TR_ADDREQUEST;
+        tr->tr_time.tv_secs    = 0;
+        tr->tr_time.tv_micro   = 1000;
+        if (DoIO((struct IORequest *)tr))
+            w->w_Errors++;
+        else
+            w->w_Completed++;
+    }
+
+    close_timer(tr, port);
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestDoIO(void)
+{
+    struct IOWorker w[4];
+    struct Task *t[4];
+    int n = g_NumCPUs < 4 ? g_NumCPUs : 4, k, ok = 1;
+
+    bug("[smpdoio] phase 1: %d workers x %d DoIO timer round trips...\n",
+        n, DOIO_ITERS);
+
+    memset(w, 0, sizeof(w));
+    for (k = 0; k < n; k++)
+    {
+        t[k] = spawn_pinned("smpdoio.doio", DoIOWorker, k, &w[k]);
+        if (!t[k])
+        {
+            bug("[smpdoio] phase 1: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    if (!wait_all("phase 1", w, n))
+        ok = 0;
+
+    Forbid();
+    for (k = 0; k < n; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < n; k++)
+    {
+        if (w[k].w_Errors || w[k].w_Completed != DOIO_ITERS)
+        {
+            bug("[smpdoio] phase 1: *** FAIL *** worker %d: %lu done, %lu errors\n",
+                k, (unsigned long)w[k].w_Completed, (unsigned long)w[k].w_Errors);
+            return 0;
+        }
+    }
+    bug("[smpdoio] phase 1: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 2: SendIO with AbortIO on every second request                      */
+/******************************************************************************/
+
+static void SendIOWorker(void)
+{
+    struct IOWorker *w = myworker();
+    struct MsgPort *port;
+    struct timerequest *tr;
+    ULONG i;
+
+    tr = open_timer(&port);
+    if (!tr)
+    {
+        w->w_Errors = 1;
+        w->w_Started = 1;
+        w->w_Done = 1;
+        Wait(0);
+    }
+
+    w->w_Started = 1;
+
+    for (i = 0; i < SENDIO_ITERS; i++)
+    {
+        BYTE err;
+
+        tr->tr_node.io_Command = TR_ADDREQUEST;
+        tr->tr_time.tv_secs    = 0;
+        tr->tr_time.tv_micro   = (i & 1) ? 500000 : 500;
+        SendIO((struct IORequest *)tr);
+
+        /* Abort the long ones so the phase stays fast; the short ones
+         * usually complete first and the abort must cope with that. */
+        if (i & 1)
+            AbortIO((struct IORequest *)tr);
+
+        err = WaitIO((struct IORequest *)tr);
+        if (err == IOERR_ABORTED)
+            w->w_Aborted++;
+        else if (err == 0)
+            w->w_Completed++;
+        else
+            w->w_Errors++;
+    }
+
+    close_timer(tr, port);
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestSendIO(void)
+{
+    struct IOWorker w[4];
+    struct Task *t[4];
+    int n = g_NumCPUs < 4 ? g_NumCPUs : 4, k, ok = 1;
+
+    bug("[smpdoio] phase 2: %d workers x %d SendIO/AbortIO/WaitIO...\n",
+        n, SENDIO_ITERS);
+
+    memset(w, 0, sizeof(w));
+    for (k = 0; k < n; k++)
+    {
+        t[k] = spawn_pinned("smpdoio.sendio", SendIOWorker, k, &w[k]);
+        if (!t[k])
+        {
+            bug("[smpdoio] phase 2: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    if (!wait_all("phase 2", w, n))
+        ok = 0;
+
+    Forbid();
+    for (k = 0; k < n; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < n; k++)
+    {
+        bug("[smpdoio] phase 2: worker %d: %lu completed, %lu aborted, %lu errors\n",
+            k, (unsigned long)w[k].w_Completed, (unsigned long)w[k].w_Aborted,
+            (unsigned long)w[k].w_Errors);
+        if (w[k].w_Errors ||
+            (w[k].w_Completed + w[k].w_Aborted) != SENDIO_ITERS)
+        {
+            bug("[smpdoio] phase 2: *** FAIL *** worker %d lost requests\n", k);
+            return 0;
+        }
+    }
+    bug("[smpdoio] phase 2: OK\n");
+    return 1;
+}
+
+int main(void)
+{
+    int pass = 0, fail = 0, inval = 0;
+    int r;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        g_NumCPUs = KrnGetCPUCount();
+
+    bug("[smpdoio] start: cpus=%ld\n", (LONG)g_NumCPUs);
+
+    r = TestDoIO();    if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestSendIO();  if (r > 0) pass++; else if (!r) fail++; else inval++;
+
+    bug("[smpdoio] DONE: %d PASS, %d FAIL, %d INVALID\n", pass, fail, inval);
+    return fail ? RETURN_FAIL : RETURN_OK;
+}

--- a/developer/debug/test/smp/smpsched.c
+++ b/developer/debug/test/smp/smpsched.c
@@ -1,0 +1,333 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP scheduler coverage the other tests skip: whether unpinned
+          tasks migrate between cores, whether waking a high-priority task
+          preempts a busy core, and whether SetTaskPri survives being
+          aimed at a task running on another core.
+*/
+
+#include <exec/memory.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+static int g_NumCPUs = 1;
+
+#define STACKSIZE       16384
+#define WAIT_TICKS      500
+#define MIGRATE_TICKS   100         /* observation window, ~2s */
+#define SETPRI_LOOPS    400
+
+struct SchedWorker
+{
+    volatile ULONG  w_Started;
+    volatile ULONG  w_Stop;
+    volatile ULONG  w_Done;
+    volatile ULONG  w_Count;
+    volatile ULONG  w_CpuMask;      /* cores this worker has run on */
+    volatile ULONG  w_RanOn;
+};
+
+static struct SchedWorker *myworker(void)
+{
+    return (struct SchedWorker *)FindTask(NULL)->tc_UserData;
+}
+
+static struct Task *spawn_pinned(const char *name, APTR pc, int cpu, LONG pri,
+                                 struct SchedWorker *w)
+{
+    cpumask_t *mask = KrnAllocCPUMask();
+
+    if (!mask)
+        return NULL;
+    KrnClearCPUMask(mask);
+    KrnGetCPUMask(cpu, mask);
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       pri,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TASKTAG_AFFINITY,  (IPTR)mask,
+                         TAG_DONE);
+}
+
+static struct Task *spawn_free(const char *name, APTR pc, LONG pri,
+                               struct SchedWorker *w)
+{
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       pri,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TAG_DONE);
+}
+
+static int wait_flag(volatile ULONG *flag, int ticks)
+{
+    int i;
+
+    for (i = 0; i < ticks && !*flag; i++)
+        Delay(1);
+    return *flag != 0;
+}
+
+/******************************************************************************/
+/*  Phase 1: migration of unpinned busy tasks                                 */
+/*                                                                            */
+/*  More runnable unpinned workers than cores. All must make progress, and   */
+/*  the per-worker record of observed cores shows whether any migrated.      */
+/******************************************************************************/
+
+static void BusyTracker(void)
+{
+    struct SchedWorker *w = myworker();
+
+    w->w_Started = 1;
+
+    while (!w->w_Stop)
+    {
+        w->w_CpuMask |= 1UL << KrnGetCPUNumber();
+        w->w_Count++;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestMigration(void)
+{
+    struct SchedWorker w[8];
+    struct Task *t[8];
+    int n = 2 * g_NumCPUs, k, migrated = 0, ok = 1;
+
+    if (n > 8)
+        n = 8;
+
+    bug("[smpsched] phase 1: %d unpinned busy workers on %d cores...\n", n, g_NumCPUs);
+
+    memset(w, 0, sizeof(w));
+    for (k = 0; k < n; k++)
+    {
+        t[k] = spawn_free("smpsched.busy", BusyTracker, 0, &w[k]);
+        if (!t[k])
+        {
+            bug("[smpsched] phase 1: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    Delay(MIGRATE_TICKS);
+
+    for (k = 0; k < n; k++)
+        w[k].w_Stop = 1;
+
+    for (k = 0; k < n; k++)
+    {
+        if (!wait_flag(&w[k].w_Done, WAIT_TICKS))
+        {
+            bug("[smpsched] phase 1: *** FAIL *** worker %d never stopped\n", k);
+            ok = 0;
+            break;
+        }
+    }
+
+    Forbid();
+    for (k = 0; k < n; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < n; k++)
+    {
+        bug("[smpsched] phase 1: worker %d: %lu iters, cpumask %02lx\n",
+            k, (unsigned long)w[k].w_Count, (unsigned long)w[k].w_CpuMask);
+        if (w[k].w_Count == 0)
+        {
+            bug("[smpsched] phase 1: *** FAIL *** worker %d starved\n", k);
+            return 0;
+        }
+        if (w[k].w_CpuMask & (w[k].w_CpuMask - 1))
+            migrated++;
+    }
+    bug("[smpsched] phase 1: OK (%d of %d workers ran on more than one core)\n",
+        migrated, n);
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 2: waking a high-priority task preempts a busy core                 */
+/*                                                                            */
+/*  Every core spins on priority 0. A priority 10 task is woken by Signal()  */
+/*  and must run anyway - if no core gets preempted, it never reports back.  */
+/******************************************************************************/
+
+static void PinnedSpinner(void)
+{
+    struct SchedWorker *w = myworker();
+
+    w->w_Started = 1;
+    while (!w->w_Stop)
+        w->w_Count++;
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static void HighPrioWaiter(void)
+{
+    struct SchedWorker *w = myworker();
+
+    w->w_Started = 1;
+    Wait(SIGBREAKF_CTRL_C);
+    w->w_RanOn = KrnGetCPUNumber();
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestPriorityWake(void)
+{
+    struct SchedWorker sw[4], hw;
+    struct Task *st[4], *ht;
+    int k, ok = 1;
+
+    if (g_NumCPUs < 2)
+    {
+        bug("[smpsched] phase 2: SKIP (needs SMP)\n");
+        return 1;
+    }
+
+    bug("[smpsched] phase 2: high-priority wake with all %d cores busy...\n",
+        g_NumCPUs);
+
+    memset(sw, 0, sizeof(sw));
+    memset(&hw, 0, sizeof(hw));
+
+    ht = spawn_free("smpsched.hiprio", HighPrioWaiter, 10, &hw);
+    if (!ht || !wait_flag(&hw.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsched] phase 2: INVALID (waiter did not start)\n");
+        return -1;
+    }
+    Delay(1);   /* let it reach Wait() */
+
+    for (k = 0; k < g_NumCPUs && k < 4; k++)
+    {
+        st[k] = spawn_pinned("smpsched.spin", PinnedSpinner, k, 0, &sw[k]);
+        if (!st[k] || !wait_flag(&sw[k].w_Started, WAIT_TICKS))
+        {
+            bug("[smpsched] phase 2: INVALID (spinner %d did not start)\n", k);
+            return -1;
+        }
+    }
+
+    /* All cores now run priority-0 spinners. Wake the priority-10 task. */
+    Signal(ht, SIGBREAKF_CTRL_C);
+
+    if (!wait_flag(&hw.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsched] phase 2: *** FAIL *** high-priority task never ran - "
+            "no core was preempted for it\n");
+        ok = 0;
+    }
+    else
+        bug("[smpsched] phase 2: woke on cpu %lu\n", (unsigned long)hw.w_RanOn);
+
+    for (k = 0; k < g_NumCPUs && k < 4; k++)
+        sw[k].w_Stop = 1;
+    for (k = 0; k < g_NumCPUs && k < 4; k++)
+        wait_flag(&sw[k].w_Done, WAIT_TICKS);
+
+    Forbid();
+    for (k = 0; k < g_NumCPUs && k < 4; k++)
+        RemTask(st[k]);
+    RemTask(ht);
+    Permit();
+
+    if (ok)
+        bug("[smpsched] phase 2: OK\n");
+    return ok;
+}
+
+/******************************************************************************/
+/*  Phase 3: SetTaskPri aimed at a task running on another core               */
+/******************************************************************************/
+
+static int TestCrossSetPri(void)
+{
+    struct SchedWorker w;
+    struct Task *t;
+    ULONG before, after;
+    int i;
+
+    bug("[smpsched] phase 3: cross-core SetTaskPri while running...\n");
+
+    memset(&w, 0, sizeof(w));
+    t = spawn_free("smpsched.pri", BusyTracker, 0, &w);
+    if (!t || !wait_flag(&w.w_Started, WAIT_TICKS))
+    {
+        bug("[smpsched] phase 3: INVALID (worker did not start)\n");
+        return -1;
+    }
+
+    for (i = 0; i < SETPRI_LOOPS; i++)
+    {
+        SetTaskPri(t, 5);
+        SetTaskPri(t, -5);
+        SetTaskPri(t, 0);
+    }
+
+    before = w.w_Count;
+    Delay(10);
+    after = w.w_Count;
+
+    w.w_Stop = 1;
+    if (!wait_flag(&w.w_Done, WAIT_TICKS))
+    {
+        bug("[smpsched] phase 3: *** FAIL *** worker lost after SetTaskPri storm\n");
+        return 0;
+    }
+
+    Forbid();
+    RemTask(t);
+    Permit();
+
+    if (after == before)
+    {
+        bug("[smpsched] phase 3: *** FAIL *** worker stopped progressing\n");
+        return 0;
+    }
+    bug("[smpsched] phase 3: OK\n");
+    return 1;
+}
+
+int main(void)
+{
+    int pass = 0, fail = 0, inval = 0;
+    int r;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        g_NumCPUs = KrnGetCPUCount();
+
+    bug("[smpsched] start: cpus=%ld\n", (LONG)g_NumCPUs);
+
+    r = TestMigration();     if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestPriorityWake();  if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestCrossSetPri();   if (r > 0) pass++; else if (!r) fail++; else inval++;
+
+    bug("[smpsched] DONE: %d PASS, %d FAIL, %d INVALID\n", pass, fail, inval);
+    return fail ? RETURN_FAIL : RETURN_OK;
+}

--- a/developer/debug/test/smp/smpsem.c
+++ b/developer/debug/test/smp/smpsem.c
@@ -1,0 +1,584 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP coverage for the semaphore paths the other tests skip:
+          ObtainSemaphoreList against single obtainers, the asynchronous
+          Procure/Vacate protocol against blocking obtainers, and shared
+          readers holding an invariant against an exclusive writer.
+
+          Workers are pinned across cores, so these paths race for real
+          instead of being serialised by a single CPU.
+*/
+
+#include <exec/semaphores.h>
+#include <exec/memory.h>
+#include <exec/ports.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <clib/alib_protos.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+static int g_NumCPUs = 1;
+
+#define STACKSIZE       16384
+#define WAIT_TICKS      500         /* 10s bound for Delay-based waits */
+#define LIST_SEMS       4
+#define LIST_ITERS      2000
+#define SINGLE_ITERS    4000
+#define PROCURE_ITERS   2000
+#define OBTAIN_ITERS    4000
+#define READER_ITERS    4000
+#define WRITER_ITERS    4000
+
+struct SemWorker
+{
+    volatile ULONG  w_Started;
+    volatile ULONG  w_Done;
+    volatile ULONG  w_Errors;
+    volatile ULONG  w_Progress;
+    APTR            w_Arg;
+    APTR            w_Arg2;
+};
+
+static struct SemWorker *myworker(void)
+{
+    return (struct SemWorker *)FindTask(NULL)->tc_UserData;
+}
+
+static struct Task *spawn(const char *name, APTR pc, int cpu, struct SemWorker *w)
+{
+    if (KernelBase && g_NumCPUs > 1)
+    {
+        cpumask_t *mask = KrnAllocCPUMask();
+
+        if (mask)
+        {
+            KrnClearCPUMask(mask);
+            KrnGetCPUMask(cpu % g_NumCPUs, mask);
+            /* The mask becomes iet_CpuAffinity, freed by exec at teardown. */
+            return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                                 TASKTAG_PRI,       0,
+                                 TASKTAG_PC,        (IPTR)pc,
+                                 TASKTAG_STACKSIZE, STACKSIZE,
+                                 TASKTAG_USERDATA,  (IPTR)w,
+                                 TASKTAG_AFFINITY,  (IPTR)mask,
+                                 TAG_DONE);
+        }
+    }
+
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       0,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TAG_DONE);
+}
+
+static int wait_all(const char *phase, struct SemWorker *w, int n)
+{
+    int i, t;
+    ULONG last = ~0UL;
+
+    for (t = 0; t < WAIT_TICKS; t++)
+    {
+        int done = 0;
+        ULONG sum = 0;
+
+        for (i = 0; i < n; i++)
+        {
+            if (w[i].w_Done)
+                done++;
+            sum += w[i].w_Progress;
+        }
+        if (done == n)
+            return 1;
+        if ((t % 100) == 99)
+        {
+            bug("[smpsem] %s: %ds, %d/%d done, progress %lu\n",
+                phase, (t + 1) / 50, done, n, (unsigned long)sum);
+            if (sum == last)   /* markers included: equal sums = frozen */
+            {
+                bug("[smpsem] %s: *** STUCK *** (no progress in 2s)\n", phase);
+                for (i = 0; i < n; i++)
+                    bug("[smpsem]   worker %d: done=%lu progress=%lu\n", i,
+                        (unsigned long)w[i].w_Done, (unsigned long)w[i].w_Progress);
+                return 0;
+            }
+            last = sum;
+        }
+        Delay(1);
+    }
+    bug("[smpsem] %s: *** TIMEOUT *** (still progressing but too slow)\n", phase);
+    return 0;
+}
+
+/******************************************************************************/
+/*  Phase 1: ObtainSemaphoreList vs single obtainers                          */
+/*                                                                            */
+/*  One task locks the whole list (its documented contract allows only one   */
+/*  such task), while other cores hammer single members. Each member guards  */
+/*  its own counter; the list worker checks it owns all members while held.  */
+/******************************************************************************/
+
+struct ListCtx
+{
+    struct List             lc_List;
+    struct SignalSemaphore  lc_Sem[LIST_SEMS];
+    volatile ULONG          lc_Counter[LIST_SEMS];
+};
+
+static void ListWorker(void)
+{
+    struct SemWorker *w = myworker();
+    struct ListCtx *ctx = (struct ListCtx *)w->w_Arg;
+    struct Task *me = FindTask(NULL);
+    ULONG i;
+    int k;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < LIST_ITERS; i++)
+    {
+        /* Phase markers so a hang dump shows which call we are inside:
+         * 1M+i = in ObtainSemaphoreList, 2M+i = critical section,
+         * 3M+i = in ReleaseSemaphoreList, i+1 = iteration complete. */
+        w->w_Progress = 1000000 + i;
+        ObtainSemaphoreList(&ctx->lc_List);
+        w->w_Progress = 2000000 + i;
+        for (k = 0; k < LIST_SEMS; k++)
+        {
+            if (ctx->lc_Sem[k].ss_Owner != me)
+                w->w_Errors++;
+            ctx->lc_Counter[k]++;
+        }
+        w->w_Progress = 3000000 + i;
+        ReleaseSemaphoreList(&ctx->lc_List);
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static void SingleWorker(void)
+{
+    struct SemWorker *w = myworker();
+    struct SignalSemaphore *sem = (struct SignalSemaphore *)w->w_Arg;
+    volatile ULONG *counter = (volatile ULONG *)w->w_Arg2;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < SINGLE_ITERS; i++)
+    {
+        ULONG v;
+
+        w->w_Progress = 1000000 + i;
+        ObtainSemaphore(sem);
+        v = *counter;
+        *counter = v + 1;
+        w->w_Progress = 3000000 + i;
+        ReleaseSemaphore(sem);
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestSemList(void)
+{
+    static struct ListCtx ctx;
+    struct SemWorker w[4];
+    struct Task *t[4];
+    int k, ok = 1;
+
+    bug("[smpsem] phase 1: ObtainSemaphoreList vs single obtainers...\n");
+
+    memset(&ctx, 0, sizeof(ctx));
+    memset(w, 0, sizeof(w));
+    NEWLIST(&ctx.lc_List);
+    for (k = 0; k < LIST_SEMS; k++)
+    {
+        InitSemaphore(&ctx.lc_Sem[k]);
+        AddTail(&ctx.lc_List, (struct Node *)&ctx.lc_Sem[k]);
+    }
+
+    /* Uncontended sanity check first: if this hangs, the list path is
+     * broken on its own rather than by the contention below. */
+    bug("[smpsem] phase 1: uncontended list obtain/release x100...\n");
+    for (k = 0; k < 100; k++)
+    {
+        ObtainSemaphoreList(&ctx.lc_List);
+        ReleaseSemaphoreList(&ctx.lc_List);
+    }
+    bug("[smpsem] phase 1: uncontended OK (nest=%ld queue=%ld owner=%p)\n",
+        (LONG)ctx.lc_Sem[0].ss_NestCount, (LONG)ctx.lc_Sem[0].ss_QueueCount,
+        ctx.lc_Sem[0].ss_Owner);
+
+    w[0].w_Arg = &ctx;
+    t[0] = spawn("smpsem.list", ListWorker, 0, &w[0]);
+
+    /* Three single obtainers on the first three members, one core each. */
+    for (k = 1; k < 4; k++)
+    {
+        w[k].w_Arg  = &ctx.lc_Sem[k - 1];
+        w[k].w_Arg2 = (APTR)&ctx.lc_Counter[k - 1];
+        t[k] = spawn("smpsem.single", SingleWorker, k, &w[k]);
+    }
+
+    for (k = 0; k < 4; k++)
+    {
+        if (!t[k])
+        {
+            bug("[smpsem] phase 1: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    if (!wait_all("phase 1", w, 4))
+    {
+        /* Dump the frozen state so the deadlock shape is visible. */
+        for (k = 0; k < 4; k++)
+            bug("[smpsem]   task %d = %p\n", k, t[k]);
+        for (k = 0; k < 4; k++)
+        {
+            ULONG *rf = (ULONG *)t[k]->tc_UnionETask.tc_ETask->et_RegFrame;
+            int j;
+
+            bug("[smpsem]   task %d '%s' @%p state=%ld sigwait=%08lx sigrecvd=%08lx sigalloc=%08lx\n", k,
+                t[k]->tc_Node.ln_Name, t[k],
+                (LONG)t[k]->tc_State,
+                (unsigned long)t[k]->tc_SigWait,
+                (unsigned long)t[k]->tc_SigRecvd,
+                (unsigned long)t[k]->tc_SigAlloc);
+            bug("[smpsem]     regframe:");
+            for (j = 0; j < 20; j++)
+                bug(" %08lx", (unsigned long)rf[j]);
+            bug("\n");
+            if (k == 0)
+            {
+                ULONG *sp = (ULONG *)t[k]->tc_SPReg;
+
+                bug("[smpsem]     stack @%p:", sp);
+                for (j = 0; j < 48; j++)
+                    bug(" %08lx", (unsigned long)sp[j]);
+                bug("\n");
+            }
+        }
+        for (k = 0; k < LIST_SEMS; k++)
+        {
+            struct SignalSemaphore *ss = &ctx.lc_Sem[k];
+
+            bug("[smpsem]   sem %d: owner=%p queue=%ld nest=%ld waiters=%s mlink-queued=%s lockword=%08lx\n",
+                k, ss->ss_Owner, (LONG)ss->ss_QueueCount, (LONG)ss->ss_NestCount,
+                (ss->ss_WaitQueue.mlh_Head->mln_Succ != NULL) ? "yes" : "no",
+                (ss->ss_MultipleLink.sr_Link.mln_Succ != NULL) ? "yes" : "no",
+                (unsigned long)*(volatile ULONG *)&ss->ss_MultipleLink.sr_SpinLock);
+        }
+        ok = 0;
+    }
+
+    Forbid();
+    for (k = 0; k < 4; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    if (w[0].w_Errors)
+    {
+        bug("[smpsem] phase 1: *** FAIL *** list holder saw %lu foreign owners\n",
+            (unsigned long)w[0].w_Errors);
+        return 0;
+    }
+    for (k = 0; k < LIST_SEMS; k++)
+    {
+        ULONG expect = LIST_ITERS + ((k < 3) ? SINGLE_ITERS : 0);
+
+        if (ctx.lc_Counter[k] != expect)
+        {
+            bug("[smpsem] phase 1: *** FAIL *** sem %d counter %lu, expected %lu\n",
+                k, (unsigned long)ctx.lc_Counter[k], (unsigned long)expect);
+            return 0;
+        }
+    }
+    bug("[smpsem] phase 1: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 2: Procure/Vacate vs blocking obtainers                             */
+/*                                                                            */
+/*  Two tasks take the semaphore through the asynchronous bid protocol       */
+/*  while two others use plain ObtainSemaphore, all guarding one counter.    */
+/******************************************************************************/
+
+struct ProcCtx
+{
+    struct SignalSemaphore  pc_Sem;
+    volatile ULONG          pc_Counter;
+};
+
+static void ProcureWorker(void)
+{
+    struct SemWorker *w = myworker();
+    struct ProcCtx *ctx = (struct ProcCtx *)w->w_Arg;
+    struct MsgPort *port;
+    struct SemaphoreMessage bid;
+    ULONG i;
+
+    port = CreateMsgPort();
+    if (!port)
+    {
+        w->w_Errors = 1;
+        w->w_Started = 1;
+        w->w_Done = 1;
+        Wait(0);
+    }
+
+    w->w_Started = 1;
+
+    for (i = 0; i < PROCURE_ITERS; i++)
+    {
+        ULONG v;
+
+        memset(&bid, 0, sizeof(bid));
+        bid.ssm_Message.mn_ReplyPort = port;
+
+        Procure(&ctx->pc_Sem, &bid);
+        WaitPort(port);
+        GetMsg(port);
+
+        if (bid.ssm_Semaphore != &ctx->pc_Sem)
+            w->w_Errors++;
+
+        v = ctx->pc_Counter;
+        ctx->pc_Counter = v + 1;
+
+        Vacate(&ctx->pc_Sem, &bid);
+    }
+
+    DeleteMsgPort(port);
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static void ObtainWorker(void)
+{
+    struct SemWorker *w = myworker();
+    struct ProcCtx *ctx = (struct ProcCtx *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < OBTAIN_ITERS; i++)
+    {
+        ULONG v;
+
+        ObtainSemaphore(&ctx->pc_Sem);
+        v = ctx->pc_Counter;
+        ctx->pc_Counter = v + 1;
+        ReleaseSemaphore(&ctx->pc_Sem);
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestProcure(void)
+{
+    static struct ProcCtx ctx;
+    struct SemWorker w[4];
+    struct Task *t[4];
+    ULONG expect;
+    int k, ok = 1;
+
+    bug("[smpsem] phase 2: Procure/Vacate vs ObtainSemaphore...\n");
+
+    memset(&ctx, 0, sizeof(ctx));
+    memset(w, 0, sizeof(w));
+    InitSemaphore(&ctx.pc_Sem);
+
+    for (k = 0; k < 4; k++)
+    {
+        w[k].w_Arg = &ctx;
+        t[k] = spawn(k < 2 ? "smpsem.procure" : "smpsem.obtain",
+                     k < 2 ? (APTR)ProcureWorker : (APTR)ObtainWorker, k, &w[k]);
+        if (!t[k])
+        {
+            bug("[smpsem] phase 2: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    if (!wait_all("phase 2", w, 4))
+        ok = 0;
+
+    Forbid();
+    for (k = 0; k < 4; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < 4; k++)
+    {
+        if (w[k].w_Errors)
+        {
+            bug("[smpsem] phase 2: *** FAIL *** worker %d reported %lu errors\n",
+                k, (unsigned long)w[k].w_Errors);
+            return 0;
+        }
+    }
+    expect = 2 * PROCURE_ITERS + 2 * OBTAIN_ITERS;
+    if (ctx.pc_Counter != expect)
+    {
+        bug("[smpsem] phase 2: *** FAIL *** counter %lu, expected %lu (lost updates)\n",
+            (unsigned long)ctx.pc_Counter, (unsigned long)expect);
+        return 0;
+    }
+    bug("[smpsem] phase 2: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 3: shared readers vs exclusive writer                               */
+/*                                                                            */
+/*  The writer makes the counter odd only while holding the semaphore        */
+/*  exclusively; readers holding it shared must never observe an odd value   */
+/*  or a value that changes during their hold.                               */
+/******************************************************************************/
+
+static void SharedReader(void)
+{
+    struct SemWorker *w = myworker();
+    struct ProcCtx *ctx = (struct ProcCtx *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < READER_ITERS; i++)
+    {
+        ULONG a, b;
+
+        ObtainSemaphoreShared(&ctx->pc_Sem);
+        a = ctx->pc_Counter;
+        b = ctx->pc_Counter;
+        ReleaseSemaphore(&ctx->pc_Sem);
+
+        if ((a & 1) || a != b)
+            w->w_Errors++;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static void ExclusiveWriter(void)
+{
+    struct SemWorker *w = myworker();
+    struct ProcCtx *ctx = (struct ProcCtx *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < WRITER_ITERS; i++)
+    {
+        ObtainSemaphore(&ctx->pc_Sem);
+        ctx->pc_Counter++;      /* odd while held */
+        ctx->pc_Counter++;      /* even again before release */
+        ReleaseSemaphore(&ctx->pc_Sem);
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestSharedInvariant(void)
+{
+    static struct ProcCtx ctx;
+    struct SemWorker w[4];
+    struct Task *t[4];
+    int k, ok = 1;
+
+    bug("[smpsem] phase 3: shared readers vs exclusive writer...\n");
+
+    memset(&ctx, 0, sizeof(ctx));
+    memset(w, 0, sizeof(w));
+    InitSemaphore(&ctx.pc_Sem);
+
+    for (k = 0; k < 4; k++)
+    {
+        w[k].w_Arg = &ctx;
+        t[k] = spawn(k < 3 ? "smpsem.reader" : "smpsem.writer",
+                     k < 3 ? (APTR)SharedReader : (APTR)ExclusiveWriter, k, &w[k]);
+        if (!t[k])
+        {
+            bug("[smpsem] phase 3: INVALID (task create failed)\n");
+            return -1;
+        }
+    }
+
+    if (!wait_all("phase 3", w, 4))
+        ok = 0;
+
+    Forbid();
+    for (k = 0; k < 4; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < 3; k++)
+    {
+        if (w[k].w_Errors)
+        {
+            bug("[smpsem] phase 3: *** FAIL *** reader %d saw %lu odd/torn values\n",
+                k, (unsigned long)w[k].w_Errors);
+            return 0;
+        }
+    }
+    if (ctx.pc_Counter != 2 * WRITER_ITERS)
+    {
+        bug("[smpsem] phase 3: *** FAIL *** counter %lu, expected %lu\n",
+            (unsigned long)ctx.pc_Counter, (unsigned long)(2 * WRITER_ITERS));
+        return 0;
+    }
+    bug("[smpsem] phase 3: OK\n");
+    return 1;
+}
+
+int main(void)
+{
+    int pass = 0, fail = 0, inval = 0;
+    int r;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        g_NumCPUs = KrnGetCPUCount();
+
+    bug("[smpsem] start: cpus=%ld\n", (LONG)g_NumCPUs);
+
+    r = TestSemList();          if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestProcure();          if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestSharedInvariant();  if (r > 0) pass++; else if (!r) fail++; else inval++;
+
+    bug("[smpsem] DONE: %d PASS, %d FAIL, %d INVALID\n", pass, fail, inval);
+    return fail ? RETURN_FAIL : RETURN_OK;
+}


### PR DESCRIPTION
Cover the paths the existing SMP tests skip: ObtainSemaphoreList and the Procure/Vacate bid protocol against plain obtainers, unpinned task migration and high-priority wake with every core busy, and timer.device round trips driven from each core.