### PR TITLE
Bugfix/aarch64 gcc16 bootstrap

### DIFF
--- a/arch/aarch64-native/kernel/kernel_startup.c
+++ b/arch/aarch64-native/kernel/kernel_startup.c
@@ -77,13 +77,8 @@ asm (
     ".string \"Native/CORE AArch64 v1 (" __DATE__ ")\"" "\n\t\n\t"
 );
 
-#if defined(__clang__)
-static uint64_t * const stack_end __attribute__((used, section(".aros.init"))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
-static uint64_t * const stack_super_end __attribute__((used, section(".aros.init"))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
-#else
-static uint64_t * const stack_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
-static uint64_t * const stack_super_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
-#endif
+static uint64_t * const stack_end __attribute__((used, section(".aros.init.data"))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
+static uint64_t * const stack_super_end __attribute__((used, section(".aros.init.data"))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
 
 struct ARM_Implementation __arm_arosintern  __attribute__((aligned(8), section(".data"))) = {0,0,NULL,0};
 struct ExecBase *SysBase __attribute__((section(".data"))) = NULL;

--- a/arch/aarch64-native/kernel/mmakefile.src
+++ b/arch/aarch64-native/kernel/mmakefile.src
@@ -74,8 +74,6 @@ $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_librar
 #MM kernel-kernel-raspi-aarch64 : includes
 
 USER_INCLUDES := $(PRIV_KERNEL_INCLUDES) -I$(GENINCDIR) -I$(AROS_DEVELOPER)/include -I$(SRCDIR)/rom/openfirmware
-USER_CPPFLAGS := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"
-
 %build_archspecific \
   mainmmake=kernel-kernel modname=kernel maindir=rom/kernel arch=raspi-aarch64 \
   files="$(CFILES) $(PLATFILES)" asmfiles="$(AFILES)" compiler=kernel

--- a/arch/aarch64-raspi/boot/include/boot.h
+++ b/arch/aarch64-raspi/boot/include/boot.h
@@ -35,6 +35,7 @@ size_t mem_avail();
 size_t mem_used();
 const char *remove_path(const char *in);
 void aarch64_flush_cache(uintptr_t addr, uintptr_t length);
+void aarch64_icache_invalidate(uintptr_t addr, uintptr_t length);
 uintptr_t elf_get_ro_virt(void);
 
 extern uint8_t __bootstrap_start;

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -5,7 +5,7 @@ include $(SRCDIR)/config/aros.cfg
 TARGETDIR       := $(GENDIR)/$(CURDIR)
 FILES           := startup64 boot mmu kprintf support vc_mb serialdebug elf devicetree \
                    bc/vars bc/font8x14 bc/screen_fb vc_fb
-USER_CFLAGS     := -Wall $(CFLAGS_NO_BUILTIN)
+USER_CFLAGS     := -Wall $(CFLAGS_NO_BUILTIN) $(CFLAGS_NO_VECTORIZE)
 KERNEL_LDFLAGS  =
 USER_INCLUDES   := -isystem $(SRCDIR)/$(CURDIR)/include -I$(SRCDIR)/rom/openfirmware
 USER_CPPFLAGS   := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"

--- a/arch/aarch64-raspi/boot/support.c
+++ b/arch/aarch64-raspi/boot/support.c
@@ -39,11 +39,9 @@ void aarch64_icache_invalidate(uintptr_t addr, uintptr_t length)
  * The bootstrap runs with the MMU off, where every access is treated as
  * Device memory and must be aligned. The C library memset/memcpy use NEON
  * STP Q stores and unaligned accesses that fault in that state, so the
- * bootstrap carries its own alignment-safe versions. optnone keeps the
- * compiler from recognising the loops and calling the routines recursively
- * or re-vectorising them.
+ * bootstrap carries its own alignment-safe versions. Bootstrap compilation
+ * disables vectorization so these loops remain scalar.
  */
-__attribute__((optnone))
 void *memset(void *dst, int c, size_t n)
 {
     unsigned char *d = dst;
@@ -70,7 +68,6 @@ void *memset(void *dst, int c, size_t n)
     return dst;
 }
 
-__attribute__((optnone))
 void *memcpy(void *dst, const void *src, size_t n)
 {
     unsigned char *d = dst;
@@ -97,7 +94,6 @@ void *memcpy(void *dst, const void *src, size_t n)
     return dst;
 }
 
-__attribute__((optnone))
 void *memmove(void *dst, const void *src, size_t n)
 {
     unsigned char *d = dst;

--- a/arch/arm-native/kernel/kernel_startup.c
+++ b/arch/arm-native/kernel/kernel_startup.c
@@ -68,20 +68,9 @@ asm (
     ".string \"Native/CORE v3 (" __DATE__ ")\"" "\n\t\n\t"
 );
 
-/*
- * With clang's integrated assembler, TARGET_SECTION_COMMENT (//) is NOT
- * treated as a comment — it becomes a literal part of the section name,
- * creating ".aros.init //" as a separate section from ".aros.init".
- */
-#if defined(__clang__)
-static uint32_t * const stack_end __attribute__((used, section(".aros.init"))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
-static uint32_t * const stack_super_end __attribute__((used, section(".aros.init"))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
-static uint32_t * const stack_fiq_end __attribute__((used, section(".aros.init"))) = &stack_fiq[1024 - sizeof(IPTR)];
-#else
-static uint32_t * const stack_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
-static uint32_t * const stack_super_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
-static uint32_t * const stack_fiq_end __attribute__((used, section(".aros.init " TARGET_SECTION_COMMENT))) = &stack_fiq[1024 - sizeof(IPTR)];
-#endif
+static uint32_t * const stack_end __attribute__((used, section(".aros.init.data"))) = &stack[AROS_STACKSIZE - sizeof(IPTR)];
+static uint32_t * const stack_super_end __attribute__((used, section(".aros.init.data"))) = &stack_super[AROS_STACKSIZE - sizeof(IPTR)];
+static uint32_t * const stack_fiq_end __attribute__((used, section(".aros.init.data"))) = &stack_fiq[1024 - sizeof(IPTR)];
 
 struct ARM_Implementation __arm_arosintern  __attribute__((aligned(4), section(".data"))) = {0,0,NULL,0};
 struct ExecBase *SysBase __attribute__((section(".data"))) = NULL;

--- a/arch/arm-native/kernel/mmakefile.src
+++ b/arch/arm-native/kernel/mmakefile.src
@@ -88,8 +88,6 @@ $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_librar
 #MM kernel-kernel-raspi-armeb : includes
 
 USER_INCLUDES := $(PRIV_KERNEL_INCLUDES) -I$(GENINCDIR) -I$(AROS_DEVELOPER)/include -I$(SRCDIR)/rom/openfirmware
-USER_CPPFLAGS := -DTARGET_SECTION_COMMENT=\"$(AROS_SECTION_COMMENT)\"
-
 %build_archspecific \
   mainmmake=kernel-kernel modname=kernel maindir=rom/kernel arch=raspi-arm \
   files="$(CFILES) $(PLATFILES)" asmfiles="$(AFILES)" compiler=kernel

--- a/config/compiler.cfg.in
+++ b/config/compiler.cfg.in
@@ -57,6 +57,7 @@ CFLAGS_NO_FLOAT_STORE                   := @aros_cflags_no_float_store@
 
 # Auto vectorize
 CFLAGS_TREE_VECTORIZE                   := @aros_cflags_tree_vectorize@
+CFLAGS_NO_VECTORIZE                     := @aros_cflags_no_vectorize@
 
 #
 # LTO/Graphite optimization flags

--- a/config/features
+++ b/config/features
@@ -830,6 +830,7 @@ aros_cflags_loop_block
 aros_cflags_whole_program
 aros_cflags_nolto
 aros_cflags_lto
+aros_cflags_no_vectorize
 aros_cflags_tree_vectorize
 aros_cflags_no_float_store
 aros_cflags_float_store
@@ -4245,6 +4246,36 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 printf "%s\n" "$aros_tree_vectorize" >&6; }
 if test "x-$aros_tree_vectorize" = "x-yes" ; then
     aros_cflags_tree_vectorize=-ftree-vectorize
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for an option to disable vectorization" >&5
+printf %s "checking for an option to disable vectorization... " >&6; }
+aros_cflags_no_vectorize=
+for flag in -fno-vectorize -fno-tree-vectorize; do
+    CFLAGS="$flag -Werror"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  aros_cflags_no_vectorize=$flag; break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+done
+if test -n "$aros_cflags_no_vectorize" ; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $aros_cflags_no_vectorize" >&5
+printf "%s\n" "$aros_cflags_no_vectorize" >&6; }
+else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ${CC} accepts -flto" >&5
@@ -9068,6 +9099,7 @@ rm -f $AROS_DEVELOPER/include/__testsincdir.h
 #
 # export the feature flags...
 #
+
 
 
 

--- a/config/features.in
+++ b/config/features.in
@@ -218,6 +218,18 @@ if test "x-$aros_tree_vectorize" = "x-yes" ; then
     aros_cflags_tree_vectorize=-ftree-vectorize
 fi
 
+AC_MSG_CHECKING([for an option to disable vectorization])
+aros_cflags_no_vectorize=
+for flag in -fno-vectorize -fno-tree-vectorize; do
+    CFLAGS="$flag -Werror"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[aros_cflags_no_vectorize=$flag; break],[])
+done
+if test -n "$aros_cflags_no_vectorize" ; then
+    AC_MSG_RESULT([$aros_cflags_no_vectorize])
+else
+    AC_MSG_RESULT([no])
+fi
+
 AC_MSG_CHECKING([whether ${CC} accepts -flto])
 CFLAGS=-flto
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[aros_lto="yes"],[aros_lto="no"])
@@ -1731,6 +1743,7 @@ AC_SUBST(aros_cflags_no_trapping_math)
 AC_SUBST(aros_cflags_float_store)
 AC_SUBST(aros_cflags_no_float_store)
 AC_SUBST(aros_cflags_tree_vectorize)
+AC_SUBST(aros_cflags_no_vectorize)
 AC_SUBST(aros_cflags_lto)
 AC_SUBST(aros_cflags_nolto)
 AC_SUBST(aros_cflags_whole_program)


### PR DESCRIPTION
3 issues found while building for aarch64 in gcc 16:

### GCC rejected conflicting section attributes

Separate startup pointers from .aros.init section.

### missing aarch64_icache_invalidate() in boot.h

Just declare it

### GCC ignores __attribute__((optnone))

Use optimize("O0") for bootstrap memory routines in GCC, or we might get optimized.
I think this caused an early boot crash but changed other things at the same time. It's safer anyway.