### PR TITLE
cd32: fix Microcosm CDXL playback and reduce CD32 chip RAM usage

### DIFF
--- a/arch/m68k-amiga/boot/start.c
+++ b/arch/m68k-amiga/boot/start.c
@@ -1044,9 +1044,10 @@ void exec_boot(ULONG *membanks, ULONG *cpupcr)
     /* Attempt to allocate a real stack, and switch to it. */
     do {
         const ULONG size = AROS_STACKSIZE;
+        const ULONG entries = size / sizeof(IPTR);
         IPTR *usp;
 
-        usp = AllocMem(size * sizeof(IPTR), MEMF_PUBLIC);
+        usp = AllocMem(size, MEMF_PUBLIC);
         if (usp == NULL) {
             DEBUGPUTS(("PANIC! Can't allocate a new stack for Exec!\n"));
             Early_Alert(CODE_ALLOC_FAIL);
@@ -1062,7 +1063,7 @@ void exec_boot(ULONG *membanks, ULONG *cpupcr)
             "jmp %1@\n"
             "0:\n"
             :
-            : "a" (&usp[size-3]),
+            : "a" (&usp[entries-3]),
               "a" (doInitCode),
                   "a" (BootS)
             :);

--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -160,6 +160,10 @@ static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
 
         if (devnode)
         {
+            /* CDVDFS peaks below 2 KB while booting Microcosm.  The generic
+             * MakeDosNode() default is 16 KB, all of it scarce chip RAM on
+             * a stock CD32. */
+            devnode->dn_StackSize = 4096;
             AddBootNode(pp[DE_BOOTPRI + 4], ADNF_STARTPROC, devnode, NULL);
             
             return TRUE;
@@ -202,7 +206,7 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
                                      * under 1 KB, and its stack is
                                      * chip RAM on a stock CD32.
                                      */
-                                    TASKTAG_STACKSIZE, 8192,
+                                    TASKTAG_STACKSIZE, 4096,
                                     TASKTAG_ARG1, cb,
                                     TASKTAG_ARG2, cu,
                                     TASKTAG_TASKMSGPORT, &cu->cu_MsgPort,

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -65,6 +65,21 @@ struct CD32Mode1 {
     UBYTE cs_ECC[276];
 };
 
+struct CD32XLTransfer {
+    struct IOStdReq *io;
+    struct CDXL *node;
+    ULONG remaining;
+    ULONG sectorOffset;
+    BOOL limited;
+    BOOL nodeStarted;
+};
+
+struct CD32Unit;
+
+static VOID CD32_CompleteXLNode(struct CDXL *node);
+static BOOL CD32_CopyXL(struct CD32Unit *cu, APTR frame, ULONG sectorSize);
+static ULONG CD32_XLSectorPosition(const UBYTE *frame);
+
 struct CD32Unit {
     LIBBASETYPE *cu_CDBase;
     struct CD32Data {
@@ -78,6 +93,7 @@ struct CD32Unit {
         UBYTE Reserved[0x100];
     } *cu_Misc;
     struct Interrupt cu_Interrupt;
+    struct Interrupt cu_XLInterrupt;
     UBYTE cu_TxHead, cu_RxHead;
     struct Task *cu_Task;
     struct CDInfo cu_CDInfo;
@@ -88,6 +104,8 @@ struct CD32Unit {
     union CDTOC cu_CDTOC[100];
     ULONG cu_IntEnable;
     ULONG cu_ChangeNum;
+    struct CD32XLTransfer cu_XL;
+    volatile ULONG cu_XLProgress;
     BOOL cu_ReadXLActive;
 };
 
@@ -154,6 +172,87 @@ static VOID CD32_IntDisable(struct CD32Unit *cu, ULONG mask)
     writel(cu->cu_IntEnable, AKIKO_CDINTENA);
 }
 
+static AROS_INTH1(CD32_XLInterrupt, struct CD32Unit *, cu)
+{
+    UWORD callbackSR;
+    UWORD pbx, pending;
+    UWORD consumed = 0;
+    int i;
+
+    AROS_INTFUNC_INIT
+
+    /* The CD32 ROM processes completed PBX buffers and invokes CDXL clients
+     * at SR $2000.  AROS may drain a pending softint from the level-2 exit
+     * path, so lower the CPU IPL for this work and restore it on return. */
+    asm volatile (
+        "move.w %%sr,%0\n\t"
+        "move.w #0x2000,%%sr"
+        : "=d" (callbackSR)
+        :
+        : "cc", "memory");
+
+    pbx = readw(AKIKO_CDPBX);
+    if (cu->cu_XL.io->io_Flags & IOF_ABORT) {
+        cu->cu_ReadXLActive = FALSE;
+    } else {
+        pending = (UWORD)~pbx;
+        while (pending != 0) {
+            ULONG firstPosition = ~0UL;
+            UWORD mask;
+            int first = -1;
+
+            /* Akiko always chooses the highest armed PBX slot.  A slot can
+             * be re-armed while an older sector remains in a lower slot, so
+             * slot order alone is not arrival order.  Drain this snapshot
+             * by the raw sector's absolute MSF or MPEG/CDXL streams can have
+             * adjacent sectors swapped under normal interrupt latency. */
+            for (i = 15; i >= 0; i--) {
+                ULONG position;
+
+                mask = (UWORD)(1U << i);
+                if ((pending & mask) == 0)
+                    continue;
+                position = CD32_XLSectorPosition(cu->cu_Data[i].Data);
+                if (first < 0 || position < firstPosition) {
+                    first = i;
+                    firstPosition = position;
+                }
+            }
+
+            mask = (UWORD)(1U << first);
+            pending &= ~mask;
+            consumed |= mask;
+            cu->cu_XLProgress++;
+            if (!CD32_CopyXL(cu, &cu->cu_Data[first],
+                    cu->cu_CDInfo.SectorSize)) {
+                cu->cu_ReadXLActive = FALSE;
+                break;
+            }
+        }
+    }
+
+    if (consumed != 0)
+        writew(consumed, AKIKO_CDPBX);
+    else
+        writew(0, AKIKO_CDPBX);
+
+    if (cu->cu_ReadXLActive) {
+        CD32_IntEnable(cu, AKIKO_CDINT_PBX);
+    } else if (cu->cu_Task) {
+        Signal(cu->cu_Task, SIGF_SINGLE);
+    }
+
+    asm volatile (
+        "move.w %0,%%sr"
+        :
+        : "d" (callbackSR)
+        : "cc", "memory");
+
+    return FALSE;
+
+    AROS_INTFUNC_EXIT
+}
+
 static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
 {
     const UBYTE resp_len[16] = {
@@ -210,9 +309,24 @@ static AROS_INTH1(CD32_Interrupt, struct CD32Unit *, cu)
 
     if (status & AKIKO_CDINT_PBX) {
         UWORD pbx = readw(AKIKO_CDPBX);
-        writew(0, AKIKO_CDPBX);
-        if ((cu->cu_ReadXLActive || pbx < 0x000f) && cu->cu_Task)
-            Signal(cu->cu_Task, SIGF_SINGLE);
+
+        if (cu->cu_ReadXLActive) {
+            if (cu->cu_XL.io->io_Flags & IOF_ABORT) {
+                cu->cu_ReadXLActive = FALSE;
+                CD32_IntDisable(cu, AKIKO_CDINT_PBX);
+                if (cu->cu_Task)
+                    Signal(cu->cu_Task, SIGF_SINGLE);
+            } else {
+                /* Prevent this source from retriggering while the IPL0
+                 * software interrupt consumes and releases the buffers. */
+                CD32_IntDisable(cu, AKIKO_CDINT_PBX);
+                Cause(&cu->cu_XLInterrupt);
+            }
+        } else {
+            writew(0, AKIKO_CDPBX);
+            if (pbx < 0x000f && cu->cu_Task)
+                Signal(cu->cu_Task, SIGF_SINGLE);
+        }
         claimed = TRUE;
     }
 
@@ -550,15 +664,6 @@ static LONG CD32_CmdRead(struct CD32Unit *cu, LONG sect_start, LONG sectors, voi
     return -1;
 }
 
-struct CD32XLTransfer {
-    struct IOStdReq *io;
-    struct CDXL *node;
-    ULONG remaining;
-    ULONG sectorOffset;
-    BOOL limited;
-    BOOL nodeStarted;
-};
-
 static BOOL CD32_IsXLListTail(const struct CDXL *node)
 {
     /* Exec MinLists end in a tail sentinel whose successor is NULL and
@@ -568,10 +673,30 @@ static BOOL CD32_IsXLListTail(const struct CDXL *node)
         node->Node.mln_Pred != NULL;
 }
 
+/* CDXL callbacks use the documented register ABI, not the compiler's C ABI.
+ * In particular, applications may clobber registers such as A5.  Preserve
+ * every C nonvolatile register so callers implemented in C keep valid frame
+ * and local-variable state after the callback returns. */
+extern VOID CD32_CallXLCallbackAsm(VOID);
+asm (
+    "       .text\n"
+    "       .globl CD32_CallXLCallbackAsm\n"
+    "CD32_CallXLCallbackAsm:\n"
+    "       movem.l %d2-%d7/%a2-%a6,%sp@-\n"
+    "       jsr (%a0)\n"
+    "       movem.l %sp@+,%d2-%d7/%a2-%a6\n"
+    "       rts\n"
+);
+
 static VOID CD32_CompleteXLNode(struct CDXL *node)
 {
-    if (node->IntCode != NULL)
-        CD_READXL_INTC(node->IntCode, node, node->IntData);
+    if (node->IntCode != NULL) {
+        AROS_UFC4NR(void, CD32_CallXLCallbackAsm,
+            AROS_UFCA(VOID_FUNC, node->IntCode, A0),
+            AROS_UFCA(APTR, node->IntData, A1),
+            AROS_UFCA(struct CDXL *, node, A2),
+            AROS_UFCA(struct ExecBase *, SysBase, A6));
+    }
 }
 
 static BOOL CD32_StartXLNode(struct CD32XLTransfer *xl)
@@ -594,9 +719,9 @@ static BOOL CD32_StartXLNode(struct CD32XLTransfer *xl)
     return FALSE;
 }
 
-static BOOL CD32_CopyXL(struct CD32XLTransfer *xl, APTR frame,
-    ULONG sectorSize)
+static BOOL CD32_CopyXL(struct CD32Unit *cu, APTR frame, ULONG sectorSize)
 {
+    struct CD32XLTransfer *xl = &cu->cu_XL;
     const UBYTE *source = (const UBYTE *)frame +
         (sectorSize == 2328 ? 24 : 16) + xl->sectorOffset;
     ULONG available = sectorSize - xl->sectorOffset;
@@ -641,23 +766,22 @@ static ULONG CD32_XLSectorPosition(const UBYTE *frame)
 static LONG CD32_CmdReadXL(struct CD32Unit *cu, struct IOStdReq *io,
     LONG sect_start, LONG sectors, ULONG sectorOffset)
 {
-    struct CD32XLTransfer xl;
+    struct CD32XLTransfer *xl = &cu->cu_XL;
     UBYTE cmd[12], resp[2];
     UBYTE cmd_pause[1] = { CHCD_PAUSE };
     UBYTE cmd_unpause[1] = { CHCD_UNPAUSE };
-    ULONG wakeups = 0;
-    ULONG watchdogWakeups = 0;
+    ULONG watchdogProgress = 0;
     BOOL watchdogActive = FALSE;
     LONG err;
 
-    xl.io = io;
-    xl.node = io->io_Data;
-    xl.remaining = io->io_Length;
-    xl.sectorOffset = sectorOffset;
-    xl.limited = io->io_Length != 0;
-    xl.nodeStarted = FALSE;
+    xl->io = io;
+    xl->node = io->io_Data;
+    xl->remaining = io->io_Length;
+    xl->sectorOffset = sectorOffset;
+    xl->limited = io->io_Length != 0;
+    xl->nodeStarted = FALSE;
 
-    if (!CD32_StartXLNode(&xl))
+    if (!CD32_StartXLNode(xl))
         return 0;
 
     cu->cu_CDInfo.Status &= ~(CDSTSF_PLAYING | CDSTSF_PAUSED |
@@ -683,6 +807,7 @@ static LONG CD32_CmdReadXL(struct CD32Unit *cu, struct IOStdReq *io,
         goto out;
     }
 
+    cu->cu_XLProgress = 0;
     cu->cu_ReadXLActive = TRUE;
     CD32_IntEnable(cu, AKIKO_CDINT_PBX);
     writel(readl(AKIKO_CDFLAG) | AKIKO_CDFLAG_ENABLE, AKIKO_CDFLAG);
@@ -690,73 +815,23 @@ static LONG CD32_CmdReadXL(struct CD32Unit *cu, struct IOStdReq *io,
     watchdogActive = TRUE;
     err = 0;
 
-    while (xl.node != NULL && (!xl.limited || xl.remaining != 0) &&
-           !(io->io_Flags & IOF_ABORT)) {
-        UWORD pbx, pending, consumed = 0;
-        int i;
-
+    while (cu->cu_ReadXLActive && !(io->io_Flags & IOF_ABORT)) {
         Wait(SIGF_SINGLE);
-        pbx = readw(AKIKO_CDPBX);
 
-        if (pbx == 0xffff) {
-            if (CheckIO((struct IORequest *)&cu->cu_CDBase->cb_TimerRequest)) {
-                WaitIO((struct IORequest *)&cu->cu_CDBase->cb_TimerRequest);
-                watchdogActive = FALSE;
+        if (CheckIO((struct IORequest *)&cu->cu_CDBase->cb_TimerRequest)) {
+            ULONG progress = cu->cu_XLProgress;
+
+            WaitIO((struct IORequest *)&cu->cu_CDBase->cb_TimerRequest);
+            watchdogActive = FALSE;
+            if (progress == watchdogProgress) {
                 D(bug("%s: no sectors delivered\n", __func__));
                 err = CDERR_NotSpecified;
                 break;
             }
-            continue;
-        }
 
-        pending = (UWORD)~pbx;
-        while (pending != 0) {
-            ULONG firstPosition = ~0UL;
-            UWORD mask;
-            int first = -1;
-
-            /* Akiko always chooses the highest armed PBX slot.  A slot can
-             * be re-armed while an older sector remains in a lower slot, so
-             * slot order alone is not arrival order.  Drain this snapshot
-             * by the raw sector's absolute MSF or MPEG/CDXL streams can have
-             * adjacent sectors swapped under normal interrupt latency. */
-            for (i = 15; i >= 0; i--) {
-                ULONG position;
-
-                mask = (UWORD)(1U << i);
-                if ((pending & mask) == 0)
-                    continue;
-                position = CD32_XLSectorPosition(cu->cu_Data[i].Data);
-                if (first < 0 || position < firstPosition) {
-                    first = i;
-                    firstPosition = position;
-                }
-            }
-
-            mask = (UWORD)(1U << first);
-            pending &= ~mask;
-            consumed |= mask;
-            if (!CD32_CopyXL(&xl, &cu->cu_Data[first],
-                    cu->cu_CDInfo.SectorSize))
-                break;
-        }
-
-        /* A one bit makes that DMA slot available again.  Re-arm only after
-         * its contents have been copied; other sectors may arrive while the
-         * unit task is walking this batch. */
-        if (consumed != 0)
-            writew(consumed, AKIKO_CDPBX);
-
-        wakeups++;
-        watchdogWakeups++;
-
-        /* Refresh the stall watchdog in coarse batches.  Restarting a timer
-         * request for every 75-Hz sector would add two device operations to
-         * every frame and distort the continuous-transfer path itself. */
-        if (watchdogWakeups >= 64) {
-            cd32TimeoutEnd(cu);
+            watchdogProgress = progress;
             cd32TimeoutStart(cu, CD32_CMD_TIMEOUT_MS);
-            watchdogWakeups = 0;
+            watchdogActive = TRUE;
         }
     }
 
@@ -767,8 +842,8 @@ static LONG CD32_CmdReadXL(struct CD32Unit *cu, struct IOStdReq *io,
     cu->cu_ReadXLActive = FALSE;
     if (watchdogActive)
         cd32TimeoutEnd(cu);
-    D(bug("[CDXL] bytes=%lu wakeups=%lu error=%ld\n",
-        io->io_Actual, wakeups, err));
+    D(bug("[CDXL] bytes=%lu sectors=%lu error=%ld\n",
+        io->io_Actual, cu->cu_XLProgress, err));
 
 out:
     CD32_Cmd(cu, cmd_pause, 1, resp, sizeof(resp));
@@ -1293,9 +1368,11 @@ static int CD32_InitLib(LIBBASETYPE *cb)
     priv = AllocVec(sizeof(*priv), MEMF_ANY | MEMF_CLEAR);
     if (priv) {
         priv->cu_CDBase = cb;
-        priv->cu_Misc = LibAllocAligned(sizeof(struct CD32Misc), MEMF_24BITDMA | MEMF_CLEAR, 1024);
+        priv->cu_Misc = LibAllocAligned(sizeof(struct CD32Misc),
+            MEMF_24BITDMA | MEMF_CLEAR, 1024);
         if (priv->cu_Misc) {
-            priv->cu_Data = LibAllocAligned(sizeof(struct CD32Data) * 16, MEMF_24BITDMA | MEMF_CLEAR, 4096);
+            priv->cu_Data = LibAllocAligned(sizeof(struct CD32Data) * 16,
+                MEMF_24BITDMA | MEMF_CLEAR, 4096);
             if (priv->cu_Data) {
                 priv->cu_Interrupt.is_Node.ln_Pri = 0;
                 priv->cu_Interrupt.is_Node.ln_Name = (STRPTR)CD32Ops.uo_Name;
@@ -1303,6 +1380,14 @@ static int CD32_InitLib(LIBBASETYPE *cb)
                 priv->cu_Interrupt.is_Data = priv;
                 priv->cu_Interrupt.is_Code = (VOID_FUNC)CD32_Interrupt;
                 AddIntServer(INTB_PORTS, &priv->cu_Interrupt);
+
+                priv->cu_XLInterrupt.is_Node.ln_Pri = 0;
+                priv->cu_XLInterrupt.is_Node.ln_Name =
+                    (STRPTR)CD32Ops.uo_Name;
+                priv->cu_XLInterrupt.is_Node.ln_Type = NT_INTERRUPT;
+                priv->cu_XLInterrupt.is_Data = priv;
+                priv->cu_XLInterrupt.is_Code =
+                    (VOID_FUNC)CD32_XLInterrupt;
 
                 writel((IPTR)priv->cu_Data, AKIKO_CDADRDATA);
                 writel((IPTR)priv->cu_Misc,  AKIKO_CDADRMISC);

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -701,20 +701,24 @@ static VOID CD32_CompleteXLNode(struct CDXL *node)
 
 static BOOL CD32_StartXLNode(struct CD32XLTransfer *xl)
 {
-    while (xl->node != NULL && !CD32_IsXLListTail(xl->node)) {
-        if (!xl->nodeStarted) {
-            xl->node->Actual = 0;
-            xl->nodeStarted = TRUE;
-        }
+    if (xl->node == NULL || CD32_IsXLListTail(xl->node))
+        goto finished;
 
-        if (xl->node->Length != 0)
-            return TRUE;
-
-        CD32_CompleteXLNode(xl->node);
-        xl->node = (struct CDXL *)xl->node->Node.mln_Succ;
-        xl->nodeStarted = FALSE;
+    if (!xl->nodeStarted) {
+        xl->node->Actual = 0;
+        xl->nodeStarted = TRUE;
     }
 
+    /* Per cd.device/CD_READXL, encountering a zero-length node terminates
+     * the transfer.  Do not complete it or follow its successor: circular
+     * clients use this to stop an otherwise unlimited stream from inside
+     * the preceding node's callback. */
+    if (xl->node->Length == 0)
+        goto finished;
+
+    return TRUE;
+
+finished:
     xl->node = NULL;
     return FALSE;
 }

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -1339,15 +1339,12 @@ static const struct DosEnvec CD32Envec = {
     .de_HighCyl = 0,
     /*
      * CDVDFS sizes its sector cache as de_NumBuffers 16-sector (32 KB)
-     * prefetch chunks, so 32 here cost a full megabyte of BufMemType
-     * memory the moment CD0: mounts. A CD32 without expansion RAM backs
-     * MEMF_24BITDMA with its only 2 MB of chip RAM, and half the machine
-     * disappearing before the boot handoff is what forced fast RAM onto
-     * titles that run chip-only under the CD32 Kickstart (whose
-     * CDFileSystem treats a buffer as one 2 KB block). Four chunks
-     * (128 KB) keep sequential streaming ahead of the drive.
+     * prefetch chunks. A CD32 without expansion RAM backs MEMF_24BITDMA
+     * with its only 2 MB of chip RAM, so keep a single readahead chunk.
+     * The Akiko data ring already buffers incoming sectors below this
+     * filesystem cache.
      */
-    .de_NumBuffers = 4,
+    .de_NumBuffers = 1,
     .de_BufMemType = MEMF_24BITDMA,
     .de_MaxTransfer = 32 * 2048,
     .de_Mask = 0x00fffffe,

--- a/arch/m68k-amiga/devs/cd32mpeg/cd32mpeg.c
+++ b/arch/m68k-amiga/devs/cd32mpeg/cd32mpeg.c
@@ -724,6 +724,24 @@ static void fmvTask(IPTR baseArg)
     }
 }
 
+static BOOL fmvStartTask(LIBBASETYPEPTR base)
+{
+    if (base->cmb_Task)
+        return TRUE;
+
+    base->cmb_Task = NewCreateTask(TASKTAG_PC, fmvTask,
+        TASKTAG_NAME, "cd32mpeg.device",
+        /* Match Commodore's FMV worker.  It must drain each CDXL sector into
+         * both decoders before their small input FIFOs run dry. */
+        TASKTAG_PRI, 10,
+        TASKTAG_STACKSIZE, 8192,
+        TASKTAG_ARG1, base,
+        TASKTAG_TASKMSGPORT, &base->cmb_MsgPort,
+        TAG_DONE);
+
+    return base->cmb_Task != NULL;
+}
+
 static int cd32mpeg_Init(LIBBASETYPE *base)
 {
     base->cmb_Present = FALSE;
@@ -739,17 +757,9 @@ static int cd32mpeg_Init(LIBBASETYPE *base)
     base->cmb_Interrupt.is_Node.ln_Name = "cd32mpeg.device";
     base->cmb_Interrupt.is_Data = base;
     base->cmb_Interrupt.is_Code = (VOID_FUNC)fmvInterrupt;
-    base->cmb_Task = NewCreateTask(TASKTAG_PC, fmvTask,
-        TASKTAG_NAME, "cd32mpeg.device",
-        /* Match Commodore's FMV worker.  It must drain each CDXL sector into
-         * both decoders before their small input FIFOs run dry. */
-        TASKTAG_PRI, 10,
-        TASKTAG_STACKSIZE, 8192,
-        TASKTAG_ARG1, base,
-        TASKTAG_TASKMSGPORT, &base->cmb_MsgPort,
-        TAG_DONE);
+    base->cmb_Task = NULL;
 
-    return base->cmb_Task != NULL;
+    return TRUE;
 }
 
 ADD2INITLIB(cd32mpeg_Init, 0)
@@ -767,6 +777,9 @@ static int GM_UNIQUENAME(Open)(LIBBASETYPEPTR base,
             base->cmb_Present, unit));
         return FALSE;
     }
+
+    if (!fmvStartTask(base))
+        return FALSE;
 
     if (!base->cmb_InterruptInstalled)
     {

--- a/arch/m68k-amiga/disk/disk_intern_init.c
+++ b/arch/m68k-amiga/disk/disk_intern_init.c
@@ -19,6 +19,9 @@
 
 #define HAVE_NO_DF0_DISK_ID 1
 
+#define AKIKO_ID        0xb80002
+#define AKIKO_ID_MAGIC  0xcafe
+
 #define DEBUG 0
 #include <aros/debug.h>
 
@@ -43,7 +46,12 @@ void readunitid_internal (struct DiscResource *DiskBase, LONG unitNum)
                         id |= 1;
                 ciab->ciaprb |= unitmask; // SELX
         }
-        if (unitNum == 0 && HAVE_NO_DF0_DISK_ID && id == DRT_EMPTY)
+        /* A standard Amiga DF0: does not return an ID stream, so an empty
+         * response normally means a legacy drive.  A CD32 has no onboard
+         * floppy drive at all; Akiko lets us distinguish that machine from
+         * a legacy drive and avoid starting trackdisk.device needlessly. */
+        if (unitNum == 0 && HAVE_NO_DF0_DISK_ID && id == DRT_EMPTY &&
+            *((volatile UWORD *)AKIKO_ID) != AKIKO_ID_MAGIC)
                 id = DRT_AMIGA;
         DiskBase->dr_UnitID[unitNum] = id;
 }

--- a/arch/m68k-amiga/dos/dos_platform.h
+++ b/arch/m68k-amiga/dos/dos_platform.h
@@ -1,0 +1,10 @@
+#ifndef DOS_PLATFORM_H
+#define DOS_PLATFORM_H
+
+/* Amiga interrupts and exceptions use the supervisor stack.  Keep a
+ * conservative default for arbitrary applications while allowing measured
+ * system processes to request the classic 4 KiB process stack. */
+#define PROC_STACKSIZE     8192
+#define PROC_MINSTACKSIZE  4096
+
+#endif

--- a/arch/m68k-amiga/dos/mmakefile.src
+++ b/arch/m68k-amiga/dos/mmakefile.src
@@ -1,0 +1,7 @@
+include $(SRCDIR)/config/aros.cfg
+
+%set_archincludes mainmmake=kernel-dos maindir=rom/dos \
+  modname=dos pri=0 arch=amiga-m68k \
+  includes="-I$(SRCDIR)/$(CURDIR)"
+
+%common

--- a/arch/m68k-amiga/nvdisk/akiko.c
+++ b/arch/m68k-amiga/nvdisk/akiko.c
@@ -1,0 +1,644 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    CD32 Akiko 24C08 nonvolatile storage backend.
+*/
+
+#include "nvdisk_intern.h"
+#include "nvdisk_arch.h"
+
+#include <exec/memory.h>
+#include <exec/semaphores.h>
+#include <proto/exec.h>
+
+#include <string.h>
+
+#define AKIKO_ID_ADDR       (*(volatile UWORD *)0x00b80002)
+#define AKIKO_ID_MAGIC      0xcafe
+#define AKIKO_I2C_LINES     (*(volatile UBYTE *)0x00b80030)
+#define AKIKO_I2C_DIRECTION (*(volatile UBYTE *)0x00b80032)
+
+#define I2C_SCL 0x80
+#define I2C_SDA 0x40
+
+#define EEPROM_SIZE         1024
+#define EEPROM_PAGE_SIZE    16
+#define EEPROM_RECORD_START 0x18
+
+#define RECORD_APP          0x20
+#define RECORD_ITEM         0x40
+#define RECORD_LENGTH       0x60
+#define RECORD_END          0xa0
+#define RECORD_TYPE_MASK    0xe0
+#define RECORD_VALUE_MASK   0x1f
+#define RECORD_LOCKED       0x80
+
+#define NV_NODESIZE (sizeof(struct NVEntry) + 32)
+
+struct AkikoItem
+{
+    ULONG app;
+    ULONG item;
+    ULONG protection;
+    ULONG data;
+    ULONG length;
+    ULONG end;
+};
+
+#define AKIKO_LOCATION ((BPTR)-1)
+
+static struct SignalSemaphore *akiko_lock(struct NVDBase *base)
+{
+    return (struct SignalSemaphore *)base->nvd_DOSBase;
+}
+
+static void i2c_delay(void)
+{
+    volatile UBYTE value = 0;
+    unsigned int i;
+
+    /* Akiko register accesses use the slow peripheral bus.  Extra reads keep
+     * the software clock below the 24C08's 100 kHz limit on a CD32. */
+    for (i = 0; i < 8; i++)
+        value = AKIKO_I2C_LINES;
+    (void)value;
+}
+
+static void i2c_drive(UBYTE lines)
+{
+    AKIKO_I2C_LINES = 0;
+    AKIKO_I2C_DIRECTION |= lines;
+    i2c_delay();
+}
+
+static void i2c_release(UBYTE lines)
+{
+    AKIKO_I2C_DIRECTION &= ~lines;
+    i2c_delay();
+}
+
+static void i2c_start(void)
+{
+    i2c_release(I2C_SDA | I2C_SCL);
+    i2c_drive(I2C_SDA);
+    i2c_drive(I2C_SCL);
+}
+
+static void i2c_stop(void)
+{
+    i2c_drive(I2C_SDA);
+    i2c_release(I2C_SCL);
+    i2c_release(I2C_SDA);
+}
+
+static BOOL i2c_write_byte(UBYTE value)
+{
+    unsigned int bit;
+    BOOL ack;
+
+    for (bit = 0; bit < 8; bit++)
+    {
+        if (value & 0x80)
+            i2c_release(I2C_SDA);
+        else
+            i2c_drive(I2C_SDA);
+        i2c_release(I2C_SCL);
+        i2c_drive(I2C_SCL);
+        value <<= 1;
+    }
+
+    i2c_release(I2C_SDA);
+    i2c_release(I2C_SCL);
+    ack = (AKIKO_I2C_LINES & I2C_SDA) == 0;
+    i2c_drive(I2C_SCL);
+    return ack;
+}
+
+static UBYTE i2c_read_byte(BOOL last)
+{
+    UBYTE value = 0;
+    unsigned int bit;
+
+    i2c_release(I2C_SDA);
+    for (bit = 0; bit < 8; bit++)
+    {
+        i2c_release(I2C_SCL);
+        value = (value << 1) | ((AKIKO_I2C_LINES & I2C_SDA) != 0);
+        i2c_drive(I2C_SCL);
+    }
+
+    if (last)
+        i2c_release(I2C_SDA);
+    else
+        i2c_drive(I2C_SDA);
+    i2c_release(I2C_SCL);
+    i2c_drive(I2C_SCL);
+    i2c_release(I2C_SDA);
+    return value;
+}
+
+static UBYTE eeprom_device(ULONG address, BOOL read)
+{
+    /* The 24C08 carries address bits A9:A8 in control-byte bits 2:1. */
+    return 0xa0 | ((address >> 7) & 6) | (read ? 1 : 0);
+}
+
+static BOOL eeprom_read(UBYTE *data)
+{
+    ULONG address;
+
+    for (address = 0; address < EEPROM_SIZE; address += 256)
+    {
+        ULONG i;
+
+        i2c_start();
+        if (!i2c_write_byte(eeprom_device(address, FALSE)) ||
+            !i2c_write_byte((UBYTE)address))
+        {
+            i2c_stop();
+            return FALSE;
+        }
+        i2c_start();
+        if (!i2c_write_byte(eeprom_device(address, TRUE)))
+        {
+            i2c_stop();
+            return FALSE;
+        }
+        for (i = 0; i < 256; i++)
+            data[address + i] = i2c_read_byte(i == 255);
+        i2c_stop();
+    }
+    return TRUE;
+}
+
+static BOOL eeprom_wait_ready(ULONG address)
+{
+    unsigned int retry;
+
+    /* ACK polling accommodates modern EEPROMs with a 5 ms page-write cycle,
+     * as well as the unusually fast original Atmel part. */
+    for (retry = 0; retry < 4096; retry++)
+    {
+        BOOL ready;
+        i2c_start();
+        ready = i2c_write_byte(eeprom_device(address, FALSE));
+        i2c_stop();
+        if (ready)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOL eeprom_write_page(ULONG address, const UBYTE *data)
+{
+    ULONG i;
+
+    i2c_start();
+    if (!i2c_write_byte(eeprom_device(address, FALSE)) ||
+        !i2c_write_byte((UBYTE)address))
+    {
+        i2c_stop();
+        return FALSE;
+    }
+    for (i = 0; i < EEPROM_PAGE_SIZE; i++)
+    {
+        if (!i2c_write_byte(data[i]))
+        {
+            i2c_stop();
+            return FALSE;
+        }
+    }
+    i2c_stop();
+    return eeprom_wait_ready(address);
+}
+
+static BOOL eeprom_write_changed(const UBYTE *old, const UBYTE *data)
+{
+    ULONG address;
+
+    for (address = 0; address < EEPROM_SIZE; address += EEPROM_PAGE_SIZE)
+    {
+        if (memcmp(old + address, data + address, EEPROM_PAGE_SIZE) != 0 &&
+            !eeprom_write_page(address, data + address))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL image_valid(const UBYTE *image)
+{
+    return image[0] == 0x00 && image[1] == 0x56 &&
+        image[2] == 0xa9 && image[3] == 0x00;
+}
+
+static void image_init(UBYTE *image)
+{
+    memset(image, 0, EEPROM_SIZE);
+    image[0] = 0x00;
+    image[1] = 0x56;
+    image[2] = 0xa9;
+    image[3] = 0x00;
+    image[EEPROM_RECORD_START] = RECORD_END;
+}
+
+static int folded_char(UBYTE value)
+{
+    if (value >= 'A' && value <= 'Z')
+        value += 'a' - 'A';
+    return value;
+}
+
+static BOOL name_equal(const UBYTE *stored, ULONG length,
+    CONST_STRPTR wanted)
+{
+    ULONG i;
+
+    if (strlen(wanted) != length)
+        return FALSE;
+    for (i = 0; i < length; i++)
+    {
+        if (folded_char(stored[i]) != folded_char((UBYTE)wanted[i]))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL parse_item(const UBYTE *image, ULONG app, ULONG item,
+    struct AkikoItem *parsed)
+{
+    ULONG appLength = image[app] & RECORD_VALUE_MASK;
+    ULONG itemLength = image[item] & RECORD_VALUE_MASK;
+    ULONG lengthMarker;
+
+    parsed->app = app;
+    parsed->item = item;
+    parsed->protection = item + 1 + itemLength;
+    lengthMarker = parsed->protection + 1;
+    if (parsed->protection >= EEPROM_SIZE ||
+        lengthMarker + 1 >= EEPROM_SIZE ||
+        (image[lengthMarker] & RECORD_TYPE_MASK) != RECORD_LENGTH ||
+        app + 1 + appLength > item)
+        return FALSE;
+    parsed->length = ((ULONG)(image[lengthMarker] & RECORD_VALUE_MASK) << 8) |
+        image[lengthMarker + 1];
+    parsed->data = lengthMarker + 2;
+    parsed->end = parsed->data + parsed->length;
+    return parsed->end < EEPROM_SIZE;
+}
+
+static BOOL find_item(const UBYTE *image, CONST_STRPTR wantedApp,
+    CONST_STRPTR wantedItem, struct AkikoItem *found)
+{
+    ULONG pos = EEPROM_RECORD_START;
+    ULONG app = 0;
+    BOOL appMatches = FALSE;
+
+    while (pos < EEPROM_SIZE)
+    {
+        UBYTE marker = image[pos];
+        ULONG type = marker & RECORD_TYPE_MASK;
+        ULONG length = marker & RECORD_VALUE_MASK;
+
+        if (marker == RECORD_END)
+            return FALSE;
+        if (type == RECORD_APP)
+        {
+            if (pos + 1 + length >= EEPROM_SIZE)
+                return FALSE;
+            app = pos;
+            appMatches = name_equal(image + pos + 1, length, wantedApp);
+            pos += 1 + length;
+        }
+        else if (type == RECORD_ITEM && app != 0)
+        {
+            struct AkikoItem item;
+            if (!parse_item(image, app, pos, &item))
+                return FALSE;
+            if (appMatches && name_equal(image + pos + 1, length, wantedItem))
+            {
+                if (found)
+                    *found = item;
+                return TRUE;
+            }
+            pos = item.end;
+        }
+        else
+            return FALSE;
+    }
+    return FALSE;
+}
+
+static BOOL image_end(const UBYTE *image, ULONG *end)
+{
+    ULONG pos = EEPROM_RECORD_START;
+    ULONG app = 0;
+
+    while (pos < EEPROM_SIZE)
+    {
+        UBYTE marker = image[pos];
+        ULONG type = marker & RECORD_TYPE_MASK;
+        ULONG length = marker & RECORD_VALUE_MASK;
+
+        if (marker == RECORD_END)
+        {
+            *end = pos;
+            return TRUE;
+        }
+        if (type == RECORD_APP)
+        {
+            if (pos + 1 + length >= EEPROM_SIZE)
+                return FALSE;
+            app = pos;
+            pos += 1 + length;
+        }
+        else if (type == RECORD_ITEM && app != 0)
+        {
+            struct AkikoItem item;
+            if (!parse_item(image, app, pos, &item))
+                return FALSE;
+            pos = item.end;
+        }
+        else
+            return FALSE;
+    }
+    return FALSE;
+}
+
+static UBYTE *load_images(UBYTE **oldImage)
+{
+    UBYTE *memory = AllocVec(EEPROM_SIZE * 2, MEMF_ANY);
+
+    if (!memory)
+        return NULL;
+    *oldImage = memory;
+    if (!eeprom_read(memory))
+    {
+        FreeVec(memory);
+        return NULL;
+    }
+    CopyMem(memory, memory + EEPROM_SIZE, EEPROM_SIZE);
+    if (!image_valid(memory + EEPROM_SIZE))
+        image_init(memory + EEPROM_SIZE);
+    return memory + EEPROM_SIZE;
+}
+
+BOOL NVDisk_ArchInit(struct NVDBase *base)
+{
+    struct SignalSemaphore *semaphore;
+
+    if (AKIKO_ID_ADDR != AKIKO_ID_MAGIC)
+        return FALSE;
+    semaphore = AllocMem(sizeof(*semaphore), MEMF_PUBLIC | MEMF_CLEAR);
+    if (!semaphore)
+        return FALSE;
+    InitSemaphore(semaphore);
+    base->nvd_location = AKIKO_LOCATION;
+    base->nvd_DOSBase = (struct Library *)semaphore;
+    return TRUE;
+}
+
+BOOL NVDisk_ArchActive(const struct NVDBase *base)
+{
+    return base->nvd_location == AKIKO_LOCATION;
+}
+
+void NVDisk_ArchExpunge(struct NVDBase *base)
+{
+    FreeMem(base->nvd_DOSBase, sizeof(struct SignalSemaphore));
+}
+
+APTR NVDisk_ArchRead(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName)
+{
+    UBYTE *image = AllocVec(EEPROM_SIZE, MEMF_ANY);
+    APTR result = NULL;
+    struct AkikoItem item;
+
+    if (!image)
+        return NULL;
+    ObtainSemaphore(akiko_lock(base));
+    if (eeprom_read(image) && image_valid(image) &&
+        find_item(image, appName, itemName, &item))
+    {
+        result = AllocVec(item.length, MEMF_ANY);
+        if (result)
+            CopyMem(image + item.data, result, item.length);
+    }
+    ReleaseSemaphore(akiko_lock(base));
+    FreeVec(image);
+    return result;
+}
+
+LONG NVDisk_ArchWrite(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName, CONST_APTR data, ULONG length)
+{
+    UBYTE *oldImage;
+    UBYTE *image;
+    struct AkikoItem item;
+    ULONG end, appLength = strlen(appName), itemLength = strlen(itemName);
+    ULONG needed;
+    BOOL reuseApp = FALSE;
+    LONG result = NVERR_FAIL;
+
+    if (appLength > 31 || itemLength > 31 || length > 0x1fff)
+        return NVERR_BADNAME;
+
+    ObtainSemaphore(akiko_lock(base));
+    image = load_images(&oldImage);
+    if (!image)
+        goto out;
+
+    if (find_item(image, appName, itemName, &item))
+    {
+        if (image[item.protection] & RECORD_LOCKED)
+        {
+            result = NVERR_WRITEPROT;
+            goto free;
+        }
+        reuseApp = image[item.end] == RECORD_END;
+        memmove(image + item.item, image + item.end,
+            EEPROM_SIZE - item.end);
+    }
+    needed = (reuseApp ? 0 : 1 + appLength) +
+        1 + itemLength + 1 + 2 + length + 1;
+    if (!image_end(image, &end) || end + needed > EEPROM_SIZE)
+        goto free;
+
+    if (!reuseApp)
+    {
+        image[end++] = RECORD_APP | appLength;
+        CopyMem(appName, image + end, appLength);
+        end += appLength;
+    }
+    image[end++] = RECORD_ITEM | itemLength;
+    CopyMem(itemName, image + end, itemLength);
+    end += itemLength;
+    image[end++] = 0;
+    image[end++] = RECORD_LENGTH | ((length >> 8) & RECORD_VALUE_MASK);
+    image[end++] = length;
+    CopyMem(data, image + end, length);
+    end += length;
+    image[end] = RECORD_END;
+
+    result = eeprom_write_changed(oldImage, image) ? 0 : NVERR_FATAL;
+free:
+    FreeVec(oldImage);
+out:
+    ReleaseSemaphore(akiko_lock(base));
+    return result;
+}
+
+BOOL NVDisk_ArchDelete(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName)
+{
+    UBYTE *oldImage;
+    UBYTE *image;
+    struct AkikoItem item;
+    BOOL result = FALSE;
+
+    ObtainSemaphore(akiko_lock(base));
+    image = load_images(&oldImage);
+    if (image && find_item(image, appName, itemName, &item) &&
+        !(image[item.protection] & RECORD_LOCKED))
+    {
+        memmove(image + item.item, image + item.end,
+            EEPROM_SIZE - item.end);
+        result = eeprom_write_changed(oldImage, image);
+    }
+    if (image)
+        FreeVec(oldImage);
+    ReleaseSemaphore(akiko_lock(base));
+    return result;
+}
+
+BOOL NVDisk_ArchInfo(struct NVDBase *base, struct NVInfo *info)
+{
+    UBYTE *image = AllocVec(EEPROM_SIZE, MEMF_ANY);
+    ULONG end;
+    BOOL result = FALSE;
+
+    if (!image)
+        return FALSE;
+    ObtainSemaphore(akiko_lock(base));
+    if (eeprom_read(image))
+    {
+        if (!image_valid(image))
+            image_init(image);
+        if (image_end(image, &end))
+        {
+            info->nvi_MaxStorage = EEPROM_SIZE - EEPROM_RECORD_START;
+            info->nvi_FreeStorage = EEPROM_SIZE - end - 1;
+            result = TRUE;
+        }
+    }
+    ReleaseSemaphore(akiko_lock(base));
+    FreeVec(image);
+    return result;
+}
+
+BOOL NVDisk_ArchProtect(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName, ULONG mask)
+{
+    UBYTE *oldImage;
+    UBYTE *image;
+    struct AkikoItem item;
+    BOOL result = FALSE;
+
+    ObtainSemaphore(akiko_lock(base));
+    image = load_images(&oldImage);
+    if (image && find_item(image, appName, itemName, &item))
+    {
+        if (mask & NVEF_DELETE)
+            image[item.protection] |= RECORD_LOCKED;
+        else
+            image[item.protection] &= ~RECORD_LOCKED;
+        result = eeprom_write_changed(oldImage, image);
+    }
+    if (image)
+        FreeVec(oldImage);
+    ReleaseSemaphore(akiko_lock(base));
+    return result;
+}
+
+struct MinList *NVDisk_ArchList(struct NVDBase *base, CONST_STRPTR appName)
+{
+    UBYTE *image = AllocVec(EEPROM_SIZE, MEMF_ANY);
+    struct MinList *result = NULL;
+    ULONG pos = EEPROM_RECORD_START, app = 0, count = 0, offset;
+    BOOL appMatches = FALSE;
+
+    if (!image)
+        return NULL;
+    ObtainSemaphore(akiko_lock(base));
+    if (!eeprom_read(image) || !image_valid(image))
+        goto out;
+
+    while (pos < EEPROM_SIZE && image[pos] != RECORD_END)
+    {
+        ULONG type = image[pos] & RECORD_TYPE_MASK;
+        ULONG length = image[pos] & RECORD_VALUE_MASK;
+        if (type == RECORD_APP)
+        {
+            app = pos;
+            appMatches = name_equal(image + pos + 1, length, appName);
+            pos += 1 + length;
+        }
+        else if (type == RECORD_ITEM && app)
+        {
+            struct AkikoItem item;
+            if (!parse_item(image, app, pos, &item))
+                goto out;
+            if (appMatches)
+                count++;
+            pos = item.end;
+        }
+        else
+            goto out;
+    }
+
+    result = AllocVec(sizeof(*result) + count * NV_NODESIZE, MEMF_CLEAR);
+    if (!result)
+        goto out;
+    NEWLIST((struct List *)result);
+    pos = EEPROM_RECORD_START;
+    app = 0;
+    appMatches = FALSE;
+    offset = sizeof(*result);
+    while (pos < EEPROM_SIZE && image[pos] != RECORD_END)
+    {
+        ULONG type = image[pos] & RECORD_TYPE_MASK;
+        ULONG length = image[pos] & RECORD_VALUE_MASK;
+        if (type == RECORD_APP)
+        {
+            app = pos;
+            appMatches = name_equal(image + pos + 1, length, appName);
+            pos += 1 + length;
+        }
+        else
+        {
+            struct AkikoItem item;
+            if (!parse_item(image, app, pos, &item))
+                break;
+            if (appMatches)
+            {
+                struct NVEntry *entry =
+                    (struct NVEntry *)((UBYTE *)result + offset);
+                ULONG nameLength = image[pos] & RECORD_VALUE_MASK;
+                entry->nve_Name = (STRPTR)entry + sizeof(*entry);
+                CopyMem(image + pos + 1, entry->nve_Name, nameLength);
+                entry->nve_Name[nameLength] = 0;
+                entry->nve_Size = item.length;
+                entry->nve_Protection =
+                    (image[item.protection] & RECORD_LOCKED) ?
+                    NVEF_DELETE : 0;
+                AddTail((struct List *)result, (struct Node *)entry);
+                offset += NV_NODESIZE;
+            }
+            pos = item.end;
+        }
+    }
+out:
+    ReleaseSemaphore(akiko_lock(base));
+    FreeVec(image);
+    return result;
+}

--- a/arch/m68k-amiga/nvdisk/mmakefile.src
+++ b/arch/m68k-amiga/nvdisk/mmakefile.src
@@ -1,0 +1,15 @@
+include $(SRCDIR)/config/aros.cfg
+
+%set_archincludes mainmmake=workbench-libs-nvdisk \
+  maindir=workbench/libs/nonvolatile/nvdisk \
+  modname=nvdisk pri=0 arch=amiga-m68k \
+  includes="-I$(SRCDIR)/$(CURDIR)"
+
+USER_INCLUDES := -I$(SRCDIR)/workbench/libs/nonvolatile/nvdisk
+
+%build_archspecific \
+  mainmmake=workbench-libs-nvdisk \
+  maindir=workbench/libs/nonvolatile/nvdisk \
+  arch=amiga-m68k modname=nvdisk files="akiko"
+
+%common

--- a/arch/m68k-amiga/nvdisk/nvdisk_arch.h
+++ b/arch/m68k-amiga/nvdisk/nvdisk_arch.h
@@ -1,0 +1,25 @@
+#ifndef NVDISK_ARCH_H
+#define NVDISK_ARCH_H
+
+#include <exec/types.h>
+#include <exec/lists.h>
+#include <libraries/nonvolatile.h>
+
+struct NVDBase;
+
+BOOL NVDisk_ArchInit(struct NVDBase *base);
+BOOL NVDisk_ArchActive(const struct NVDBase *base);
+void NVDisk_ArchExpunge(struct NVDBase *base);
+APTR NVDisk_ArchRead(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName);
+LONG NVDisk_ArchWrite(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName, CONST_APTR data, ULONG length);
+BOOL NVDisk_ArchDelete(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName);
+BOOL NVDisk_ArchInfo(struct NVDBase *base, struct NVInfo *info);
+BOOL NVDisk_ArchProtect(struct NVDBase *base, CONST_STRPTR appName,
+    CONST_STRPTR itemName, ULONG mask);
+struct MinList *NVDisk_ArchList(struct NVDBase *base,
+    CONST_STRPTR appName);
+
+#endif

--- a/arch/m68k-amiga/timer/lowlevel.c
+++ b/arch/m68k-amiga/timer/lowlevel.c
@@ -118,7 +118,15 @@ void CheckTimer(struct TimerBase *TimerBase, UWORD unitnum)
                 if (!TimerBase->tb_micro_on) {
                         // not active, kickstart it
                         TimerBase->tb_micro_on = TRUE;
-                        TimerBase->tb_micro_started = 0;
+                        /* AbortIO() can leave the one-shot CIA timer stopped
+                         * with no pending interrupt.  Start a one-tick timer
+                         * so ciaint_timer() can program the real deadline. */
+                        TimerBase->tb_micro_started = 1;
+                        *TimerBase->tb_micro_cr &= 0x40;
+                        *TimerBase->tb_micro_cr |= 0x08;
+                        *TimerBase->tb_micro_lo = 1;
+                        *TimerBase->tb_micro_hi = 0;
+                        *TimerBase->tb_micro_cr |= 0x01;
                         D(bug("ciaint_timer kickstarted\n"));
                 } else {
                         UBYTE lo, hi;

--- a/compiler/include/devices/cd.h
+++ b/compiler/include/devices/cd.h
@@ -157,19 +157,19 @@ union CDTOC {
 #define CD_READXL_INTP(n, cdxl, data) \
     AROS_UFP3(VOID, n, \
             AROS_UFPA(struct CDXL *, cdxl, A2), \
-            AROS_UFPA(APTR, data, A4), \
+            AROS_UFPA(APTR, data, A1), \
             AROS_UFPA(struct ExecBase *, __cxdl_SysBase, A6))
 
 #define CD_READXL_INTC(n, cdxl, data) \
     AROS_UFC3(VOID, n, \
             AROS_UFCA(struct CDXL *, cdxl, A2), \
-            AROS_UFCA(APTR, data, A4), \
+            AROS_UFCA(APTR, data, A1), \
             AROS_UFCA(struct ExecBase *, SysBase, A6))
 
 #define CD_READXL_INTH(n, cdxl, data) \
     AROS_UFH3(VOID, n, \
             AROS_UFHA(struct CDXL *, cdxl, A2), \
-            AROS_UFHA(APTR, data, A4), \
+            AROS_UFHA(APTR, data, A1), \
             AROS_UFHA(struct ExecBase *, SysBase, A6))
 
 #define CD_READXL_INTFUNC_INIT  AROS_USERFUNC_INIT

--- a/rom/devs/console/console_gcc.h
+++ b/rom/devs/console/console_gcc.h
@@ -22,11 +22,11 @@ struct ConsoleBase;
 /* Constants */
 /*
  * The console task renders through intuition/graphics, but its measured
- * peak on m68k stays under 1 KB even with a console window open; 8 KB
- * keeps generous headroom without pinning 16 KB of chip RAM.
+ * peak on m68k stays under 1 KB even with a console window open; 4 KB
+ * retains more than four times that measured requirement.
  */
 #ifdef __mc68000
-#define COTASK_STACKSIZE (8192 + 4)
+#define COTASK_STACKSIZE (4096 + 4)
 #else
 #define COTASK_STACKSIZE (AROS_STACKSIZE + 4)
 #endif

--- a/rom/devs/input/input.c
+++ b/rom/devs/input/input.c
@@ -29,6 +29,9 @@
 
 static const UWORD SupportedCommands[] =
 {
+    CMD_RESET,
+    CMD_STOP,
+    CMD_START,
     IND_ADDHANDLER,
     IND_REMHANDLER,
     IND_WRITEEVENT,
@@ -149,6 +152,9 @@ AROS_LH1(void, beginio,
     case IND_ADDEVENT:
     case IND_SETTHRESH:
     case IND_SETPERIOD:
+    case CMD_RESET:
+    case CMD_STOP:
+    case CMD_START:
         done_quick = FALSE;
         break;
 

--- a/rom/devs/input/input_intern.h
+++ b/rom/devs/input/input_intern.h
@@ -33,10 +33,9 @@
 /* Size of the input device's stack. Input handlers run on it, so it
  * keeps generous headroom over the measured peak (under 1 KB on m68k);
  * Kickstart gives its input.device task 4 KB and handlers are expected
- * to be frugal, so 8 KB is still double the classic budget without
- * pinning 26 KB of chip RAM. */
+ * to be frugal, so use the same size after measuring a peak below 1 KB. */
 #ifdef __mc68000
-#define IDTASK_STACKSIZE    	    8192
+#define IDTASK_STACKSIZE    	    4096
 #else
 #define IDTASK_STACKSIZE    	    (AROS_STACKSIZE + 10240)
 #endif

--- a/rom/devs/input/input_intern.h
+++ b/rom/devs/input/input_intern.h
@@ -69,6 +69,7 @@ struct inputbase
     UBYTE Prev1DownQual;
     UBYTE Prev2DownCode;
     UBYTE Prev2DownQual;
+    BOOL Stopped;
 };
 
 /* Prototypes */

--- a/rom/devs/input/processevents.c
+++ b/rom/devs/input/processevents.c
@@ -97,7 +97,7 @@ VOID ForwardQueuedEvents(struct inputbase *InputDevice)
     struct Interrupt *ihiterator;
 
     ie_chain = GetEventsFromQueue(InputDevice);
-    if (ie_chain)
+    if (ie_chain && !InputDevice->Stopped)
     {
         ForeachNode(&(InputDevice->HandlerList), ihiterator)
         {
@@ -261,34 +261,12 @@ void ProcessEvents(struct inputbase *InputDevice)
 
     for (;;)
     {
-        wakeupsigs = Wait(commandsig |
-            kbdsig |
-            gpdsig | timersig | keytimersig | InputDevice->ResetSig);
+        wakeupsigs = Wait(commandsig | InputDevice->ResetSig |
+            (InputDevice->Stopped ? 0 :
+                (kbdsig | gpdsig | timersig | keytimersig)));
 
         D(bug("Wakeup sig: %x, cmdsig: %x, kbdsig: %x\n, timersig: %x",
                 wakeupsigs, commandsig, kbdsig, timersig));
-
-        if (wakeupsigs & timersig)
-        {
-            struct InputEvent timer_ie;
-
-            GetMsg(timermp);
-
-            timer_ie.ie_NextEvent = NULL;
-            timer_ie.ie_Class = IECLASS_TIMER;
-            timer_ie.ie_SubClass = 0;
-            timer_ie.ie_Code = 0;
-            timer_ie.ie_Qualifier = InputDevice->ActQualifier;
-            timer_ie.ie_position.ie_addr = 0;
-
-            /* Add a timestamp to the event */
-            GetSysTime(&(timer_ie.ie_TimeStamp));
-
-            AddEQTail(&timer_ie, InputDevice);
-            ForwardQueuedEvents(InputDevice);
-
-            SEND_TIMER_REQUEST(timerio);
-        }
 
         if (wakeupsigs & commandsig)
         {
@@ -301,6 +279,15 @@ void ProcessEvents(struct inputbase *InputDevice)
 
                 switch (ioreq->io_Command)
                 {
+                case CMD_STOP:
+                    InputDevice->Stopped = TRUE;
+                    break;
+
+                case CMD_START:
+                case CMD_RESET:
+                    InputDevice->Stopped = FALSE;
+                    break;
+
                 case IND_ADDHANDLER:
 #ifdef __mc68000
                     /* Older m68k programs copied input handler code without
@@ -447,7 +434,29 @@ void ProcessEvents(struct inputbase *InputDevice)
             }
         }
 
-        if (wakeupsigs & keytimersig)
+        if (!InputDevice->Stopped && (wakeupsigs & timersig))
+        {
+            struct InputEvent timer_ie;
+
+            GetMsg(timermp);
+
+            timer_ie.ie_NextEvent = NULL;
+            timer_ie.ie_Class = IECLASS_TIMER;
+            timer_ie.ie_SubClass = 0;
+            timer_ie.ie_Code = 0;
+            timer_ie.ie_Qualifier = InputDevice->ActQualifier;
+            timer_ie.ie_position.ie_addr = 0;
+
+            /* Add a timestamp to the event */
+            GetSysTime(&(timer_ie.ie_TimeStamp));
+
+            AddEQTail(&timer_ie, InputDevice);
+            ForwardQueuedEvents(InputDevice);
+
+            SEND_TIMER_REQUEST(timerio);
+        }
+
+        if (!InputDevice->Stopped && (wakeupsigs & keytimersig))
         {
             struct InputEvent ie;
 
@@ -470,7 +479,7 @@ void ProcessEvents(struct inputbase *InputDevice)
                 InputDevice->KeyRepeatInterval);
         }
 
-        if (wakeupsigs & kbdsig)
+        if (!InputDevice->Stopped && (wakeupsigs & kbdsig))
         {
             GetMsg(kbdmp);      /* Only one message */
             if (kbdio->io_Error != 0)
@@ -521,7 +530,7 @@ void ProcessEvents(struct inputbase *InputDevice)
             SEND_KBD_REQUEST(kbdio, kbdie);
         }
 
-        if (wakeupsigs & gpdsig)
+        if (!InputDevice->Stopped && (wakeupsigs & gpdsig))
         {
             GetMsg(gpdmp);      /* Only one message */
             if (gpdio->io_Error != 0)

--- a/rom/dos/cliinit.c
+++ b/rom/dos/cliinit.c
@@ -188,10 +188,9 @@ static void internalSetTimeFromBootVolume(BPTR lock, struct DosLibrary *DOSBase)
      * This process mounts the boot volume and then becomes the initial
      * shell; commands it launches run on their own cli_DefaultStack
      * stacks, so its own stack only carries mount packets and script
-     * parsing. 8 KB is double the classic shell budget, and the block
-     * is chip RAM on an unexpanded machine.
+     * parsing. Its measured peak during CD32 boot is below 2 KB.
      */
-    mp = CreateProc("Boot Mount", 0, seg, 8192);
+    mp = CreateProc("Boot Mount", 0, seg, 4096);
 #else
     mp = CreateProc("Boot Mount", 0, seg, AROS_STACKSIZE);
 #endif

--- a/rom/dos/createnewproc.c
+++ b/rom/dos/createnewproc.c
@@ -23,10 +23,19 @@
 #include <proto/m68kemu.h>
 
 #include "dos_intern.h"
+#include <dos_platform.h>
 #include LC_LIBDEFS_FILE
 #include <string.h>
 
 #define SEGARRAY_LENGTH 6       /* Minimum needed for HUNK overlays */
+
+#ifndef PROC_STACKSIZE
+#define PROC_STACKSIZE AROS_STACKSIZE
+#endif
+
+#ifndef PROC_MINSTACKSIZE
+#define PROC_MINSTACKSIZE PROC_STACKSIZE
+#endif
 
 static void DosEntry(void);
 static void freeLocalVars(struct Process *process, struct DosLibrary *DOSBase);
@@ -104,7 +113,7 @@ void internal_ChildFree(APTR tid, struct DosLibrary * DOSBase);
     /* 6 */    { NP_Error         , TAGDATA_NOT_SPECIFIED       },
     /* 7 */    { NP_CloseError    , 1                           },
     /* 8 */    { NP_CurrentDir    , TAGDATA_NOT_SPECIFIED       },
-    /* 9 */    { NP_StackSize     , AROS_STACKSIZE              },
+    /* 9 */    { NP_StackSize     , PROC_STACKSIZE              },
     /*10 */    { NP_Name          , (IPTR)"New Process"         },
     /*11 */    { NP_Priority      , me->pr_Task.tc_Node.ln_Pri  },
     /*12 */    { NP_Arguments     , TAGDATA_NOT_SPECIFIED       },
@@ -139,7 +148,7 @@ void internal_ChildFree(APTR tid, struct DosLibrary * DOSBase);
             LONG parentstack = cli->cli_DefaultStack * CLI_DEFAULTSTACK_UNIT;
 
             D(bug("[createnewproc] Parent stack: %u (0x%08X)\n", parentstack, parentstack));
-            if (parentstack > AROS_STACKSIZE)
+            if (parentstack > PROC_STACKSIZE)
             {
                 defaults[9].ti_Data = parentstack;
             }
@@ -220,10 +229,10 @@ void internal_ChildFree(APTR tid, struct DosLibrary * DOSBase);
      * Yes, 64-bit systems appear to be strictly typed in such places.
      */
     process->pr_StackSize = defaults[9].ti_Data;
-    /* We need a minimum stack to handle interrupt contexts */
-    if (process->pr_StackSize < AROS_STACKSIZE)
+    /* Enforce the platform's minimum process stack. */
+    if (process->pr_StackSize < PROC_MINSTACKSIZE)
     {
-        process->pr_StackSize = AROS_STACKSIZE;
+        process->pr_StackSize = PROC_MINSTACKSIZE;
     }
 
     stack = AllocMem(process->pr_StackSize, MEMF_PUBLIC);

--- a/rom/dos/dos_platform.h
+++ b/rom/dos/dos_platform.h
@@ -1,0 +1,7 @@
+#ifndef DOS_PLATFORM_H
+#define DOS_PLATFORM_H
+
+/* Architecture-specific DOS policy may be supplied by an earlier include
+ * directory selected by the build system. */
+
+#endif

--- a/rom/dos/mmakefile.src
+++ b/rom/dos/mmakefile.src
@@ -1,12 +1,15 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+%get_archincludes modname=dos \
+    includeflag=TARGET_DOS_INCLUDES maindir=$(CURDIR)
+
 REPODIR      ?= $(SRCDIR)
 REPOTYPE     := $(shell $(SRCDIR)/scripts/repo_type.sh $(REPODIR))
 REPOREVISION := $(shell $(SRCDIR)/scripts/repo_rev.sh $(REPODIR))
 REPOID       := $(shell $(SRCDIR)/scripts/repo_id.sh $(REPODIR))
 
-USER_INCLUDES := -I$(GENDIR)/$(CURDIR)/dos
+USER_INCLUDES := $(TARGET_DOS_INCLUDES) -I$(GENDIR)/$(CURDIR)/dos
 DOS_CPPFLAGS := \
                -DUSE_EXEC_DEBUG \
 	       -D__DOS_NOLIBBASE__ \

--- a/rom/dos/systemtaglist.c
+++ b/rom/dos/systemtaglist.c
@@ -364,7 +364,12 @@
             { NP_Entry      , (IPTR)entry                   }, /* 13 */
             { NP_CurrentDir , (IPTR)BNULL                   }, /* 14 */
             { NP_ConsoleTask, (IPTR)BNULL,                  }, /* 15 */
-            { TAG_END       , 0                             }  /* 16 */
+#ifdef __mc68000
+            /* Shell-seg itself peaks below 2 KB during CD32 boot. Commands
+             * retain the conservative 8 KB m68k process default. */
+            { NP_StackSize  , 4096                          }, /* 16 */
+#endif
+            { TAG_END       , 0                             }  /* 17 */
         };
 
         Tag filterList[] =

--- a/rom/exec/exec_init.c
+++ b/rom/exec/exec_init.c
@@ -339,11 +339,10 @@ int Exec_InitServices(struct ExecBase *SysBase)
                   TASKTAG_PRI        , 126,
 #ifdef __mc68000
                   /*
-                   * Idle until an alert fires; the alert display path
-                   * runs well within 8 KB and the stack is chip RAM on
-                   * an unexpanded machine.
+                   * Idle until an alert fires; its normal-path peak is a
+                   * few hundred bytes and 4 KB matches the m68k task floor.
                    */
-                  TASKTAG_STACKSIZE  , 8192,
+                  TASKTAG_STACKSIZE  , 4096,
 #endif
                   TASKTAG_PC         , SupervisorAlertTask,
                   TASKTAG_ARG1       , SysBase,

--- a/rom/filesys/CDVDFS/src/prefs.c
+++ b/rom/filesys/CDVDFS/src/prefs.c
@@ -23,25 +23,30 @@ void SAVEDS Prefs_Process (void)
     global = (APTR)msg->mn_Node.ln_Name;
 
     D(bug("Prefs handler process started for CDVDBase %lx\n", (IPTR)global));
+
+    /* Open codesets.library outside the filesystem handler context: loading
+     * it can itself issue filesystem requests.  If it is unavailable (as on
+     * CD32 game discs), there is no late-retry signal implemented here, so
+     * retaining this process and its stack serves no purpose. */
+    InitCharset(global);
+    if (!CodesetsBase)
+    {
+        global->PrefsProc = NULL;
+        ReplyMsg(msg);
+        return;
+    }
+
     ReplyMsg(msg);
 
     do
     {
 	/*
-	 * Init character set translation only from within here
-	 * because this can trigger loading some files from disk,
-	 * which in turn can trigger new requests to our handler.
-	 */
-	InitCharset(global);
-
-	/*
 	 * TODO:
 	 * 1. In future this process will be responsible for reading
 	 *    preferences file from disk.
 	 * 2. For AROS we need some way to trigger late codesets.library
-	 *    initialization. CDVDFS is mounder before SYS: is available.
+	 *    initialization. CDVDFS is mounted before SYS: is available.
 	 */
-
 	Sigset = Wait(SIGBREAKF_CTRL_C|SIGBREAKF_CTRL_D);
     } while (!(Sigset & SIGBREAKF_CTRL_C));
 

--- a/rom/lddemon/lddemon.c
+++ b/rom/lddemon/lddemon.c
@@ -834,6 +834,10 @@ static ULONG LDDemon_Init(struct IntLDDemonBase *ldBase)
         { NP_WindowPtr, -1 },
         { NP_Name, (IPTR)ldDemonName },
         { NP_Priority, 5 },
+#ifdef __mc68000
+        /* The loader daemon peaks below 1 KB during CD32 boot. */
+        { NP_StackSize, 4096 },
+#endif
         { TAG_END , 0 }
     };
 

--- a/workbench/libs/lowlevel/lowlevel_init.c
+++ b/workbench/libs/lowlevel/lowlevel_init.c
@@ -231,6 +231,7 @@ static int Init(LIBBASETYPEPTR LowLevelBase)
     NEWLIST(&LowLevelBase->ll_KBInterrupts);
     LowLevelBase->ll_LastKey = 0xFF;
     LowLevelBase->ll_SysReqNest = -1;
+    LowLevelBase->ll_InputNest = -1;
 
     if ((LowLevelBase->ll_UtilityBase = OpenLibrary("utility.library", 0)))
     {

--- a/workbench/libs/lowlevel/lowlevel_intern.h
+++ b/workbench/libs/lowlevel/lowlevel_intern.h
@@ -68,6 +68,9 @@ struct LowLevelBase
     APTR                        ll_EasyRequestOrig;
     LONG                        ll_SysReqNest;
 
+    struct Task                 *ll_InputOwner;
+    BYTE                        ll_InputNest;
+
     struct llArchData           ll_Arch;
 };
 
@@ -80,4 +83,3 @@ VOID llSysReq_Cleanup(struct LowLevelBase *LowLevelBase);
  */
 
 #endif /* __LOWLEVEL_INTERN_H__  */
-

--- a/workbench/libs/lowlevel/systemcontrola.c
+++ b/workbench/libs/lowlevel/systemcontrola.c
@@ -10,10 +10,57 @@
 
 #include <aros/libcall.h>
 #include <exec/types.h>
+#include <exec/io.h>
 #include <dos/dosextens.h>
 #include <libraries/lowlevel.h>
 
 #include "lowlevel_intern.h"
+
+static BOOL SetInputState(BOOL stop, struct LowLevelBase *LowLevelBase)
+{
+    struct Task *me = FindTask(NULL);
+    struct MsgPort *port;
+    struct IOStdReq *io;
+    BOOL change = FALSE;
+    BOOL success = TRUE;
+
+    Forbid();
+    if (LowLevelBase->ll_InputOwner == NULL)
+        LowLevelBase->ll_InputOwner = me;
+
+    if (LowLevelBase->ll_InputOwner != me)
+        success = FALSE;
+    else if (stop)
+        change = (++LowLevelBase->ll_InputNest == 0);
+    else if (LowLevelBase->ll_InputNest >= 0)
+    {
+        change = (--LowLevelBase->ll_InputNest < 0);
+        if (change)
+            LowLevelBase->ll_InputOwner = NULL;
+    }
+    Permit();
+
+    if (!success || !change)
+        return success;
+
+    port = CreateMsgPort();
+    io = port ? (struct IOStdReq *)CreateIORequest(port, sizeof(*io)) : NULL;
+    if (io && OpenDevice("input.device", 0, (struct IORequest *)io, 0) == 0)
+    {
+        io->io_Command = stop ? CMD_STOP : CMD_RESET;
+        success = DoIO((struct IORequest *)io) == 0;
+        CloseDevice((struct IORequest *)io);
+    }
+    else
+        success = FALSE;
+
+    if (io)
+        DeleteIORequest((struct IORequest *)io);
+    if (port)
+        DeleteMsgPort(port);
+
+    return success;
+}
 
 /*****************************************************************************
 
@@ -76,7 +123,7 @@
         of queried controls.
 
     BUGS
-        This function’s implementation is incomplete and not all control
+        This function's implementation is incomplete and not all control
         tags are acted upon in current releases.
 
     SEE ALSO
@@ -84,7 +131,7 @@
 
     INTERNALS
         SystemControlA() modifies or queries global state flags held within
-        lowlevel.library.  These flags are checked by the library’s input
+        lowlevel.library.  These flags are checked by the library's input
         handling routines to determine whether to pass events to the system
         or suppress them for exclusive mode operation.
 
@@ -97,7 +144,6 @@
 
     D(bug("[lowlevel] %s()\n", __func__);)
 
-    /* For now, dump all tags in debug mode */
     while ((tag = LibNextTagItem(&tagp))) {
         switch (tag->ti_Tag)
         {
@@ -120,8 +166,12 @@
                 }
                 break;
 
-        case SCON_CDReboot:
         case SCON_StopInput:
+                if (!SetInputState(tag->ti_Data != 0, LowLevelBase))
+                    failtag = tag->ti_Tag;
+                break;
+
+        case SCON_CDReboot:
         case SCON_RemCreateKeys:
         default:
                 D(bug("%s: Tag SCON_Dummy+%d, Data %p\n", __func__, tag->ti_Tag - SCON_Dummy, (APTR)tag->ti_Data));

--- a/workbench/libs/nonvolatile/nvdisk/deletenvddata.c
+++ b/workbench/libs/nonvolatile/nvdisk/deletenvddata.c
@@ -11,6 +11,7 @@
 #include <aros/debug.h>
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 
 #include <dos/dos.h>
 #include <proto/dos.h>
@@ -62,6 +63,9 @@ AROS_LH2(BOOL, DeleteNVDData,
 
 {
     AROS_LIBFUNC_INIT
+
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchDelete(GPB(nvdBase), appName, itemName);
 
     BPTR oldCDir = CurrentDir(GPB(nvdBase)->nvd_location);
     BPTR lock = Lock(appName, SHARED_LOCK);

--- a/workbench/libs/nonvolatile/nvdisk/getnvditemlist.c
+++ b/workbench/libs/nonvolatile/nvdisk/getnvditemlist.c
@@ -9,6 +9,7 @@
     NAME */
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 #include <dos/dos.h>
 #include <exec/memory.h>
 #include <exec/nodes.h>
@@ -68,6 +69,9 @@ AROS_LH1(struct MinList *, GetNVDItemList,
 
 {
     AROS_LIBFUNC_INIT
+
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchList(GPB(nvdBase), appName);
 
     BPTR            lock;
     BPTR            oldCDir;
@@ -186,4 +190,3 @@ void FreeAll(struct MinList *ml, struct Library *nvdBase)
 }
 
 #undef  NV_NODESIZE
-

--- a/workbench/libs/nonvolatile/nvdisk/meminfonvd.c
+++ b/workbench/libs/nonvolatile/nvdisk/meminfonvd.c
@@ -9,6 +9,7 @@
     NAME */
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 #include <dos/dos.h>
 #include <proto/dos.h>
 #include <libraries/nonvolatile.h>
@@ -60,6 +61,9 @@ AROS_LH1(BOOL, MemInfoNVD,
 
 {
     AROS_LIBFUNC_INIT
+
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchInfo(GPB(nvdBase), nvInfo);
 
     struct InfoData info;
 

--- a/workbench/libs/nonvolatile/nvdisk/mmakefile.src
+++ b/workbench/libs/nonvolatile/nvdisk/mmakefile.src
@@ -3,6 +3,12 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_LDFLAGS := -static
 
+%get_archincludes modname=nvdisk \
+    includeflag=TARGET_NVDISK_INCLUDES \
+    maindir=workbench/libs/nonvolatile/nvdisk
+
+USER_INCLUDES := $(TARGET_NVDISK_INCLUDES)
+
 FUNCS := meminfonvd \
 	 readnvddata \
 	 setnvdprotection \

--- a/workbench/libs/nonvolatile/nvdisk/nvdisk_arch.h
+++ b/workbench/libs/nonvolatile/nvdisk/nvdisk_arch.h
@@ -1,0 +1,17 @@
+#ifndef NVDISK_ARCH_H
+#define NVDISK_ARCH_H
+
+/* Platforms without a native nonvolatile-storage backend use the filesystem
+ * implementation in nvdisk.library.  These constants let the compiler remove
+ * the architecture dispatch entirely. */
+#define NVDisk_ArchInit(base)                         FALSE
+#define NVDisk_ArchActive(base)                       FALSE
+#define NVDisk_ArchExpunge(base)                      ((void)0)
+#define NVDisk_ArchRead(base, appName, itemName)      ((APTR)0)
+#define NVDisk_ArchWrite(base, appName, itemName, data, length) 0
+#define NVDisk_ArchDelete(base, appName, itemName)    FALSE
+#define NVDisk_ArchInfo(base, info)                   FALSE
+#define NVDisk_ArchProtect(base, appName, itemName, mask) FALSE
+#define NVDisk_ArchList(base, appName)                ((struct MinList *)0)
+
+#endif

--- a/workbench/libs/nonvolatile/nvdisk/nvdisk_init.c
+++ b/workbench/libs/nonvolatile/nvdisk/nvdisk_init.c
@@ -8,6 +8,7 @@
 #define  DEBUG  0
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 
 #include <aros/debug.h>
 
@@ -35,6 +36,9 @@ static int Init(LIBBASETYPEPTR LIBBASE)
     BOOL error = TRUE;    // Notice the initialization to 'TRUE' here.
     char *temp = NULL;
     BPTR locFile;
+
+    if (NVDisk_ArchInit(LIBBASE))
+        return TRUE;
 
     LIBBASE->nvd_DOSBase = OpenLibrary("dos.library",0);
     if (LIBBASE->nvd_DOSBase == NULL)
@@ -99,6 +103,12 @@ static int Expunge(LIBBASETYPEPTR LIBBASE)
         This function is single-threaded by exec by calling Forbid.
         Never break the Forbid() or strange things might happen.
     */
+
+    if (NVDisk_ArchActive(LIBBASE))
+    {
+        NVDisk_ArchExpunge(LIBBASE);
+        return TRUE;
+    }
 
     UnLock(nvdBase->nvd_location);
 

--- a/workbench/libs/nonvolatile/nvdisk/readnvddata.c
+++ b/workbench/libs/nonvolatile/nvdisk/readnvddata.c
@@ -9,6 +9,7 @@
     NAME */
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 #include <dos/dos.h>
 #include <dos/dosextens.h>
 #include <proto/dos.h>
@@ -58,6 +59,9 @@ AROS_LH2(APTR, ReadNVDData,
 
 {
     AROS_LIBFUNC_INIT
+
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchRead(GPB(nvdBase), appName, itemName);
 
     APTR  mem = NULL;
     BPTR  lock, lock2;

--- a/workbench/libs/nonvolatile/nvdisk/setnvdprotection.c
+++ b/workbench/libs/nonvolatile/nvdisk/setnvdprotection.c
@@ -9,6 +9,7 @@
     NAME */
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 #include <dos/dos.h>
 #include <proto/dos.h>
 #include <libraries/nonvolatile.h>
@@ -58,6 +59,9 @@ AROS_LH3(BOOL, SetNVDProtection,
 
 {
     AROS_LIBFUNC_INIT
+
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchProtect(GPB(nvdBase), appName, itemName, mask);
 
     BPTR lock;
     BOOL result = FALSE;

--- a/workbench/libs/nonvolatile/nvdisk/writenvddata.c
+++ b/workbench/libs/nonvolatile/nvdisk/writenvddata.c
@@ -9,6 +9,7 @@
     NAME */
 
 #include "nvdisk_intern.h"
+#include <nvdisk_arch.h>
 #include <dos/dos.h>
 #include <proto/dos.h>
 #include <libraries/nonvolatile.h>
@@ -61,6 +62,10 @@ AROS_LH4(LONG, WriteNVDData,
 {
     AROS_LIBFUNC_INIT
 
+    if (NVDisk_ArchActive(GPB(nvdBase)))
+        return NVDisk_ArchWrite(GPB(nvdBase), appName, itemName, data,
+            length);
+
     LONG retval  = 0;
     BPTR oldCDir = CurrentDir(GPB(nvdBase)->nvd_location);
     BPTR lock    = Lock(appName, SHARED_LOCK);
@@ -107,4 +112,3 @@ AROS_LH4(LONG, WriteNVDData,
 
     AROS_LIBFUNC_EXIT
 } /* WriteData */
-


### PR DESCRIPTION
Fixes Microcosm and other memory-sensitive CD32 games by:

- Correcting CDXL startup, completion, and zero-length transfer handling.
- Calling CDXL callbacks through the documented register ABI while preserving C nonvolatile registers.
- Implementing the required SystemControlA() controls, including input and low-level library handling.
- Reducing CD32 boot-time chip RAM usage from 1,236,496 to 1,562,168 bytes free.
- Restarting the CIA timer correctly after an aborted request.

Tested with Microcosm, Pinball Illusions, and Superfrog on a stock CD32 configuration with 2 MB chip RAM:

<img width="712" height="602" alt="Capture d’écran 2026-09-01 à 01 50 32" src="https://github.com/user-attachments/assets/2e8c273b-d110-4a50-b917-985176f5d61a" />

<img width="704" height="605" alt="Capture d’écran 2026-09-01 à 01 51 23" src="https://github.com/user-attachments/assets/1078ab9c-5e4c-4b60-8526-8748d534edf3" />

<img width="708" height="610" alt="Capture d’écran 2026-09-01 à 10 06 49" src="https://github.com/user-attachments/assets/9e9b5334-8985-4a61-8ef3-5ad3cddf4325" />

<img width="715" height="612" alt="Capture d’écran 2026-09-01 à 10 03 54" src="https://github.com/user-attachments/assets/c23b9133-62ad-42fb-8651-af4bd2e2fad0" />
