### PR TITLE
raspi aarch64: implement ShutdownA(SD_ACTION_POWEROFF)

### DIFF
--- a/arch/aarch64-native/exec/mmakefile.src
+++ b/arch/aarch64-native/exec/mmakefile.src
@@ -26,7 +26,7 @@ PRIV_EXEC_INCLUDES = \
     -I$(SRCDIR)/rom/kernel
 
 CFILES          := \
-        platform_init exec_idle superstate userstate coldreboot cachepredma cachepostdma cachecleare \
+        platform_init exec_idle superstate userstate coldreboot shutdowna cachepredma cachepostdma cachecleare \
         preparecontext
 
 #MM kernel-exec-raspi-aarch64 : kernel-kernel-aarch64-includes kernel-kernel-includes

--- a/arch/aarch64-native/exec/shutdowna.c
+++ b/arch/aarch64-native/exec/shutdowna.c
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: ShutdownA() - Shut down the operating system (AArch64).
+*/
+
+#include <exec/types.h>
+#include <exec/execbase.h>
+#include <aros/libcall.h>
+
+#include <proto/exec.h>
+
+#include "exec_intern.h"
+#include "exec_util.h"
+
+#include "kernel_cpu.h"
+#include "kernel_syscall.h"
+
+/* See rom/exec/shutdowna.c for documentation */
+
+AROS_LH1(ULONG, ShutdownA,
+    AROS_LHA(ULONG, action, D0),
+    struct ExecBase *, SysBase, 173, Exec)
+{
+    AROS_LIBFUNC_INIT
+
+    /* The SVC immediate has to be a compile-time constant, so the call
+     * cannot be shared between the two actions. */
+    switch (action & SD_ACTION_MASK)
+    {
+    case SD_ACTION_POWEROFF:
+        Exec_DoResetCallbacks((struct IntExecBase *)SysBase, action);
+        krnSysCall(SC_POWEROFF);
+        break;
+
+    case SD_ACTION_COLDREBOOT:
+        Exec_DoResetCallbacks((struct IntExecBase *)SysBase, action);
+        krnSysCall(SC_REBOOT);
+        break;
+    }
+
+    return 0;       /* Unknown action code, or the kernel declined */
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/aarch64-native/kernel/syscall.c
+++ b/arch/aarch64-native/kernel/syscall.c
@@ -171,7 +171,7 @@ void handle_syscall(void *regs)
 
     D(bug("[Kernel] ## SVC %d @ 0x%p\n", svc_no, ((struct ExceptionContext *)regs)->pc));
 
-    if (svc_no <= SC_USERSTATE || svc_no == SC_REBOOT)
+    if (svc_no <= SC_USERSTATE || svc_no == SC_REBOOT || svc_no == SC_POWEROFF)
     {
         DREGS(cpu_DumpRegs(regs));
 
@@ -245,6 +245,31 @@ void handle_syscall(void *regs)
                 uint32_t rstc = rd32le(pm + 0x1c);          /* PM_RSTC */
                 wr32le(pm + 0x24, 0x5a000000 | 10);         /* PM_WDOG: short timeout */
                 wr32le(pm + 0x1c, 0x5a000000 | (rstc & ~0x30) | 0x20); /* full reset */
+                for (;;)
+                    asm volatile("wfe");
+                break;
+            }
+
+            case SC_POWEROFF:
+            {
+                D(bug("[Kernel] ## POWEROFF...\n"));
+                /*
+                 * Halt through the same PM watchdog as the reboot above,
+                 * but with the boot partition set to 63 first: the firmware
+                 * reads that as "do not boot" and drops the board into its
+                 * low-power state instead. The partition number lives in
+                 * the even bits of PM_RSTS, so 63 is 0x555.
+                 */
+                uintptr_t pm = (uintptr_t)__arm_arosintern.ARMI_PeripheralBase + 0x100000;
+                uint32_t rsts = rd32le(pm + 0x20);          /* PM_RSTS */
+                uint32_t rstc;
+
+                rsts &= ~0xfffffaaa;
+                wr32le(pm + 0x20, 0x5a000000 | rsts | 0x555);
+
+                rstc = rd32le(pm + 0x1c);                   /* PM_RSTC */
+                wr32le(pm + 0x24, 0x5a000000 | 10);         /* PM_WDOG */
+                wr32le(pm + 0x1c, 0x5a000000 | (rstc & ~0x30) | 0x20);
                 for (;;)
                     asm volatile("wfe");
                 break;

--- a/rom/kernel/kernel_syscall.h
+++ b/rom/kernel/kernel_syscall.h
@@ -27,5 +27,6 @@
 #define SC_GETCPUNUMBER 0x00C
 #define SC_USERSTATE    0x00D
 #define SC_REBOOT	    0x100
+#define SC_POWEROFF	    0x101
 
 #endif


### PR DESCRIPTION
Only reboot was wired up, so C:Shutdown and Wanderer's menu entry did nothing. SC_POWEROFF sets boot partition 63 in PM_RSTS before the watchdog reset, which firmware reads as halt and drops the board into its low power state.