### PR TITLE
kernel: link libamiga into the remaining kickstarts

### DIFF
--- a/arch/aarch64-native/kernel/mmakefile.src
+++ b/arch/aarch64-native/kernel/mmakefile.src
@@ -68,7 +68,7 @@ kernel-raspi-aarch64-quick: $(OSGENDIR)/boot/core.elf
 $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_library.o  $(KOBJSDIR)/task_resource.o
 		@$(ECHO) "Creating   $@"
 		%mkdirs_q $(OSGENDIR)/boot
-		@$(TARGET_LD) --emit-relocs -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static $(TARGET_C_LIBS)
+		@$(TARGET_LD) --emit-relocs -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -lamiga -llibinit -lstdc.static $(TARGET_C_LIBS)
 		@$(TARGET_STRIP) --strip-debug -R .note -R .comment $@
 
 #MM kernel-kernel-raspi-aarch64 : includes

--- a/arch/arm-efika/kernel/mmakefile.src
+++ b/arch/arm-efika/kernel/mmakefile.src
@@ -29,7 +29,7 @@ kernel-efika-arm: $(AROSDIR)/boot/aros-efikamx
 $(AROSDIR)/boot/aros-efikamx: $(KOBJSDIR)/kernel_resource.o 
 		%mkdirs_q $(OSGENDIR)/boot
 		%mkdirs_q $(AROSDIR)/boot
-		$(TARGET_LD) -Map $(OSGENDIR)/boot/kernel.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $(KOBJSDIR)/kernel_resource.o -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static -laeabi
+		$(TARGET_LD) -Map $(OSGENDIR)/boot/kernel.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $(KOBJSDIR)/kernel_resource.o -L$(AROS_LIB) -larossupport -lautoinit -lamiga -llibinit -lstdc.static -laeabi
 		$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $@
 	
 

--- a/arch/arm-native/kernel/mmakefile.src
+++ b/arch/arm-native/kernel/mmakefile.src
@@ -81,7 +81,7 @@ kernel-raspi-armeb-quick: $(OSGENDIR)/boot/core.elf
 $(OSGENDIR)/boot/core.elf: $(KOBJSDIR)/kernel_resource.o $(KOBJSDIR)/exec_library.o  $(KOBJSDIR)/task_resource.o
 		@$(ECHO) "Creating   $@"
 		%mkdirs_q $(OSGENDIR)/boot
-		@$(TARGET_LD) -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static $(TARGET_C_LIBS)
+		@$(TARGET_LD) -Map $(OSGENDIR)/boot/core.map -T $(SRCDIR)/$(CURDIR)/ldscript.lds -o $@ $^ -L$(AROS_LIB) -larossupport -lautoinit -lamiga -llibinit -lstdc.static $(TARGET_C_LIBS)
 		@$(TARGET_STRIP) --strip-unneeded -R .note -R .comment $@
 
 #MM kernel-kernel-raspi-arm : includes

--- a/arch/riscv-native/sifive_u/kernel/mmakefile.src
+++ b/arch/riscv-native/sifive_u/kernel/mmakefile.src
@@ -27,7 +27,7 @@ kernel-sifive_u-riscv: $(OSGENDIR)/boot/core.elf
 
 #MM- kernel-sifive_u-riscv-quick: setup-native-riscv-sifive_u-quick kernel-kernel-kobj-quick kernel-exec-kobj-quick kernel-task-kobj-quick kernel-sifive_u-riscv
 
-ELFCORELIBS := -L$(AROS_LIB) -larossupport -lautoinit -llibinit -lstdc.static
+ELFCORELIBS := -L$(AROS_LIB) -larossupport -lautoinit -lamiga -llibinit -lstdc.static
 ifeq ("$(AROS_TOOLCHAIN)","gnu")
 ELFCORELIBS += -L$(CROSSTOOLSDIR)/lib/gcc/$(AROS_TARGET_CPU)-aros/$(TARGET_GCC_VER) -lgcc
 endif


### PR DESCRIPTION
7405611e23 moved the module init sequence out of line, pulling libautoinit's __showerror into every kickstart. 68a72e535f added -lamiga for riscv64-opensbi only, leaving aarch64-native, arm-native, arm-efika and sifive_u to fail the link on GetDataStreamFromFormat.