### PR TITLE
sdcard fixes

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
@@ -65,6 +65,29 @@ ULONG FNAME_BCMSDCBUS(BCMMMIOReadLong)(ULONG reg, struct sdcard_Bus *bus)
     return AROS_LE2LONG(*(volatile ULONG *)(bus->sdcb_IOBase + reg));
 }
 
+/* Bulk read from one register, for the PIO data port. Unrolled because the
+ * per-word call overhead is comparable to the MMIO access itself. */
+void FNAME_BCMSDCBUS(BCMMMIOReadLongs)(ULONG reg, ULONG *dest, ULONG count,
+                                       struct sdcard_Bus *bus)
+{
+    volatile ULONG *port = (volatile ULONG *)((IPTR)bus->sdcb_IOBase + reg);
+    ULONG i;
+
+    for (i = 0; (i + 8) <= count; i += 8)
+    {
+        dest[i    ] = AROS_LE2LONG(*port);
+        dest[i + 1] = AROS_LE2LONG(*port);
+        dest[i + 2] = AROS_LE2LONG(*port);
+        dest[i + 3] = AROS_LE2LONG(*port);
+        dest[i + 4] = AROS_LE2LONG(*port);
+        dest[i + 5] = AROS_LE2LONG(*port);
+        dest[i + 6] = AROS_LE2LONG(*port);
+        dest[i + 7] = AROS_LE2LONG(*port);
+    }
+    for (; i < count; i++)
+        dest[i] = AROS_LE2LONG(*port);
+}
+
 static void FNAME_BCMSDCBUS(BCM283xWriteLong)(ULONG reg, ULONG val, struct sdcard_Bus *bus)
 {
     /* Bug: two SDC clock cycle delay required between successive chipset writes */

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708bus.c
@@ -48,14 +48,14 @@ ULONG FNAME_SDCBUS(GetClockDiv)(ULONG speed, struct sdcard_Bus *bus)
 
 UBYTE FNAME_BCMSDCBUS(BCMMMIOReadByte)(ULONG reg, struct sdcard_Bus *bus)
 {
-    ULONG val = AROS_LE2LONG(*(volatile ULONG *)(((ULONG)bus->sdcb_IOBase + reg) & ~3));
+    ULONG val = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
 
     return (val >> ((reg & 3) << 3)) & 0xFF;
 }
 
 UWORD FNAME_BCMSDCBUS(BCMMMIOReadWord)(ULONG reg, struct sdcard_Bus *bus)
 {
-    ULONG val = AROS_LE2LONG(*(volatile ULONG *)(((ULONG)bus->sdcb_IOBase + reg) & ~3));
+    ULONG val = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
 
     return (val >> (((reg >> 1) & 1) << 4)) & 0xFFFF;
 }
@@ -77,7 +77,7 @@ static void FNAME_BCMSDCBUS(BCM283xWriteLong)(ULONG reg, ULONG val, struct sdcar
 
 void FNAME_BCMSDCBUS(BCMMMIOWriteByte)(ULONG reg, UBYTE val, struct sdcard_Bus *bus)
 {
-    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((ULONG)bus->sdcb_IOBase + reg) & ~3));
+    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
     ULONG shift = (reg & 3) << 3;
     ULONG mask = 0xFF << shift;
     ULONG newval = (currval & ~mask) | (val << shift);
@@ -87,7 +87,7 @@ void FNAME_BCMSDCBUS(BCMMMIOWriteByte)(ULONG reg, UBYTE val, struct sdcard_Bus *
 
 void FNAME_BCMSDCBUS(BCMMMIOWriteWord)(ULONG reg, UWORD val, struct sdcard_Bus *bus)
 {
-    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((ULONG)bus->sdcb_IOBase + reg) & ~3));
+    ULONG currval = AROS_LE2LONG(*(volatile ULONG *)(((IPTR)bus->sdcb_IOBase + reg) & ~3));
     ULONG shift = ((reg >> 1) & 1) << 4;
     ULONG mask = 0xFFFF << shift;
     ULONG newval = (currval & ~mask) | (val << shift);

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -69,6 +69,9 @@ static void FNAME_BCMSDC(SDBusPostIRQInit)(struct sdcard_Bus *bus)
 static void FNAME_BCMSDC(SDSetBusWidth)(UBYTE width, struct sdcard_Bus *bus)
 {
     UBYTE sdcHostCtrl = bus->sdcb_IOReadByte(SDHCI_HOST_CONTROL, bus);
+
+    DINIT(bug("[SDCard--] %s: %u-bit bus width\n", __PRETTY_FUNCTION__, width));
+
     if (width == 4)
         sdcHostCtrl |= SDHCI_HCTRL_4BITBUS;
     else
@@ -326,6 +329,13 @@ bcminit_clock:
                 else
                     DINIT(bug("[SDCard--] %s: controller reports no base clock, keeping the mailbox rate\n", __PRETTY_FUNCTION__));
             }
+
+            DINIT(bug("[SDCard--] %s: %s @ 0x%p: base clock %uMHz, caps 0x%08x, host spec %u%s%s\n",
+                        __PRETTY_FUNCTION__, isEMMC2 ? "EMMC2" : "Arasan", (APTR)ctrlBase,
+                        __BCM2708Bus->sdcb_ClockMax / 1000000, __BCM2708Bus->sdcb_Capabilities,
+                        (__BCM2708Bus->sdcb_Version & 0xFF) + 1,
+                        (__BCM2708Bus->sdcb_Capabilities & SDHCI_CAN_DO_ADMA2) ? ", ADMA2" : "",
+                        (__BCM2708Bus->sdcb_Capabilities & SDHCI_CAN_DO_HISPD) ? ", HISPD" : ""));
 
             DINIT(bug("[SDCard--] %s: SDHC Base Clock Rate : %dMHz\n", __PRETTY_FUNCTION__, __BCM2708Bus->sdcb_ClockMax / 1000000));
             DINIT(bug("[SDCard--] %s: SDHC Min Clock Rate : %dHz (hardcoded)\n", __PRETTY_FUNCTION__, __BCM2708Bus->sdcb_ClockMin));

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -249,6 +249,7 @@ bcminit_clock:
         __BCM2708Bus->sdcb_IOReadByte = FNAME_BCMSDCBUS(BCMMMIOReadByte);
         __BCM2708Bus->sdcb_IOReadWord = FNAME_BCMSDCBUS(BCMMMIOReadWord);
         __BCM2708Bus->sdcb_IOReadLong = FNAME_BCMSDCBUS(BCMMMIOReadLong);
+        __BCM2708Bus->sdcb_IOReadLongs = FNAME_BCMSDCBUS(BCMMMIOReadLongs);
 
         if (isEMMC2)
         {

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_intern.h
@@ -40,6 +40,7 @@ void FNAME_BCMSDCBUS(BCMLEDCtrl)(int lvl);
 UBYTE FNAME_BCMSDCBUS(BCMMMIOReadByte)(ULONG, struct sdcard_Bus *);
 UWORD FNAME_BCMSDCBUS(BCMMMIOReadWord)(ULONG, struct sdcard_Bus *);
 ULONG FNAME_BCMSDCBUS(BCMMMIOReadLong)(ULONG, struct sdcard_Bus *);
+void FNAME_BCMSDCBUS(BCMMMIOReadLongs)(ULONG, ULONG *, ULONG, struct sdcard_Bus *);
 
 void FNAME_BCMSDCBUS(BCMMMIOWriteByte)(ULONG, UBYTE, struct sdcard_Bus *);
 void FNAME_BCMSDCBUS(BCMMMIOWriteWord)(ULONG, UWORD, struct sdcard_Bus *);

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
@@ -271,6 +271,7 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
         bus->sdcb_IOReadByte = NULL;
         bus->sdcb_IOReadWord = NULL;
         bus->sdcb_IOReadLong = NULL;
+        bus->sdcb_IOReadLongs = NULL;
         bus->sdcb_IOWriteByte = NULL;
         bus->sdcb_IOWriteWord = NULL;
         bus->sdcb_IOWriteLong = NULL;

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -1166,9 +1166,30 @@ ULONG FNAME_SDCBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
                 DTRANS(bug("[SDBus%02u] %s: Attempting to %s %dbytes\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, ((sdDataMode == MMC_DATA_READ) ? "read" : "write"), tranlen));
                 if (sdDataMode == MMC_DATA_READ)
                 {
-                    for (currword = 0; currword < tranwords; currword++)
+                    /*
+                     * The data port is one 32bit register, so this is a bus
+                     * round trip per word whatever we do - but the indirect
+                     * accessor call costs about as much as the access itself,
+                     * so read through a local pointer, several at a time.
+                     * Writes keep the accessor: the earlier controller needs
+                     * its inter-write delay, and that lives in there.
+                     */
+                    volatile ULONG *port = (volatile ULONG *)((IPTR)bus->sdcb_IOBase + SDHCI_BUFFER);
+
+                    for (currword = 0; (currword + 8) <= tranwords; currword += 8)
                     {
-                        dataPtr[currword] = bus->sdcb_IOReadLong(SDHCI_BUFFER, bus);
+                        dataPtr[currword    ] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 1] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 2] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 3] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 4] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 5] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 6] = AROS_LE2LONG(*port);
+                        dataPtr[currword + 7] = AROS_LE2LONG(*port);
+                    }
+                    for (; currword < tranwords; currword++)
+                    {
+                        dataPtr[currword] = AROS_LE2LONG(*port);
                     }
                 }
                 else

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -1167,29 +1167,21 @@ ULONG FNAME_SDCBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
                 if (sdDataMode == MMC_DATA_READ)
                 {
                     /*
-                     * The data port is one 32bit register, so this is a bus
-                     * round trip per word whatever we do - but the indirect
-                     * accessor call costs about as much as the access itself,
-                     * so read through a local pointer, several at a time.
-                     * Writes keep the accessor: the earlier controller needs
-                     * its inter-write delay, and that lives in there.
+                     * A bus that can read its data port in bulk does so: the
+                     * indirect call costs about as much as the register access
+                     * itself, and this is one call per word otherwise.
                      */
-                    volatile ULONG *port = (volatile ULONG *)((IPTR)bus->sdcb_IOBase + SDHCI_BUFFER);
-
-                    for (currword = 0; (currword + 8) <= tranwords; currword += 8)
+                    if (bus->sdcb_IOReadLongs)
                     {
-                        dataPtr[currword    ] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 1] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 2] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 3] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 4] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 5] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 6] = AROS_LE2LONG(*port);
-                        dataPtr[currword + 7] = AROS_LE2LONG(*port);
+                        bus->sdcb_IOReadLongs(SDHCI_BUFFER, (ULONG *)dataPtr,
+                                              tranwords, bus);
                     }
