### PR TITLE
DiskImage: honor catalog versions

### DIFF
--- a/workbench/devs/diskimage/device/unit.c
+++ b/workbench/devs/diskimage/device/unit.c
@@ -29,6 +29,7 @@
 
 #ifdef __AROS__
 #include <expat.h>
+#include "catalogs/catalog_version.h"
 #else
 #include <proto/expat.h>
 #endif
@@ -121,7 +122,8 @@ int UnitProcMain (struct DiskImageUnit *unit) {
 #ifdef __AROS__
 	ObtainSemaphore(libBase->PluginSemaphore);
 	if (IsListEmpty(libBase->Plugins)) {
-		InitLocaleInfo(SysBase, &libBase->LocaleInfo, "diskimagedevice.catalog");
+		InitLocaleInfoVersion(SysBase, &libBase->LocaleInfo,
+			"diskimagedevice.catalog", CATALOG_VERSION);
 		LoadPlugins(libBase);
 	}
 	ReleaseSemaphore(libBase->PluginSemaphore);

--- a/workbench/devs/diskimage/include/support.h
+++ b/workbench/devs/diskimage/include/support.h
@@ -198,6 +198,7 @@ struct LocaleInfo {
 
 /* localeinfo.c */
 void InitLocaleInfo (APTR SysBase, struct LocaleInfo *li, CONST_STRPTR catalog);
+void InitLocaleInfoVersion (APTR SysBase, struct LocaleInfo *li, CONST_STRPTR catalog, ULONG version);
 void FreeLocaleInfo (APTR SysBase, struct LocaleInfo *li);
 CONST_STRPTR GetString (struct LocaleInfo *li, LONG stringNum);
 

--- a/workbench/devs/diskimage/support/localeinfo.c
+++ b/workbench/devs/diskimage/support/localeinfo.c
@@ -26,13 +26,28 @@
 
 #include "support.h"
 
-void InitLocaleInfo (APTR SysBase, struct LocaleInfo *li, CONST_STRPTR catalog) {
+static void InitLocaleInfoTags (APTR SysBase, struct LocaleInfo *li,
+	CONST_STRPTR catalog, struct TagItem *tags) {
 	struct Library *LocaleBase;
 	li->li_LocaleBase =
 	LocaleBase = OpenLibrary("locale.library", MIN_OS_VERSION);
 	if (LocaleBase) {
-		li->li_Catalog = OpenCatalogA(NULL, (STRPTR)catalog, NULL);
+		li->li_Catalog = OpenCatalogA(NULL, (STRPTR)catalog, tags);
 	}
+}
+
+void InitLocaleInfo (APTR SysBase, struct LocaleInfo *li, CONST_STRPTR catalog) {
+	InitLocaleInfoTags(SysBase, li, catalog, NULL);
+}
+
+void InitLocaleInfoVersion (APTR SysBase, struct LocaleInfo *li,
+	CONST_STRPTR catalog, ULONG version) {
+	struct TagItem tags[] = {
+		{ OC_Version, version },
+		{ TAG_DONE, 0 }
+	};
+
+	InitLocaleInfoTags(SysBase, li, catalog, tags);
 }
 
 void FreeLocaleInfo (APTR SysBase, struct LocaleInfo *li) {

--- a/workbench/devs/diskimage/zune_gui/main.c
+++ b/workbench/devs/diskimage/zune_gui/main.c
@@ -39,6 +39,7 @@
 #include "rev/DiskImageGUI_rev.h"
 
 #ifdef __AROS__
+#include "catalogs/catalog_version.h"
 #define DEBUG 0
 #include <aros/debug.h>
 #else
@@ -69,7 +70,13 @@ int main (void) {
 	struct Hook *ReloadPluginsHook = NULL;
 	ULONG sigs = 0;
 
-    InitLocaleInfo((struct Library *)SysBase, &LocaleInfo, "System/System/"PROGNAME".catalog");
+#ifdef __AROS__
+    InitLocaleInfoVersion((struct Library *)SysBase, &LocaleInfo,
+        "System/System/"PROGNAME".catalog", CATALOG_VERSION);
+#else
+    InitLocaleInfo((struct Library *)SysBase, &LocaleInfo,
+        "System/System/"PROGNAME".catalog");
+#endif
 
 	DiskChangeSignal = AllocSignal(-1);
 	if (DiskChangeSignal == -1) {


### PR DESCRIPTION
Use the catalog versions provided by the DiskImage device and GUI translation contracts when opening their catalogs.

The shared locale helper now accepts optional catalog tags while preserving the existing unversioned interface for other callers.

The affected DiskImage support, device and GUI sources compile successfully, and DiskImageGUI links successfully.
