### PR TITLE
GCC 16 / AArch64: memset is no longer implicit

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_intern.h
@@ -28,6 +28,8 @@
 #include <exec/initializers.h>
 #include <dos/dos.h>
 
+#include <string.h>
+
 #include <devices/timer.h>
 #include <utility/utility.h>
 

--- a/compiler/crt/posixc/include/aros/posixc/sys/select.h
+++ b/compiler/crt/posixc/include/aros/posixc/sys/select.h
@@ -17,6 +17,8 @@
 #include <aros/types/sigset_t.h>
 #include <aros/types/timespec_s.h>
 
+#include <string.h>
+
 #define NBBY            8
 
 #ifndef FD_SETSIZE


### PR DESCRIPTION
Updating to GCC 16 for the AArch64 build exposed an implicit import:

* GCC 6.5 tolerated undeclared memset.
* GCC 6.5’s AArch64 runtime lacked floating-point helpers.
* Moving to GCC 16.2 supplied the helpers.
* Fails compile in GCC 16