### PR TITLE
raspi arm smp bringup

### DIFF
--- a/arch/arm-native/kernel/mmu.c
+++ b/arch/arm-native/kernel/mmu.c
@@ -18,23 +18,61 @@
 void core_MMUUpdatePageTables(void)
 {
     static pde_t *pde = (pde_t *)BOOTMEMADDR(bm_pde);
+    unsigned int ttbr;
 
-    /* Invalidate caches */
-    asm volatile("mcr   p15, 0, %[r], c8, c7, 0" : : [r] "r" (0x0));   //Invalidate entire unified TLB
-    asm volatile("mcr   p15, 0, %[r], c8, c6, 0" : : [r] "r" (0x0));   //Invalidate entire data TLB
-    asm volatile("mcr   p15, 0, %[r], c8, c5, 0" : : [r] "r" (0x0));   //Invalidate entire instruction TLB
-    asm volatile("mcr   p15, 0, %[r], c7, c5, 6" : : [r] "r" (0x0));   //Invalidate entire branch prediction array
-    asm volatile("mcr   p15, 0, %[r], c7, c5, 0" : : [r] "r" (0x0));   //Invalidate icache
+    /* Invalidate caches and TLBs */
+#if defined(__AROSEXEC_SMP__)
+    /* Broadcast variants; need ACTLR.SMP set on each CPU to be honoured. */
+    asm volatile("mcr   p15, 0, %[r], c8, c3, 0" : : [r] "r" (0x0));   // TLBIALLIS
+    asm volatile("mcr   p15, 0, %[r], c7, c1, 6" : : [r] "r" (0x0));   // BPIALLIS
+    asm volatile("mcr   p15, 0, %[r], c7, c1, 0" : : [r] "r" (0x0));   // ICIALLUIS
+#else
+    asm volatile("mcr   p15, 0, %[r], c8, c7, 0" : : [r] "r" (0x0));   // TLBIALL
+    asm volatile("mcr   p15, 0, %[r], c8, c6, 0" : : [r] "r" (0x0));   // DTLBIALL
+    asm volatile("mcr   p15, 0, %[r], c8, c5, 0" : : [r] "r" (0x0));   // ITLBIALL
+    asm volatile("mcr   p15, 0, %[r], c7, c5, 6" : : [r] "r" (0x0));   // BPIALL
+    asm volatile("mcr   p15, 0, %[r], c7, c5, 0" : : [r] "r" (0x0));   // ICIALLU
+#endif
 
-    /* setup_ttbr0/1 */
-    asm volatile("mcr   p15, 0, %[addr], c2, c0, 1" : : [addr] "r" (pde));
-    /* setup_ttbrc */
+    /* setup_ttbr1 */
+    ttbr = (unsigned int)pde;
+#if defined(__AROSEXEC_SMP__)
+    /* Inner-shareable WB-WA table walks: S | RGN[0] | IRGN[0]. The
+     * descriptors need their S bit too - the bootstrap sets that. */
+    ttbr |= 0x4A;
+#endif
+    asm volatile("mcr   p15, 0, %[addr], c2, c0, 1" : : [addr] "r" (ttbr));
+#if defined(__AROSEXEC_SMP__)
+    /* TTBR0 (low 32MB - SysBase, scheduler lists) needs the same walk
+     * attributes as the secondaries use, or the mismatch lets the boot
+     * CPU read stale descriptors. The bootstrap leaves them clear. */
+    asm volatile("mcr   p15, 0, %[addr], c2, c0, 0" : : [addr] "r" (ttbr));
+    asm volatile("mcr   p15, 0, %[r], c7, c10, 4" : : [r] "r" (0)); /* dsb */
+    asm volatile("mcr   p15, 0, %[r], c7, c5, 4" : : [r] "r" (0));  /* isb */
+#endif
+    /* setup_ttbrc - TTBR0 covers low 32MB, TTBR1 covers the rest */
     asm volatile("mcr   p15, 0, %[n], c2, c0, 2" : : [n] "r" (7));
 }
 
 void core_SetupMMU(struct TagItem *msg)
 {
     register unsigned int control;
+
+#if defined(__AROSEXEC_SMP__)
+    /* SMP/snoop enable. Only Cortex-A7 has SMPEN at ACTLR bit 6; on A53
+     * that bit is something else (SMPEN lives in EL3-only CPUECTLR), so
+     * gate on MIDR. */
+    register unsigned int midr, actlr;
+    asm volatile("mrc p15, 0, %0, c0, c0, 0" : "=r" (midr));
+    if ((midr & 0xfff0) == 0xc070)
+    {
+        asm volatile("mrc p15, 0, %0, c1, c0, 1" : "=r" (actlr));
+        actlr |= (1 << 6);
+        asm volatile("mcr p15, 0, %0, c1, c0, 1" : : "r" (actlr));
+        asm volatile("dsb" ::: "memory");
+        asm volatile("isb" ::: "memory");
+    }
+#endif
 
     core_MMUUpdatePageTables();
 

--- a/arch/arm-native/kernel/platform_bcm2708.c
+++ b/arch/arm-native/kernel/platform_bcm2708.c
@@ -90,6 +90,11 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
         uint32_t tmp;
         tls_t   *__tls;
 
+        /* Firmware leaves the prescaler at its 1MHz default; run the
+         * generic timer off the crystal so CNTPCT matches CNTFRQ. */
+        wr32le(BCM2836_CTRL, 0);
+        wr32le(BCM2836_PRESCALER, 0x80000000);
+
         /* Register the boot CPU as an IPI receiver before waking the
          * secondaries (they do it themselves in cpu_Register), or
          * bcm2708_cpuipid[0] stays NULL and IPIs to it are dropped. */
@@ -223,6 +228,31 @@ static inline uint32_t bcm2708_cntfrq_get(void)
     return v;
 }
 
