### PR TITLE
usb2otg: accept BCM2835 device-tree binding

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
+++ b/arch/arm-native/soc/broadcom/2708/usb/usb2otg/usb2otg_device.c
@@ -21,7 +21,8 @@
 
 #define DEVNAME         "usb2otg.device"
 
-#define USB2OTG_DT_COMPATIBLE "brcm,bcm2708-usb"
+#define USB2OTG_DT_COMPATIBLE "brcm,bcm2835-usb"
+#define USB2OTG_DT_COMPATIBLE_LEGACY "brcm,bcm2708-usb"
 
 const char devname[]    = MOD_NAME_STRING;
 
@@ -61,6 +62,8 @@ static BOOL FNAME_DEV(DTEnabled)(void)
        such node means this machine has no OTG core of ours - BCM2712 puts a
        different controller somewhere else entirely. */
     key = OF_FindNodeByCompatible(NULL, USB2OTG_DT_COMPATIBLE);
+    if (key == NULL)
+        key = OF_FindNodeByCompatible(NULL, USB2OTG_DT_COMPATIBLE_LEGACY);
     if (key == NULL)
         return FALSE;
 


### PR DESCRIPTION
Couldn't get it to auto-mount my fake USB disks using qemu's Pi 3 profile with Broadcom USB.

Raspberry Pi device tree identifies the DWC2 controller as brcm,bcm2835-usb, but usb2otg.device only looks for brcm,bcm2708-usb, and the driver disables itself. (Looks like it regressed in ebda96b)

So look for BCM2835 first, keep BCM2708 as a fallback for older devices.