### PR TITLE
PFS3 qemu aarch64 build + boot bugfixes

### DIFF
--- a/rom/filesys/pfs3/fs/boot.c
+++ b/rom/filesys/pfs3/fs/boot.c
@@ -159,7 +159,7 @@ BOOL debug=FALSE;
 
 /* protos */
 // extern void __saveds EntryWithNewStack(void);
-void __saveds EntryPoint(void);
+void __saveds EntryPoint(struct ExecBase *);
 void NormalCommands(struct DosPacket *, globaldata *);
 void HandleSleepMsg (globaldata *g);
 void ReturnPacket(struct DosPacket *, struct MsgPort *, globaldata *);
@@ -219,7 +219,8 @@ static UBYTE debugbuf[120];
 /*                                MAIN                                */
 /**********************************************************************/
 
-void __saveds EntryPoint (void)
+#undef SysBase
+void __saveds EntryPoint (struct ExecBase *SysBase)
 {
 	/* globals */
 	struct globaldata *g;
@@ -231,11 +232,6 @@ void __saveds EntryPoint (void)
 	struct Message *msg;
 	UBYTE *mountname;
 	ULONG signal, dossig, timesig, notifysig, sleepsig, waitmask;
-#undef SysBase
-	struct ExecBase *SysBase;
-
-	SysBase =  *((struct ExecBase **)4);
-
 	/* init globaldata */
 	g = AllocMem(sizeof(struct globaldata), MEMF_CLEAR);
 	if (!g)
@@ -706,12 +702,13 @@ static void Quit (globaldata *g)
 #ifdef __AROS__
 LONG AROSEntryPoint(struct ExecBase *SysBase)
 {
-    return (LONG)EntryPoint;
+    EntryPoint(SysBase);
+    return RETURN_OK;
 }
 #else
 LONG __saveds __startup Main(void)
 {
-    return EntryPoint(*(struct ExecBase **)4L);
+    EntryPoint(*(struct ExecBase **)4L);
+    return RETURN_OK;
 }
 #endif
-

--- a/rom/filesys/pfs3/fs/dd_funcs.c
+++ b/rom/filesys/pfs3/fs/dd_funcs.c
@@ -1631,6 +1631,9 @@ static SIPTR dd_InhibitOff(struct DosPacket *pkt, globaldata * g)
 
 static SIPTR dd_Format(struct DosPacket *pkt, globaldata * g)
 {
+	struct Task *caller;
+	BOOL showrequesters = TRUE;
+
 	/* argumenten stemmen NIET met de dosmanual overeen */
 	// ARG1 = BSTR Name of device (with trailing ':')
 	// ARG2 = LONG Type of format (file system specific ==> ID_FDOS_DISK of 0)
@@ -1645,6 +1648,14 @@ static SIPTR dd_Format(struct DosPacket *pkt, globaldata * g)
 	}
 #endif
 
+	caller = NULL;
+	if (pkt->dp_Port &&
+		(pkt->dp_Port->mp_Flags & PF_ACTION) == PA_SIGNAL)
+		caller = pkt->dp_Port->mp_SigTask;
+	if (caller && caller->tc_Node.ln_Type == NT_PROCESS)
+		showrequesters = ((struct Process *)caller)->pr_WindowPtr !=
+			(APTR)(SIPTR)-1;
+
 	/* Ik neem aan dat er geen Lock check nodig is ... */
 	/* if not inhibited then 'remove disk' */
 	if (g->inhibitcount == 0)
@@ -1657,7 +1668,8 @@ static SIPTR dd_Format(struct DosPacket *pkt, globaldata * g)
 	}
 
 	/* format disk */
-	return FDSFormat((DSTR)BADDR(pkt->dp_Arg1), pkt->dp_Arg2, &pkt->dp_Res2, g);
+	return FDSFormat((DSTR)BADDR(pkt->dp_Arg1), pkt->dp_Arg2,
+		&pkt->dp_Res2, showrequesters, g);
 }
 
 
@@ -2316,4 +2328,3 @@ static void dd_ChangeFilePosition64(struct DosPacket *pkt, globaldata *g)
 
 
 #endif
-

--- a/rom/filesys/pfs3/fs/format.c
+++ b/rom/filesys/pfs3/fs/format.c
@@ -143,7 +143,7 @@
  */
 static void ShowVersion (globaldata *g);
 static ULONG MakeBootBlock(globaldata *g);
