### PR TITLE
bcm2708: link DMA resource statically

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/dma/mmakefile.src
@@ -1,6 +1,8 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+USER_LDFLAGS := -static
+
 %build_module mmake=kernel-dma-bcm2708 	\
   modname=dma modtype=resource		\
   files="dma_init"


### PR DESCRIPTION
One-liner - just static link this. It wouldn't initialize when linked dynamically.

Gippidy's long description of it follows:

---

What we observed was a runtime problem, not merely a compiler warning:

  - The AArch64 image built.
  - The DMA resource was present but did not initialise correctly during boot.
  - Consequently the SD-card path could not proceed.
  - Adding stdc.static at the wider BSP level did not solve it correctly and linked extra runtime code into unrelated modules.
  - Making dma.resource itself static fixed the ownership boundary: the module that needs the runtime closure carries it.
  - We subsequently reached DMA initialisation and SD-card detection.