### PR TITLE
camdusbmidi: build the class on arm and aarch64

### DIFF
--- a/rom/usb/classes/camdmidi/camd/mmakefile.src
+++ b/rom/usb/classes/camdmidi/camd/mmakefile.src
@@ -15,10 +15,16 @@ USER_INCLUDES := -I$(OBJDIR)/../include -iquote $(SRCDIR)/$(CURDIR)/..
 $(OBJDIR)/%.o : $(SRCDIR)/$(CURDIR)/%.c | $(OBJDIR)
 	%compile_q
 
+# lld calls these armelf/aarch64elf; elf_$(cpu) only holds for i386/x86_64.
+LLD_EMULATION_arm := armelf
+LLD_EMULATION_aarch64 := aarch64elf
+
 ifeq ($(AROS_TOOLCHAIN),llvm)
-BINLDFLAGS := -m elf_$(AROS_TARGET_CPU)
+BINLDFLAGS := -m $(or $(LLD_EMULATION_$(AROS_TARGET_CPU)),elf_$(AROS_TARGET_CPU))
 endif
-BINLDFLAGS += $(LDFLAGS)
+# LDFLAGS is written for the compiler driver; this rule invokes ld directly,
+# so its -Wl, options would arrive as unknown arguments (aarch64 has one).
+BINLDFLAGS += $(filter-out -Wl%,$(LDFLAGS))
  
 %rule_link_binary ldflags=$(BINLDFLAGS) file=$(CAMDOBJDIR)/$(SRCFILE).bin.o name=$(SRCFILE) objs=$(OBJDIR)/$(SRCFILE).o
 

--- a/rom/usb/classes/camdmidi/mmakefile.src
+++ b/rom/usb/classes/camdmidi/mmakefile.src
@@ -6,7 +6,8 @@ include $(SRCDIR)/config/aros.cfg
 
 #MM- kernel-usb-classes-camdusbmidi-i386 : kernel-usb-classes-camd-usbmidi
 #MM- kernel-usb-classes-camdusbmidi-x86_64 : kernel-usb-classes-camd-usbmidi
-##MM- kernel-usb-classes-camdusbmidi-arm : kernel-usb-classes-camd-usbmidi
+#MM- kernel-usb-classes-camdusbmidi-arm : kernel-usb-classes-camd-usbmidi
+#MM- kernel-usb-classes-camdusbmidi-aarch64 : kernel-usb-classes-camd-usbmidi
 #MM- kernel-usb-classes-camdusbmidi-ppc : kernel-usb-classes-camd-usbmidi
 
 USER_CPPFLAGS := -DMUIMASTER_YES_INLINE_STDARG


### PR DESCRIPTION
`camdusbmidi.class` has not been built for ARM since e4b16b1210, which
disabled the rule with:

> disable build of camdusbmidid for ARM, until it is fixed (needs to use
> objcopy instead of ld to produce the object file, which cannot then be
> linked to the main binary!)

That is no longer what happens. The object links fine; what fails is two
flags reaching `ld` in a form it cannot parse.

**1. lld emulation name.** `camd/mmakefile.src` passed `-m elf_$(AROS_TARGET_CPU)`.
That is correct for i386 and x86_64 only — lld calls the ARM emulations
`armelf` and `aarch64elf`:

```
ld.lld: error: unknown emulation: elf_arm
```

**2. `-Wl,` in LDFLAGS on aarch64.** `%rule_link_binary` hands `$(LDFLAGS)`
straight to `$(KERNEL_LD)`, but LDFLAGS is written for the compiler driver.
On aarch64 `config/make.cfg.in` adds `-Wl,--allow-multiple-definition` for
clang's weak `__aros_libreq_` marker, so:

```
ld.lld: error: unknown argument '-Wl,--allow-multiple-definition'
```

The other targets never hit this because none of them put a `-Wl,` option in
LDFLAGS.

With both fixed, the arm rule is re-enabled and an aarch64 rule added.

### Testing

Compile-tested on both, each with `poseidonusb.bin.o` and the class binary
deleted first to force a full relink:

- `raspi-arm-smp` (llvm-armhf, lld 11) — `Building Module AROS/Classes/USB/camdusbmidi.class`
- `raspi-aarch64` (llvm-aarch64-20)

The resulting `poseidonusb.bin.o` exports the symbols the class expects
(`_binary_poseidonusb_start` / `_end` / `_size`).

### What this does not cover

Only that it builds. `camd/poseidonusb.c` — the CAMD driver blob that
camd.library loads and relocates — has never been run on any architecture; it
went in as "highly experimental and needs testing" (ea4b45f378), and m68k
still uses the hardcoded hunk blob in `CAMDDriver.c`. So this makes the class
available on ARM, it does not claim USB MIDI works there. No behaviour change
on i386/x86_64/ppc/m68k: the emulation mapping falls through to the old
`elf_$(cpu)` for them, and their LDFLAGS contain no `-Wl,` options.