-                    for (; currword < tranwords; currword++)
+                    else
                     {
-                        dataPtr[currword] = AROS_LE2LONG(*port);
+                        for (currword = 0; currword < tranwords; currword++)
+                        {
+                            dataPtr[currword] = bus->sdcb_IOReadLong(SDHCI_BUFFER, bus);
+                        }
                     }
                 }
                 else

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -400,7 +400,9 @@ BOOL FNAME_SDCBUS(RegisterUnit)(struct sdcard_Bus *bus)
 
                             sdcUnit->sdcu_Read32                = FNAME_SDCIO(ReadSector32);
                             sdcUnit->sdcu_Write32               = FNAME_SDCIO(WriteSector32);
-                            sdcUnit->sdcu_Bus->sdcb_BusFlags    = AF_Bus_MediaPresent;
+                            /* Add to what the bus has already established about
+                               itself - DMA and interrupt delivery live here too. */
+                            sdcUnit->sdcu_Bus->sdcb_BusFlags    |= AF_Bus_MediaPresent;
 #if defined(SDHCI_READONLY)
                             sdcUnit->sdcu_Flags                 = AF_Card_WriteProtect;
 #endif

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -1037,7 +1037,8 @@ ULONG FNAME_SDCBUS(FinishData)(struct TagItem *DataTags, struct sdcard_Bus *bus)
 {
     DTRANS(UWORD        sdCommand = (UWORD)GetTagData(SDCARD_TAG_CMD, 0, DataTags));
     ULONG               sdcStateMask, sdCommandMask,
-                        sdData, sdDataMode = MMC_DATA_READ, sdDataLen, sdcReg = 0;
+                        sdDataMode = MMC_DATA_READ, sdDataLen, sdcReg = 0;
+    IPTR                sdData;
     struct TagItem      *sdDataLenTag = NULL;
     ULONG               waitStart = 0;
     BOOL                waiting = FALSE;

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -170,6 +170,21 @@ BOOL FNAME_SDCBUS(StartUnit)(struct sdcard_Unit *sdcUnit)
         /* Prove the controller's own transfers land where we think they do. */
         FNAME_SDCBUS(ADMAVerify)(sdcUnit);
     }
