### PR TITLE
BoingIconBar: polish pass (screen reset, wallpaper, focus, alignment)

### DIFF
--- a/workbench/tools/BoingIconBar/BiB_Eng.guide
+++ b/workbench/tools/BoingIconBar/BiB_Eng.guide
@@ -108,6 +108,8 @@ Version 1.02
 
     @{FG HighLight}STATIC/N/K@{FG Text} - if we want our toolbar to be visible after having been run, you have to specify this parameter with a number bigger than 0. This number informs us about the time in seconds after which the window will be displayed on the screen e.g. during the start up of the operating system.
 
+    @{FG HighLight}ALIGN/K@{FG Text} - alignment of the toolbar on the screen: LEFT, RIGHT or CENTER (default). LEFT aligns the toolbar to the left edge of the screen, RIGHT to the right edge.
+
     @{FG HighLight}AUTOREMAP/S@{FG Text} - this parameter is unavailable for MorphOS users. It can happen that the icons might be displayed inappropriately, e.g. after choosing an option from the menu of Workbench "Tools -> ResetWB". Using this parameter causes automatic remapping of icons to the actual colour palette, before displaying the toolbar.
    
     @{FG HighLight}BACKGROUND/S@{FG Text} - (AROS only) Displays the toolbar background images.

--- a/workbench/tools/BoingIconBar/iconbar.c
+++ b/workbench/tools/BoingIconBar/iconbar.c
@@ -80,6 +80,7 @@
 #include <datatypes/pictureclass.h>
 #include <dos/dos.h>
 #include <devices/rawkeycodes.h>
+#include <devices/timer.h>
 #include <aros/detach.h>
 
 #include <stdio.h>
@@ -111,6 +112,8 @@ static void Reload(void);                                               // reloa
 static void HandleScreenNotify(void);                                   // handle Workbench screen reset
 static BOOL DrainAndReplyPort(struct MsgPort *port);                    // drain port, replying every message
 static BOOL NoIconBouncing(void);                                       // check if no icon is bouncing
+static BOOL MouseOverToolbar(void);                                     // check if mouse is over the toolbar
+static void HandleFocus(void);                                          // focus follows the mouse
 static void RefreshBackground(void);                                    // refresh toolbar background
 static void IconLabel(void);                                            // add label to icon
 
@@ -163,7 +166,13 @@ static ULONG                                    ScreenNotifyMask = 0;
 static APTR                                     ScreenNotifyHandle = NULL;
 static BOOL                                     ScreenResetInProgress = FALSE;
 
-static BOOL                                     NoActivate = FALSE;
+static struct Window                            *PrevActiveWindow = NULL;
+static BOOL                                     FocusOver = FALSE;
+static LONG                                     FocusStableTicks = 0;
+
+static struct MsgPort                           *FocusPort = NULL;
+static struct timerequest                       *FocusTimer = NULL;
+static ULONG                                    FocusMask = 0;
 
 static struct MsgPort                           *WallpaperPort = NULL;
 static ULONG                                    WallpaperMask = 0;
@@ -412,6 +421,29 @@ int main(int argc, char *argv[])
         }
     }
 
+    // periodic timer for focus-follows-mouse (works even when the window is inactive)
+    FocusPort = CreateMsgPort();
+    if (FocusPort)
+    {
+        FocusTimer = (struct timerequest *)CreateIORequest(FocusPort, sizeof(struct timerequest));
+        if (FocusTimer)
+        {
+            if (OpenDevice("timer.device", UNIT_MICROHZ, (struct IORequest *)FocusTimer, 0) == 0)
+            {
+                FocusTimer->tr_node.io_Command = TR_ADDREQUEST;
+                FocusTimer->tr_time.tv_secs = 0;
+                FocusTimer->tr_time.tv_micro = 100000;   /* 100 ms */
+                SendIO((struct IORequest *)FocusTimer);
+                FocusMask = 1 << FocusPort->mp_SigBit;
+            }
+            else
+            {
+                DeleteIORequest((struct IORequest *)FocusTimer);
+                FocusTimer = NULL;
+            }
+        }
+    }
+
     // ------ Opening font if parameter NAMES is active
 
     if (FontSize)
