### PR TITLE
BoingIconBar: fix cut-off right edge of bouncing icons

### DIFF
--- a/workbench/tools/BoingIconBar/iconbar.c
+++ b/workbench/tools/BoingIconBar/iconbar.c
@@ -928,6 +928,7 @@ static void Decode_Toolbar_IDCMP(struct IntuiMessage *KomIDCMP)
                                 Icons[x].Icon_PositionY,
                                 IDS_NORMAL,
                                 ICONDRAWA_Frameless, TRUE,
+                                ICONDRAWA_Borderless, TRUE,
                                 ICONDRAWA_EraseBackground, FALSE,
                                 TAG_DONE);
                         }
@@ -1033,6 +1034,7 @@ static void Insert_Icon(LONG Mode, LONG NrIcon)
         Icons[NrIcon].Icon_PositionY - MovingTable[(Icons[NrIcon].Icon_Status & 0x07)],
         Mode,
         ICONDRAWA_Frameless, TRUE,
+        ICONDRAWA_Borderless, TRUE,
         ICONDRAWA_EraseBackground, FALSE,
         TAG_DONE);
 
@@ -1206,6 +1208,7 @@ static BOOL OpenMainWindow(void)
                     Icons[x].Icon_PositionY,
                     IDS_NORMAL,
                     ICONDRAWA_Frameless, TRUE,
+                    ICONDRAWA_Borderless, TRUE,
                     ICONDRAWA_EraseBackground, FALSE,
                     TAG_DONE);
             }


### PR DESCRIPTION
DrawIconState with only ICONDRAWA_Frameless offsets the icon image by the icon.library emboss rectangle (4px right/down), so Insert_Icon's copy region of Icon_Width+1 left the rightmost columns stale while the icon bounced. Add ICONDRAWA_Borderless to all DrawIconState calls to draw at the exact requested position.