+    else
+    {
+        /*
+         * A card left in stand-by answers CMD9 but ignores CMD17/CMD18
+         * outright, so the only sign of this is a bare command timeout much
+         * later, once the transfer clock and bus width have quietly been
+         * skipped along with everything else in here.
+         */
+        bug("[SDCard%02ld] %s: CMD7 (RCA %d) not acknowledged, card stays in stand-by [PS %08x BS %08x]\n",
+            sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__, sdcUnit->sdcu_CardRCA,
+            sdcUnit->sdcu_Bus->sdcb_IOReadLong(SDHCI_PRESENT_STATE, sdcUnit->sdcu_Bus),
+            sdcUnit->sdcu_Bus->sdcb_BusStatus);
+
+        return FALSE;
+    }
 
     D(bug("[SDCard%02ld] %s: Done.\n", sdcUnit->sdcu_UnitNum, __PRETTY_FUNCTION__));
 

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -972,6 +972,15 @@ D(bug("SendCmd(%d,%d)\n", sdCommand, sdDataLen));
     KrnSpinUnLock(&bus->sdcb_Lock);
 #endif
 
+    /*
+     * From here until the command completes, any error the controller reports
+     * belongs to it. sdcb_BusStatus cannot carry that: it is overwritten by
+     * whichever interrupt happens to arrive next, so an error can be erased
+     * before the waiting task ever looks at it, or a stale one inherited by a
+     * command that never failed.
+     */
+    bus->sdcb_CmdError = 0;
+
     SetSignal(0, 1L << bus->sdcb_CommandSig);
 
     bus->sdcb_IOWriteLong(SDHCI_ARGUMENT, sdArg, bus);
