### PR TITLE
m68k-amiga: cd.device must only act on Akiko interrupt sources it has armed

### DIFF
--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -151,7 +151,16 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
 
     AROS_INTFUNC_INIT
 
-    status = readl(AKIKO_CDINTREQ);
+    /* CDINTREQ returns the raw request latches; CDINTENA only gates the
+     * INT2 line. Completion bits stay latched until the matching index
+     * comparator is rewritten, so between exchanges the previous
+     * command's TXDMA/RXDMA bits are still visible. This server runs on
+     * every PORTS interrupt (CIA-A events included) and must only act
+     * on the sources it has armed: reacting to a stale latch signals
+     * the unit task at a moment it never asked about, desynchronising
+     * the command exchange.
+     */
+    status = readl(AKIKO_CDINTREQ) & cu->cu_IntEnable;
     if (!status)
         return FALSE;
 


### PR DESCRIPTION
While getting Jim Power in Mutant Planet (CD32) running under Copperline I had to correct the emulator's model of Akiko's CDINTREQ register: reads return the raw request latches, with CDINTENA only gating the INT2 line. WinUAE and MAME both model it that way, and the game depends on it - its loader drives the drive port directly in PIO mode and polls DRIVEXMIT before every command byte without ever enabling it. With the register model corrected, this driver stopped booting CDs, and the trail led back to cd.device rather than the emulator.

The Akiko completion bits stay latched until the matching comparator register is rewritten (CDRXCMP clears RXDMADONE, CDTXCMP clears TXDMADONE), so between exchanges the previous command's completion bits are still sitting in CDINTREQ. CD32_Interrupt is on the PORTS chain, so it also runs for every CIA-A event, and it acts on whatever CDINTREQ shows. On one of those stale entries it signals the unit task at a moment it never asked about; the task then misreads the receive ring and re-arms CDRXCMP behind a half-delivered response, and from there the exchange is desynchronised for good - the drive protocol won't accept another command while that response is pending, so boot parks on the splash screen. I suspect the driver only ever behaved on real hardware by luck: during a quiet CD boot almost nothing else raises INT2, so the stale-latch windows were rarely probed, but a keyboard event landing in the wrong microsecond would have done it.

The fix is the usual discipline for a server on a shared chain: mask the status with the sources the driver has actually armed. Stale latches from disarmed sources are ignored, and the chain falls through cleanly to the CIA server. Verified under Copperline with the corrected register model: Pinball Fantasies boots from CD to its attract mode again, and the same image still boots under the CD32 Kickstart's own cd.device. As before, this is all under emulation, so a test on real hardware would be very welcome.