+static inline uint32_t bcm2708_cntpct_get(void)
+{
+    uint32_t lo, hi;
+    asm volatile ("mrrc p15, 0, %0, %1, c14" : "=r"(lo), "=r"(hi));
+    (void)hi;
+    return lo;
+}
+
+/* CNTFRQ is firmware-programmed and not always true - QEMU reports
+ * 19.2MHz while counting at 1MHz - so measure against the system timer
+ * and keep CNTFRQ as the fallback. */
+static uint32_t bcm2708_cntp_measure(void)
+{
+    const uint32_t window = 10000;      /* microseconds */
+    uint32_t s0, c0, c1;
+
+    s0 = rd32le(SYSTIMER_CLO);
+    c0 = bcm2708_cntpct_get();
+    while ((rd32le(SYSTIMER_CLO) - s0) < window)
+        ;
+    c1 = bcm2708_cntpct_get();
+
+    return (c1 - c0) * (1000000 / window);
+}
+
 static inline void bcm2708_cntp_tval_set(uint32_t v)
 {
     asm volatile ("mcr p15, 0, %0, c14, c2, 0" :: "r"(v));
@@ -260,7 +290,15 @@ static void bcm2708_init_cntp_timer(void)
     int cpunum = GetCPUNumber();
 
     if (!bcm2708_cntp_interval)
-        bcm2708_cntp_interval = bcm2708_cntfrq_get() / 50;
+    {
+        uint32_t hz = bcm2708_cntp_measure();
+
+        /* Sanity-bound the measurement before trusting it over CNTFRQ. */
+        if (hz < 100000 || hz > 100000000)
+            hz = bcm2708_cntfrq_get();
+
+        bcm2708_cntp_interval = hz / 50;
+    }
 
     DTIMER(bug("[Kernel:BCM2708] %s: CPU #%02d CNTP interval %u\n", __PRETTY_FUNCTION__, cpunum, bcm2708_cntp_interval));
 

--- a/arch/arm-native/kernel/platform_bcm2708.c
+++ b/arch/arm-native/kernel/platform_bcm2708.c
@@ -302,6 +302,13 @@ static void bcm2708_init_cntp_timer(void)
 
     DTIMER(bug("[Kernel:BCM2708] %s: CPU #%02d CNTP interval %u\n", __PRETTY_FUNCTION__, cpunum, bcm2708_cntp_interval));
 
+    /* PrepareExecBase calls SCHEDQUANTUM_SET once, but on arm that macro
+     * writes per-CPU TLS, not the SysBase field the generic code assumes,
+     * so no core ends up with a usable quantum. Set it per core, before
+     * the heartbeat starts consuming it. */
+    SCHEDQUANTUM_SET(SCHEDQUANTUM_VALUE);
+    SCHEDELAPSED_SET(SCHEDQUANTUM_VALUE);
+
     /* Route this core's non-secure physical timer interrupt as an FIQ */
     wr32le(BCM2836_TIMER_INT_CTRL0 + (0x4 * cpunum), BCM2836_TIMER_CNTPNS_FIQ);
 

--- a/arch/arm-native/kernel/platform_bcm2708.c
+++ b/arch/arm-native/kernel/platform_bcm2708.c
@@ -23,6 +23,9 @@
 #include "kernel_interrupts.h"
 #include "kernel_intr.h"
 #include "kernel_fb.h"
+#if defined(__AROSEXEC_SMP__)
+#include "kernel_ipi.h"
+#endif
 #include "tls.h"
 #include "io.h"
 
@@ -69,6 +72,10 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
 
     KrnSpinInit(&startup_lock);
 
+#if defined(__AROSEXEC_SMP__)
+    core_IPIInit();
+#endif
+
     D(bug("[Kernel:BCM2708] %s()\n", __PRETTY_FUNCTION__));
 
     if (__arm_arosintern.ARMI_PeripheralBase == (APTR)BCM2836_PERIPHYSBASE)
@@ -82,6 +89,12 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
         uint32_t *cpu_fiq_stack;
         uint32_t tmp;
         tls_t   *__tls;
+
+        /* Register the boot CPU as an IPI receiver before waking the
+         * secondaries (they do it themselves in cpu_Register), or
+         * bcm2708_cpuipid[0] stays NULL and IPIs to it are dropped. */
+        if (__arm_arosintern.ARMI_InitCore)
+            __arm_arosintern.ARMI_InitCore(_kernelBase, _sysBase);
 
         bug("[Kernel:BCM2708] Initialising Multicore System\n");
         D(bug("[Kernel:BCM2708] %s: Copy SMP trampoline from %p to %p (%d bytes)\n", __PRETTY_FUNCTION__, trampoline_src, trampoline_dst, trampoline_length));
@@ -103,7 +116,7 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
             ((uint32_t *)(trampoline_dst + trampoline_data_offset))[4] = (uint32_t)&cpu_fiq_stack[1024-sizeof(IPTR)];
 
 
-#if defined(__AROSEXEC_SMP)
+#if defined(__AROSEXEC_SMP__)
             __tls =  (tls_t *)AllocMem(sizeof(tls_t) + sizeof(struct cpu_ipidata),  MEMF_CLEAR); /* MEMF_PRIVATE */
 #else
             __tls =  (tls_t *)AllocMem(sizeof(tls_t),  MEMF_CLEAR); /* MEMF_PRIVATE */
@@ -111,6 +124,7 @@ static void bcm2708_init(APTR _kernelBase, APTR _sysBase)
             __tls->SysBase = _sysBase;
             __tls->KernelBase = _kernelBase;
             __tls->ThisTask = NULL;
+            __tls->CPUNumber = cpu;     /* logical id - GetCPUNumber reads this */
             arm_flush_cache(((uint32_t)__tls) & ~63, 512);
             ((uint32_t *)(trampoline_dst + trampoline_data_offset))[3] = (uint32_t)__tls;
 
@@ -161,18 +175,103 @@ static void bcm2708_init_cpu(APTR _kernelBase, APTR _sysBase)
     wr32le(BCM2836_MAILBOX3_CLR0 + (16 * cpunum), 0xffffffff);
 
 #if defined(__AROSEXEC_SMP__)
-    bcm2708_cpuipid[cpunum] = (unsigned int)__tls + sizeof(tls_t);
+    bcm2708_cpuipid[cpunum] = (struct cpu_ipidata *)(__tls + 1);
     D(bug("[Kernel:BCM2708] %s: CPU #%02d IPI data @ 0x%p\n", __PRETTY_FUNCTION__, cpunum, bcm2708_cpuipid[cpunum]));
 
-    // enable FIQ mailbox interupt
-    wr32le(BCM2836_MAILBOX_INT_CTRL0 + (0x4 * cpunum), 0x10);
+    /* FIQ on all 4 mailboxes - senders index by source CPU number, so
+     * they never OR-collide in the SET register. */
+    wr32le(BCM2836_MAILBOX_INT_CTRL0 + (0x4 * cpunum), 0xf0);
 #endif
 }
 
