### PR TITLE
Detect CD boots by filesystem type

### DIFF
--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -674,8 +674,8 @@ static LONG internalBootCliHandler(void)
      * be no pointing device to answer one), and titles rely on it - for
      * example probing for their harddisk-install volume by name and
      * expecting the lookup to fail silently on CD. Mirror that when the
-     * boot device is cd.device: the boot shell (and thus everything the
-     * Startup-Sequence runs in it) gets pr_WindowPtr = -1.
+     * boot filesystem is a CD filesystem: the boot shell (and thus
+     * everything the Startup-Sequence runs in it) gets pr_WindowPtr = -1.
      */
     ObtainSemaphore(&IntExpBase(ExpansionBase)->BootSemaphore);
     bn = (struct BootNode *)GetHead(&ExpansionBase->MountList);
@@ -686,19 +686,20 @@ static LONG internalBootCliHandler(void)
 
         /* dn_Startup may hold a small integer instead of a BPTR for some
          * handlers; require a plausible pointer before dereferencing.
-         * The device name is a BSTR and need not be NUL-terminated, so
-         * compare by length.
          */
-        if ((IPTR)fssm > 0x1000 && fssm->fssm_Device != BNULL)
+        if ((IPTR)fssm > 0x1000 && fssm->fssm_Environ != BNULL)
         {
-            CONST_STRPTR dev = AROS_BSTR_ADDR(fssm->fssm_Device);
-            int devlen = AROS_BSTR_strlen(fssm->fssm_Device);
-            D(bug("CliInit: boot device '%s' len %d\n", dev, devlen));
-            if (devlen >= 9 && memcmp(dev, "cd.device", 9) == 0 &&
-                (devlen == 9 || dev[9] == '\0'))
+            struct DosEnvec *de = BADDR(fssm->fssm_Environ);
+
+            if (de->de_TableSize >= DE_DOSTYPE)
             {
-                D(bug("CliInit: appliance boot (requesters off)\n"));
-                IntExpBase(ExpansionBase)->BootFlags |= BF_NO_BOOT_REQUESTERS;
+                PRINT_DOSTYPE(de->de_DosType);
+                if (de->de_DosType == AROS_MAKE_ID('C', 'D', 'V', 'D') ||
+                    de->de_DosType == AROS_MAKE_ID('C', 'D', 'F', 'S'))
+                {
+                    D(bug("CliInit: appliance boot (requesters off)\n"));
+                    IntExpBase(ExpansionBase)->BootFlags |= BF_NO_BOOT_REQUESTERS;
+                }
             }
         }
     }


### PR DESCRIPTION
QEMU exposes its IDE CD-ROM through ata.device, but we do requester suppression via cd.device so the config gets missed.

So let's detect CD boot via DosEnvec instead. CDVD and CDFS now enable BF_NO_BOOT_REQUESTERS regardless of controller type.