### PR TITLE
bcm2711 dma4

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
@@ -23,7 +23,8 @@
  * Full engines (2, 4, 5) support 2D/TDMODE and wide bursts, lite engines
  * do 32-bit transfers only. Lite channels 13-14 have no dedicated ARM
  * IRQ line (only DMA0-12 map to GPU IRQ 16+N), so they are excluded —
- * users may rely on per-channel completion interrupts.
+ * users may rely on per-channel completion interrupts. (On the BCM2711
+ * 13-14 are DMA4 engines with a line each, see below.)
  */
 #define DMA_POOL_FULL   ((1 << 2) | (1 << 4) | (1 << 5))
 #define DMA_POOL_LITE   ((1 << 8) | (1 << 9) | (1 << 10) | (1 << 11) | \
@@ -35,6 +36,16 @@
  */
 #define DMA_POOL_FULL_BCM2711  ((1 << 2) | (1 << 4))
 #define DMA_POOL_LITE_BCM2711  ((1 << 8) | (1 << 9) | (1 << 10))
+
+/*
+ * The BCM2711 DMA4 engines: 40-bit addressing and a 128-bit AXI path, so no
+ * bus alias and no 1GB ceiling on either end of a transfer. All four are the
+ * OS's - the firmware keeps channel 15, which is not ours to hand out anyway.
+ *
+ * Handed out only on request (DMACHF_DMA4): the control block layout differs,
+ * so a caller that got one unasked would program it as garbage.
+ */
+#define DMA_POOL_DMA4_BCM2711  ((1 << 11) | (1 << 12) | (1 << 13) | (1 << 14))
 
 /*
  * BCM2712 DMA channel allocation.
@@ -102,14 +113,51 @@ static void dma_irq_handler(void *data1, void *data2)
     }
 }
 
-/* Enable the channel and bring the engine to a clean, idle state. */
-static void dma_channel_reset(struct DMABase *DMABase, int channel)
+/* Where a channel reports its errors - DMA4 moved the register. */
+static inline IPTR dma_debug_reg(struct DMABase *DMABase, int channel)
 {
-    volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
+    if (BCM2708_DMA_IS_DMA4(DMABase->dma_periiobase, channel))
+        return DMA4_DEBUG(channel);
+
+    return DMA_DEBUG(channel);
+}
+
+/* Stop the channel and leave the engine idle with its flags clear. */
+static void dma_channel_quiesce(struct DMABase *DMABase, int channel)
+{
     volatile ULONG *cs = (volatile ULONG *)DMA_CS(channel);
     int try = 10000;
 
-    *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) | (1 << channel));
+    if (BCM2708_DMA_IS_DMA4(DMABase->dma_periiobase, channel))
+    {
+        /*
+         * DMA4 has no reset bit in CS - bit 31 is HALT there - and resetting
+         * while the AXI bus still has transactions in flight is documented as
+         * probably fatal. So halt, let the engine drain, then reset via DEBUG.
+         */
+        *cs = AROS_LONG2LE(DMA4_CS_HALT);
+        while (try-- > 0)
+        {
+            if (!(AROS_LE2LONG(*cs) & (DMA4_CS_HALT | DMA4_CS_DMA_BUSY)))
+                break;
+        }
+
+        /* The DMA4 error latches are read-to-clear, not W1C - and they
+         * must be cleared, or CS.ERROR stays up and the engine
+         * misbehaves on later transfers. */
+        (void)*(volatile ULONG *)DMA4_DEBUG(channel);
+
+        if (AROS_LE2LONG(*cs) & (DMA4_CS_HALT | DMA4_CS_DMA_BUSY))
+            /* Still draining: a DEBUG reset now is documented as
+             * "probably fatal", so leave the engine as it stands. */
+            bug("[DMA] channel %d would not halt (cs=0x%08x) - "
+                "reset skipped\n", channel, AROS_LE2LONG(*cs));
+        else
+            *(volatile ULONG *)DMA4_DEBUG(channel) =
+                AROS_LONG2LE(DMA4_DEBUG_RESET);
+        *cs = AROS_LONG2LE(DMA4_CS_INT | DMA4_CS_END);
+        return;
+    }
 
     *cs = AROS_LONG2LE(DMA_CS_RESET);
     while (try-- > 0)
