### PR TITLE
LoginWindow: honor security catalog version

### DIFF
--- a/workbench/classes/zune/loginwindow/loginwindow.c
+++ b/workbench/classes/zune/loginwindow/loginwindow.c
@@ -7,6 +7,7 @@
 
 #include <utility/tagitem.h>
 #include <libraries/mui.h>
+#include <libraries/security.h>
 #include <dos/dos.h>
 #include <zune/iconimage.h>
 #include <exec/memory.h>
@@ -139,7 +140,8 @@ Object *LoginWindow__OM_NEW
     if (pool == NULL) return NULL;
 
     /* Initialize locale ---------------------------------------------------*/
-    catalog = OpenCatalogA(NULL, "System/security.catalog", NULL);
+    catalog = OpenCatalog(NULL, SECURITYCATALOGNAME,
+        OC_Version, SECURITYCATALOGVERSION, TAG_DONE);
 
     tag = FindTagItem(WindowContents, message->ops_AttrList);
 


### PR DESCRIPTION
Use the security library's catalog name and version definitions when opening the LoginWindow catalog.

This keeps LoginWindow consistent with the other security catalog users and prevents translations with a mismatching catalog version from being opened.
