### PR TITLE
raspi: take the LED wiring from the device tree

### DIFF
--- a/arch/aarch64-native/kernel/platform_bcm27xx.c
+++ b/arch/aarch64-native/kernel/platform_bcm27xx.c
@@ -23,6 +23,7 @@
 
 #include "kernel_intern.h"
 #include "kernel_debug.h"
+#include "of_intern.h"
 #include "kernel_cpu.h"
 #include "tls.h"
 #include "io.h"
@@ -228,28 +229,71 @@ void bcm27xx_fiq_process()
     }
 }
 
+/*
+ * Which pin carries which light is board wiring, and the tree spells it out:
+ * /leds/led-pwr and /leds/led-act each hold a gpios triple of (controller
+ * phandle, pin, flags). A Pi 2 puts PWR on GPIO 35, a Pi 400 on 42. The
+ * Pi 3B and 4B hand theirs to firmware controllers (expgpio, virtgpio) this
+ * code cannot reach - those keep the state firmware left, which for the
+ * power light is lit. Fixed pin numbers used to be right for one board and
+ * a stray write to somebody else's GPIO on the rest.
+ */
+static struct
+{
+    int pin;                    /* < 0: not ours to drive */
+    int active_low;
+} bcm27xx_led[2] = { { -2, 0 }, { -2, 0 } };    /* -2: not looked up yet */
+
+static int bcm27xx_led_on_soc(const char *name)
+{
+    return name && name[0] == 'g' && name[1] == 'p' && name[2] == 'i' &&
+           name[3] == 'o' && (name[4] == '@' || name[4] == 0);
+}
+
+static void bcm27xx_led_query(int LED)
+{
+    void *node = dt_find_node((LED == ARM_LED_ACTIVITY) ? "/leds/led-act"
+                                                        : "/leds/led-pwr");
+    void *gprop = node ? dt_find_property(node, "gpios") : NULL;
+    void *sprop = node ? dt_find_property(node, "status") : NULL;
+    uint32_t *cells;
+    of_node_t *ctrl;
+
+    bcm27xx_led[LED].pin = -1;
+
+    if (!gprop || dt_get_prop_len(gprop) < 8)
+        return;
+
+    /* A node for a light the board does not have is marked disabled */
+    if (sprop && ((char *)dt_get_prop_value(sprop))[0] == 'd')
+        return;
+
+    cells = dt_get_prop_value(gprop);
+    ctrl = dt_find_node_by_phandle(AROS_BE2LONG(cells[0]));
+    if (!ctrl || !bcm27xx_led_on_soc(ctrl->on_name))
+        return;
+
+    bcm27xx_led[LED].pin = AROS_BE2LONG(cells[1]);
+    bcm27xx_led[LED].active_low = (dt_get_prop_len(gprop) >= 12) &&
+                                  (AROS_BE2LONG(cells[2]) & 1);
+}
+
 void bcm27xx_toggle_led(int LED, int state)
 {
-    if (__arm_arosintern.ARMI_PeripheralBase == (APTR)BCM2836_PERIPHYSBASE)
-    {
-        int pin = 35;
-        IPTR gpiofunc = GPCLR1;
+    int pin, lit;
 
-        if (LED == ARM_LED_ACTIVITY)
-            pin = 47;
+    if (LED != ARM_LED_POWER && LED != ARM_LED_ACTIVITY)
+        return;
 
-        if (state == ARM_LED_ON)
-            gpiofunc = GPSET1;
+    if (bcm27xx_led[LED].pin == -2)
+        bcm27xx_led_query(LED);
 
-        wr32le(gpiofunc, (1 << (pin - 32)));
-    }
-    else
-    {
-        if (state)
-            wr32le(GPCLR0, (1 << 16));
-        else
-            wr32le(GPSET0, (1 << 16));
-    }
+    if ((pin = bcm27xx_led[LED].pin) < 0)
+        return;
+
+    lit = (state == ARM_LED_ON) != (bcm27xx_led[LED].active_low != 0);
+
+    wr32le((lit ? GPSET0 : GPCLR0) + 4 * (pin / 32), 1 << (pin % 32));
 }
 
 static inline void bcm27xx_ser_waitout()

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -469,7 +469,14 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         ForeachNode(&e->on_children, led)
         {
             of_property_t *p = dt_find_property(led, "gpios");
+            of_property_t *st = dt_find_property(led, "status");
             int32_t gpio = 0;
+
+            /* The Pi 400 keeps a led-act node for a light it does not have
+             * and marks it disabled; driving its pin would clamp ID_SDA. */
+            if (st && !strncmp(st->op_value, "disabled", 9))
+                continue;
+
             if (p && p->op_length >= 8) {
                 uint32_t *data = p->op_value;
                 uint32_t phandle = AROS_BE2LONG(data[0]);
@@ -486,6 +493,9 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
                     {
                         int gpio_sel = gpio / 10;
                         int gpio_soff = 3 * (gpio - 10 * gpio_sel);
+                        of_property_t *trg = dt_find_property(led, "linux,default-trigger");
+                        int on = trg && !strncmp(trg->op_value, "default-on", 11);
+                        int low = (p->op_length >= 12) && (AROS_BE2LONG(data[2]) & 1);
 
                         kprintf("[BOOT] GPFSEL=%x, bit=%d\n", gpio_sel * 4, gpio_soff);
 
@@ -495,8 +505,9 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
                         tmp |= (1 << gpio_soff);
                         wr32le(GPFSEL0 + 4*gpio_sel, tmp);
 
-                        /* Turn LED off */
-                        wr32le(GPCLR0 + 4 * (gpio / 32), 1 << (gpio % 32));
+                        /* Turn LED off, leave PWR-LED on */
+                        wr32le((on != low ? GPSET0 : GPCLR0) + 4 * (gpio / 32),
+                               1 << (gpio % 32));
                     }
                 }
             }