@@ -118,6 +166,16 @@ static void dma_channel_reset(struct DMABase *DMABase, int channel)
             break;
     }
     *cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+}
+
+/* Enable the channel and bring the engine to a clean, idle state. */
+static void dma_channel_reset(struct DMABase *DMABase, int channel)
+{
+    volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
+
+    *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) | (1 << channel));
+
+    dma_channel_quiesce(DMABase, channel);
 }
 
 AROS_LH1(int, DMAAllocChannel,
@@ -140,9 +198,13 @@ AROS_LH1(int, DMAAllocChannel,
         ULONG full = is2712 ? DMA_POOL_FULL_BCM2712 : (is2711 ? DMA_POOL_FULL_BCM2711 : DMA_POOL_FULL);
         ULONG lite = is2712 ? DMA_POOL_LITE_BCM2712 : (is2711 ? DMA_POOL_LITE_BCM2711 : DMA_POOL_LITE);
 
+        /* DMA4 is a distinct programming model, so it is exactly what was
+         * asked for or nothing - never a substitute from another pool. */
+        if (flags & DMACHF_DMA4)
+            avail = is2711 ? (DMA_POOL_DMA4_BCM2711 & ~DMABase->dma_InUse) : 0;
         /* Prefer lite channels so the scarce full engines stay available
          * for users that need TDMODE. */
-        if (flags & DMACHF_TDMODE)
+        else if (flags & DMACHF_TDMODE)
             avail = full & ~DMABase->dma_InUse;
         else
         {
@@ -204,15 +266,8 @@ AROS_LH1(void, DMAFreeChannel,
     if (DMABase->dma_InUse & (1 << channel))
     {
         volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
-        volatile ULONG *cs = (volatile ULONG *)DMA_CS(channel);
-        int try = 10000;
 
-        *cs = AROS_LONG2LE(DMA_CS_RESET);
-        while (try-- > 0)
-        {
-            if (!(AROS_LE2LONG(*cs) & DMA_CS_RESET))
-                break;
-        }
+        dma_channel_quiesce(DMABase, channel);
 
         *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) & ~(1 << channel));
         DMABase->dma_InUse &= ~(1 << channel);
@@ -301,6 +356,23 @@ AROS_LH2(int, DMAWaitChannel,
         if (v & DMA_CS_END)
         {
             *cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+            /* DMA4: the error latches are read-to-clear and CS.ERROR
+             * mirrors them; clear on every completion so latched state
+             * cannot poison the channel's next transfer. Report the
+             * transfer as failed if any were set. */
+            if (BCM2708_DMA_IS_DMA4(DMABase->dma_periiobase, channel))
+            {
+                ULONG dbg = AROS_LE2LONG(
+                    *(volatile ULONG *)DMA4_DEBUG(channel));
+
+                if (dbg & DMA4_DEBUG_ERRORS)
+                {
+                    bug("[DMA] channel %d completed with errors: "
+                        "debug=0x%08x\n", channel, dbg);
+                    ret = -1;
+                    break;
+                }
+            }
             ret = 0;
             break;
         }
@@ -352,21 +424,19 @@ AROS_LH2(int, DMAWaitChannel,
      * writes, so the next transfer would silently run the old control block. */
     if (do_reset)
     {
-        int try = 10000;
+        /* Before the reset wipes them. Legacy DEBUG bit 0 is
+         * READ_LAST_NOT_SET, 1 FIFO_ERROR, 2 READ_ERROR; CS bit 0
+         * ACTIVE, 1 END, 8 ERROR. DMA4: bit 0 is WRITE_ERROR, bit 3
+         * READ_CB_ERROR, CS.ERROR at bit 10, and this DEBUG read
+         * CLEARS the DMA4 latches (they are RC). Note the time printed
+         * is the actual elapsed time, not the caller's budget. */
+        bug("[DMA] channel %d %s after %uus (budget %uus): "
+            "cs=0x%08x debug=0x%08x\n",
+            channel, reason, (unsigned)(dma_now_us(DMABase) - start),
+            timeout_us, AROS_LE2LONG(*cs),
+            AROS_LE2LONG(*(volatile ULONG *)dma_debug_reg(DMABase, channel)));
 
-        /* Before the reset wipes them. DEBUG bit 0 READ_LAST_NOT_SET, 1
-         * FIFO_ERROR, 2 READ_ERROR; CS bit 0 ACTIVE, 1 END, 8 ERROR. */
-        bug("[DMA] channel %d %s after %uus: cs=0x%08x debug=0x%08x\n",
-            channel, reason, timeout_us, AROS_LE2LONG(*cs),
-            AROS_LE2LONG(*(volatile ULONG *)DMA_DEBUG(channel)));
-
-        *cs = AROS_LONG2LE(DMA_CS_RESET);
-        while (try-- > 0)
-        {
-            if (!(AROS_LE2LONG(*cs) & DMA_CS_RESET))
-                break;
-        }
-        *cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+        dma_channel_quiesce(DMABase, channel);
     }
 
     if (dsig >= 0)

--- a/arch/arm-native/soc/broadcom/2708/dma/dma_private.h
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_private.h
@@ -23,7 +23,7 @@ struct DMAChWait {
 struct DMABase {
     struct Node                 dma_Node;
     struct SignalSemaphore      dma_Sem;
-    unsigned int                dma_periiobase;
+    IPTR                        dma_periiobase;
     unsigned int                dma_InUse;      /* Bitmask of allocated channels */
 
     struct DMAChWait            dma_Wait[15];

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -146,6 +146,108 @@
 /* DMA DREQ peripheral map IDs */
 #define DMA_DREQ_PWM                                    5
 
+/*
+ * BCM2711 DMA4 engines (channels 11-14): 40-bit addressing and a 128-bit
+ * AXI path. Same 0x100 channel stride as the legacy engines, but only CS
+ * and the control block address keep their offsets - everything else moved,
+ * and the control block is a different structure (see bcm2708_dma.h).
+ */
+#define DMA4_CS(ch)                                     (DMA_CH_BASE(ch) + 0x00)
+#define DMA4_CB(ch)                                     (DMA_CH_BASE(ch) + 0x04)
+#define DMA4_DEBUG(ch)                                  (DMA_CH_BASE(ch) + 0x0C)
+#define DMA4_TI(ch)                                     (DMA_CH_BASE(ch) + 0x10)
+#define DMA4_SRC(ch)                                    (DMA_CH_BASE(ch) + 0x14)
+#define DMA4_SRCI(ch)                                   (DMA_CH_BASE(ch) + 0x18)
+#define DMA4_DEST(ch)                                   (DMA_CH_BASE(ch) + 0x1C)
+#define DMA4_DESTI(ch)                                  (DMA_CH_BASE(ch) + 0x20)
+#define DMA4_LEN(ch)                                    (DMA_CH_BASE(ch) + 0x24)
+#define DMA4_NEXT_CB(ch)                                (DMA_CH_BASE(ch) + 0x28)
+#define DMA4_DEBUG2(ch)                                 (DMA_CH_BASE(ch) + 0x2C)
+
+/*
+ * DMA4 CS bits. ACTIVE/END/INT sit where the legacy engine has them, so a
+ * completion poll is shared - but bit 31 is HALT here, not RESET, and there
+ * is no reset bit in CS at all (it lives in DEBUG).
+ */
+#define DMA4_CS_ACTIVE                                  (1 << 0)
+#define DMA4_CS_END                                     (1 << 1)
+#define DMA4_CS_INT                                     (1 << 2)
+#define DMA4_CS_DREQ                                    (1 << 3)
+#define DMA4_CS_ERROR                                   (1 << 10)
+#define DMA4_CS_QOS(x)                                  (((x) & 0xF) << 16)
+#define DMA4_CS_PANIC_QOS(x)                            (((x) & 0xF) << 20)
+#define DMA4_CS_DMA_BUSY                                (1 << 24)
+#define DMA4_CS_OUTSTANDING_TRANSACTIONS                (1 << 25)
+#define DMA4_CS_WAIT_FOR_WRITES                         (1 << 28)
+#define DMA4_CS_ABORT                                   (1 << 30)
+#define DMA4_CS_HALT                                    (1UL << 31)
+
+/*
+ * DMA4 DEBUG bits. RESET is write-1-self-clearing and reads back as 0,
+ * and is documented as "probably fatal" while the AXI bus still has
+ * outstanding transactions - halt and drain first.
+ *
+ * The four error latches are READ-TO-CLEAR (RC), not W1C like the
+ * legacy engines' - reading DEBUG clears them. They matter beyond
+ * diagnostics: CS.ERROR (bit 10) mirrors them and latched error state
+ * makes the engine misbehave on subsequent transfers, so read DEBUG
+ * after every completed or failed transfer. Bit 0 is a WRITE response
+ * error on DMA4 (the legacy engines have READ_LAST_NOT_SET there).
+ * Bits 27:24 hold the channel ID, 31:28 the version - a DMA4 DEBUG
+ * readback of 0x1b000000 is just "version 1, channel 11".
+ */
+#define DMA4_DEBUG_WRITE_ERROR                          (1 << 0)
+#define DMA4_DEBUG_FIFO_ERROR                           (1 << 1)
+#define DMA4_DEBUG_READ_ERROR                           (1 << 2)
+#define DMA4_DEBUG_READ_CB_ERROR                        (1 << 3)
+#define DMA4_DEBUG_INT_ON_ERROR                         (1 << 8)
+#define DMA4_DEBUG_HALT_ON_ERROR                        (1 << 9)
+#define DMA4_DEBUG_ABORT_ON_ERROR                       (1 << 10)  /* resets to 1 */
+#define DMA4_DEBUG_DISABLE_CLK_GATE                     (1 << 11)
+#define DMA4_DEBUG_RESET                                (1 << 23)
+#define DMA4_DEBUG_ERRORS                               (DMA4_DEBUG_WRITE_ERROR |  \
+                                                         DMA4_DEBUG_FIFO_ERROR |   \
+                                                         DMA4_DEBUG_READ_ERROR |   \
+                                                         DMA4_DEBUG_READ_CB_ERROR)
+
+/* DMA4 TI bits */
+#define DMA4_TI_INTEN                                   (1 << 0)
+#define DMA4_TI_TDMODE                                  (1 << 1)
+#define DMA4_TI_WAIT_RESP                               (1 << 2)
+#define DMA4_TI_WAIT_RD_RESP                            (1 << 3)
+#define DMA4_TI_PERMAP(x)                               (((x) & 0x1F) << 9)
+#define DMA4_TI_S_DREQ                                  (1 << 14)
+#define DMA4_TI_D_DREQ                                  (1 << 15)
+#define DMA4_TI_S_WAITS(x)                              (((x) & 0xFF) << 16)
+#define DMA4_TI_D_WAITS(x)                              (((x) & 0xFF) << 24)
+
+/*
+ * DMA4 SRCI/DESTI: the top 8 address bits packed with the per-side transfer
+ * attributes. SIZE is an AXI beat width, capped at 128 bits on BCM2711.
+ */
+#define DMA4_XI_ADDR_HI(addr)                           ((ULONG)(((UQUAD)(addr) >> 32) & 0xFF))
+#define DMA4_XI_BURST_LENGTH(x)                         (((x) & 0xF) << 8)
+#define DMA4_XI_INC                                     (1 << 12)
+#define DMA4_XI_SIZE_32                                 (0 << 13)
+#define DMA4_XI_SIZE_64                                 (1 << 13)
+#define DMA4_XI_SIZE_128                                (2 << 13)
+#define DMA4_XI_IGNORE                                  (1 << 15)
+#define DMA4_XI_STRIDE(x)                               (((ULONG)(x) & 0xFFFF) << 16)
+
+/*
+ * DMA4 LEN. Linear mode treats YLENGTH as the high bits of a 30-bit byte
+ * count; 2D mode performs YLENGTH+1 rows of XLENGTH bytes.
+ */
+#define DMA4_LEN_LINEAR(bytes)                          ((ULONG)(bytes) & 0x3FFFFFFF)
+#define DMA4_LEN_2D(xlength, ylength)                   ((((ULONG)(ylength) & 0x3FFF) << 16) | \
+                                                         ((ULONG)(xlength) & 0xFFFF))
+
+/*
+ * Both the CB register and a control block's next-CB field hold the address
+ * shifted right by 5 - the block must be 32-byte aligned anyway.
+ */
+#define DMA4_CB_ADDR(addr)                              ((ULONG)((UQUAD)(addr) >> 5))
+
 #define SYSTIMER_CS                                     (SYSTIMER_BASE + 0x00)
 #define SYSTIMER_CLO                                    (SYSTIMER_BASE + 0x04)
 #define SYSTIMER_CHI                                    (SYSTIMER_BASE + 0x08)

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708_dma.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708_dma.h
@@ -25,6 +25,12 @@
 #define DMACHF_IRQ                  (1 << 1)    /* Resource owns the channel IRQ for
                                                  * DMAWaitChannel(). Leave unset when the
                                                  * driver installs its own handler (AHI). */
+#define DMACHF_DMA4                 (1 << 2)    /* Wants a BCM2711 DMA4 engine. These are a
+                                                 * different programming model, not just a
+                                                 * faster channel - see BCM2711DMA4CB below -
+                                                 * so they are never handed out unasked, and
+                                                 * the request fails on other SoCs. DMA4 does
+                                                 * 2D as well, so TDMODE need not be set. */
 
 /* DMA control block — hardware-defined layout, must be 32-byte aligned.
  * All fields are little-endian; callers convert with AROS_LONG2LE. */
@@ -40,8 +46,70 @@ struct BCM2708DMACB
 };
 
 /*
+ * BCM2711 DMA4 control block - hardware-defined layout, must be 32-byte
+ * aligned (the CB address is stored shifted right by 5).
+ *
+ * Not a superset of BCM2708DMACB: the two address words carry the low 32 bits
+ * only, with the top 8 bits packed into the matching info word next to that
+ * side's burst length, increment, AXI beat width and 2D stride. Fill them with
+ * DMA4_XI_* from bcm2708.h. All fields little-endian.
+ */
+struct BCM2711DMA4CB
+{
+    ULONG   ti;             /* Transfer information (DMA4_TI_*) */
+    ULONG   src;            /* Source address [31:0] */
+    ULONG   srci;           /* Source address [39:32] plus attributes and stride */
+    ULONG   dest;           /* Destination address [31:0] */
+    ULONG   desti;          /* Destination address [39:32] plus attributes and stride */
+    ULONG   len;            /* Transfer length (DMA4_LEN_*) */
+    ULONG   next_cb;        /* Next control block address >> 5, 0 = stop */
+    ULONG   reserved;
+};
+
+/* Channels 11-14 on the BCM2711 are DMA4; nothing on the other SoCs is. */
+#define BCM2708_DMA_IS_DMA4(periiobase, ch) \
+    (((periiobase) == BCM2708_DMA_PERIIOBASE_2711) && ((ch) >= 11) && ((ch) <= 14))
+
+/*
+ * What a DMA4 caller must know, all measured on a Pi 400 (v3d bring-up
+ * 2026-08-23) - the datasheet alone is not enough:
+ *
+ * - SDRAM sits at bus 0x4_00000000 for DMA4 (the "large address" map,
+ *   the same window the PCIe inbound BAR uses). A raw physical address
+ *   points into the legacy/VPU alias space and the engine faults its CB
+ *   fetch with READ_CB_ERROR. Use BCM2711_DMA4_SDRAM() on the source,
+ *   destination AND control block addresses.
+ *
+ * - The kick value needs the PROT bits (CS[9:8]). The datasheet calls
+ *   them reserved, but transfers kicked without them were rejected
+ *   outright, so they belong in every DMA4 kick.
+ *
+ * - ERRATUM: a CB transfers at most low16(LEN) bytes. The documented
+ *   30-bit linear length does not work on this silicon: LEN=0x100000
+ *   moves 0 bytes and completes "successfully". Split transfers above
+ *   60KB into multiple CBs.
+ *
+ * - WARNING: CB chains via next_cb have been observed to WANDER - the
+ *   engine left a correctly built, cache-cleaned 160-link chain and
+ *   executed unrelated RAM as control blocks ("if garbage is read then
+ *   it will execute it"), spraying copies at random addresses. Cause
+ *   not yet understood. Until it is, drive DMA4 with SINGLE CBs of
+ *   <=60KB and kick each one separately.
+ *
+ * - TDMODE errors out instantly on DMA4, whatever the register layout
+ *   suggests. Linear only.
+ */
+#define BCM2711_DMA4_SDRAM(x)   (0x400000000ULL | (UQUAD)(IPTR)(x))
+#define BCM2711_DMA4_CS_PROT    (3UL << 8)
+#define BCM2711_DMA4_CS_RUN     (BCM2708_DMA_CS_RUN | BCM2711_DMA4_CS_PROT)
+#define BCM2711_DMA4_CS_ACK     (BCM2708_DMA_CS_ACK | BCM2711_DMA4_CS_PROT)
+#define BCM2711_DMA4_MAX_LEN    (60 << 10)
+
+/*
  * The uncached VideoCore bus alias covers the first gigabyte only. Above that
  * the cast drops the high bits and the engine reads elsewhere, so check first.
+ * DMA4 has none of this: it takes a 40-bit physical address directly, so the
+ * bus alias must not be applied to a DMA4 control block.
  */
 #define BCM2708_DMA_MAX_ADDR        0x40000000UL
 #define BCM2708_DMA_ADDRESSABLE(x)  (((IPTR)(x)) < BCM2708_DMA_MAX_ADDR)
@@ -86,8 +154,10 @@ struct BCM2708DMACB
 
 static inline unsigned int BCM2708_DMA_IRQ(IPTR periiobase, unsigned int channel)
 {
-    /* The SPI each channel raises on the BCM2711, in channel order. */
-    static const UBYTE spi[] = { 80, 81, 82, 83, 84, 85, 86, 87, 87, 88, 88 };
+    /* The SPI each channel raises on the BCM2711, in channel order. The four
+     * DMA4 engines get a line each again, so the sharing stops after 10. */
+    static const UBYTE spi[] = { 80, 81, 82, 83, 84, 85, 86, 87, 87, 88, 88,
+                                 89, 90, 91, 92 };
 
     if (periiobase != BCM2708_DMA_PERIIOBASE_2711)
         return BCM2708_DMA_IRQ_BASE + channel;


### PR DESCRIPTION
Adds support for BCM2711 DMA4 engines (channels 11-14) in dma.resource