### PR TITLE
exec smp semlocks

### DIFF
--- a/developer/debug/test/smp/mmakefile.src
+++ b/developer/debug/test/smp/mmakefile.src
@@ -2,8 +2,8 @@
 #MM- test : test-smp
 #MM- test-quick : test-smp-quick
 #
-#MM- test-smp : test-smp-stress test-smp-trace test-smp-smp test-smp-smp-smallpt test-smp-preempt test-smp-sigrace test-smp-sem test-smp-sched test-smp-doio
-#MM- test-smp-quick : test-smp-stress-quick test-smp-trace-quick test-smp-smp-quick test-smp-smp-smallpt-quick test-smp-preempt-quick test-smp-sigrace-quick test-smp-sem-quick test-smp-sched-quick test-smp-doio-quick
+#MM- test-smp : test-smp-stress test-smp-trace test-smp-smp test-smp-smp-smallpt test-smp-preempt test-smp-sigrace test-smp-sem test-smp-sched test-smp-doio test-smp-lists
+#MM- test-smp-quick : test-smp-stress-quick test-smp-trace-quick test-smp-smp-quick test-smp-smp-smallpt-quick test-smp-preempt-quick test-smp-sigrace-quick test-smp-sem-quick test-smp-sched-quick test-smp-doio-quick test-smp-lists-quick
 
 include $(SRCDIR)/config/aros.cfg
 
@@ -38,5 +38,9 @@ USER_CFLAGS := $(PARANOIA_CFLAGS)
 %build_prog mmake=test-smp-doio \
     files=smpdoio targetdir=$(EXEDIR) \
     progname=SMP-DoIO
+
+%build_prog mmake=test-smp-lists \
+    files=smplists targetdir=$(EXEDIR) \
+    progname=SMP-Lists
 
 %common