--- a/arch/arm-native/kernel/platform_bcm2708.c
+++ b/arch/arm-native/kernel/platform_bcm2708.c
@@ -18,6 +18,7 @@
 
 #include "kernel_intern.h"
 #include "kernel_debug.h"
+#include "of_intern.h"
 #include "kernel_cpu.h"
 #include "kernel_interrupts.h"
 #include "kernel_intr.h"
@@ -315,29 +316,67 @@ static void bcm2708_fiq_process()
     }
 }
 
+/*
+ * A Pi 2 puts PWR on GPIO 35, a Pi 400 on 42. The Pi 3B and 4B hand theirs to 
+ * firmware controllers (expgpio, virtgpio) this code cannot reach - those keep 
+ * the state firmware left, which for the power light is lit.
+ */
+static struct
+{
+    int pin;                    /* < 0: not ours to drive */
+    int active_low;
+} bcm2708_led[2] = { { -2, 0 }, { -2, 0 } };    /* -2: not looked up yet */
+
+static int bcm2708_led_on_soc(const char *name)
+{
+    return name && name[0] == 'g' && name[1] == 'p' && name[2] == 'i' &&
+           name[3] == 'o' && (name[4] == '@' || name[4] == 0);
+}
+
+static void bcm2708_led_query(int LED)
+{
+    void *node = dt_find_node((LED == ARM_LED_ACTIVITY) ? "/leds/led-act"
+                                                        : "/leds/led-pwr");
+    void *gprop = node ? dt_find_property(node, "gpios") : NULL;
+    void *sprop = node ? dt_find_property(node, "status") : NULL;
+    uint32_t *cells;
+    of_node_t *ctrl;
+
+    bcm2708_led[LED].pin = -1;
+
+    if (!gprop || dt_get_prop_len(gprop) < 8)
+        return;
+
+    /* A node for a light the board does not have is marked disabled */
+    if (sprop && ((char *)dt_get_prop_value(sprop))[0] == 'd')
+        return;
+
+    cells = dt_get_prop_value(gprop);
+    ctrl = dt_find_node_by_phandle(AROS_BE2LONG(cells[0]));
+    if (!ctrl || !bcm2708_led_on_soc(ctrl->on_name))
+        return;
+
+    bcm2708_led[LED].pin = AROS_BE2LONG(cells[1]);
+    bcm2708_led[LED].active_low = (dt_get_prop_len(gprop) >= 12) &&
+                                  (AROS_BE2LONG(cells[2]) & 1);
+}
+
 static void bcm2708_toggle_led(int LED, int state)
 {
-    if (__arm_arosintern.ARMI_PeripheralBase == (APTR)BCM2836_PERIPHYSBASE)
-    {
-        int pin = 35;
-        IPTR gpiofunc = GPCLR1;
+    int pin, lit;
 
-        if (LED == ARM_LED_ACTIVITY)
-            pin = 47;
+    if (LED != ARM_LED_POWER && LED != ARM_LED_ACTIVITY)
+        return;
 
-        if (state == ARM_LED_ON)
-            gpiofunc = GPSET1;
+    if (bcm2708_led[LED].pin == -2)
+        bcm2708_led_query(LED);
 
-        wr32le(gpiofunc, (1 << (pin-32)));
-    }
-    else
-    {
-        // RasPi 1 only allows us to toggle the activity LED
-        if (state)
-            wr32le(GPCLR0, (1 << 16));
-        else
-            wr32le(GPSET0, (1 << 16));
-    }
+    if ((pin = bcm2708_led[LED].pin) < 0)
+        return;
+
+    lit = (state == ARM_LED_ON) != (bcm2708_led[LED].active_low != 0);
+
+    wr32le((lit ? GPSET0 : GPCLR0) + 4 * (pin / 32), 1 << (pin % 32));
 }
 
 /* Use system timer 3 for our scheduling heartbeat */