-static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g);
+static rootblock_t *MakeRootBlock (DSTR diskname, BOOL showrequesters, globaldata *g);
 static void MakeBitmap (globaldata *g);
 static void MakeRootDir (globaldata *g);
 static ULONG CalcNumReserved (globaldata *g, ULONG resblocksize);
@@ -156,7 +156,8 @@ static crootblockextension_t *MakeFormatRBlkExtension (struct rootblock *rbl, gl
 /*                               FORMAT                               */
 /**********************************************************************/
 
-BOOL FDSFormat (DSTR diskname, LONG disktype, SIPTR *error, globaldata *g)
+BOOL FDSFormat (DSTR diskname, LONG disktype, SIPTR *error, BOOL showrequesters,
+	globaldata *g)
 {
   struct rootblock *rootblock;
   struct volumedata *volume;
@@ -181,7 +182,8 @@ BOOL FDSFormat (DSTR diskname, LONG disktype, SIPTR *error, globaldata *g)
 
 	/* update dos envec and geom */
 	GetDriveGeometry (g);
-	ShowVersion (g);
+	if (showrequesters)
+		ShowVersion (g);
 
 	/* issue 00118: disk cannot exceed MAX_DISK_SIZE */
 	if (g->geom->dg_TotalSectors > MAXDISKSIZE) {
@@ -195,7 +197,7 @@ BOOL FDSFormat (DSTR diskname, LONG disktype, SIPTR *error, globaldata *g)
  		return DOSFALSE;
 	}
 
-	if (!(rootblock = MakeRootBlock (diskname, g))) {
+	if (!(rootblock = MakeRootBlock (diskname, showrequesters, g))) {
 		*error = ERROR_NO_FREE_STORE;
 		return DOSFALSE;
 	}
@@ -316,7 +318,7 @@ static ULONG MakeBootBlock (globaldata *g)
  * including reserved bitmap
  * (will be written by Update and freed by FreeVolumeRes.)
  */
-static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g)
+static rootblock_t *MakeRootBlock (DSTR diskname, BOOL showrequesters, globaldata *g)
 {
   struct rootblock *rbl;
   struct DateStamp time;
@@ -356,7 +358,8 @@ static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g)
 				resblocksize = 4096;
 			}
 			rbl->disktype = ID_PFS2_DISK;
-			NormalErrorMsg(AFS_WARNING_EXPERIMENTAL_DISK, NULL, 1);
+			if (showrequesters)
+				NormalErrorMsg(AFS_WARNING_EXPERIMENTAL_DISK, NULL, 1);
 		}
 	}
 
@@ -371,7 +374,8 @@ static rootblock_t *MakeRootBlock (DSTR diskname, globaldata *g)
 #if LARGE_FILE_SIZE
 	rbl->options |= MODE_LARGEFILE;
 	rbl->disktype = ID_PFS2_DISK;
-	NormalErrorMsg(AFS_WARNING_EXPERIMENTAL_FILE, NULL, 1);
+	if (showrequesters)
+		NormalErrorMsg(AFS_WARNING_EXPERIMENTAL_FILE, NULL, 1);
 #endif
 
 	rbl->datestamp = 1;

--- a/rom/filesys/pfs3/fs/format_protos.h
+++ b/rom/filesys/pfs3/fs/format_protos.h
@@ -2,5 +2,5 @@
 Format.c
  */
 
-BOOL FDSFormat (DSTR , LONG , SIPTR * , globaldata * );
+BOOL FDSFormat (DSTR , LONG , SIPTR * , BOOL , globaldata * );
 BOOL MakeRBlkExtension (globaldata *g);

--- a/rom/filesys/pfs3/fs/mmakefile.src
+++ b/rom/filesys/pfs3/fs/mmakefile.src
@@ -71,7 +71,7 @@ USER_CPPFLAGS := \
     -DAROS_KERNEL $(PFS3_CFLAGS) -DMIN_LIB_VERSION=36 \
 	-DREVDATE="\"$(shell date '+%d.%m.%Y')\""
 
-USER_LDFLAGS += --static -nosysbase -Wl,--defsym -Wl,SysBase=0x4
+USER_LDFLAGS += --static
 
 %build_module mmake=kernel-fs-pfs3 \
     modname=pfs3 modtype=handler \


### PR DESCRIPTION
Trying to cross-compile an aarch64 headless qemu guest and fixed a couple of blockers:

1. Use the SysBase from AROS startup instead of setting `-nosysbase -Wl,--defsym -Wl,SysBase=0x4`.
2. PFS3 was calling `ShowVersion` and `NormalErrorMsg`, pass it a bool to switch off requesters when window pointer == -1.