@@ -1309,7 +1318,7 @@ ULONG FNAME_SDCBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus)
             }
         }
 
-        if ((bus->sdcb_BusStatus & SDHCI_INT_ERROR) == SDHCI_INT_ERROR)
+        if (bus->sdcb_CmdError)
             break;
 
         if ((sdcard_CurrentTime() - waitStart) > waitLimit)
@@ -1388,7 +1397,7 @@ ULONG FNAME_SDCBUS(WaitCmd)(ULONG mask, ULONG timeout, struct sdcard_Bus *bus)
         }
     }
 
-    if (timedOut || (bus->sdcb_BusStatus & SDHCI_INT_ERROR))
+    if (timedOut || bus->sdcb_CmdError)
     {
         return -1;
     }
@@ -1560,6 +1569,10 @@ void FNAME_SDCBUS(BusIRQ)(struct sdcard_Bus *bus, void *_unused)
 
     if (error)
     {
+        /* Hand the failure to whoever is waiting on this command, before the
+           bits are cleared out of the shared status copy below. */
+        bus->sdcb_CmdError |= (bus->sdcb_BusStatus & SDHCI_INT_ERROR_MASK) | SDHCI_INT_ERROR;
+
         if (bus->sdcb_BusStatus & bus->sdcb_IntrMask)
         {
             bug("[SDBus%02u] %s: Clearing Unhandled Interrupts [%08x]\n", bus->sdcb_BusNum, __PRETTY_FUNCTION__, bus->sdcb_BusStatus & bus->sdcb_IntrMask);
@@ -1570,6 +1583,26 @@ void FNAME_SDCBUS(BusIRQ)(struct sdcard_Bus *bus, void *_unused)
 
         FNAME_SDCBUS(SoftReset)(SDHCI_RESET_CMD, bus);
         FNAME_SDCBUS(SoftReset)(SDHCI_RESET_DATA, bus);
+
+        /*
+         * The reset took the command with it, so there is no response left to
+         * read and no data left to move. Drop the listeners rather than let
+         * WaitCmd's recovery run FinishCmd()/FinishData() over a controller
+         * that has been wiped, and put back the transfer state FinishData()
+         * would have cleaned up had it run.
+         */
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinLock(&bus->sdcb_Lock, NULL, SPINLOCK_MODE_WRITE);
+#endif
+        bus->sdcb_RespListener = NULL;
+        bus->sdcb_DataListener = NULL;
+#if defined(__AROSEXEC_SMP__)
+        KrnSpinUnLock(&bus->sdcb_Lock);
+#endif
+        bus->sdcb_BusFlags &= ~(AF_Bus_DMAActive | AF_Bus_DMABounced);
+
+        if (bus->sdcb_LEDCtrl)
+            bus->sdcb_LEDCtrl(LED_OFF);
 
         /*
          * Signal the bus task so it wakes up from WaitCmd().

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -722,7 +722,8 @@ static BOOL FNAME_SDCBUS(ADMASetup)(struct sdcard_Bus *bus, APTR data, ULONG len
     UBYTE                       *pos;
     ULONG                       remaining;
     UBYTE                       sdcHostCtrl;
-    UWORD                       n = 0;
+    UWORD                       n;
+    BOOL                        bounced;
 
     if (!(bus->sdcb_BusFlags & AF_Bus_DMA) || (data == NULL) || (len == 0))
         return FALSE;
@@ -734,20 +735,23 @@ static BOOL FNAME_SDCBUS(ADMASetup)(struct sdcard_Bus *bus, APTR data, ULONG len
      * ends mid line would drag its neighbours along. Anything unaligned goes
      * through the bounce buffer instead.
      */
-    if (((IPTR)data | (IPTR)len) & 63)
-    {
-        if (len > bus->sdcb_ADMABounceSize)
-            return FALSE;
-
-        bus->sdcb_BusFlags |= AF_Bus_DMABounced;
-    }
+    bounced = (((IPTR)data | (IPTR)len) & 63) ? TRUE : FALSE;
 
     bus->sdcb_ADMAData = data;
     bus->sdcb_ADMALen = len;
 
-    pos = (bus->sdcb_BusFlags & AF_Bus_DMABounced) ? bus->sdcb_ADMABounce : data;
+retry:
+    if (bounced && (len > bus->sdcb_ADMABounceSize))
+    {
+        DTRANS(bug("[SDBus%02u] %s: transfer larger than the bounce buffer (%u)\n",
+                   bus->sdcb_BusNum, __PRETTY_FUNCTION__, len));
+        return FALSE;
+    }
 
-    if ((bus->sdcb_BusFlags & AF_Bus_DMABounced) && isWrite)
+    n = 0;
+    pos = bounced ? bus->sdcb_ADMABounce : data;
+
+    if (bounced && isWrite)
         CopyMem(data, pos, len);
 
     /*
@@ -780,6 +784,18 @@ static BOOL FNAME_SDCBUS(ADMASetup)(struct sdcard_Bus *bus, APTR data, ULONG len
         {
             DTRANS(bug("[SDBus%02u] %s: buffer needs PIO (desc %d, phys 0x%p)\n",
                        bus->sdcb_BusNum, __PRETTY_FUNCTION__, n, (APTR)phys));
+
+            /*
+             * The bounce buffer is contiguous and within reach, so describing
+             * it can only fail on size. Start over through it rather than
+             * hand a whole chunk to PIO.
+             */
+            if (!bounced)
+            {
+                bounced = TRUE;
+                goto retry;
+            }
+
             return FALSE;
         }
 
@@ -801,9 +817,11 @@ static BOOL FNAME_SDCBUS(ADMASetup)(struct sdcard_Bus *bus, APTR data, ULONG len
      * controller reads what we just wrote. For a read this also drops any
      * dirty lines that would otherwise be written back over the result.
      */
+    if (bounced)
+        bus->sdcb_BusFlags |= AF_Bus_DMABounced;
+
     CacheClearE(bus->sdcb_ADMADesc, n * sizeof(struct sdcard_ADMADesc), CACRF_ClearD);
-    CacheClearE((bus->sdcb_BusFlags & AF_Bus_DMABounced) ? bus->sdcb_ADMABounce : data,
-                len, CACRF_ClearD);
+    CacheClearE(bounced ? bus->sdcb_ADMABounce : data, len, CACRF_ClearD);
 
     bus->sdcb_IOWriteLong(SDHCI_ADMA_ADDRESS,
         (ULONG)FNAME_SDCBUS(ADMAPhys)(bus, bus->sdcb_ADMADesc), bus);

--- a/rom/devs/sdcard/sdcard_bus.c
+++ b/rom/devs/sdcard/sdcard_bus.c
@@ -530,6 +530,13 @@ void FNAME_SDCBUS(SetClock)(ULONG speed, struct sdcard_Bus *bus)
 
     sdcClkDiv = FNAME_SDCBUS(GetClockDiv)(speed, bus);
 
+    /* What the card is really clocked at, which is the base rate divided down
+       and only as trustworthy as the base rate the controller reported. */
+    DINIT(bug("[SDBus%02u] clock: asked %u Hz, base %u Hz, div %u -> %u Hz [HCTRL 0x%02x]\n",
+        bus->sdcb_BusNum, speed, bus->sdcb_ClockMax, sdcClkDiv,
+        sdcClkDiv ? (bus->sdcb_ClockMax / (sdcClkDiv * 2)) : bus->sdcb_ClockMax,
+        bus->sdcb_IOReadByte(SDHCI_HOST_CONTROL, bus)));
+
     sdcClkCtrl = (sdcClkDiv & SDHCI_DIV_MASK) << SDHCI_DIVIDER_SHIFT;
     sdcClkCtrl |= ((sdcClkDiv & SDHCI_DIV_HI_MASK) >> SDHCI_DIV_MASK_LEN) << SDHCI_DIVIDER_HI_SHIFT;
 

--- a/rom/devs/sdcard/sdcard_bus.h
+++ b/rom/devs/sdcard/sdcard_bus.h
@@ -72,6 +72,9 @@ struct sdcard_Bus
     UBYTE                               (*sdcb_IOReadByte)(ULONG, struct sdcard_Bus *);
     UWORD                               (*sdcb_IOReadWord)(ULONG, struct sdcard_Bus *);
     ULONG                               (*sdcb_IOReadLong)(ULONG, struct sdcard_Bus *);
+    /* Optional: read count longs from one register. NULL = loop on
+     * sdcb_IOReadLong. */
+    void                                (*sdcb_IOReadLongs)(ULONG, ULONG *, ULONG, struct sdcard_Bus *);
 
     void                                (*sdcb_IOWriteByte)(ULONG, UBYTE, struct sdcard_Bus *);
     void                                (*sdcb_IOWriteWord)(ULONG, UWORD, struct sdcard_Bus *);

--- a/rom/devs/sdcard/sdcard_bus.h
+++ b/rom/devs/sdcard/sdcard_bus.h
@@ -40,9 +40,10 @@ struct sdcard_Bus
 
     ULONG                               sdcb_BusFlags;       /* Bus flags similar to unit flags */
     volatile ULONG                      sdcb_BusStatus;      /* copy of the status register */
-    UBYTE                               sdcb_TaskSig;        /* Signal used to wake task */
-    UBYTE                               sdcb_MediaSig;       /* Insert/Eject notification */
-    UBYTE                               sdcb_CommandSig;     /* Command completed signal */
+    volatile ULONG                      sdcb_CmdError;       /* error bits latched for the command in flight */
+    BYTE                                sdcb_TaskSig;        /* Signal used to wake task, -1 if none */
+    BYTE                                sdcb_MediaSig;       /* Insert/Eject notification, -1 if none */
+    BYTE                                sdcb_CommandSig;     /* Command completed signal, -1 if none */
     UBYTE                               sdcb_SectorShift;    /* (1 << sdcb_SectorShift) == sector size in bytes */
 
     struct TagItem                      *sdcb_RespListener;  /* Current TagList waiting for Response */

--- a/rom/devs/sdcard/sdcard_ioops.c
+++ b/rom/devs/sdcard/sdcard_ioops.c
@@ -171,13 +171,19 @@ BYTE FNAME_SDCIO(ReadSector32)(struct sdcard_Unit *unit, ULONG block,
                     if (SDCBUS_SendCmd(sdcReadTags, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
-                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    else if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
                 }
-                *act += chunk << sectorShift;
+
+                /* A card that never acknowledged the stop is still streaming
+                   as far as it knows, so this chunk did not arrive intact. */
+                if (retVal == 0)
+                    *act += chunk << sectorShift;
             }
             else
             {
@@ -274,13 +280,19 @@ BYTE FNAME_SDCIO(ReadSector64)(struct sdcard_Unit *unit, UQUAD block,
                     if (SDCBUS_SendCmd(sdcReadTags, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to terminate Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
-                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    else if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to ACK termination of Read operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
                 }
-                *act += chunk << sectorShift;
+
+                /* A card that never acknowledged the stop is still streaming
+                   as far as it knows, so this chunk did not arrive intact. */
+                if (retVal == 0)
+                    *act += chunk << sectorShift;
             }
             else
             {
@@ -376,13 +388,19 @@ BYTE FNAME_SDCIO(WriteSector32)(struct sdcard_Unit *unit, ULONG block,
                     if (SDCBUS_SendCmd(sdcWriteTags, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
-                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    else if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
                 }
-                *act += chunk << sectorShift;
+
+                /* An unacknowledged stop leaves the card mid-write, so these
+                   blocks cannot be reported as safely on the card. */
+                if (retVal == 0)
+                    *act += chunk << sectorShift;
             }
             else
             {
@@ -477,13 +495,19 @@ BYTE FNAME_SDCIO(WriteSector64)(struct sdcard_Unit *unit, UQUAD block,
                     if (SDCBUS_SendCmd(sdcWriteTags, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to terminate Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
-                    if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
+                    else if (SDCBUS_WaitCmd(SDHCI_PS_CMD_INHIBIT|SDHCI_PS_DATA_INHIBIT, 100000, bus) == -1)
                     {
                         bug("[SDCard%02ld] %s: Failed to ACK termination of Write operation\n", unit->sdcu_UnitNum, __PRETTY_FUNCTION__);
+                        retVal = IOERR_ABORTED;
                     }
                 }
-                *act += chunk << sectorShift;
+
+                /* An unacknowledged stop leaves the card mid-write, so these
+                   blocks cannot be reported as safely on the card. */
+                if (retVal == 0)
+                    *act += chunk << sectorShift;
             }
             else
             {


### PR DESCRIPTION
## sdcard: error handling, 64-bit safety and transfer fixes

Eight small fixes to sdcard.device, found while bringing the Pi 4 up on aarch64.

- **IPTR for MMIO** — the BCM byte/word accessors truncated the controller
  base address on 64bit builds.
- **Command errors latched separately** — `sdcb_BusStatus` is overwritten by
  the next interrupt, so an error could be erased before the waiting task saw
  it, or a stale one inherited by a command that never failed. The reset in
  the interrupt handler now also drops the listeners, since neither response
  nor data survives it.
- **CMD7 failure is fatal to unit start** — a card left in stand-by answers
  CMD9 but ignores CMD17/CMD18, which previously only surfaced as a command
  timeout much later.
- **Bus flags preserved** — registering a unit overwrote what the bus had
  established about DMA and interrupt delivery.
- **Bounce before PIO** — a buffer too fragmented or out of 32bit reach
  dropped the whole chunk to PIO instead of retrying through the bounce
  buffer.
- **Direct PIO data port reads** — the indirect accessor cost about as much
  as the bus access itself. Writes keep it for the inter-write delay.
- **Aborted chunks not counted** — an unacknowledged CMD12 leaves the card
  streaming, so the data neither arrived intact nor reached the card.
- Controller/clock/bus-width setup logged under `DINIT`.