--- a/arch/arm-raspi/boot/boot.c
+++ b/arch/arm-raspi/boot/boot.c
@@ -369,7 +369,14 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
         ForeachNode(&e->on_children, led)
         {
             of_property_t *p = dt_find_property(led, "gpios");
+            of_property_t *st = dt_find_property(led, "status");
             int32_t gpio = 0;
+
+            /* The Pi 400 keeps a led-act node for a light it does not have
+             * and marks it disabled; driving its pin would clamp ID_SDA. */
+            if (st && !strncmp(st->op_value, "disabled", 9))
+                continue;
+
             if (p && p->op_length >= 8) {
                 uint32_t *data = p->op_value;
                 uint32_t phandle = AROS_BE2LONG(data[0]);
@@ -386,6 +393,9 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
                     {
                         int gpio_sel = gpio / 10;
                         int gpio_soff = 3 * (gpio - 10 * gpio_sel);
+                        of_property_t *trg = dt_find_property(led, "linux,default-trigger");
+                        int on = trg && !strncmp(trg->op_value, "default-on", 11);
+                        int low = (p->op_length >= 12) && (AROS_BE2LONG(data[2]) & 1);
 
                         kprintf("[BOOT] GPFSEL=%x, bit=%d\n", gpio_sel * 4, gpio_soff);
 
@@ -395,8 +405,8 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
                         tmp |= (1 << gpio_soff);
                         wr32le(GPFSEL0 + 4*gpio_sel, tmp);
 
-                        /* Turn LED off */
-                        wr32le(GPCLR0 + 4 * (gpio / 32), 1 << (gpio % 32));
+                        /* Turn LED off, leave PWR-LED on */
+                        wr32le((on != low ? GPSET0 : GPCLR0) + 4 * (gpio / 32), 1 << (gpio % 32));
                     }
                 }
             }


### PR DESCRIPTION
The bootstrap cleared every LED it found, which put out the Pi 400's power light, and the kernel drove fixed pins that were right for the Pi 2 only. Both now read /leds, honour polarity and default-on, and skip disabled nodes.