### PR TITLE
i386 debug: add udis86 dependency to linklib target

### DIFF
--- a/arch/i386-all/debug/mmakefile.src
+++ b/arch/i386-all/debug/mmakefile.src
@@ -22,5 +22,6 @@ FUNCS := debug_platform disassemble
   files=" $(FUNCS)"
 
 #MM kernel-debug-i386 : linklibs-udis86
+#MM kernel-debug-i386-linklib : linklibs-udis86
 
 %common


### PR DESCRIPTION
The i386 debug linklib target can reach `disassemble.c` without first making the udis86 headers and link library available.

Add `linklibs-udis86` as a prerequisite of `kernel-debug-i386-linklib`, matching the existing dependency of the normal `kernel-debug-i386` target.

Verified with a fresh pc-i386 build of `kernel-debug-i386-linklib`.
