### PR TITLE
locale.library: honor DOS catalog version

### DIFF
--- a/workbench/libs/locale/initlocale.c
+++ b/workbench/libs/locale/initlocale.c
@@ -8,6 +8,7 @@
 #include <proto/dos.h>
 #include <proto/iffparse.h>
 #include "locale_intern.h"
+#include "catalog_version.h"
 #include <libraries/iffparse.h>
 #include <prefs/prefhdr.h>
 #include <prefs/locale.h>
@@ -241,7 +242,8 @@ void SetLocaleLanguage(struct IntLocale *il, struct LocaleBase *LocaleBase)
 
     /* Open dos.catalog (needed for DosGetLocalizedString patch) */
     il->il_DosCatalog =
-        OpenCatalogA((struct Locale *)il, "System/Libs/dos.catalog", NULL);
+        OpenCatalog((struct Locale *)il, "System/Libs/dos.catalog",
+            OC_Version, CATALOG_VERSION, TAG_DONE);
 
     DEBUG_INITLOCALE(dprintf("SetLocaleLanguage: DosCatalog 0x%lx\n",
             il->il_DosCatalog));

--- a/workbench/libs/locale/mmakefile.src
+++ b/workbench/libs/locale/mmakefile.src
@@ -2,6 +2,7 @@
 include $(SRCDIR)/config/aros.cfg
 
 USER_LDFLAGS := -static
+USER_INCLUDES := -I$(SRCDIR)/rom/dos/catalogs
 
 FILES := defaultlocale english initlocale catalog_funcs patches 
 FUNCS := \
@@ -18,7 +19,7 @@ FUNCS := \
 #MM     workbench-libs-iffparse-includes \
 #MM     workbench-libs-rexxsyslib-includes \
 #MM     includes-copy
-#MM- workbench-libs-locale : linklibs
+#MM- workbench-libs-locale : linklibs workbench-libs-dos-catalogs
 #MM- core-linklibs: linklibs-locale
 
 %build_module mmake=workbench-libs-locale \


### PR DESCRIPTION
Open dos.catalog using the catalog version provided by the DOS translation contract.

Also make locale.library depend on the DOS catalog target so the version header is available when the library is built.

pc-i386 `workbench-libs-locale` builds successfully with the updated contract.
