### PR TITLE
gpio: Fix the GPIOGet build error on arm

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
@@ -154,9 +154,9 @@ AROS_LH1(unsigned int, GPIOGet,
         val = (reg_val >> (pin & 0x1F)) & 1;
     }
 
-    AROS_LIBFUNC_EXIT
-
     return val;
+
+    AROS_LIBFUNC_EXIT
 }
 
 AROS_LH2(void, GPIOSetPull,


### PR DESCRIPTION
AROS_LIBFUNC_EXIT closes the scope that holds the function's locals, so returning val after it did not compile. Move the return ahead of the macro, as every other library function does.