### PR TITLE
ciab.resource: stop driving the RS-232 and printer status inputs

### DIFF
--- a/arch/m68k-amiga/cia/cia_init.c
+++ b/arch/m68k-amiga/cia/cia_init.c
@@ -178,7 +178,11 @@ static AROS_UFH3 (APTR, Cia_Init,
     base->hw->ciacrb = 0x00;
     base->hw->ciapra = 0xff;
     base->hw->ciaprb = 0xff;
-    base->hw->ciaddra = 0xff;
+    /* Only /DTR and /RTS are outputs on CIA-B port A; PA0-2 are the
+     * parallel port's Centronics status inputs and PA3-5 the serial
+     * port's /DSR, /CTS and /CD, all driven by the peripheral through
+     * the 1489 receivers. Same value the boot debug code uses. */
+    base->hw->ciaddra = 0xc0;
     base->hw->ciaddrb = 0xff;
     base->inten_mask = INTF_EXTER;
 


### PR DESCRIPTION
While wiring up RS-232 handshake emulation in Copperline I noticed that AROS guests could never see any of the serial control lines, where Kickstart guests could. The reason turned out to be in cia_init.c: ciab.resource initialises CIA-B DDRA to 0xff, all eight port A pins as outputs.

Only /DTR (PA7) and /RTS (PA6) are outputs on that port. PA0-2 are the parallel port's Centronics status inputs (BUSY, POUT, SEL) and PA3-5 the serial port's /DSR, /CTS and /CD, all driven by the peripheral through the 1489 receivers. With the whole port driven as outputs holding 0xff those six lines can never be read: the parallel hidd's status query (`ciab->ciapra & 7` in ParallelUnitClass.c) reads back its own driven ones instead of the printer's, nothing can ever observe carrier, CTS or DSR change - a program doing 7-wire handshake waits on CTS forever - and on a real machine the CIA is left driving against whatever the 1489s put on those lines.

The boot debug code already knows the right value: boot/debug.c and AROSBootstrap.c both program 0xc0, with a comment saying only DTR and RTS are driven as outputs. This brings cia_init in line with them and with Kickstart, which leaves DDRA at 0xc0. The initial PRA value stays 0xff, which on the two remaining output pins parks /DTR and /RTS released until something opens the port.

Tested on amiga-m68k under Copperline, which models these lines now. With the current ROM a test program polling $BFD000 reads 0xff forever; with this change it reads 0xe7 with a serial bridge attached but no connection (DSR and CTS asserted), 0xc7 while a TCP peer is connected (carrier present), and back to 0xe7 when the peer hangs up - the same values the identical test reads under Kickstart 3.1 on the same machine. The ROM otherwise boots to the usual waiting-for-media screen as before; the floppy control lines all live on port B, which is untouched.