-static unsigned int bcm2708_get_time(void)
+static uint64_t bcm2708_get_time(void)
 {
-    return rd32le(SYSTIMER_CLO);
+    uint32_t hi, lo;
+
+    /* 64-bit 1MHz counter split over CHI:CLO - re-read CHI to close the
+     * carry window (CLO alone wraps every ~71min). */
+    do
+    {
+        hi = rd32le(SYSTIMER_CHI);
+        lo = rd32le(SYSTIMER_CLO);
+    } while (rd32le(SYSTIMER_CHI) != hi);
+
+    return ((uint64_t)hi << 32) | lo;
 }
+
+#if defined(__AROSEXEC_SMP__)
+/*
+ * Per-core scheduler heartbeat on the generic timer (CNTP). The BCM2708
+ * system timer only reaches core 0, so every core arms its own CNTP and
+ * takes the tick as an FIQ. CNTP_* are PL1-banked, so arming has to run
+ * on the target core (ARMI_InitTimerCore, from cpu_Register).
+ */
+#define CNTP_CTL_ENABLE         (1 << 0)
+#define CNTP_CTL_IMASK          (1 << 1)
+#define CNTP_CTL_ISTATUS        (1 << 2)
+
+#define BCM2836_TIMER_CNTPNS_FIQ (1 << 5)       /* TIMER_INT_CTRLx: route CNTPNS as FIQ */
+#define BCM2836_FIQ_CNTPNS       (1 << 1)       /* FIQ_PENDx: CNTPNS pending */
+
+/* CNTP reload value (counter ticks per heartbeat). Same on every core. */
+static uint32_t bcm2708_cntp_interval = 0;
+
+static inline uint32_t bcm2708_cntfrq_get(void)
+{
+    uint32_t v;
+    asm volatile ("mrc p15, 0, %0, c14, c0, 0" : "=r"(v));
+    return v;
+}
+
+static inline void bcm2708_cntp_tval_set(uint32_t v)
+{
+    asm volatile ("mcr p15, 0, %0, c14, c2, 0" :: "r"(v));
+}
+
+static inline void bcm2708_cntp_ctl_set(uint32_t v)
+{
+    asm volatile ("mcr p15, 0, %0, c14, c2, 1" :: "r"(v));
+}
+
+static void bcm2708_cntp_tick(void)
+{
+    tls_t *__tls;
+
+    /* Rearm for the next tick - writing TVAL clears the pending condition */
+    bcm2708_cntp_tval_set(bcm2708_cntp_interval);
+
+    /* The first tick can land before Exec is up on this core; keep
+     * rearming regardless. Deliberately not gated on IDNESTCOUNT - a task
+     * busy-looping in short Disable windows must still expire. */
+    if (!SysBase || !KernelBase)
+        return;
+
+    /* Mirror of VBlankServer, minus the INTB_VERTB chain. Per-CPU TLS,
+     * touched only by the owning core, so no atomics. */
+    asm volatile ("mrc p15, 0, %0, c13, c0, 3" : "=r"(__tls));
+    if (__tls->Elapsed)
+        __tls->Elapsed--;
+    if (__tls->Elapsed == 0)
+        __tls->ScheduleFlags |= (TLSSF_Quantum | TLSSF_Switch);
+}
+
+static void bcm2708_init_cntp_timer(void)
+{
+    int cpunum = GetCPUNumber();
+
+    if (!bcm2708_cntp_interval)
+        bcm2708_cntp_interval = bcm2708_cntfrq_get() / 50;
+
+    DTIMER(bug("[Kernel:BCM2708] %s: CPU #%02d CNTP interval %u\n", __PRETTY_FUNCTION__, cpunum, bcm2708_cntp_interval));
+
+    /* Route this core's non-secure physical timer interrupt as an FIQ */
+    wr32le(BCM2836_TIMER_INT_CTRL0 + (0x4 * cpunum), BCM2836_TIMER_CNTPNS_FIQ);
+
+    /* Arm: fire one interval from now, enabled and unmasked */
+    bcm2708_cntp_tval_set(bcm2708_cntp_interval);
+    bcm2708_cntp_ctl_set(CNTP_CTL_ENABLE);
+}
+#endif
 
 static void bcm2708_irq_init(void)
 {
@@ -182,24 +281,47 @@ static void bcm2708_irq_init(void)
     wr32le(ARMIRQ_DIBL, ~0);
     wr32le(GPUIRQ_DIBL0, ~0);
     wr32le(GPUIRQ_DIBL1, ~0);
+
+    /* BCM2836/2837 puts a local interrupt controller in front of the
+     * legacy GPU IRQ controller. Route the shared GPU IRQ to core 0
+     * ([1:0] IRQ target, [3:2] FIQ target), or enabled sources go
+     * pending without ever reaching the ARM dispatcher. */
+    if (__arm_arosintern.ARMI_PeripheralBase == (APTR)BCM2836_PERIPHYSBASE)
+        wr32le(BCM2836_GPU_INT_ROUTING, 0);
 }
 
 static void bcm2708_send_ipi(uint32_t ipi, uint32_t ipi_data, uint32_t cpumask)
 {
     int cpu;
+#if defined(__AROSEXEC_SMP__)
+    /*
+     * Index the mailbox by source CPU, so every (sender, target) pair
+     * gets its own slot and never OR-collides in the SET register.
+     * Back-to-back IPIs from the same sender coalesce by OR, which is
+     * lossless: ipi_msg values are bit flags, and the only payload
+     * carrier (IPI_CALL_HOOK) keeps its data on the ipi_call_queue.
+     * Disable() keeps an interrupt-driven Signal from re-entering and
+     * overwriting the slot mid-write.
+     */
+    int mbno = GetCPUNumber();
+    Disable();
+#endif
 
     for (cpu = 0; cpu < 4; cpu++)
     {
 #if defined(__AROSEXEC_SMP__)
-        int mbno = 0;
         if ((cpumask & (1 << cpu)) && bcm2708_cpuipid[cpu])
         {
-            /* TODO:  check which mailbox is available and use it */
             bcm2708_cpuipid[cpu]->ipi_data[mbno] = ipi_data;
+            dsb();
             wr32le(BCM2836_MAILBOX0_SET0 + 4 * mbno + (0x10 * cpu), ipi);
         }
 #endif
     }
+
+#if defined(__AROSEXEC_SMP__)
+    Enable();
+#endif
 }
 
 static void bcm2708_irq_enable(int irq)