@@ -473,7 +505,7 @@ int main(int argc, char *argv[])
 
             if(Window_Open || MenuWindow_Open)
             {
-                WindowSignal = Wait(WindowMask | MenuMask | ScreenNotifyMask | WallpaperMask | SIGBREAKF_CTRL_C);
+                WindowSignal = Wait(WindowMask | MenuMask | ScreenNotifyMask | WallpaperMask | FocusMask | SIGBREAKF_CTRL_C);
 
                 if(WindowSignal & WindowMask)
                 {
@@ -512,6 +544,16 @@ int main(int argc, char *argv[])
                     WallpaperPending = TRUE;
                 }
 
+                if(WindowSignal & FocusMask)
+                {
+                    BOOL fired = FALSE;
+                    while(GetMsg(FocusPort) != NULL)
+                        fired = TRUE;
+                    if (fired)
+                        SendIO((struct IORequest *)FocusTimer);
+                    HandleFocus();
+                }
+
                 if(WindowSignal & SIGBREAKF_CTRL_C)
                 {
                     D(bug("CTRL-C reveived\n"));
@@ -547,6 +589,15 @@ int main(int argc, char *argv[])
                 {
                     if (DrainAndReplyPort(WallpaperPort))
                         WallpaperPending = FALSE;
+                }
+
+                if (FocusMask)
+                {
+                    BOOL fired = FALSE;
+                    while(GetMsg(FocusPort) != NULL)
+                        fired = TRUE;
+                    if (fired)
+                        SendIO((struct IORequest *)FocusTimer);
                 }
 
                 CheckMousePosition();
@@ -588,6 +639,19 @@ EndNotify(WallpaperNotRequest);
 
     if (WallpaperPort)
         DeleteMsgPort(WallpaperPort);
+
+    if (FocusTimer)
+    {
+        if (FocusTimer->tr_node.io_Device)
+        {
+            AbortIO((struct IORequest *)FocusTimer);
+            WaitIO((struct IORequest *)FocusTimer);
+        }
+        DeleteIORequest((struct IORequest *)FocusTimer);
+    }
+
+    if (FocusPort)
+        DeleteMsgPort(FocusPort);
     
     for(x=0; x<SUM_ICON; x++)
     {
@@ -1172,6 +1236,10 @@ static BOOL OpenMainWindow(void)
 {
     LONG x, y, a;
 
+    PrevActiveWindow = NULL;
+    FocusOver = FALSE;
+    FocusStableTicks = 0;
+
     if((MyScreen=LockPubScreen(NULL)))
     {
         BltBitMapRastPort(MyScreen->RastPort.BitMap,
@@ -1274,7 +1342,7 @@ static BOOL OpenMainWindow(void)
             WA_MouseQueue, 3,
             WA_Borderless, TRUE,
             WA_SizeGadget, FALSE,
-            WA_Activate, ((NoActivate || (FirstOpening && Static)) ? FALSE : TRUE),
+            WA_Activate, FALSE,
             WA_PubScreenName, NULL,
             WA_BackFill, LAYERS_NOBACKFILL,
             WA_Flags, WFLG_NOCAREREFRESH|
@@ -1696,12 +1764,63 @@ static BOOL NoIconBouncing(void)
 }
 
 
+static BOOL MouseOverToolbar(void)
+{
+    LONG mx = MyScreen->MouseX;
+    LONG my = MyScreen->MouseY;
+
+    return (mx >= BeginningWindow &&
+            mx < BeginningWindow + WindowWidth &&
+            my >= ScreenHeight - WindowHeight &&
+            my < ScreenHeight);
+}
+
+
+static void HandleFocus(void)
+{
+    BOOL over;
+
+    if (ScreenResetInProgress || !Window_Open || MenuWindow_Open)
+        return;
+
+    over = MouseOverToolbar();
+
+    /* Debounce: only act when the mouse-over state is stable for two
+       consecutive timer ticks, to avoid flapping activation when the
+       pointer crosses the toolbar border. */
+    if (over == FocusOver)
+        FocusStableTicks++;
+    else
+    {
+        FocusOver = over;
+        FocusStableTicks = 0;
+    }
+
+    if (FocusStableTicks < 2)
+        return;
+
+    if (over)
+    {
+        if (IntuitionBase->ActiveWindow != MainWindow)
+        {
+            if (PrevActiveWindow == NULL)
+                PrevActiveWindow = IntuitionBase->ActiveWindow;
+            ActivateWindow(MainWindow);
+        }
+    }
+    else if (PrevActiveWindow != NULL)
+    {
+        ActivateWindow(PrevActiveWindow);
+        PrevActiveWindow = NULL;
+    }
+}
+
+
 static void RefreshBackground(void)
 {
     if(ScreenResetInProgress)
         return;
 
-    NoActivate = TRUE;
     CloseMainWindow();
 
     /* Let the layers/Wanderer repaint the revealed wallpaper before we
@@ -1712,7 +1831,6 @@ static void RefreshBackground(void)
     {
         BiB_Exit = TRUE;
     }
-    NoActivate = FALSE;
 }
 
 

--- a/workbench/tools/BoingIconBar/iconbar.c
+++ b/workbench/tools/BoingIconBar/iconbar.c
@@ -114,6 +114,8 @@ static BOOL DrainAndReplyPort(struct MsgPort *port);                    // drain
 static BOOL NoIconBouncing(void);                                       // check if no icon is bouncing
 static BOOL MouseOverToolbar(void);                                     // check if mouse is over the toolbar
 static void HandleFocus(void);                                          // focus follows the mouse
+static void ParseAlign(STRPTR str);                                     // parse ALIGN parameter
+static void ComputeWindowPosition(void);                                // set toolbar position from Align
 static void RefreshBackground(void);                                    // refresh toolbar background
 static void IconLabel(void);                                            // add label to icon
 
@@ -124,13 +126,14 @@ static void IconLabel(void);                                            // add l
 #define ICON_ACTIVE (1<<7)
 #define SELECTED_ICON (1<<6)
 
-#define TEMPLATE        "SPACE/N/K,STATIC/N/K,AUTOREMAP/S/K,NAMES/S/K,SYSFONT/K,LABELFONT/K,FONTSIZE/N/K"
+#define TEMPLATE        "SPACE/N/K,STATIC/N/K,ALIGN/K,AUTOREMAP/S/K,NAMES/S/K,SYSFONT/K,LABELFONT/K,FONTSIZE/N/K"
 
 // ------------------------------
 
 enum {
     ARG_SPACE = 0,
     ARG_STATIC,
+    ARG_ALIGN,
     ARG_AUTOREMAP,
     ARG_NAMES,
     ARG_SYSFONT,
@@ -141,7 +144,7 @@ enum {
 
 #define BIB_PREFS "ENV:Iconbar.prefs"
 
-const TEXT version[]="$VER: BoingIconBar 1.12 (01.05.2023) by Robert 'Phibrizzo' Krajcarz - AROS port by LuKeJerry";
+const TEXT version[]="$VER: BoingIconBar 1.13 (23.08.2026) by Robert 'Phibrizzo' Krajcarz - AROS port by LuKeJerry";
 
 static BOOL                                     BiB_Exit=FALSE, Icon_Remap=FALSE, PositionMenuOK=FALSE; 
 static BOOL                                     Window_Active=FALSE, Window_Open=FALSE, MenuWindow_Open=FALSE, FirstOpening=TRUE;
@@ -150,9 +153,10 @@ static BOOL                                     B_Labels=FALSE;
 static TEXT                                     IT_Labels[100];  // buffer for label
 
 // -----------
-static char                                     *argSysFont = NULL, *argLabelFont = NULL;
+static char                                     *argSysFont = NULL, *argLabelFont = NULL, *argAlign = NULL;
 
 static IPTR                                     Spacing=5, Static=0, FontSize = 0;
+static LONG                                     Align = 0;             // 0=center, 1=left, 2=right
 static LONG                                     Position, OldPosition; 
 static LONG                                     WindowHeight, WindowWidth, ScreenHeight, ScreenWidth, IconWidth;
 static LONG                                     IconCounter, LevelCounter, CurrentLevel=0, lbm=0, rbm=0, MouseIcon;
@@ -182,6 +186,7 @@ static BOOL                                     WallpaperPending = FALSE;
 static IPTR                                     args[ARG_TOTAL] = {
                         (IPTR)&Spacing,
                         (IPTR)&Static,
+                        (IPTR)&argAlign,
                         0,
                         0,
                         0,
@@ -262,6 +267,11 @@ int main(int argc, char *argv[])
             Static = *(LONG*)args[ARG_STATIC];
         }
 
+        if (args[ARG_ALIGN])
+        {
+            ParseAlign((STRPTR)args[ARG_ALIGN]);
+        }
+
         if (args[ARG_SYSFONT])
         {
             argSysFont = AllocVec(strlen((char *)args[ARG_SYSFONT]) + 1, MEMF_CLEAR);
@@ -300,6 +310,9 @@ int main(int argc, char *argv[])
 
                     if ((str = FindToolType(dob->do_ToolTypes, "STATIC")))
                         Static = atoi(str);
+
+                    if ((str = FindToolType(dob->do_ToolTypes, "ALIGN")))
+                        ParseAlign(str);
 
                     if ((str = FindToolType(dob->do_ToolTypes, "AUTOREMAP")))
                         Icon_Remap = TRUE;
@@ -791,8 +804,7 @@ static BOOL ReadPrefs(void)
             IconCounter = Levels[1].Beginning;
             WindowWidth = Levels[0].WindowPos_X;
             WindowHeight = Levels[0].WindowPos_Y;
-            BeginningWindow = ScreenWidth / 2 - WindowWidth / 2;
-            EndingWindow = ScreenWidth / 2 + WindowWidth / 2;
+            ComputeWindowPosition();
             CurrentLevel= 0;
 
             // add Settings menu entry
@@ -1243,7 +1255,7 @@ static BOOL OpenMainWindow(void)
     if((MyScreen=LockPubScreen(NULL)))
     {
         BltBitMapRastPort(MyScreen->RastPort.BitMap,
-            ScreenWidth / 2 - WindowWidth / 2,
+            BeginningWindow,
             ScreenHeight - WindowHeight,
             &RP_Buffer,
             0, 0,
@@ -1451,8 +1463,7 @@ static void Show_Selected_Level(void)
     IconCounter   = Levels[CurrentLevel+1].Beginning;
     WindowWidth = Levels[CurrentLevel].WindowPos_X;
     WindowHeight  = Levels[CurrentLevel].WindowPos_Y;
-    BeginningWindow = ScreenWidth / 2 - WindowWidth / 2;
-    EndingWindow   = ScreenWidth / 2 + WindowWidth / 2;
+    ComputeWindowPosition();
 
     //LJ: delay needed for AROS, otherwise garbage from old icons remains
     Delay(10); // 200 ms seems to be enough
@@ -1812,6 +1823,40 @@ static void HandleFocus(void)
     {
         ActivateWindow(PrevActiveWindow);
         PrevActiveWindow = NULL;
+    }
+}
+
+
+static void ParseAlign(STRPTR str)
+{
+    if (str)
+    {
+        if (stricmp(str, "LEFT") == 0)
+            Align = 1;
+        else if (stricmp(str, "RIGHT") == 0)
+            Align = 2;
+        else
+            Align = 0;
+    }
+}
+
+
+static void ComputeWindowPosition(void)
+{
+    if (Align == 1)                      /* LEFT */
+    {
+        BeginningWindow = 0;
+        EndingWindow = WindowWidth;
+    }
+    else if (Align == 2)                 /* RIGHT */
+    {
+        BeginningWindow = ScreenWidth - WindowWidth;
+        EndingWindow = ScreenWidth;
+    }
+    else                                 /* CENTER (default) */
+    {
+        BeginningWindow = ScreenWidth / 2 - WindowWidth / 2;
+        EndingWindow = ScreenWidth / 2 + WindowWidth / 2;
     }
 }
 

--- a/workbench/tools/BoingIconBar/iconbar.c
+++ b/workbench/tools/BoingIconBar/iconbar.c
@@ -108,6 +108,8 @@ static void Decode_Menu_IDCMP(struct IntuiMessage *KomIDCMP);           // decod
 static void Launch_Program(STRPTR Program);                             // start the chosed program
 static void Settings(void);                                             // open the prefs program
 static void Reload(void);                                               // reload the BiB
+static void HandleScreenNotify(void);                                   // handle Workbench screen reset
+static BOOL DrainAndReplyPort(struct MsgPort *port);                    // drain port, replying every message
 static void IconLabel(void);                                            // add label to icon
 
 // ------------------------------
@@ -153,6 +155,11 @@ static LONG                                     Length, BeginningWindow, EndingW
 static BYTE                                     MovingTable[8]={0, 4, 7, 9, 10, 9, 7, 4};
 static TEXT                                     BufferList[20]; 
 static ULONG                                    WindowMask=0, MenuMask=0, WindowSignal;
+
+static struct MsgPort                           *ScreenNotifyPort = NULL;
+static ULONG                                    ScreenNotifyMask = 0;
+static APTR                                     ScreenNotifyHandle = NULL;
+static BOOL                                     ScreenResetInProgress = FALSE;
 
 static IPTR                                     args[ARG_TOTAL] = {
                         (IPTR)&Spacing,
@@ -358,6 +365,22 @@ int main(int argc, char *argv[])
         goto bailout;
     }
 
+    // start notification on Workbench screen reset (e.g. resolution change)
+    ScreenNotifyPort = CreateMsgPort();
+    if (ScreenNotifyPort)
+    {
+        ScreenNotifyHandle = StartScreenNotifyTags(
+            SNA_Notify,   SNOTIFY_WAIT_REPLY | SNOTIFY_BEFORE_CLOSEWB | SNOTIFY_AFTER_OPENWB,
+            SNA_MsgPort,  ScreenNotifyPort,
+            SNA_Priority, 0,
+            TAG_END);
+
+        if (ScreenNotifyHandle)
+        {
+            ScreenNotifyMask = 1 << ScreenNotifyPort->mp_SigBit;
+        }
+    }
+
     // ------ Opening font if parameter NAMES is active
 
     if (FontSize)
@@ -411,14 +434,15 @@ int main(int argc, char *argv[])
         while (BiB_Exit==FALSE)
         {
 
-            if (GetMsg(BIBport) != NULL)
+            if (DrainAndReplyPort(BIBport))
             {
-                Reload();
+                if (!ScreenResetInProgress)
+                    Reload();
             }
 
             if(Window_Open || MenuWindow_Open)
             {
-                WindowSignal = Wait(WindowMask | MenuMask | SIGBREAKF_CTRL_C);
+                WindowSignal = Wait(WindowMask | MenuMask | ScreenNotifyMask | SIGBREAKF_CTRL_C);
 
                 if(WindowSignal & WindowMask)
                 {
@@ -446,6 +470,11 @@ int main(int argc, char *argv[])
                         CloseMenuWindow();
                 }
 
+                if(WindowSignal & ScreenNotifyMask)
+                {
+                    HandleScreenNotify();
+                }
+
                 if(WindowSignal & SIGBREAKF_CTRL_C)
                 {
                     D(bug("CTRL-C reveived\n"));
@@ -462,6 +491,11 @@ int main(int argc, char *argv[])
                     D(bug("CTRL-C reveived\n"));
                     SetSignal(0, SIGBREAKF_CTRL_C);
                     BiB_Exit=TRUE;
+                }
+
+                if (ScreenNotifyMask)
+                {
+                    HandleScreenNotify();
                 }
 
                 CheckMousePosition();
@@ -487,6 +521,12 @@ bailout:
 
     if (BIBport)
         DeleteMsgPort(BIBport);
+
+    if (ScreenNotifyHandle)
+        EndScreenNotify(ScreenNotifyHandle);
+
+    if (ScreenNotifyPort)
+        DeleteMsgPort(ScreenNotifyPort);
     
     for(x=0; x<SUM_ICON; x++)
     {
@@ -1245,6 +1285,9 @@ static void CloseMainWindow(void)
 
 static void CheckMousePosition(void)
 {
+    if (ScreenResetInProgress)
+        return;
+
     if((MyScreen->MouseY > ScreenHeight - 8) &&
         Window_Open == FALSE &&
         MyScreen->MouseX > BeginningWindow &&
@@ -1468,6 +1511,114 @@ static void Launch_Program(STRPTR Program)
 static void Settings(void)
 {
     OpenWorkbenchObject("SYS:Prefs/BoingIconBar", TAG_DONE);
+}
+
+
+static void ScreenResetCleanup(void)
+{
+    LONG x;
+
+    if (MenuWindow_Open)
+    {
+        MenuWindow_Open = FALSE;
+        if (MenuWindow)
+            CloseWindow(MenuWindow);
+        MenuWindow = NULL;
+        MenuMask = 0;
+    }
+
+    if (Window_Open == TRUE)
+    {
+        CloseMainWindow();
+    }
+
+    for(x=0; x<SUM_ICON; x++)
+    {
+        if(Icon[x] != NULL)
+        {
+            FreeDiskObject(Icon[x]);
+            Icon[x]=NULL;
+        }
+        Icons[x].Icon_Height  = 0;
+        Icons[x].Icon_Width = 0;
+        Icons[x].Icon_PositionX  = 0;
+        Icons[x].Icon_PositionY  = 0;
+    }
+
+    if(BMP_Buffer)
+        FreeBitMap(BMP_Buffer);
+    if(BMP_DoubleBuffer)
+        FreeBitMap(BMP_DoubleBuffer);
+
+    for(x=0; x<3; x++)
+    {
+        if(picture[x])
+            DisposeDTObject(picture[x]);
+        picture[x] = NULL;
+        bm[x] = NULL;
+    }
+}
+
+
+static void ScreenResetRestore(void)
+{
+    if(ReadPrefs() == FALSE)
+    {
+        puts("Prefs error\n");
+        return;
+    }
+
+    LoadBackground();
+
+    if(Static)
+    {
+        Delay(Static * 50);
+        OpenMainWindow();
+        FirstOpening = FALSE;
+    }
+}
+
+
+static void HandleScreenNotify(void)
+{
+    struct ScreenNotifyMessage *msg;
+
+    while((msg = (struct ScreenNotifyMessage *)GetMsg(ScreenNotifyPort)))
+    {
+        switch(msg->snm_Class)
+        {
+            case SNOTIFY_BEFORE_CLOSEWB:
+                D(bug("[IconBar] screen reset: closing toolbar\n"));
+                ScreenResetInProgress = TRUE;
+                ScreenResetCleanup();
+                break;
+
+            case SNOTIFY_AFTER_OPENWB:
+                D(bug("[IconBar] screen reset: reopening toolbar\n"));
+                ScreenResetInProgress = FALSE;
+                ScreenResetRestore();
+                break;
+
+            default:
+                break;
+        }
+
+        ReplyMsg((struct Message *)msg);
+    }
+}
+
+
+static BOOL DrainAndReplyPort(struct MsgPort *port)
+{
+    struct Message *msg;
+    BOOL got = FALSE;
+
+    while ((msg = GetMsg(port)))
+    {
+        got = TRUE;
+        ReplyMsg(msg);
+    }
+    return got;
 }
 
 

--- a/workbench/tools/BoingIconBar/iconbar.c
+++ b/workbench/tools/BoingIconBar/iconbar.c
@@ -110,6 +110,8 @@ static void Settings(void);                                             // open 
 static void Reload(void);                                               // reload the BiB
 static void HandleScreenNotify(void);                                   // handle Workbench screen reset
 static BOOL DrainAndReplyPort(struct MsgPort *port);                    // drain port, replying every message
+static BOOL NoIconBouncing(void);                                       // check if no icon is bouncing
+static void RefreshBackground(void);                                    // refresh toolbar background
 static void IconLabel(void);                                            // add label to icon
 
 // ------------------------------
@@ -160,6 +162,13 @@ static struct MsgPort                           *ScreenNotifyPort = NULL;
 static ULONG                                    ScreenNotifyMask = 0;
 static APTR                                     ScreenNotifyHandle = NULL;
 static BOOL                                     ScreenResetInProgress = FALSE;
+
+static BOOL                                     NoActivate = FALSE;
+
+static struct MsgPort                           *WallpaperPort = NULL;
+static ULONG                                    WallpaperMask = 0;
+static struct NotifyRequest                     *WallpaperNotRequest = NULL;
+static BOOL                                     WallpaperPending = FALSE;
 
 static IPTR                                     args[ARG_TOTAL] = {
                         (IPTR)&Spacing,
@@ -381,6 +390,28 @@ int main(int argc, char *argv[])
         }
     }
 
+    // start notification on the wallpaper prefs file
+    WallpaperPort = CreateMsgPort();
+    if (WallpaperPort)
+    {
+        WallpaperNotRequest = AllocVec(sizeof(struct NotifyRequest), MEMF_CLEAR);
+        if (WallpaperNotRequest)
+        {
+            WallpaperNotRequest->nr_Name = "ENV:SYS/Wanderer/global.prefs";
+            WallpaperNotRequest->nr_Flags = NRF_SEND_MESSAGE;
+            WallpaperNotRequest->nr_stuff.nr_Msg.nr_Port = WallpaperPort;
+
+            if (StartNotify(WallpaperNotRequest) != DOSFALSE)
+            {
+                WallpaperMask = 1 << WallpaperPort->mp_SigBit;
+            }
+            else
+            {
+                WallpaperNotRequest->nr_Name = NULL;
+            }
+        }
+    }
+
     // ------ Opening font if parameter NAMES is active
 
     if (FontSize)
@@ -442,7 +473,7 @@ int main(int argc, char *argv[])
 
             if(Window_Open || MenuWindow_Open)
             {
-                WindowSignal = Wait(WindowMask | MenuMask | ScreenNotifyMask | SIGBREAKF_CTRL_C);
+                WindowSignal = Wait(WindowMask | MenuMask | ScreenNotifyMask | WallpaperMask | SIGBREAKF_CTRL_C);
 
                 if(WindowSignal & WindowMask)
                 {
@@ -475,10 +506,24 @@ int main(int argc, char *argv[])
                     HandleScreenNotify();
                 }
 
+                if(WindowSignal & WallpaperMask)
+                {
+                    DrainAndReplyPort(WallpaperPort);
+                    WallpaperPending = TRUE;
+                }
+
                 if(WindowSignal & SIGBREAKF_CTRL_C)
                 {
                     D(bug("CTRL-C reveived\n"));
                     BiB_Exit=TRUE;
+                }
+
+                if(WallpaperPending && Window_Open && NoIconBouncing())
+                {
+                    /* Let Wanderer repaint the new wallpaper before recapturing */
+                    Delay(20);
+                    RefreshBackground();
+                    WallpaperPending = FALSE;
                 }
 
             }
@@ -496,6 +541,12 @@ int main(int argc, char *argv[])
                 if (ScreenNotifyMask)
                 {
                     HandleScreenNotify();
+                }
+
+                if (WallpaperMask)
+                {
+                    if (DrainAndReplyPort(WallpaperPort))
+                        WallpaperPending = FALSE;
                 }
 
                 CheckMousePosition();
@@ -527,6 +578,16 @@ bailout:
 
     if (ScreenNotifyPort)
         DeleteMsgPort(ScreenNotifyPort);
+
+    if (WallpaperNotRequest)
+    {
+        if (WallpaperNotRequest->nr_Name)
+EndNotify(WallpaperNotRequest);
+        FreeVec(WallpaperNotRequest);
+    }
+
+    if (WallpaperPort)
+        DeleteMsgPort(WallpaperPort);
     
     for(x=0; x<SUM_ICON; x++)
     {
@@ -1213,7 +1274,7 @@ static BOOL OpenMainWindow(void)
             WA_MouseQueue, 3,
             WA_Borderless, TRUE,
             WA_SizeGadget, FALSE,
-            WA_Activate, ((FirstOpening && Static) ? FALSE : TRUE),
+            WA_Activate, ((NoActivate || (FirstOpening && Static)) ? FALSE : TRUE),
             WA_PubScreenName, NULL,
             WA_BackFill, LAYERS_NOBACKFILL,
             WA_Flags, WFLG_NOCAREREFRESH|
@@ -1619,6 +1680,39 @@ static BOOL DrainAndReplyPort(struct MsgPort *port)
         ReplyMsg(msg);
     }
     return got;
+}
+
+
+static BOOL NoIconBouncing(void)
+{
+    LONG x;
+
+    for(x=Levels[CurrentLevel].Beginning; x<IconCounter; x++)
+    {
+        if(Icons[x].Icon_OK && Icons[x].Icon_Status != 0)
+            return FALSE;
+    }
+    return TRUE;
+}
+
+
+static void RefreshBackground(void)
+{
+    if(ScreenResetInProgress)
+        return;
+
+    NoActivate = TRUE;
+    CloseMainWindow();
+
+    /* Let the layers/Wanderer repaint the revealed wallpaper before we
+       recapture it, otherwise we would just grab the old cached pixels. */
+    Delay(2);
+
+    if(OpenMainWindow() == FALSE)
+    {
+        BiB_Exit = TRUE;
+    }
+    NoActivate = FALSE;
 }
 
 


### PR DESCRIPTION
- **Survive Workbench screen resets** — register for `SNOTIFY_BEFORE_CLOSEWB`/`SNOTIFY_AFTER_OPENWB` so resolution changes no longer stall on the "Intuition is attempting to reset the screen" requester; closes/reopens the toolbar and reloads its resources against the new screen.
- **Refresh background on wallpaper change** — watch `ENV:SYS/Wanderer/global.prefs` with `StartNotify` and recapture the toolbar background when the wallpaper is changed in Wanderer.
- **Focus follows the mouse** — the toolbar activates on hover (100 ms timer poll, debounced) and returns focus to the previous window on leave, so keyboard shortcuts work without a click.
- **ALIGN tooltype** — position the toolbar LEFT/RIGHT/CENTER via tooltype or command line (`ComputeWindowPosition()`); version bumped to 1.13.