### PR TITLE
dosboot: don't reuse the boot IORequest after the boot block's init returns

### DIFF
--- a/rom/dosboot/bootstrap.c
+++ b/rom/dosboot/bootstrap.c
@@ -178,9 +178,12 @@ BOOL dosboot_DevicePresent(struct IORequest*bootDevIO, BPTR bootDevName, ULONG b
     return FALSE;
 }
 
-/* Returns TRUE if it was a BootBlock style, but couldn't
- * be booted, FALSE if not a BootBlock style, and doesn't
- * return at all on a successful boot.
+/* Does not return at all on a successful boot. Otherwise the
+ * return value tells the caller whether it is done with the node:
+ * on m68k it is always TRUE, so a node whose boot block did not
+ * boot (or that had none) is not tried any other way, as on
+ * AmigaOS; elsewhere it is always FALSE and the caller goes on to
+ * try the BootPoint and DOS methods.
  *
  * The boot block's init code is called after *iop and its reply
  * port have been closed and freed. Should that code come back,
@@ -344,23 +347,28 @@ LONG dosboot_BootStrap(LIBBASETYPEPTR LIBBASE)
                 if (!BootNodeDeviceUnit || (dosboot_DevicePresent((struct IORequest*)io, device, unit)))
                 {
                     /* First try as a BootBlock.
-                     * dosboot_BootBlock returns TRUE if it *was*
-                     * a BootBlock device, but couldn't be booted.
-                     * Returns FALSE if not a bootblock device,
-                     * and doesn't return at all if the bootblock
-                     * was successful.
+                     * dosboot_BootBlock does not return at all if
+                     * the boot block booted. TRUE (always, on m68k)
+                     * means the node is done with; FALSE (always,
+                     * elsewhere) means try BootPoint and DOS next.
+                     * Either way io and msgport may have been freed
+                     * and cleared along the way.
                      */
                     
                     D(bug("[DOSBoot:bootstrap] %s: Attempting %b\n",__func__, ((struct DeviceNode *)bn->bn_DeviceNode)->dn_Name));
                     if (!BootNodeDeviceUnit || !dosboot_BootBlock(&io, &msgport, bn, ExpansionBase, bootblock_size)) {
-                        if (BootNodeDeviceUnit)
+                        if (io)
                         {
-                            CloseDevice((struct IORequest *)io);
+                            if (BootNodeDeviceUnit)
+                                CloseDevice((struct IORequest *)io);
+                            DeleteIORequest((struct IORequest*)io);
+                            io = NULL;
                         }
-                        DeleteIORequest((struct IORequest*)io);
-                        io = NULL;
-                        DeleteMsgPort(msgport);
-                        msgport = NULL;
+                        if (msgport)
+                        {
+                            DeleteMsgPort(msgport);
+                            msgport = NULL;
+                        }
 
                         /* Then as a BootPoint node */
                         D(bug("[DOSBoot:bootstrap] %s: Attempting %b as BootPoint\n", __func__, ((struct DeviceNode *)bn->bn_DeviceNode)->dn_Name));

--- a/rom/dosboot/bootstrap.c
+++ b/rom/dosboot/bootstrap.c
@@ -181,9 +181,14 @@ BOOL dosboot_DevicePresent(struct IORequest*bootDevIO, BPTR bootDevName, ULONG b
 /* Returns TRUE if it was a BootBlock style, but couldn't
  * be booted, FALSE if not a BootBlock style, and doesn't
  * return at all on a successful boot.
+ *
+ * The boot block's init code is called after *iop and its reply
+ * port have been closed and freed. Should that code come back,
+ * both pointers are cleared so the caller does not touch them.
  */
-static BOOL dosboot_BootBlock(struct IOStdReq *io, struct BootNode *bn, struct ExpansionBase *ExpansionBase, ULONG bootblock_size)
+static BOOL dosboot_BootBlock(struct IOStdReq **iop, struct MsgPort **portp, struct BootNode *bn, struct ExpansionBase *ExpansionBase, ULONG bootblock_size)
 {
+    struct IOStdReq *io = *iop;
     VOID_FUNC init = NULL;
     UBYTE *buffer;
 
@@ -232,7 +237,9 @@ static BOOL dosboot_BootBlock(struct IOStdReq *io, struct BootNode *bn, struct E
 
        CloseDevice((struct IORequest *)io);
        DeleteIORequest((struct IORequest*)io);
-       DeleteMsgPort(((struct IORequest*)io)->io_Message.mn_ReplyPort);
+       DeleteMsgPort(*portp);
+       *iop = NULL;
+       *portp = NULL;
 
        /*
         * This is actually rt_Init calling convention for non-autoinit residents.
@@ -243,6 +250,10 @@ static BOOL dosboot_BootBlock(struct IOStdReq *io, struct BootNode *bn, struct E
         * This is needed because dos.library contains the second part of "bootable"
         * test, trying to mount a filesystem and read the volume.
         * We hope it won't do any harm for NDOS game disks.
+        *
+        * dos.library's init only returns if that second part failed (it
+        * RemTask()s itself otherwise), so landing here means the volume
+        * could not be mounted. The IORequest is already gone by now.
        */
        AROS_UFC3NR(void, init,
                  AROS_UFCA(APTR, NULL, D0),
@@ -341,7 +352,7 @@ LONG dosboot_BootStrap(LIBBASETYPEPTR LIBBASE)
                      */
                     
                     D(bug("[DOSBoot:bootstrap] %s: Attempting %b\n",__func__, ((struct DeviceNode *)bn->bn_DeviceNode)->dn_Name));
-                    if (!BootNodeDeviceUnit || !dosboot_BootBlock(io, bn, ExpansionBase, bootblock_size)) {
+                    if (!BootNodeDeviceUnit || !dosboot_BootBlock(&io, &msgport, bn, ExpansionBase, bootblock_size)) {
                         if (BootNodeDeviceUnit)
                         {
                             CloseDevice((struct IORequest *)io);
@@ -361,7 +372,7 @@ LONG dosboot_BootStrap(LIBBASETYPEPTR LIBBASE)
                     }
                     else
                     {
-                        if (BootNodeDeviceUnit)
+                        if (BootNodeDeviceUnit && io)
                             CloseDevice((struct IORequest *)io);
                     }
                 }


### PR DESCRIPTION
I ran into this while chasing a floppy emulation bug. A game disk with a perfectly ordinary AmigaDOS boot block (the Lemmings 2 demo) had a root-block track the emulated trackdisk.device couldn't read. Under Kickstart that just means the disk doesn't boot. Under AROS the machine died instead, about thirty seconds in:

```
Program failed
Task : 0x00C123B0 - Exec Bootstrap Task
Error: 0x80000003 - Illegal address access
PC   : 0xC0E10010
```

and after a while with a watchpoint it became clear this had nothing to do with the disk.

What actually happens: `dosboot_BootBlock()` reads the boot block and, before calling the init code it hands back (dos.library's init, for a DOS disk), it does `CloseDevice()`, `DeleteIORequest()` and `DeleteMsgPort()` on the request it had been using, same as the Kickstart strap does. The comments around it assume that init never comes back. It does come back, though, whenever `CliInit()` can't mount the boot volume: `DosInit()` only `RemTask()`s itself on success, otherwise it expunges and returns NULL. At that point `dosboot_BootBlock()` returns TRUE ("was a boot block, couldn't boot") and `dosboot_BootStrap()` carries on with the pointers it still holds, so we get a second `CloseDevice(io)`, `DeleteIORequest(io)` and `DeleteMsgPort(msgport)` on memory that was freed a moment earlier. By then exec had already handed that memory out again as a library jump table, so `io_Device` read as `0x4EF9C0ED` (a JMP opcode and half an address), `CloseDevice()` jumped through it, and there's your illegal address access.

The fix is small. `dosboot_BootBlock()` now takes the request and its port by reference and clears both once it has freed them, and the caller only closes the device if it still has a request to close. A boot block whose init fails is then treated like any other node that didn't boot, and the strap moves on.

To reproduce it you don't need a broken emulator: take any bootable OFS disk and zero its root block (I used xdftool to make a disk with a one-line startup-sequence and wiped block 880). On the current ROM that gurus as above; with this patch it falls through to the "Waiting for bootable media" screen. A normal boot disk still boots exactly as before, frame-for-frame identical under Copperline. I've only built and tested amiga-m68k, but there's nothing architecture specific in the change.
