### PR TITLE
docs: fix typo availabe -> available

### DIFF
--- a/compiler/pthread/README.md
+++ b/compiler/pthread/README.md
@@ -8,7 +8,7 @@ Due to underlying API limitations detached threads are not supported.
 
 ## License
 
-The library is availabe under the zlib license.
+The library is available under the zlib license.
 
 ## Website
 [http://bszili.morphos.me](http://bszili.morphos.me)


### PR DESCRIPTION
One-word typo fix in `compiler/pthread/README.md:11`: "The library is availabe under the..." → `available`.