--- a/developer/debug/test/smp/smplists.c
+++ b/developer/debug/test/smp/smplists.c
@@ -1,0 +1,551 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: SMP coverage for the system lists and the library checksum, the
+          paths the other SMP tests never touch: AddPort/FindPort/RemPort,
+          the semaphore list, the resource list, and SumLibrary racing
+          SetFunction.
+
+          The library phase is the sharp one. SumLibrary clears LIBF_CHANGED
+          before it sums, and Alert(AT_DeadEnd|AN_LibChkSum)s if the flag was
+          already clear and the sum moved. Unless SetFunction and SumLibrary
+          exclude each other, a vector patched mid-sum trips that Alert and
+          takes the machine down - so a failure here is a dead-end guru, not
+          a FAIL line.
+
+          Workers are pinned across cores, so these paths race for real
+          instead of being serialised by a single CPU.
+*/
+
+#include <exec/libraries.h>
+#include <exec/memory.h>
+#include <exec/ports.h>
+#include <exec/semaphores.h>
+#include <exec/tasks.h>
+#include <utility/tagitem.h>
+#include <dos/dos.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/kernel.h>
+
+#include <clib/alib_protos.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(__AROSEXEC_SMP__)
+#define DEBUG 1
+#include <aros/debug.h>
+
+APTR KernelBase;
+static int g_NumCPUs = 1;
+
+#define STACKSIZE       16384
+#define WAIT_TICKS      500         /* 10s bound for Delay-based waits */
+#define LIST_WORKERS    4
+#define CHURN_ITERS     2000
+#define SUM_ITERS       4000
+#define SETFUNC_ITERS   4000
+#define NAMELEN         32
+
+struct ListWorker
+{
+    volatile ULONG  w_Started;
+    volatile ULONG  w_Done;
+    volatile ULONG  w_Errors;
+    volatile ULONG  w_Progress;
+    int             w_Index;
+    APTR            w_Arg;
+    char            w_Name[NAMELEN];
+};
+
+static struct ListWorker *myworker(void)
+{
+    return (struct ListWorker *)FindTask(NULL)->tc_UserData;
+}
+
+static struct Task *spawn(const char *name, APTR pc, int cpu, struct ListWorker *w)
+{
+    if (KernelBase && g_NumCPUs > 1)
+    {
+        cpumask_t *mask = KrnAllocCPUMask();
+
+        if (mask)
+        {
+            KrnClearCPUMask(mask);
+            KrnGetCPUMask(cpu % g_NumCPUs, mask);
+            /* The mask becomes iet_CpuAffinity, freed by exec at teardown. */
+            return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                                 TASKTAG_PRI,       0,
+                                 TASKTAG_PC,        (IPTR)pc,
+                                 TASKTAG_STACKSIZE, STACKSIZE,
+                                 TASKTAG_USERDATA,  (IPTR)w,
+                                 TASKTAG_AFFINITY,  (IPTR)mask,
+                                 TAG_DONE);
+        }
+    }
+    return NewCreateTask(TASKTAG_NAME,      (IPTR)name,
+                         TASKTAG_PRI,       0,
+                         TASKTAG_PC,        (IPTR)pc,
+                         TASKTAG_STACKSIZE, STACKSIZE,
+                         TASKTAG_USERDATA,  (IPTR)w,
+                         TAG_DONE);
+}
+
+static int wait_all(const char *phase, struct ListWorker *w, int n)
+{
+    int i, t;
+    ULONG last = ~0UL;
+
+    for (t = 0; t < WAIT_TICKS; t++)
+    {
+        int done = 0;
+        ULONG sum = 0;
+
+        for (i = 0; i < n; i++)
+        {
+            if (w[i].w_Done)
+                done++;
+            sum += w[i].w_Progress;
+        }
+        if (done == n)
+            return 1;
+        if ((t % 100) == 99)
+        {
+            bug("[smplists] %s: %ds, %d/%d done, progress %lu\n",
+                phase, (t + 1) / 50, done, n, (unsigned long)sum);
+            if (sum == last)   /* markers included: equal sums = frozen */
+            {
+                bug("[smplists] %s: *** STUCK *** (no progress in 2s)\n", phase);
+                for (i = 0; i < n; i++)
+                    bug("[smplists]   worker %d: done=%lu progress=%lu\n", i,
+                        (unsigned long)w[i].w_Done, (unsigned long)w[i].w_Progress);
+                return 0;
+            }
+            last = sum;
+        }
+        Delay(1);
+    }
+    bug("[smplists] %s: *** TIMEOUT *** (still progressing but too slow)\n", phase);
+    return 0;
+}
+
+static int collect(const char *phase, struct ListWorker *w, struct Task **t, int n)
+{
+    int k, ok = wait_all(phase, w, n);
+
+    Forbid();
+    for (k = 0; k < n; k++)
+        RemTask(t[k]);
+    Permit();
+
+    if (!ok)
+        return 0;
+
+    for (k = 0; k < n; k++)
+    {
+        if (w[k].w_Errors)
+        {
+            bug("[smplists] %s: *** FAIL *** worker %d: %lu errors\n",
+                phase, k, (unsigned long)w[k].w_Errors);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 1: the public message port list                                     */
+/*                                                                            */
+/*  AddPort and FindPort take PortListSpinLock; RemPort has to take the same  */
+/*  one. Each worker churns a uniquely named port, so a Find that misses its  */
+/*  own entry - or turns one up after removal - means the list was walked     */
+/*  while another core was mutating it.                                       */
+/******************************************************************************/
+
+static void PortChurn(void)
+{
+    struct ListWorker *w = myworker();
+    struct MsgPort *port = (struct MsgPort *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < CHURN_ITERS; i++)
+    {
+        port->mp_Node.ln_Name = w->w_Name;
+        AddPort(port);
+
+        if (FindPort(w->w_Name) != port)
+            w->w_Errors++;
+
+        RemPort(port);
+
+        if (FindPort(w->w_Name) != NULL)
+            w->w_Errors++;
+
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestPortList(void)
+{
+    struct ListWorker w[LIST_WORKERS];
+    struct Task *t[LIST_WORKERS];
+    struct MsgPort port[LIST_WORKERS];
+    int k, started = 0;
+
+    bug("[smplists] phase 1: port list churn on %d cores...\n", LIST_WORKERS);
+
+    memset(w, 0, sizeof(w));
+    memset(port, 0, sizeof(port));
+
+    for (k = 0; k < LIST_WORKERS; k++)
+    {
+        NEWLIST(&port[k].mp_MsgList);
+        port[k].mp_Flags = PA_IGNORE;
+        port[k].mp_Node.ln_Type = NT_MSGPORT;
+        snprintf(w[k].w_Name, NAMELEN, "smplists.port.%d", k);
+        w[k].w_Index = k;
+        w[k].w_Arg = &port[k];
+
+        t[k] = spawn("smplists.port", PortChurn, k, &w[k]);
+        if (!t[k])
+            break;
+        started++;
+    }
+
+    if (started != LIST_WORKERS)
+    {
+        bug("[smplists] phase 1: INVALID (only %d of %d tasks created)\n",
+            started, LIST_WORKERS);
+        Forbid();
+        for (k = 0; k < started; k++)
+            RemTask(t[k]);
+        Permit();
+        return -1;
+    }
+
+    if (!collect("phase 1", w, t, LIST_WORKERS))
+        return 0;
+
+    bug("[smplists] phase 1: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 2: the semaphore list                                               */
+/*                                                                            */
+/*  RemSemaphore now takes SemListSpinLock, the lock AddSemaphore and         */
+/*  FindSemaphore already used.                                               */
+/******************************************************************************/
+
+static void SemListChurn(void)
+{
+    struct ListWorker *w = myworker();
+    struct SignalSemaphore *sem = (struct SignalSemaphore *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < CHURN_ITERS; i++)
+    {
+        sem->ss_Link.ln_Name = w->w_Name;
+        AddSemaphore(sem);
+
+        if (FindSemaphore(w->w_Name) != sem)
+            w->w_Errors++;
+
+        RemSemaphore(sem);
+
+        if (FindSemaphore(w->w_Name) != NULL)
+            w->w_Errors++;
+
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestSemList(void)
+{
+    struct ListWorker w[LIST_WORKERS];
+    struct Task *t[LIST_WORKERS];
+    struct SignalSemaphore sem[LIST_WORKERS];
+    int k, started = 0;
+
+    bug("[smplists] phase 2: semaphore list churn on %d cores...\n", LIST_WORKERS);
+
+    memset(w, 0, sizeof(w));
+    memset(sem, 0, sizeof(sem));
+
+    for (k = 0; k < LIST_WORKERS; k++)
+    {
+        InitSemaphore(&sem[k]);
+        snprintf(w[k].w_Name, NAMELEN, "smplists.sem.%d", k);
+        w[k].w_Index = k;
+        w[k].w_Arg = &sem[k];
+
+        t[k] = spawn("smplists.sem", SemListChurn, k, &w[k]);
+        if (!t[k])
+            break;
+        started++;
+    }
+
+    if (started != LIST_WORKERS)
+    {
+        bug("[smplists] phase 2: INVALID (only %d of %d tasks created)\n",
+            started, LIST_WORKERS);
+        Forbid();
+        for (k = 0; k < started; k++)
+            RemTask(t[k]);
+        Permit();
+        return -1;
+    }
+
+    if (!collect("phase 2", w, t, LIST_WORKERS))
+        return 0;
+
+    bug("[smplists] phase 2: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 3: the resource list                                                */
+/*                                                                            */
+/*  RemResource moved from bare Forbid() to the list lock OpenResource uses.  */
+/******************************************************************************/
+
+static void ResourceChurn(void)
+{
+    struct ListWorker *w = myworker();
+    struct Node *res = (struct Node *)w->w_Arg;
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < CHURN_ITERS; i++)
+    {
+        res->ln_Name = w->w_Name;
+        AddResource(res);
+
+        if (OpenResource(w->w_Name) != (APTR)res)
+            w->w_Errors++;
+
+        RemResource(res);
+
+        if (OpenResource(w->w_Name) != NULL)
+            w->w_Errors++;
+
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestResourceList(void)
+{
+    struct ListWorker w[LIST_WORKERS];
+    struct Task *t[LIST_WORKERS];
+    struct Node res[LIST_WORKERS];
+    int k, started = 0;
+
+    bug("[smplists] phase 3: resource list churn on %d cores...\n", LIST_WORKERS);
+
+    memset(w, 0, sizeof(w));
+    memset(res, 0, sizeof(res));
+
+    for (k = 0; k < LIST_WORKERS; k++)
+    {
+        res[k].ln_Type = NT_RESOURCE;
+        snprintf(w[k].w_Name, NAMELEN, "smplists.res.%d", k);
+        w[k].w_Index = k;
+        w[k].w_Arg = &res[k];
+
+        t[k] = spawn("smplists.res", ResourceChurn, k, &w[k]);
+        if (!t[k])
+            break;
+        started++;
+    }
+
+    if (started != LIST_WORKERS)
+    {
+        bug("[smplists] phase 3: INVALID (only %d of %d tasks created)\n",
+            started, LIST_WORKERS);
+        Forbid();
+        for (k = 0; k < started; k++)
+            RemTask(t[k]);
+        Permit();
+        return -1;
+    }
+
+    if (!collect("phase 3", w, t, LIST_WORKERS))
+        return 0;
+
+    bug("[smplists] phase 3: OK\n");
+    return 1;
+}
+
+/******************************************************************************/
+/*  Phase 4: SumLibrary against SetFunction                                   */
+/*                                                                            */
+/*  A private library, never added to the system list, so only this test      */
+/*  touches it. Two workers re-sum it while two others patch a vector each.   */
+/*  Each patcher owns its own LVO and alternates between two stubs, so the    */
+/*  old pointer SetFunction hands back must alternate too - anything else     */
+/*  means a concurrent patch landed on our vector. The real verdict, though,  */
+/*  is simply surviving: an unserialised sum trips AN_LibChkSum.              */
+/******************************************************************************/
+
+static void stubA(void) { }
+static void stubB(void) { }
+static void stubPad(void) { }
+
+/* Open, Close, Expunge, Reserved, then the vectors the patchers own. */
+static CONST_APTR libfuncs[] =
+{
+    (APTR)stubPad, (APTR)stubPad, (APTR)stubPad, (APTR)stubPad,
+    (APTR)stubA,   (APTR)stubA,   (APTR)stubA,   (APTR)stubA,
+    (APTR)-1
+};
+
+static struct Library *g_Lib;
+
+static void SumChurn(void)
+{
+    struct ListWorker *w = myworker();
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < SUM_ITERS; i++)
+    {
+        SumLibrary(g_Lib);
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static void SetFuncChurn(void)
+{
+    struct ListWorker *w = myworker();
+    LONG off = LIB_USERDEF - (LONG)(w->w_Index * LIB_VECTSIZE);
+    ULONG i;
+
+    w->w_Started = 1;
+
+    for (i = 0; i < SETFUNC_ITERS; i++)
+    {
+        APTR old;
+
+        old = SetFunction(g_Lib, off, (APTR)stubB);
+        if (old != (APTR)stubA)
+            w->w_Errors++;
+
+        old = SetFunction(g_Lib, off, (APTR)stubA);
+        if (old != (APTR)stubB)
+            w->w_Errors++;
+
+        w->w_Progress = i + 1;
+    }
+
+    w->w_Done = 1;
+    Wait(0);
+}
+
+static int TestLibrarySum(void)
+{
+    struct ListWorker w[LIST_WORKERS];
+    struct Task *t[LIST_WORKERS];
+    int k, started = 0;
+
+    bug("[smplists] phase 4: SumLibrary vs SetFunction...\n");
+
+    g_Lib = MakeLibrary((CONST_APTR)libfuncs, NULL, NULL,
+                        sizeof(struct Library), (BPTR)0);
+    if (!g_Lib)
+    {
+        bug("[smplists] phase 4: INVALID (MakeLibrary failed)\n");
+        return -1;
+    }
+
+    g_Lib->lib_Node.ln_Type = NT_LIBRARY;
+    g_Lib->lib_Node.ln_Name = "smplists.library";
+    g_Lib->lib_Flags |= LIBF_SUMUSED | LIBF_CHANGED;
+    SumLibrary(g_Lib);          /* establish the baseline checksum */
+
+    memset(w, 0, sizeof(w));
+
+    /* Two summers, two patchers - the patchers own LVO 0 and 1 past the
+     * reserved vectors, so they never collide with each other. */
+    for (k = 0; k < LIST_WORKERS; k++)
+    {
+        w[k].w_Index = (k < 2) ? k : (k - 2);
+        t[k] = spawn(k < 2 ? "smplists.sum" : "smplists.setfunc",
+                     k < 2 ? (APTR)SumChurn : (APTR)SetFuncChurn, k, &w[k]);
+        if (!t[k])
+            break;
+        started++;
+    }
+
+    if (started != LIST_WORKERS)
+    {
+        bug("[smplists] phase 4: INVALID (only %d of %d tasks created)\n",
+            started, LIST_WORKERS);
+        Forbid();
+        for (k = 0; k < started; k++)
+            RemTask(t[k]);
+        Permit();
+        FreeMem((UBYTE *)g_Lib - g_Lib->lib_NegSize,
+                g_Lib->lib_NegSize + g_Lib->lib_PosSize);
+        return -1;
+    }
+
+    if (!collect("phase 4", w, t, LIST_WORKERS))
+        return 0;
+
+    /* Quiesced: one last sum must agree with the jumptable as it stands. */
+    g_Lib->lib_Flags |= LIBF_CHANGED;
+    SumLibrary(g_Lib);
+
+    FreeMem((UBYTE *)g_Lib - g_Lib->lib_NegSize,
+            g_Lib->lib_NegSize + g_Lib->lib_PosSize);
+    g_Lib = NULL;
+
+    bug("[smplists] phase 4: OK\n");
+    return 1;
+}
+
+int main(void)
+{
+    int pass = 0, fail = 0, inval = 0;
+    int r;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase)
+        g_NumCPUs = KrnGetCPUCount();
+
+    bug("[smplists] start: cpus=%d\n", g_NumCPUs);
+
+    r = TestPortList();     if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestSemList();      if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestResourceList(); if (r > 0) pass++; else if (!r) fail++; else inval++;
+    r = TestLibrarySum();   if (r > 0) pass++; else if (!r) fail++; else inval++;
+
+    bug("[smplists] DONE: %d PASS, %d FAIL, %d INVALID\n", pass, fail, inval);
+    return fail ? RETURN_FAIL : RETURN_OK;
+}
+#else
+int main(void)
+{
+    return RETURN_FAIL;
+}
+#endif

--- a/rom/exec/obtainsemaphorelist.c
+++ b/rom/exec/obtainsemaphorelist.c
@@ -75,6 +75,10 @@
 
     ForeachNode(sigSem, ss)
     {
+        /* Each member has its own lock - the one ObtainSemaphore()
+         * takes - so counts cannot be lost against a single obtainer. */
+        SEM_LOCK(ss);
+
         /* QueueCount == -1 means unlocked */
         ss->ss_QueueCount++;
         if(ss->ss_QueueCount != 0)
@@ -107,6 +111,8 @@
             ss->ss_NestCount++;
             ss->ss_Owner = ThisTask;
         }
+
+        SEM_UNLOCK(ss);
     }
 
     if(failedObtain > 0)
@@ -115,7 +121,14 @@
 
         while(ss->ss_Link.ln_Succ != NULL)
         {
-            if(ss->ss_Owner != ThisTask)
+            struct Task *owner;
+
+            /* Read the owner under the member's own lock. */
+            SEM_LOCK(ss);
+            owner = ss->ss_Owner;
+            SEM_UNLOCK(ss);
+
+            if(owner != ThisTask)
             {
                 /*
                  *  Somebody else has this one. Wait, then check again.

--- a/rom/exec/procure.c
+++ b/rom/exec/procure.c
@@ -67,6 +67,7 @@
 
     /* Arbitrate for the semaphore structure - following like ObtainSema() */
     Forbid();
+    SEM_LOCK(sigSem);
 
     sigSem->ss_QueueCount++;
     /*
@@ -124,6 +125,7 @@
         AddTail((struct List *)&sigSem->ss_WaitQueue, (struct Node *)bidMsg);
     }
     /* All done. */
+    SEM_UNLOCK(sigSem);
     Permit();
 
     return 0;

--- a/rom/exec/releasesemaphore.c
+++ b/rom/exec/releasesemaphore.c
@@ -71,8 +71,14 @@
     if (!CheckSemaphore(sigSem, &tp, SysBase))
         return;
 
-    /* Protect the semaphore structure from multiple access. */
+    /*
+     * Forbid() only holds off this core, so the lock is what keeps the
+     * wait-queue walk and the grant atomic against other cores.
+     */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&sigSem->ss_MultipleLink.sr_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /* Release one on the nest count */
     sigSem->ss_NestCount--;
@@ -198,6 +204,9 @@
         Alert( AN_SemCorrupt );
     }
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&sigSem->ss_MultipleLink.sr_SpinLock);
+#endif
     /* All done. */
     Permit();
 

--- a/rom/exec/remport.c
+++ b/rom/exec/remport.c
@@ -8,6 +8,8 @@
 #include <aros/libcall.h>
 #include <proto/exec.h>
 
+#include "exec_intern.h"
+
 /*****************************************************************************
 
     NAME */
@@ -44,16 +46,22 @@
 {
     AROS_LIBFUNC_INIT
 
-    /* Arbitrate for the list of message ports.*/
+    /* AddPort and FindPort use PortListSpinLock, so removal must take
+     * that same lock. */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->PortListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /* Remove the current port. */
     Remove(&port->mp_Node);
 
     /* All done. */
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->PortListSpinLock);
+#endif
     Permit();
     AROS_LIBFUNC_EXIT
 } /* RemPort */
-
 
 

--- a/rom/exec/remresource.c
+++ b/rom/exec/remresource.c
@@ -7,6 +7,9 @@
 #include <aros/libcall.h>
 #include <proto/exec.h>
 
+#include "exec_intern.h"
+#include "exec_locks.h"
+
 /*****************************************************************************
 
     NAME */
@@ -43,12 +46,11 @@
     AROS_LIBFUNC_INIT
 
     /* Arbitrate for the resource list */
-    Forbid();
+    EXEC_LOCK_LIST_WRITE_AND_FORBID(&SysBase->ResourceList);
 
     Remove((struct Node *)resource);
 
     /* All done. */
-    Permit();
+    EXEC_UNLOCK_LIST_AND_PERMIT(&SysBase->ResourceList);
     AROS_LIBFUNC_EXIT
 } /* RemResource */
-

--- a/rom/exec/remsemaphore.c
+++ b/rom/exec/remsemaphore.c
@@ -46,10 +46,14 @@
 
     /* Arbitrate for the semaphore list */
     Forbid();
-
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&PrivExecBase(SysBase)->SemListSpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
     /* Remove the semaphore */
     Remove(&sigSem->ss_Link);
-
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&PrivExecBase(SysBase)->SemListSpinLock);
+#endif
     /* All done. */
     Permit();
     AROS_LIBFUNC_EXIT

--- a/rom/exec/semaphores.c
+++ b/rom/exec/semaphores.c
@@ -10,6 +10,7 @@
 #include <aros/debug.h>
 #include <proto/exec.h>
 
+#include "exec_intern.h"
 #include "exec_util.h"
 #include "semaphores.h"
 
@@ -69,10 +70,18 @@ void InternalObtainSemaphore(struct SignalSemaphore *sigSem, struct Task *owner,
         return;  /* A crude attempt to recover... */
 
     /*
-     * Arbitrate for the semaphore structure.
-     * TODO: SMP-aware versions of this code likely need to use spinlocks here
+     * Arbitrate for the semaphore structure. Forbid() blocks local-CPU
+     * preemption only; under SMP a spinlock on the semaphore protects
+     * ss_QueueCount/ss_NestCount/ss_Owner and the ss_WaitQueue list
+     * against concurrent obtain/release from other cores. The spinlock
+     * field lives in ss_MultipleLink.sr_SpinLock (InitSemaphore initialises
+     * it). Must be released before Wait() / Permit() to allow other cores
+     * to release the semaphore and signal us.
      */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&sigSem->ss_MultipleLink.sr_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /*
      * ss_QueueCount == -1 indicates that the semaphore is
@@ -128,12 +137,26 @@ void InternalObtainSemaphore(struct SignalSemaphore *sigSem, struct Task *owner,
         AddTail((struct List *)&sigSem->ss_WaitQueue, (struct Node *)&sr);
 
         /*
+         * Drop the lock before Wait() so a Release elsewhere can reach
+         * us. Order: semaphore lock outer, tc_SpinLock inner.
+         */
+#if defined(__AROSEXEC_SMP__)
+        EXEC_SPINLOCK_UNLOCK(&sigSem->ss_MultipleLink.sr_SpinLock);
+#endif
+        /*
          * Finally, we simply wait, ReleaseSemaphore() will fill in
          * who owns the semaphore.
          */
         Wait(SIGF_SINGLE);
+
+        /* All Done! */
+        Permit();
+        return;
     }
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&sigSem->ss_MultipleLink.sr_SpinLock);
+#endif
     /* All Done! */
     Permit();
 }
@@ -147,10 +170,14 @@ ULONG InternalAttemptSemaphore(struct SignalSemaphore *sigSem, struct Task *owne
         return FALSE;  /* A crude attempt to recover... */
 
     /*
-     * Arbitrate for the semaphore structure.
-     * TODO: SMP-aware versions of this code likely need to use spinlocks here
+     * Arbitrate for the semaphore structure. See InternalObtainSemaphore
+     * for rationale. AttemptSemaphore never waits, so we can hold the
+     * spinlock for the whole critical section.
      */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&sigSem->ss_MultipleLink.sr_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /* Increment the queue count */
     sigSem->ss_QueueCount++;
@@ -173,6 +200,9 @@ ULONG InternalAttemptSemaphore(struct SignalSemaphore *sigSem, struct Task *owne
         retval = FALSE;
     }
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&sigSem->ss_MultipleLink.sr_SpinLock);
+#endif
     /* All done. */
     Permit();
 

--- a/rom/exec/semaphores.h
+++ b/rom/exec/semaphores.h
@@ -10,6 +10,19 @@
 #include <aros/types/spinlock_s.h>
 #endif
 
+/*
+ * Every path that touches ss_QueueCount, ss_NestCount, ss_Owner or
+ * ss_WaitQueue takes this lock, so they exclude each other across cores.
+ */
+#if defined(__AROSEXEC_SMP__)
+#define SEM_LOCK(ss)    EXEC_SPINLOCK_LOCK(&(ss)->ss_MultipleLink.sr_SpinLock, \
+                                           NULL, SPINLOCK_MODE_WRITE)
+#define SEM_UNLOCK(ss)  EXEC_SPINLOCK_UNLOCK(&(ss)->ss_MultipleLink.sr_SpinLock)
+#else
+#define SEM_LOCK(ss)    do { } while (0)
+#define SEM_UNLOCK(ss)  do { } while (0)
+#endif
+
 struct TraceLocation;
 
 BOOL CheckSemaphore(struct SignalSemaphore *sigSem, struct TraceLocation *caller, struct ExecBase *SysBase);

--- a/rom/exec/setfunction.c
+++ b/rom/exec/setfunction.c
@@ -10,6 +10,7 @@
 #include <aros/libcall.h>
 #include <proto/exec.h>
 
+#include "exec_intern.h"
 #include "exec_debug.h"
 
 /*****************************************************************************
@@ -76,6 +77,9 @@
         functions - but it need not be.
     */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&library->lib_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /* Mark the library as changed. */
     library->lib_Flags|=LIBF_CHANGED;
@@ -104,6 +108,9 @@
 #endif
 #endif
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&library->lib_SpinLock);
+#endif
     /* Arbitration is no longer needed */
     Permit();
 

--- a/rom/exec/sumlibrary.c
+++ b/rom/exec/sumlibrary.c
@@ -8,6 +8,8 @@
 #include <aros/libcall.h>
 #include <proto/exec.h>
 
+#include "exec_intern.h"
+
 /*****************************************************************************
 
     NAME */
@@ -50,6 +52,9 @@
 
     /* Arbitrate for library base */
     Forbid();
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_LOCK(&library->lib_SpinLock, NULL, SPINLOCK_MODE_WRITE);
+#endif
 
     /*
         If the library checksumming is already in progress or if the
@@ -57,37 +62,24 @@
     */
     if(library->lib_Flags&LIBF_SUMUSED&&!(library->lib_Flags&LIBF_SUMMING))
     {
-        /* As long as the library is marked as changed */
-        do
-        {
-            ULONG *lp;
+        ULONG *lp;
 
-            /* Memorize library flags */
-            oldflags=library->lib_Flags;
+        /* Memorize library flags */
+        oldflags=library->lib_Flags;
+        library->lib_Flags&=~LIBF_CHANGED;
 
-            /* Tell other tasks: Summing in progress */
-            library->lib_Flags|=LIBF_SUMMING;
-            library->lib_Flags&=~LIBF_CHANGED;
+        /*
+         * Keep the lock across the sum: releasing it would let another
+         * core expunge the library while we read its jumptable.
+         */
 
-            /* As long as the summing goes multitasking may be permitted. */
-            Permit();
-
-            /* Build checksum. Note: library bases are LONG aligned */
-            sum=0;
-            /* Get start of jumptable */
-            lp=(ULONG *)((UBYTE *)library+library->lib_NegSize);
-            /* And sum it up */
-            while(lp<(ULONG *)library)
-                sum+=*lp++;
-
-            /* Summing complete. Arbitrate again. */
-            Forbid();
-
-            /* Remove summing flag */
-            library->lib_Flags&=~LIBF_SUMMING;
-
-            /* Do it again if the library changed while summing. */
-        }while(library->lib_Flags&LIBF_CHANGED);
+        /* Build checksum. Note: library bases are LONG aligned */
+        sum=0;
+        /* Get start of jumptable */
+        lp=(ULONG *)((UBYTE *)library+library->lib_NegSize);
+        /* And sum it up */
+        while(lp<(ULONG *)library)
+            sum+=*lp++;
 
         /*
             Alert() if the library wasn't marked as changed and if the
@@ -100,6 +92,9 @@
         library->lib_Sum=sum;
     }
 
+#if defined(__AROSEXEC_SMP__)
+    EXEC_SPINLOCK_UNLOCK(&library->lib_SpinLock);
+#endif
     /* All done. */
     Permit();
     AROS_LIBFUNC_EXIT

--- a/rom/exec/vacate.c
+++ b/rom/exec/vacate.c
@@ -53,6 +53,7 @@
 
     /* Arbitrate for the semaphore structure */
     Forbid();
+    SEM_LOCK(sigSem);
     bidMsg->ssm_Semaphore = NULL;
 
     /*
@@ -72,12 +73,15 @@
             ReplyMsg(&bidMsg->ssm_Message);
 
             /* All done */
+            SEM_UNLOCK(sigSem);
             Permit();
             return;
         }
     }
 
-    /* No, it must have been fulfilled. Release the semaphore and done. */
+    /* Fulfilled - release it. Drop our lock first: ReleaseSemaphore()
+     * takes the same one. */
+    SEM_UNLOCK(sigSem);
     ReleaseSemaphore(sigSem);
 
     /* All done. */


### PR DESCRIPTION
exec: lock the system lists, semaphores and libraries

Under SMP `Forbid()` only holds off the calling core, so the exec paths still relying on it alone no longer exclude anything running elsewhere. This takes the matching spinlock in the port, resource, semaphore and library paths.

This is not a claim that exec is unlocked — master already carries the list-level spinlocks in `IntExecBase` (`PortListSpinLock`, `SemListSpinLock`, the task lists and the rest), `mp_SpinLock` in `MsgPort`, and the `execlock.resource` mapping for the nine named lists. What this changes is the paths that were left behind.

**Semaphores.** `ObtainSemaphore`/`ReleaseSemaphore`/`AttemptSemaphore` were spinlocked, but `ObtainSemaphoreList` and the asynchronous `Procure`/`Vacate` bid protocol were not — so a list obtainer or a bidder no longer excluded a plain obtainer on another core. A single `SEM_LOCK`/`SEM_UNLOCK` pair in `rom/exec/semaphores.h` now covers every entry point that touches `ss_QueueCount`, `ss_NestCount`, `ss_Owner` or `ss_WaitQueue`. One gotcha worth knowing when reading `vacate.c`: the fulfilled path calls `ReleaseSemaphore`, which takes the same lock, so it has to be dropped first.

**Lists.** `RemPort` took the `execlock` list lock while `AddPort` and `FindPort` take `PortListSpinLock` — two different objects, so add and remove never excluded each other. `RemSemaphore` and `RemResource` had the same shape. All three now take the lock their `Add`/`Find` counterparts use.

**Libraries.** `SumLibrary` used to `Permit()` around the checksum loop and re-sum while `LIBF_CHANGED` stayed set. Dropping the lock mid-sum lets another core `RemLibrary()` and expunge the library, after which the loop reads freed memory and the re-lock spins on a freed lock word. It now holds `lib_SpinLock` across the whole sum; with the lock held nothing can set `LIBF_CHANGED` underneath, so the re-sum loop and `LIBF_SUMMING` go away. `SetFunction` takes the same lock around the vector patch.