### PR TITLE
aarch64-raspi: read the system timer on demand

### DIFF
--- a/arch/aarch64-raspi/timer/mmakefile.src
+++ b/arch/aarch64-raspi/timer/mmakefile.src
@@ -6,6 +6,6 @@ USER_INCLUDES := -I$(SRCDIR)/$(CURDIR) -I$(SRCDIR)/rom/timer
 %build_archspecific \
   mainmmake=kernel-timer maindir=rom/timer \
   arch=raspi-aarch64 modname=timer \
-  files="timer_init"
+  files="timer_init ticks"
 
 %common

--- a/arch/aarch64-raspi/timer/ticks.c
+++ b/arch/aarch64-raspi/timer/ticks.c
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: On-demand EClock read for the BCM free-running system timer.
+*/
+
+#include <proto/exec.h>
+
+#include "timer_intern.h"
+#include "timer_macros.h"
+
+/*
+ * Bring the clock up to date from the hardware. Called under Disable() from
+ * GetSysTime(), GetUpTime() and ReadEClock(). Without it the clock only moved
+ * on the periodic tick, so every time source had that resolution - 10ms at
+ * the default 100Hz.
+ *
+ * The tick handler reads the same counter, and both paths advance
+ * tbp_CHI/tbp_CLO past what they consumed, so no interval is counted twice.
+ */
+void EClockUpdate(struct TimerBase *TimerBase)
+{
+    unsigned int chi, clo;
+    UQUAD now, last, delta;
+    struct timeval tv;
+
+    /* CLO wraps every ~71 minutes, so CHI is re-read to be sure it did
+     * not carry between the two loads. */
+    do
+    {
+        chi = *((volatile unsigned int *)(SYSTIMER_CHI));
+        clo = *((volatile unsigned int *)(SYSTIMER_CLO));
+    } while (chi != *((volatile unsigned int *)(SYSTIMER_CHI)));
+
+    now  = ((UQUAD)chi << 32) | clo;
+    last = ((UQUAD)TimerBase->tb_Platform.tbp_CHI << 32)
+         | TimerBase->tb_Platform.tbp_CLO;
+
+    delta = now - last;
+    if (!delta)
+        return;
+
+    TimerBase->tb_Platform.tbp_CHI = chi;
+    TimerBase->tb_Platform.tbp_CLO = clo;
+
+    /* The counter runs at 1MHz, so its ticks are microseconds. */
+    tv.tv_secs  = delta / 1000000;
+    tv.tv_micro = delta % 1000000;
+
+    ADDTIME(&TimerBase->tb_CurrentTime, &tv);
+    ADDTIME(&TimerBase->tb_Elapsed, &tv);
+}
+
+void EClockSet(struct TimerBase *TimerBase)
+{
+    /* Nothing to program: the counter is read-only and free-running, and
+       SetSysTime()'s value lives in tb_CurrentTime. */
+}

--- a/arch/aarch64-raspi/timer/timer_init.c
+++ b/arch/aarch64-raspi/timer/timer_init.c
@@ -39,28 +39,9 @@
  */
 static void timer_ProcessTick(struct TimerBase *TimerBase, struct ExecBase *SysBase)
 {
-    unsigned int last_CLO;
-    D(unsigned int last_CHI);
+    /* EClockUpdate() (ticks.c) owns the counter arithmetic. */
+    EClockUpdate(TimerBase);
 
-    D(last_CHI = TimerBase->tb_Platform.tbp_CHI);
-    last_CLO = TimerBase->tb_Platform.tbp_CLO;
-
-    TimerBase->tb_Platform.tbp_CHI = *((volatile unsigned int *)(SYSTIMER_CHI));
-    TimerBase->tb_Platform.tbp_CLO = *((volatile unsigned int *)(SYSTIMER_CLO));
-
-    D(bug("[Timer] %s: Updating EClock..\n", __func__));
-    D(bug("[Timer] %s:   diff_CHI = %d\n", __func__, (TimerBase->tb_Platform.tbp_CHI - last_CHI)));
-    D(bug("[Timer] %s:   diff_CLO = %d\n", __func__, (TimerBase->tb_Platform.tbp_CLO - last_CLO)));
-
-    TimerBase->tb_Platform.tbp_TickRate.tv_secs  = 0;
-    if ((TimerBase->tb_Platform.tbp_CLO - last_CLO) > 0)
-        TimerBase->tb_Platform.tbp_TickRate.tv_micro = TimerBase->tb_Platform.tbp_CLO - last_CLO;
-    else
-        TimerBase->tb_Platform.tbp_TickRate.tv_micro = ((1000000 - last_CLO) + TimerBase->tb_Platform.tbp_CLO);
-
-    /* Increment EClock value and process microhz requests */
-    ADDTIME(&TimerBase->tb_CurrentTime, &TimerBase->tb_Platform.tbp_TickRate);
-    ADDTIME(&TimerBase->tb_Elapsed, &TimerBase->tb_Platform.tbp_TickRate);
     TimerBase->tb_ticks_total++;
 
     D(bug("[Timer] %s: Processing events.. \n", __func__));


### PR DESCRIPTION
The platform used the generic no-op EClockUpdate, so the clock only moved when the periodic tick fired and every time source, GetSysTime() and the clock_gettime() ports build on included, had the resolution of the tick: 10ms at 100Hz. Anything integrating motion over the interval it measures then advanced in lurches, worse the faster it ran.