### PR TITLE
usb2otg: declare memset for inline helpers

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
@@ -28,6 +28,8 @@
 #include <exec/initializers.h>
 #include <dos/dos.h>
 
+#include <string.h>
+
 #include <devices/timer.h>
 #include <utility/utility.h>
 


### PR DESCRIPTION
Failed compile in my build system