@@ -299,6 +421,11 @@ static void bcm2708_fiq_process()
 
     if (fiq)
     {
+#if defined(__AROSEXEC_SMP__)
+        /* Per-core scheduler heartbeat (CNTP) - expire the local quantum */
+        if (fiq & BCM2836_FIQ_CNTPNS)
+            bcm2708_cntp_tick();
+#endif
         for (mbno=0; mbno < 4; mbno++)
         {
             if (fiq & (0x10 << mbno))
@@ -307,10 +434,15 @@ static void bcm2708_fiq_process()
                 (void)fiq_data;
                 DFIQ(bug("[Kernel:BCM2708] %s: Mailbox%d: FIQ Data %08x\n", __PRETTY_FUNCTION__, mbno, fiq_data));
 #if defined(__AROSEXEC_SMP__)
+                /* Pairs with the sender's dsb; ipi_data is indexed by
+                 * mailbox because senders index by source CPU. */
+                dsb();
                 if (bcm2708_cpuipid[cpunum])
-                    handle_ipi(fiq_data, bcm2708_cpuipid[cpunum]->ipi_data[0]);
+                    handle_ipi(fiq_data, bcm2708_cpuipid[cpunum]->ipi_data[mbno]);
 #endif
-                wr32le(BCM2836_MAILBOX0_CLR0 + 4 * mbno + (16 * cpunum), 0xffffffff);
+                /* Clear only the bits read - a bit set between the read
+                 * and this write must stay pending, or the IPI is lost. */
+                wr32le(BCM2836_MAILBOX0_CLR0 + 4 * mbno + (16 * cpunum), fiq_data);
             }
         }
     }
