### PR TITLE
DiskImage: declare plugin library dependencies

### DIFF
--- a/workbench/devs/diskimage/plugins/mmakefile.src
+++ b/workbench/devs/diskimage/plugins/mmakefile.src
@@ -71,7 +71,7 @@ TARGETDIR := $(AROS_DEVS)/DiskImage
 %build_prog mmake=workbench-devs-diskimage-ccd progname=CCD files="stub_aros ccd" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport" usestartup=no
 
-#MM workbench-devs-diskimage-ciso : workbench-libs-z-linklib
+#MM workbench-devs-diskimage-ciso : includes linklibs workbench-devs-diskimage-device workbench-devs-diskimage-support workbench-libs-z-linklib
 
 %build_prog mmake=workbench-devs-diskimage-ciso progname=CISO files="stub_aros ciso" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport z" usestartup=no
@@ -86,17 +86,17 @@ CFILES := cue/cue cue/flac cue/wavpack audio/aiff audio/flac \
 %build_prog mmake=workbench-devs-diskimage-cue progname=CUE files="stub_aros $(CFILES)" \
     targetdir=$(TARGETDIR) uselibs="mpg123 FLAC wavpack vorbisfile vorbis ogg diskimagesupport" usestartup=no
 
-#MM workbench-devs-diskimage-daa : workbench-libs-z-linklib
+#MM workbench-devs-diskimage-daa : includes linklibs workbench-devs-diskimage-device workbench-devs-diskimage-support workbench-libs-z-linklib
 
 %build_prog mmake=workbench-devs-diskimage-daa progname=DAA files="stub_aros daa" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport z" usestartup=no
 
-#MM workbench-devs-diskimage-dax : workbench-libs-z-linklib
+#MM workbench-devs-diskimage-dax : includes linklibs workbench-devs-diskimage-device workbench-devs-diskimage-support workbench-libs-z-linklib
 
 %build_prog mmake=workbench-devs-diskimage-dax progname=DAX files="stub_aros dax" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport z" usestartup=no
 
-#MM workbench-devs-diskimage-dmg : workbench-libs-z-linklib
+#MM workbench-devs-diskimage-dmg : includes linklibs workbench-devs-diskimage-device workbench-devs-diskimage-support workbench-libs-z-linklib external-bz2 workbench-libs-expat
 
 CFILES := dmg/dmg dmg/base64 dmg/adc
 
@@ -121,7 +121,7 @@ CFILES := ../dms/crc_csum ../dms/getbits ../dms/tables ../dms/maketbl ../dms/u_i
 %build_prog mmake=workbench-devs-diskimage-nrg progname=NRG files="stub_aros nrg" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport" usestartup=no
 
-#MM workbench-devs-diskimage-uif : workbench-libs-z-linklib
+#MM workbench-devs-diskimage-uif : includes linklibs workbench-devs-diskimage-device workbench-devs-diskimage-support workbench-libs-z-linklib
 
 %build_prog mmake=workbench-devs-diskimage-uif progname=UIF files="stub_aros uif" \
     targetdir=$(TARGETDIR) uselibs="diskimagesupport z" usestartup=no


### PR DESCRIPTION
The z-based DiskImage plugins use `diskimagesupport` and z, but their build targets only declared the z prerequisite. DMG additionally links against bz2 and expat.

Declare the corresponding prerequisites explicitly for CISO, DAA, DAX, DMG and UIF, with the additional bz2 and expat owners for DMG.

Verified with fresh pc-i386 builds of all five affected plugin targets. DMG builds from a fresh build tree with `libdiskimagesupport.a`, `libz.a`, `libbz2.a` and `libexpat.a` produced through its dependency graph.
