### PR TITLE
exec: fix ObtainSemaphoreList's obtained-count check

### DIFF
--- a/rom/exec/obtainsemaphorelist.c
+++ b/rom/exec/obtainsemaphorelist.c
@@ -128,16 +128,18 @@
             {
                 /* We got it, go on to the next one */
                 ss = (struct SignalSemaphore *)ss->ss_Link.ln_Succ;
-                failedObtain--;
             }
         }
     }
 
 #ifndef NO_CONSISTENCY_CHECKS
-    if(failedObtain != 0)
+    ForeachNode(sigSem, ss)
     {
-        kprintf("\n\nObtainSemaList: Obtained count mismatch %d\n", failedObtain);
-        Alert(AN_BadSemaphore);
+        if(ss->ss_Owner != ThisTask)
+        {
+            kprintf("\n\nObtainSemaList: sem 0x%p not owned after obtain\n", ss);
+            Alert(AN_BadSemaphore);
+        }
     }
 #endif
 


### PR DESCRIPTION
failedObtain was counted up once per contended member but counted down once per list member, so any partially contended list tripped a false AN_BadSemaphore alert. Verify that every member is owned instead.