@@ -443,9 +575,11 @@ static APTR bcm2708_init_gputimer(APTR _kernelBase)
 
 static inline void bcm2708_ser_waitout()
 {
+    unsigned int spins = 0;
     while(1)
     {
        if ((rd32le(PL011_0_BASE + PL011_FR) & PL011_FR_TXFF) == 0) break;
+       if (++spins > 1000000) return;
     }
 }
 
@@ -472,6 +606,7 @@ static int bcm2708_ser_getc(void)
 static IPTR bcm2708_probe(struct ARM_Implementation *krnARMImpl, struct TagItem *msg)
 {
     void *bootPutC = NULL;
+    APTR bootPeriBase = NULL;
 
     while(msg->ti_Tag != TAG_DONE)
     {
@@ -479,6 +614,9 @@ static IPTR bcm2708_probe(struct ARM_Implementation *krnARMImpl, struct TagItem 
         {
         case KRN_FuncPutC:
             bootPutC = (void *)msg->ti_Data;
+            break;
+        case KRN_PeripheralBase:
+            bootPeriBase = (APTR)msg->ti_Data;
             break;
         }
         msg++;
@@ -494,9 +632,15 @@ static IPTR bcm2708_probe(struct ARM_Implementation *krnARMImpl, struct TagItem 
         krnARMImpl->ARMI_InitCore = &bcm2708_init_cpu;
         krnARMImpl->ARMI_FIQProcess = &bcm2708_fiq_process;
         krnARMImpl->ARMI_SendIPI = &bcm2708_send_ipi;
+#if defined(__AROSEXEC_SMP__)
+        krnARMImpl->ARMI_InitTimerCore = &bcm2708_init_cntp_timer;
+#endif
     }
     else
         krnARMImpl->ARMI_PeripheralBase = (APTR)BCM2835_PERIPHYSBASE;
+
+    if (bootPeriBase)
+        krnARMImpl->ARMI_PeripheralBase = bootPeriBase;
 
     krnARMImpl->ARMI_GetTime = &bcm2708_get_time;
     krnARMImpl->ARMI_InitTimer = &bcm2708_init_gputimer;

--- a/arch/arm-native/kernel/platform_init.c
+++ b/arch/arm-native/kernel/platform_init.c
@@ -81,12 +81,42 @@ static int platform_PostInit(struct KernelBase *KernelBase)
 
     D(bug("[Kernel] platform_PostInit: Performing Post Init..\n"));
 
+#if defined(__AROSEXEC_SMP__)
+    /* Pin the boot task to CPU 0 before ARMI_Init wakes the secondaries.
+     * Exec_ARMCPUSMPInit does this too, but runs after us - until then
+     * affinity is NULL ("run anywhere") and a secondary could dispatch
+     * the boot task mid-coldstart, which is not migration-safe. */
+    {
+        struct Task *bootTask = FindTask(NULL);
+        struct IntETask *iet = bootTask ? (struct IntETask *)GetETask(bootTask) : NULL;
+
+        if (iet && !iet->iet_CpuAffinity)
+        {
+            void *bootAff = KrnAllocCPUMask();
+            if (bootAff)
+            {
+                KrnGetCPUMask(0, bootAff);
+                iet->iet_CpuAffinity = bootAff;
+                iet->iet_CpuNumber = 0;
+            }
+        }
+    }
+#endif
+
     if (__arm_arosintern.ARMI_Init)
         __arm_arosintern.ARMI_Init(KernelBase, SysBase);
     
     D(bug("[Kernel] platform_PostInit: Registering Heartbeat timer..\n"));
 
     KrnAddSysTimerHandler(KernelBase);
+
+#if defined(__AROSEXEC_SMP__)
+    /* Every core expires its quantum from its own CNTP heartbeat, not
+     * the VBlank. Arm the boot CPU here; secondaries do it in
+     * cpu_Register. */
+    if (__arm_arosintern.ARMI_InitTimerCore)
+        __arm_arosintern.ARMI_InitTimerCore();
+#endif
 
     D(bug("[Kernel] platform_PostInit: Done..\n"));
 

--- a/arch/arm-native/processor/getcpuinfo.c
+++ b/arch/arm-native/processor/getcpuinfo.c
@@ -9,6 +9,8 @@
 
 #include <aros/libcall.h>
 #include <resources/processor.h>
+#include <aros/kernel.h>
+#include <proto/kernel.h>
 #include <proto/utility.h>
 
 #include "processor_intern.h"
@@ -134,10 +136,14 @@ VOID ARM_AnswerTag(struct ProcessorBase * ProcessorBase, ULONG coreNo, struct Ta
             *((ULONG *)tag->ti_Data) = ENDIANNESS_LE;
         break;
     case(GCIT_ProcessorSpeed):
-        *((UQUAD *)tag->ti_Data) = GetCurrentProcessorFrequency(processor);
+        *((UQUAD *)tag->ti_Data) = GetCurrentProcessorFrequency(ProcessorBase, processor);
         break;
     case(GCIT_ProcessorLoad):
+#if defined(__AROSEXEC_SMP__)
+        *((ULONG *)tag->ti_Data) = KrnGetSystemAttr(KATTR_CPULoad + coreNo);
+#else
         *((ULONG *)tag->ti_Data) = 0; /* TODO: IMPLEMENT */
+#endif
         break;
     case GCIT_Vendor:
         *((CONST_STRPTR *)tag->ti_Data) = processor->Vendor;

--- a/arch/arm-native/processor/processor_arch_intern.h
+++ b/arch/arm-native/processor/processor_arch_intern.h
@@ -31,6 +31,7 @@ struct ARMProcessorInformation
 
     /* Frequency information */
     UQUAD           MaxCPUFrequency;
+    UQUAD           CPUFrequency;   /* sampled once, then cached */
 
     /* Multiprocessor Affinity Register; 0 when not implemented */
     ULONG           MPIDR;
@@ -38,7 +39,8 @@ struct ARMProcessorInformation
 
 VOID ReadProcessorInformation(struct ARMProcessorInformation * info);
 VOID ReadMaxFrequencyInformation(struct ARMProcessorInformation * info);
-UQUAD GetCurrentProcessorFrequency(struct ARMProcessorInformation * info);
+/* Needs ProcessorBase to reach KernelBase - as on all-pc. */
+UQUAD GetCurrentProcessorFrequency(struct ProcessorBase *ProcessorBase, struct ARMProcessorInformation * info);
 VOID Processor_FillTopology(struct ProcessorBase * ProcessorBase);
 VOID ARM_AnswerTag(struct ProcessorBase * ProcessorBase, ULONG coreNo, struct TagItem * tag);
 

--- a/arch/arm-native/processor/processor_frequency.c
+++ b/arch/arm-native/processor/processor_frequency.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013, The AROS Development Team. All rights reserved.
+    Copyright (C) 2013-2026, The AROS Development Team. All rights reserved.
 */
 
 #define DEBUG 0
@@ -7,22 +7,95 @@
 #include <aros/config.h>
 #include <aros/debug.h>
 #include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/mbox.h>
 #include <resources/processor.h>
 
+#include <hardware/videocore.h>
+
+#include "processor_intern.h"
 #include "processor_arch_intern.h"
+
+/* Measured rather than requested rate; not in videocore.h. The firmware
+ * reports a setpoint the core is not actually running at. */
+#define VCTAG_GETCLKRATE_MEASURED   0x00030047
+
+#define MBOXMSG_WORDS   8
+#define MBOXMSG_SIZE    (MBOXMSG_WORDS * 4 + 16)
+
+APTR MBoxBase = NULL;
+
+static IPTR __arm_periiobase;
+#define ARM_PERIIOBASE __arm_periiobase
+
+static UQUAD vcQueryClock(struct ProcessorBase *ProcessorBase, ULONG tag, ULONG clockid)
+{
+    unsigned int *msg_, *msg;
+    UQUAD rate = 0;
+
+    if (!MBoxBase)
+    {
+        /* On demand, not at init: processor.resource has residentpri 99
+         * against mbox.resource's 88, so it does not exist yet. */
+        if ((MBoxBase = OpenResource("mbox.resource")) == NULL)
+            return 0;
+
+        __arm_periiobase = (IPTR)KrnGetSystemAttr(KATTR_PeripheralBase);
+    }
+
+    /* The mailbox requires the message to be 16-byte aligned. */
+    if ((msg_ = AllocMem(MBOXMSG_SIZE, MEMF_PUBLIC | MEMF_CLEAR)) == NULL)
+        return 0;
+    msg = (unsigned int *)((((IPTR)msg_) + 15) & ~15);
+
+    msg[0] = AROS_LONG2LE(MBOXMSG_WORDS * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(tag);
+    msg[3] = AROS_LONG2LE(8);           /* value buffer size    */
+    msg[4] = AROS_LONG2LE(4);           /* request length       */
+    msg[5] = AROS_LONG2LE(clockid);
+    msg[6] = 0;                         /* rate comes back here */
+    msg[7] = 0;                         /* terminating tag      */
+
+    /* MBoxCall, not MBoxWrite+MBoxRead: it serialises the exchange under
+     * the mailbox semaphore, which vc4gfx shares. */
+    if (MBoxCall((APTR)VCMB_BASE, VCMB_PROPCHAN, msg) == (volatile unsigned int *)msg)
+        rate = (UQUAD)AROS_LE2LONG(msg[6]);
+
+    FreeMem(msg_, MBOXMSG_SIZE);
+
+    D(bug("[processor.ARM] %s: tag %08x clock %u -> %u Hz\n", __func__, tag, clockid, (ULONG)rate));
+
+    return rate;
+}
 
 VOID ReadMaxFrequencyInformation(struct ARMProcessorInformation * info)
 {
     D(bug("[processor.ARM] :%s()\n", __PRETTY_FUNCTION__));
 
+    /* Left for the first query - the mailbox is not up yet here. */
     info->MaxCPUFrequency = 0;
 }
 
-UQUAD GetCurrentProcessorFrequency(struct ARMProcessorInformation * info)
+UQUAD GetCurrentProcessorFrequency(struct ProcessorBase *ProcessorBase, struct ARMProcessorInformation * info)
 {
-    UQUAD retFreq = info->MaxCPUFrequency;
-
     D(bug("[processor.ARM] :%s()\n", __PRETTY_FUNCTION__));
 
-    return retFreq;
+    /* Sampled once, then cached - a mailbox round trip per SysMon
+     * refresh is not worth it. A failure leaves the cache at zero and
+     * is retried. */
+    if (info->CPUFrequency == 0)
+    {
+        if (info->MaxCPUFrequency == 0)
+            info->MaxCPUFrequency = vcQueryClock(ProcessorBase, VCTAG_GETCLKMAX, VCCLOCK_ARM);
+
+        /* Fall back to the setpoint on firmware without the measured tag. */
+        if ((info->CPUFrequency = vcQueryClock(ProcessorBase, VCTAG_GETCLKRATE_MEASURED, VCCLOCK_ARM)) == 0)
+            info->CPUFrequency = vcQueryClock(ProcessorBase, VCTAG_GETCLKRATE, VCCLOCK_ARM);
+
+        if (info->CPUFrequency == 0)
+            info->CPUFrequency = info->MaxCPUFrequency;
+    }
+
+    return info->CPUFrequency;
 }

--- a/arch/arm-raspi/boot/boot.c
+++ b/arch/arm-raspi/boot/boot.c
@@ -328,6 +328,10 @@ void boot(uintptr_t dummy, uintptr_t arch, struct tag * atags, uintptr_t a)
     boottag->ti_Data = (IPTR)arch;
     boottag++;
 
+    boottag->ti_Tag = KRN_PeripheralBase;
+    boottag->ti_Data = (IPTR)__arm_periiobase;
+    boottag++;
+
     /*
         Check if device tree contains /soc/local_intc entry. In this case assume RasPi 2 or 3 with smp setup.
         Neither PiZero nor classic Pi provide this entry.

--- a/arch/arm-raspi/boot/mmu.c
+++ b/arch/arm-raspi/boot/mmu.c
@@ -54,9 +54,9 @@ void mmu_load()
     DMMU(kprintf("[BOOT] control register %08x\n", tmp));
     tmp |= 1;           /* Enable MMU */
     tmp |= 1 << 23;     /* v6 page tables, subpages disabled */
-    asm volatile ("mcr  p15, 0, %[r], c7, c10, 4" : : [r] "r" (0)); /* dsb */
+    asm volatile ("mcr p15, 0, %[r], c7, c10, 4" : : [r] "r" (0)); /* dsb */
     asm volatile ("mcr p15, 0, %0, c1, c0, 0"::"r"(tmp));
-    asm volatile ("mcr  p15, 0, %[r], c7, c5, 4" : : [r] "r" (0)); /* isb */
+    asm volatile ("mcr p15, 0, %[r], c7, c5, 4" : : [r] "r" (0)); /* isb */
     DMMU(kprintf("[BOOT] mmu up\n"));
 }
 
@@ -99,6 +99,9 @@ void mmu_map_section(uint32_t phys, uint32_t virt, uint32_t length, int b, int c
         s.raw |= (ap & 3) << 10;
         s.raw |= (tex) << 12;
         s.raw |= ((ap >> 2) & 1) << 15;
+        /* S bit - Inner Shareable once ACTLR.SMP is set. No-op with
+         * ACTLR.SMP=0 (ARMv7-A ARM B3.5.7), so safe on non-SMP too. */
+        s.raw |= 1 << 16;
         s.raw |= phys << 20;
 #if 0
         s.section.type = PDE_TYPE_SECTION;

--- a/arch/arm-raspi/boot/serialdebug.c
+++ b/arch/arm-raspi/boot/serialdebug.c
@@ -34,7 +34,7 @@ unsigned int uartdivint;
 unsigned int uartdivfrac;
 unsigned int uartbaud;
 
-inline void waitSerOUT()
+void waitSerOUT()
 {
     while(1)
     {
@@ -42,7 +42,7 @@ inline void waitSerOUT()
     }
 }
 
-inline void putByte(uint8_t chr)
+void putByte(uint8_t chr)
 {
     waitSerOUT();
 

--- a/arch/arm-raspi/timer/timer_init.c
+++ b/arch/arm-raspi/timer/timer_init.c
@@ -21,6 +21,7 @@
 #include <proto/arossupport.h>
 #include <proto/bootloader.h>
 #include <proto/exec.h>
+#include <proto/execlock.h>
 #include <proto/kernel.h>
 
 
@@ -86,6 +87,20 @@ int vblank_Init(struct TimerBase *LIBBASE);
 static int Timer_Init(struct TimerBase *TimerBase)
 {
     D(bug("[Timer] Timer_Init: kernel.resource @ 0x%p\n", KernelBase));
+
+#if defined(__AROSEXEC_SMP__)
+    /* tb_Lists is walked from the boot CPU's IRQ and mutated by BeginIO
+     * from any CPU. lowlevel.c only locks when tb_ExecLockBase is set,
+     * and this Init replaces the generic one that would set it. */
+    {
+        struct ExecLockBase *ExecLockBase;
+        if ((ExecLockBase = OpenResource("execlock.resource")) != NULL)
+        {
+            TimerBase->tb_ExecLockBase = ExecLockBase;
+            TimerBase->tb_ListLock = AllocLock();
+        }
+    }
+#endif
 
     TimerBase->tb_Platform.tbp_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 

--- a/compiler/include/aros/kernel.h
+++ b/compiler/include/aros/kernel.h
@@ -75,6 +75,7 @@ typedef enum
 #define KRN_FrameBufferHeight   (KRN_Dummy + 35) /* Framebuffer height in pixels			*/
 #define KRN_FrameBufferDepth    (KRN_Dummy + 36) /* Framebuffer bits per pixel			*/
 #define KRN_FrameBufferPitch    (KRN_Dummy + 37) /* Framebuffer bytes per line			*/
+#define KRN_PeripheralBase      (KRN_Dummy + 38) /* SoC peripheral IO physical base address */
 
 /*
  * KRN_MEMLower/KRN_MEMUpper may appear more than once, one pair per physical


### PR DESCRIPTION
Wakes CPUs 1-3 on BCM2836/2837 (Pi 2/3) and gets them far enough to run tasks under `__AROSEXEC_SMP__`. Five commits:

- **kernel: bring up the secondary cores on raspi** — trampoline wake-up with per-CPU stacks and TLS, IPI mailboxes (FIQ on all four, indexed by source CPU so senders never collide), inner-shareable TLB/cache maintenance and matching TTBR0/TTBR1 walk attributes, ACTLR.SMP on Cortex-A7, and GPU IRQ routing to core 0. Adds a per-core CNTP scheduler heartbeat, since the BCM system timer only reaches core 0.
- **raspi: pass SMP boot and timer data to the kernel** — `KRN_PeripheralBase` boot tag, S bit in the bootstrap's section descriptors, and a cross-CPU lock for timer.device's request lists.
- **processor: report the ARM clock rate** — `GCIT_ProcessorSpeed` was returning zero; query the firmware mailbox for the measured rate, cached after the first call. `GCIT_ProcessorLoad` now answers from `KATTR_CPULoad`.
- **kernel: get the arm generic-timer rate right on bcm2836** — program the local timer prescaler for the crystal, and measure CNTPCT against the system timer rather than trusting CNTFRQ.
- **kernel: initialise the scheduler quantum per core on arm** — `PrepareExecBase` calls `SCHEDQUANTUM_SET` once, but on arm that writes per-CPU TLS rather than the SysBase field, so no core got a usable quantum.