### PR TITLE
stdc: call __aros_getbase_StdCIOBase() instead of taking its address

### DIFF
--- a/compiler/crt/stdc/__stdcio_dos64.c
+++ b/compiler/crt/stdc/__stdcio_dos64.c
@@ -21,7 +21,7 @@
 static struct Library *__stdcio_dos64base(void)
 {
     struct StdCIOIntBase *StdCIOBase =
-        (struct StdCIOIntBase *)__aros_getbase_StdCIOBase;
+        (struct StdCIOIntBase *)__aros_getbase_StdCIOBase();
 
     if (StdCIOBase->StdCIODOS64Base == NULL)
         StdCIOBase->StdCIODOS64Base = OpenLibrary("dos64.library", 50);

--- a/compiler/crt/stdc/getenv.c
+++ b/compiler/crt/stdc/getenv.c
@@ -52,7 +52,7 @@
 ******************************************************************************/
 {
     struct StdCIOIntBase *StdCIOBase =
-        (struct StdCIOIntBase *)__aros_getbase_StdCIOBase;
+        (struct StdCIOIntBase *)__aros_getbase_StdCIOBase();
     char  c;
 
     /*


### PR DESCRIPTION
Added missing call parantheses