### PR TITLE
bluetooth: Raspberry Pi onboard controller (PL011 transport, H:4 device, Broadcom patchram loader)

### DIFF
--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -64,6 +64,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-fs-sfs-quick \
 #MM kernel-fs-ram-quick \
 #MM kernel-processor-quick \
+#MM kernel-gpio-bcm2708-quick \
 #MM kernel-mbox-bcm2708-quick \
 #MM kernel-dma-bcm2708-quick \
 #MM kernel-sdio-bcm2708-quick \
@@ -126,6 +127,7 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-fs-sfs \
 #MM kernel-fs-ram \
 #MM kernel-processor \
+#MM kernel-gpio-bcm2708 \
 #MM kernel-mbox-bcm2708 \
 #MM kernel-dma-bcm2708 \
 #MM kernel-sdio-bcm2708 \
@@ -189,7 +191,7 @@ RASPIWIFIFW_FILES  := brcm/brcmfmac43455-sdio.bin brcm/brcmfmac43455-sdio.txt \
 
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos dos64 poseidon cgxbootpic gadtools lowlevel fd
 PKG_LIBS_ARCH := expansion
-PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands entropy mbox dma sdio bwfm
+PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands entropy gpio mbox dma sdio bwfm
 PKG_RSRC_ARCH := processor
 PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg USBHardware/pcixhci
 PKG_DEVS_ARCH := timer

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -69,6 +69,9 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-dma-bcm2708-quick \
 #MM kernel-sdio-bcm2708-quick \
 #MM kernel-bwfm-bcm2708-quick \
+#MM kernel-pl011bt-bcm2708-quick \
+#MM kernel-h4bthci-bcm2708-quick \
+#MM kernel-brcmbt-bcm2708-quick \
 #MM kernel-hidd-bus-quick \
 #MM hidd-i2c-quick \
 #MM kernel-hidd-gfx-quick \
@@ -132,6 +135,9 @@ ARM_BSP := aros-$(AROS_TARGET_CPU)-bsp.rom
 #MM kernel-dma-bcm2708 \
 #MM kernel-sdio-bcm2708 \
 #MM kernel-bwfm-bcm2708 \
+#MM kernel-pl011bt-bcm2708 \
+#MM kernel-h4bthci-bcm2708 \
+#MM kernel-brcmbt-bcm2708 \
 #MM kernel-sdcard \
 #MM kernel-hidd-bus \
 #MM hidd-i2c \
@@ -191,7 +197,7 @@ RASPIWIFIFW_FILES  := brcm/brcmfmac43455-sdio.bin brcm/brcmfmac43455-sdio.txt \
 
 PKG_LIBS      := aros partition utility oop graphics layers intuition keymap dos dos64 poseidon cgxbootpic gadtools lowlevel fd
 PKG_LIBS_ARCH := expansion
-PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands entropy gpio mbox dma sdio bwfm
+PKG_RSRC      := openfirmware misc bootloader dosboot lddemon usbromstartup FileSystem shell shellcommands entropy gpio mbox dma sdio bwfm pl011bt
 PKG_RSRC_ARCH := processor
 PKG_DEVS      := input gameport keyboard console sdcard USBHardware/usb2otg USBHardware/pcixhci
 PKG_DEVS_ARCH := timer

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/.gitignore
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/.gitignore
@@ -1,0 +1,1 @@
+mmakefile

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/README.md
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/README.md
@@ -1,0 +1,80 @@
+# Raspberry Pi on-board Bluetooth
+
+AROS has a Bluetooth stack (`rom/bluetooth`), two firmware loaders and one
+HCI device -- and that device is `vbthci`, which is virtual. On real hardware
+the stack has nothing to talk to. These three modules are the missing half for
+the Raspberry Pi 3, 3B+ and Zero 2 W, whose radio hangs off the SoC's PL011.
+
+| module | where it lands | what it owns |
+|---|---|---|
+| `pl011bt.resource` | in the ROM package | the PL011: pin mux, the 32.768 kHz LPO on GPCLK2, `BT_REG_EN`, the baud divisor, the receive interrupt |
+| `h4bthci.device` | `DEVS:Bluetooth/` | H:4 framing, and the AROS device the stack opens |
+| `brcmbt.fwl` | `DEVS:Bluetooth/FWLoaders/` | the Broadcom patchram upload |
+
+The split is the one the stack already assumes. `BTStackLoader` opens every
+`*.fwl` it finds, `AddBTHardware` opens the device, and the device reaches the
+wire through the resource. Nothing above H:4 is here.
+
+## The three names
+
+Each says what is specific about it, because all three sit in one namespace
+once they are built:
+
+- **`pl011bt`** names the block. The BCM283x has two UARTs and the other one,
+  the AUX mini-UART, is where the serial console goes when the firmware hands
+  the PL011 to the radio. A resource called `btuart` would not say which.
+- **`h4bthci`** names the protocol, not the wire -- H:4 is what it speaks, and
+  it is the same shape as upstream's `vbthci`, where `v` is virtual.
+- **`brcmbt`** is vendor plus Bluetooth, the shape `rtlbtv1` and `rtlbtv2`
+  already use. Not `brcmfw`: on a Pi the SoC *and* the radio are Broadcom, so
+  "Broadcom firmware" does not distinguish this from the WiFi blob that
+  `bwfm` loads.
+
+## What the resource does and does not touch
+
+Resident initialisation is side-effect free: it finds the peripheral window,
+asks the firmware for the UART clock, and stops. The PL011 is not written
+until a client claims the resource and calls `PL011BTConfigure()`, so a
+machine that never opens Bluetooth is left exactly as the firmware set it up.
+
+It binds by naming the SoCs it has been run on rather than by excluding the
+others. The arrangement it drives -- PL011 on GPIO 30-33, console pushed onto
+the mini-UART, LPO on GPCLK2, `BT_REG_EN` on the firmware's GPIO expander --
+is the BCM2835/6/7 one, and `IRQ_VC_UART` is the legacy interrupt
+controller's numbering. A BCM2711 wires its radio the same way but presents
+GPU interrupts through the GIC at `BCM2711_GPUIRQ_OFFSET`, and a BCM2712 does
+not use this UART for Bluetooth at all. Neither has been tested, so the
+resource stands down there: absent is a state `h4bthci.device` already
+handles, present and wrong is not.
+
+## Two things that are easy to get wrong here
+
+**The receive path cannot be polled.** The FIFO holds sixteen bytes, which at
+115200 baud is 1.4 ms. Polling at 10 ms lost data on every burst and polling
+at 1 ms still reported OVERRUN on hardware during an LE scan. The interrupt
+owns the FIFO and fills an 8 KB ring; `PL011BTRead()` drains it. The ring is
+sized against the traffic, not against a tick: a BCM43430A1 batches every
+advert it heard into one HCI event of up to 1220 bytes, and an overflow costs
+the framer its synchronisation exactly as a FIFO overrun does.
+
+**Stopping GPCLK2 means clearing `ENAB` and nothing else.** Writing the
+password alone clears it, but in the same store drives `SRC` to GND and
+`MASH` to 0 -- and the datasheet forbids changing the source or the divisor
+while the generator runs. The result is `BUSY` stuck set. It passes wherever
+the register is not modelled and `BUSY` reads 0; on a Pi the firmware has
+already started the generator for the radio, so the bad write always lands on
+a running one.
+
+## Firmware
+
+`brcmbt.fwl` reads its patchram from `DEVS:Firmware/brcm/` at runtime, the
+same directory `bwfm` takes the WiFi blob from, so changing controllers is
+changing a file. Without a patchram a BCM43438 answers `HCI_Reset` from ROM
+and reports the address `AA:AA:AA:AA:AA:AA`, which is not an identity -- the
+firmware is what gives it one.
+
+`BTStackLoader` has to run *before* `AddBTHardware`, so the loader is bound
+before the radio is brought up and the patchram is applied at the bring-up's
+own firmware step. Registering the controller first sends it through the
+late-bind path instead, which uploads the patchram, restarts the controller
+and then re-runs the bring-up against a chip that is still restarting.

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/.gitignore
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/.gitignore
@@ -1,0 +1,1 @@
+mmakefile

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.c
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.c
@@ -1,0 +1,309 @@
+/*
+ *----------------------------------------------------------------------------
+ *   brcmbt.fwl - Broadcom Bluetooth firmware (patchram) loader
+ *----------------------------------------------------------------------------
+ *
+ * The log callback is bluetooth.library's, and it formats with vsnprintf --
+ * C semantics, not RawDoFmt's. A 32-bit AROS LONG is not a `long` on a
+ * 64-bit target, so the format strings below say %d and cast, rather than
+ * the %ld an Amiga-style formatter would want.
+ *
+ * A pluggable BtFirmwareLoader for Broadcom controllers, which is what the
+ * Raspberry Pi 3's onboard BCM43438 is. Modelled on AROS's Realtek loaders in
+ * rom/bluetooth/firmware; the stack calls fwl_Match/fwl_Load during a
+ * controller's bring-up, and blobs are read from disk only.
+ *
+ * Why this exists: a BCM43438 runs from ROM until it is sent a patchram image.
+ * It answers HCI_Reset and reports its version without one -- which is how the
+ * bring-up gets as far as it does today -- but reports a placeholder
+ * BD_ADDR of AA:AA:AA:AA:AA:AA, and pairing needs a real address.
+ *
+ * An alternative would be to convert the .hcd to a C source
+ * at build time (convert_hcd.py from BTstack) and compiling it into the
+ * binary. This does it the way AROS wants instead: the .hcd stays a file on
+ * the card, and swapping controllers is swapping a file rather than a rebuild.
+ */
+
+#include <aros/libcall.h>
+#include <aros/symbolsets.h>
+
+#include <exec/exec.h>
+#include <exec/types.h>
+
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/bluetooth.h>
+
+#include "brcmbt.h"
+
+#include LC_LIBDEFS_FILE
+
+/* /// "brcmFwPath()" */
+/*
+ * Which file to load.
+ *
+ * Linux names these by chip: BCM43430A1.hcd is the Pi 3 and Pi Zero W,
+ * BCM4345C0.hcd the Pi 3B+ and Pi 4. LMP subversion identifies the part, and
+ * the mapping below covers what this port can run on; anything else falls
+ * back to the generic name so an unknown board can still be given a blob by
+ * hand.
+ */
+static CONST_STRPTR brcmFwName(struct BtFirmwareContext *ctx)
+{
+    switch (ctx->fwc_LMPSubversion)
+    {
+    case 0x2209:  return "BCM43430A1.hcd";   /* BCM43430A1 - Pi 3, Zero W */
+    case 0x6119:  return "BCM4345C0.hcd";    /* BCM4345C0  - Pi 3B+, Pi 4 */
+    case 0x230f:  return "BCM4345C5.hcd";    /* BCM4345C5  - Pi 4B rev, CM4 */
+    default:      return "BCM.hcd";
+    }
+}
+/* \\\ */
+
+/* /// "brcmMatch()" */
+/*
+ * Identity only -- the contract says fwl_Match must not issue HCI.
+ *
+ * Manufacturer 15 is Broadcom in the SIG company list. Cypress parts report
+ * the same id, which is correct: they are the same silicon lineage and take
+ * the same patchram format.
+ */
+static ULONG brcmMatch(struct BtFirmwareLoader *self,
+                       struct BtFirmwareContext *ctx)
+{
+    (void)self;
+
+    if (ctx->fwc_Manufacturer != BT_MANUFACTURER_BROADCOM)
+        return 0;
+
+    /* Priority 10: above a generic loader, below anything that recognises a
+     * specific part more narrowly than "Broadcom". */
+    return 10;
+}
+/* \\\ */
+
+/* /// "brcmReadFile()" */
+static APTR brcmReadFile(struct DosLibrary *DOSBase, CONST_STRPTR path,
+                         LONG *sizep)
+{
+    BPTR fh;
+    LONG size;
+    APTR buf = NULL;
+
+    if (!(fh = Open((STRPTR)path, MODE_OLDFILE)))
+        return NULL;
+
+    if (Seek(fh, 0, OFFSET_END) >= 0)
+    {
+        size = Seek(fh, 0, OFFSET_BEGINNING);
+        if (size > 0 && (buf = AllocVec(size, MEMF_ANY)))
+        {
+            if (Read(fh, buf, size) == size)
+                *sizep = size;
+            else
+            {
+                FreeVec(buf);
+                buf = NULL;
+            }
+        }
+    }
+    Close(fh);
+    return buf;
+}
+/* \\\ */
+
+/* /// "brcmWaitRestart()" */
+/*
+ * Launch_RAM was the last record, and the controller restarts on it.
+ *
+ * The caller resumes the bring-up the moment this returns -- hwtask.c runs
+ * bDoFirmware() and then bBringupStep() with nothing in between -- so
+ * returning early sends the next HCI command to a chip that is not there.
+ * That is not hypothetical: with a fixed 50 ms wait, the step after the
+ * firmware timed out on every boot, the bring-up failed, and the radio never
+ * reached BHS_READY -- which presents as a Bluetooth prefs with no radio in
+ * it, because btEnumerateHardware() only reports controllers in that state.
+ *
+ * A bigger fixed number would be a better guess and still a guess, so ask the
+ * controller instead. HCI_Reset is the smallest command it answers and it is
+ * idempotent, so the stack issuing its own immediately afterwards costs
+ * nothing. A completed command also proves the H4 stream has resynchronised
+ * past the framing errors and zero bytes that a restarting UART peer leaves
+ * on the line.
+ *
+ * Probing is not free -- an unanswered command costs the stack's own command
+ * timeout -- so settle first and probe a bounded number of times.
+ */
+static LONG brcmWaitRestart(struct BtFirmwareContext *ctx)
+{
+    ULONG attempt;
+
+    for (attempt = 0; attempt < BRCM_RESTART_PROBES; attempt++)
+    {
+        UBYTE status = 0;
+
+        Delay(BRCM_RESTART_SETTLE_MS * TICKS_PER_SECOND / 1000);
+
+        if (ctx->fwc_HciCommand(ctx, HC_OP_HCI_RESET, NULL, 0,
+                                &status, NULL, NULL, 0) == 0 && status == 0)
+        {
+            return 0;
+        }
+
+        ctx->fwc_Log(ctx, RETURN_WARN,
+            "brcmbt: controller has not answered %u probe(s) since Launch_RAM",
+            (unsigned)(attempt + 1));
+    }
+
+    ctx->fwc_Log(ctx, RETURN_ERROR,
+        "brcmbt: controller did not come back after Launch_RAM");
+    return -1;
+}
+/* \\\ */
+
+/* /// "brcmLoad()" */
+/*
+ * The patchram protocol, which is simpler than its reputation:
+ *
+ *   1. HCI_Download_Minidriver (0xfc2e), then settle;
+ *   2. replay every command in the .hcd in order -- they are Write_RAM
+ *      records plus a trailing Launch_RAM;
+ *   3. the controller restarts on Launch_RAM and needs time before it will
+ *      answer again.
+ *
+ * The file is a flat sequence of [opcode:2][plen:1][params:plen], so parsing
+ * it is walking that. Sending each record through fwc_HciCommand gets the
+ * stack's own synchronous channel, including its completion handling.
+ */
+static LONG brcmLoad(struct BtFirmwareLoader *self,
+                     struct BtFirmwareContext *ctx)
+{
+    struct BrcmFwBase *bfw = self->fwl_UserData;
+    struct DosLibrary *DOSBase = bfw->bfw_DOSBase;
+    CONST_STRPTR name = brcmFwName(ctx);
+    UBYTE path[128];
+    UBYTE *fw;
+    LONG size = 0, offset = 0, records = 0;
+    UBYTE status = 0;
+    LONG err;
+
+    if (!DOSBase)
+        return -1;
+
+    /* BRCM_FW_DIR + name, without needing a sprintf. */
+    {
+        CONST_STRPTR d = BRCM_FW_DIR;
+        ULONG i = 0;
+
+        while (*d && i < sizeof(path) - 1)
+            path[i++] = *d++;
+        while (*name && i < sizeof(path) - 1)
+            path[i++] = *name++;
+        path[i] = '\0';
+    }
+
+    fw = brcmReadFile(DOSBase, (CONST_STRPTR)path, &size);
+    if (!fw)
+    {
+        /*
+         * Not an error. A controller that runs from ROM works without this,
+         * with a placeholder address; saying so is more useful than failing
+         * the bring-up over a file the user may deliberately not have.
+         */
+        ctx->fwc_Log(ctx, RETURN_WARN,
+            "brcmbt: no %s, continuing without patchram", path);
+        return 0;
+    }
+
+    ctx->fwc_Log(ctx, RETURN_OK, "brcmbt: %s, %d bytes", path, (int)size);
+
+    err = ctx->fwc_HciCommand(ctx, HC_OP_BRCM_DOWNLOAD_MINIDRV, NULL, 0,
+                              &status, NULL, NULL, 0);
+    if (err || status)
+    {
+        ctx->fwc_Log(ctx, RETURN_ERROR,
+            "brcmbt: Download_Minidriver failed (err %d, status 0x%02x)",
+            (int)err, (unsigned)status);
+        FreeVec(fw);
+        return -1;
+    }
+
+    while (offset + BRCM_HCD_HDR <= size)
+    {
+        UWORD opcode = fw[offset] | ((UWORD)fw[offset + 1] << 8);
+        UBYTE plen   = fw[offset + 2];
+
+        if (offset + BRCM_HCD_HDR + plen > size)
+        {
+            ctx->fwc_Log(ctx, RETURN_ERROR,
+                "brcmbt: truncated record at %d of %d",
+                (int)offset, (int)size);
+            FreeVec(fw);
+            return -1;
+        }
+
+        err = ctx->fwc_HciCommand(ctx, opcode, &fw[offset + BRCM_HCD_HDR],
+                                  plen, &status, NULL, NULL, 0);
+        if (err || status)
+        {
+            ctx->fwc_Log(ctx, RETURN_ERROR,
+                "brcmbt: record %d (opcode 0x%04x) failed"
+                " (err %d, status 0x%02x)",
+                (int)records, (unsigned)opcode, (int)err, (unsigned)status);
+            FreeVec(fw);
+            return -1;
+        }
+
+        offset += BRCM_HCD_HDR + plen;
+        records++;
+    }
+
+    FreeVec(fw);
+    ctx->fwc_Log(ctx, RETURN_OK,
+        "brcmbt: %d records applied; controller restarting", (int)records);
+
+    return brcmWaitRestart(ctx);
+}
+/* \\\ */
+
+/* /// "libInit()" */
+static int GM_UNIQUENAME(libInit)(LIBBASETYPEPTR bfw)
+{
+    struct Library *BluetoothBase;
+
+    bfw->bfw_DOSBase = (struct DosLibrary *)OpenLibrary("dos.library", 0);
+    if (!(BluetoothBase = OpenLibrary("bluetooth.library", 1)))
+    {
+        if (bfw->bfw_DOSBase)
+            CloseLibrary((struct Library *)bfw->bfw_DOSBase);
+        return FALSE;
+    }
+    bfw->bfw_BluetoothBase = BluetoothBase;
+
+    bfw->bfw_Loader.fwl_Name     = "Broadcom (patchram)";
+    bfw->bfw_Loader.fwl_Match    = brcmMatch;
+    bfw->bfw_Loader.fwl_Load     = brcmLoad;
+    bfw->bfw_Loader.fwl_UserData = bfw;
+    btAddFirmwareLoader(&bfw->bfw_Loader);
+    return TRUE;
+}
+/* \\\ */
+
+/* /// "libExpunge()" */
+static int GM_UNIQUENAME(libExpunge)(LIBBASETYPEPTR bfw)
+{
+    struct Library *BluetoothBase = bfw->bfw_BluetoothBase;
+
+    if (BluetoothBase)
+    {
+        btRemFirmwareLoader(&bfw->bfw_Loader);
+        CloseLibrary(BluetoothBase);
+    }
+    if (bfw->bfw_DOSBase)
+        CloseLibrary((struct Library *)bfw->bfw_DOSBase);
+    return TRUE;
+}
+/* \\\ */
+
+ADD2INITLIB(GM_UNIQUENAME(libInit), 0)
+ADD2EXPUNGELIB(GM_UNIQUENAME(libExpunge), 0)

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.conf
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.conf
@@ -1,0 +1,16 @@
+##begin config
+version 45.1
+libbase bfw
+libbasetype struct BrcmFwBase
+libbasetypeextern struct Library
+residentpri 9
+basename brcmbt
+##end config
+
+##begin cdef
+#include <libraries/bluetooth.h>
+#include "brcmbt.h"
+##end cdef
+
+##begin functionlist
+##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.h
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/brcmbt.h
@@ -1,0 +1,52 @@
+#ifndef BRCMBT_H
+#define BRCMBT_H
+/*
+ * Libbase for the Broadcom Bluetooth firmware loader.
+ *
+ * A pluggable BtFirmwareLoader in DEVS:Bluetooth/FWLoaders/, modelled on
+ * AROS's Realtek loaders (rom/bluetooth/firmware/rtlv1, rtlv2). It registers
+ * one loader with bluetooth.library on init; the stack offers each controller
+ * to every registered loader during bring-up (fwl_Match) and lets the best
+ * match run (fwl_Load).
+ */
+
+#include <exec/libraries.h>
+#include <dos/dosextens.h>
+#include <libraries/bluetooth.h>
+
+struct BrcmFwBase
+{
+    struct Library          bfw_Lib;
+    struct Library         *bfw_BluetoothBase;   /* for btAdd/RemFirmwareLoader */
+    struct DosLibrary      *bfw_DOSBase;         /* for reading the .hcd */
+    struct BtFirmwareLoader bfw_Loader;
+};
+
+/* Broadcom HCI vendor commands (OGF 0x3f). */
+#define BRCM_OP(ocf)                (((UWORD)0x3f << 10) | (ocf))
+#define HC_OP_BRCM_DOWNLOAD_MINIDRV BRCM_OP(0x002e)
+#define HC_OP_BRCM_WRITE_RAM        BRCM_OP(0x004c)
+#define HC_OP_BRCM_LAUNCH_RAM       BRCM_OP(0x004e)
+
+/* Host Control group: HCI_Reset, the smallest command a controller answers. */
+#define HC_OP_HCI_RESET             ((UWORD)(((UWORD)0x03 << 10) | 0x0003))
+
+/*
+ * Recovering from the restart that Launch_RAM causes. Settle, then ask the
+ * controller whether it is back, a bounded number of times -- see
+ * brcmWaitRestart().
+ */
+#define BRCM_RESTART_SETTLE_MS      300
+#define BRCM_RESTART_PROBES         3
+
+#define BT_MANUFACTURER_BROADCOM    15           /* Bluetooth SIG company id */
+#define BRCM_FW_DIR                 "DEVS:Firmware/brcm/"
+
+/*
+ * A .hcd is a flat sequence of HCI commands: 2 bytes opcode (little-endian),
+ * 1 byte parameter length, then that many parameter bytes. Sending them in
+ * order is the whole of the patchram protocol.
+ */
+#define BRCM_HCD_HDR                3
+
+#endif /* BRCMBT_H */

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/brcmbt/mmakefile.src
@@ -1,0 +1,31 @@
+include $(SRCDIR)/config/aros.cfg
+
+#
+# The Broadcom Bluetooth firmware loader.
+#
+# AROS ships two firmware loaders, rtlv1 and rtlv2, and both are Realtek. The
+# loader *mechanism* is generic -- bluetooth.library offers each controller to
+# every registered loader and runs the best match -- but the upload protocol
+# is per-vendor, so a Broadcom part needs a Broadcom loader. This is it.
+#
+# It goes in DEVS:Bluetooth/FWLoaders/ like the Realtek ones and reads its
+# blob from DEVS:Firmware/brcm/ at runtime, so changing controllers is
+# changing a file rather than rebuilding.
+#
+FILES := brcmbt
+
+USER_LDFLAGS := -static
+USER_INCLUDES := -I$(SRCDIR)/rom/bluetooth/bluetooth/include \
+                 -I$(SRCDIR)/rom/bluetooth/stack/include
+
+#MM kernel-brcmbt-bcm2708 : kernel-bluetooth-library-includes
+
+# %build_module_library with modsuffix=fwl, exactly as the Realtek loaders do
+# -- the stack looks for *.fwl in that directory, so a .library there is not
+# found however correct it is.
+%build_module_library mmake=kernel-brcmbt-bcm2708 \
+    modname=brcmbt modtype=library modsuffix="fwl" \
+    moduledir=Devs/Bluetooth/FWLoaders \
+    files="$(FILES)"
+
+%common

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/.gitignore
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/.gitignore
@@ -1,0 +1,1 @@
+mmakefile

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci.conf
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci.conf
@@ -1,0 +1,11 @@
+##begin config
+basename        H4BTHCI
+version         45.1
+libbasetype     struct H4BTHCIBase
+beginio_func    BeginIO
+abortio_func    AbortIO
+##end config
+
+##begin cdefprivate
+#include "h4bthci_intern.h"
+##end cdefprivate

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_device.c
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_device.c
@@ -1,0 +1,238 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: h4bthci.device -- device entry points.
+*/
+
+#include <aros/debug.h>
+#include <aros/symbolsets.h>
+#include <exec/exec.h>
+#include <exec/errors.h>
+#include <dos/dostags.h>
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/pl011bt.h>
+
+#include "h4bthci_intern.h"
+
+#include LC_LIBDEFS_FILE
+
+#define NewList(list) NEWLIST(list)
+
+static int GM_UNIQUENAME(Init)(LIBBASETYPEPTR H4BTHCIBase)
+{
+    InitSemaphore(&H4BTHCIBase->hu_Lock);
+    return TRUE;
+}
+
+static int GM_UNIQUENAME(Expunge)(LIBBASETYPEPTR H4BTHCIBase)
+{
+    return H4BTHCIBase->hu_Unit ? FALSE : TRUE;
+}
+
+/*
+ * One unit, because there is one controller soldered to the board. A second
+ * unit number is not a second radio, so it is refused rather than silently
+ * answered with the same hardware.
+ */
+static struct H4BTHCIUnit *h4bthci_OpenUnit(LIBBASETYPEPTR H4BTHCIBase,
+                                                ULONG unitnum)
+{
+    struct H4BTHCIUnit *unit;
+    struct Task *task;
+
+    if (unitnum != 0)
+        return NULL;
+
+    ObtainSemaphore(&H4BTHCIBase->hu_Lock);
+    if (H4BTHCIBase->hu_Unit)
+    {
+        ReleaseSemaphore(&H4BTHCIBase->hu_Lock);
+        return NULL;
+    }
+
+    unit = AllocVec(sizeof(struct H4BTHCIUnit), MEMF_PUBLIC | MEMF_CLEAR);
+    if (unit)
+    {
+        unit->hu_Base = H4BTHCIBase;
+        NewList(&unit->hu_Unit.unit_MsgPort.mp_MsgList);
+        NewList((struct List *)&unit->hu_EventQueue);
+        NewList((struct List *)&unit->hu_ACLQueue);
+        NewList((struct List *)&unit->hu_Listeners);
+        InitSemaphore(&unit->hu_QueueLock);
+
+        unit->hu_ReadySignal = SIGB_SINGLE;
+        unit->hu_ReadySigTask = FindTask(NULL);
+        SetSignal(0, SIGF_SINGLE);
+
+        task = (struct Task *)CreateNewProcTags(
+            NP_Entry,    (IPTR)h4bthci_UnitTask,
+            NP_Name,     (IPTR)"h4bthci.device unit",
+            NP_Priority, 10,
+            NP_UserData, (IPTR)unit,
+            TAG_END);
+
+        if (task)
+            Wait(SIGF_SINGLE);
+
+        unit->hu_ReadySigTask = NULL;
+
+        if (!unit->hu_Task)
+        {
+            FreeVec(unit);
+            unit = NULL;
+        }
+        else
+        {
+            unit->hu_Open = TRUE;
+            H4BTHCIBase->hu_Unit = unit;
+        }
+    }
+
+    ReleaseSemaphore(&H4BTHCIBase->hu_Lock);
+    return unit;
+}
+
+static void h4bthci_CloseUnit(LIBBASETYPEPTR H4BTHCIBase,
+                                struct H4BTHCIUnit *unit)
+{
+    ObtainSemaphore(&H4BTHCIBase->hu_Lock);
+    H4BTHCIBase->hu_Unit = NULL;
+    ReleaseSemaphore(&H4BTHCIBase->hu_Lock);
+
+    Forbid();
+    unit->hu_ReadySignal = SIGB_SINGLE;
+    unit->hu_ReadySigTask = FindTask(NULL);
+    SetSignal(0, SIGF_SINGLE);
+    if (unit->hu_Task)
+        Signal(unit->hu_Task, SIGBREAKF_CTRL_C);
+    Permit();
+
+    while (unit->hu_Task)
+        Wait(SIGF_SINGLE);
+
+    FreeVec(unit);
+}
+
+static int GM_UNIQUENAME(Open)(LIBBASETYPEPTR H4BTHCIBase,
+                               struct IOBTHCIReq *ioreq, ULONG unitnum,
+                               ULONG flags)
+{
+    struct H4BTHCIUnit *unit;
+
+    ioreq->iobt_Req.io_Unit = NULL;
+
+    if (ioreq->iobt_Req.io_Message.mn_Length < sizeof(struct IOBTHCIReq))
+    {
+        ioreq->iobt_Req.io_Error = IOERR_BADLENGTH;
+        return FALSE;
+    }
+
+    unit = h4bthci_OpenUnit(H4BTHCIBase, unitnum);
+    if (!unit)
+    {
+        ioreq->iobt_Req.io_Error = IOERR_OPENFAIL;
+        return FALSE;
+    }
+
+    ioreq->iobt_Req.io_Unit = (struct Unit *)unit;
+    ioreq->iobt_Req.io_Error = 0;
+    return TRUE;
+}
+
+static int GM_UNIQUENAME(Close)(LIBBASETYPEPTR H4BTHCIBase,
+                                struct IOBTHCIReq *ioreq)
+{
+    struct H4BTHCIUnit *unit = (struct H4BTHCIUnit *)ioreq->iobt_Req.io_Unit;
+
+    if (unit)
+        h4bthci_CloseUnit(H4BTHCIBase, unit);
+
+    ioreq->iobt_Req.io_Unit = (APTR)-1;
+    ioreq->iobt_Req.io_Device = (APTR)-1;
+    return TRUE;
+}
+
+ADD2INITLIB(GM_UNIQUENAME(Init), 0)
+ADD2EXPUNGELIB(GM_UNIQUENAME(Expunge), 0)
+ADD2OPENDEV(GM_UNIQUENAME(Open), 0)
+ADD2CLOSEDEV(GM_UNIQUENAME(Close), 0)
+
+AROS_LH1(void, BeginIO,
+         AROS_LHA(struct IOBTHCIReq *, ioreq, A1),
+         struct H4BTHCIBase *, H4BTHCIBase, 5, H4BTHCI)
+{
+    AROS_LIBFUNC_INIT
+
+    struct H4BTHCIUnit *unit = (struct H4BTHCIUnit *)ioreq->iobt_Req.io_Unit;
+    LONG ret;
+
+    ioreq->iobt_Req.io_Message.mn_Node.ln_Type = NT_MESSAGE;
+    ioreq->iobt_Req.io_Error = 0;
+
+    if (!unit || !unit->hu_Task)
+    {
+        ioreq->iobt_Req.io_Error = IOERR_OPENFAIL;
+        ret = 0;
+    }
+    else
+        ret = h4bthci_QueueRequest(unit, ioreq);
+
+    if (ret >= 0)
+    {
+        if (!(ioreq->iobt_Req.io_Flags & IOF_QUICK))
+            ReplyMsg(&ioreq->iobt_Req.io_Message);
+    }
+    else
+        ioreq->iobt_Req.io_Flags &= ~IOF_QUICK;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH1(LONG, AbortIO,
+         AROS_LHA(struct IOBTHCIReq *, ioreq, A1),
+         struct H4BTHCIBase *, H4BTHCIBase, 6, H4BTHCI)
+{
+    AROS_LIBFUNC_INIT
+
+    struct H4BTHCIUnit *unit = (struct H4BTHCIUnit *)ioreq->iobt_Req.io_Unit;
+    struct MinNode *mn;
+    LONG found = -1;
+
+    if (!unit)
+        return -1;
+
+    ObtainSemaphore(&unit->hu_QueueLock);
+    for (mn = unit->hu_EventQueue.mlh_Head; mn->mln_Succ; mn = mn->mln_Succ)
+    {
+        if ((APTR)mn == (APTR)ioreq)
+        {
+            Remove((struct Node *)mn);
+            found = 0;
+            break;
+        }
+    }
+    if (found)
+    {
+        for (mn = unit->hu_ACLQueue.mlh_Head; mn->mln_Succ; mn = mn->mln_Succ)
+        {
+            if ((APTR)mn == (APTR)ioreq)
+            {
+                Remove((struct Node *)mn);
+                found = 0;
+                break;
+            }
+        }
+    }
+    ReleaseSemaphore(&unit->hu_QueueLock);
+
+    if (!found)
+    {
+        ioreq->iobt_Req.io_Error = IOERR_ABORTED;
+        ReplyMsg(&ioreq->iobt_Req.io_Message);
+    }
+
+    return found;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_intern.h
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_intern.h
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: HCI transport for the Raspberry Pi's onboard controller.
+*/
+
+#ifndef H4BTHCI_INTERN_H
+#define H4BTHCI_INTERN_H
+
+#include <exec/devices.h>
+#include <exec/semaphores.h>
+#include <exec/lists.h>
+#include <devices/bluetoothhci.h>
+
+/*
+ * The Bluetooth stack talks to HCI devices in DEVS:Bluetooth; upstream ships
+ * one, vbthci, and it is virtual. This is the other kind: a real controller,
+ * reached over the PL011 that pl011bt.resource beside this one owns.
+ *
+ * The division of labour is the one that resource's README already states and
+ * this file does not revisit. Everything below the HCI boundary -- pin muxing,
+ * the 32.768 kHz LPO on GPCLK2, BT_REG_EN, baud rate, flow control -- belongs
+ * to pl011bt.resource. Everything here is H4 framing and the AROS device
+ * protocol, and it would work over any transport that can move bytes.
+ *
+ * H4 is the UART transport encoding from the Bluetooth spec: one type byte,
+ * then the packet. It is the whole difference between what the stack hands
+ * down and what goes on the wire.
+ */
+
+#define H4BTHCI_COMMAND    0x01
+#define H4BTHCI_ACL        0x02
+#define H4BTHCI_SCO        0x03
+#define H4BTHCI_EVENT      0x04
+
+/*
+ * 115200 8N1 with RTS/CTS.
+ *
+ * What a BCM43438 answers to from reset, and it stays there until a firmware
+ * upload changes it. This device does not upload firmware -- the Broadcom
+ * patchram protocol is brcmbt.fwl beside it -- so the
+ * higher rates the controller supports afterwards are not reachable yet and
+ * naming one here would be a guess about a state we never enter.
+ */
+#define H4BTHCI_BAUD          115200
+
+#define H4BTHCI_RXBUF         4096
+
+struct H4BTHCIBase
+{
+    struct Device            hu_Device;
+    struct SignalSemaphore   hu_Lock;
+    struct H4BTHCIUnit    *hu_Unit;
+    struct Library          *hu_PL011BTBase;
+};
+
+struct H4BTHCIUnit
+{
+    struct Unit              hu_Unit;
+    struct H4BTHCIBase    *hu_Base;
+    struct Task             *hu_Task;
+    struct Task             *hu_ReadySigTask;
+    BYTE                     hu_ReadySignal;
+    BOOL                     hu_Open;
+
+    /* Requests waiting for something to arrive from the controller. */
+    struct MinList           hu_EventQueue;
+    struct MinList           hu_ACLQueue;
+    struct SignalSemaphore   hu_QueueLock;
+
+    /* Ports registered through BTCMD_ADDMSGPORT, told about every event. */
+    struct MinList           hu_Listeners;
+
+    /* Reassembly. A UART delivers bytes, not packets. */
+    UBYTE                    hu_RX[H4BTHCI_RXBUF];
+    ULONG                    hu_RXLen;
+};
+
+struct H4BTHCIListener
+{
+    struct MinNode           hl_Node;
+    struct MsgPort          *hl_Port;
+};
+
+void h4bthci_UnitTask(void);
+LONG h4bthci_QueueRequest(struct H4BTHCIUnit *unit, struct IOBTHCIReq *ioreq);
+
+#endif /* H4BTHCI_INTERN_H */

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_unit.c
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/h4bthci_unit.c
@@ -1,0 +1,474 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: H4 framing and the unit task.
+*/
+
+#include <aros/debug.h>
+#include <exec/exec.h>
+#include <exec/errors.h>
+#include <dos/dostags.h>
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/utility.h>
+#include <proto/pl011bt.h>
+#include <bluetooth/hci.h>
+
+#include <string.h>
+
+#include "h4bthci_intern.h"
+
+/* proto/pl011bt.h declares this as APTR for a resource, not a library base --
+ * a resource is not opened with OpenLibrary and has no library node. The unit
+ * task fills it in; it is the only thing here that touches the hardware. */
+APTR PL011BTBase;
+
+/*
+ * A UART hands over bytes; HCI is packets. Everything in this file exists to
+ * bridge that, and the H4 encoding is the whole of the bridge: one type byte,
+ * then a header whose length field says how much more to wait for.
+ *
+ * The lengths differ per type and there is no generic answer:
+ *   EVENT  1 byte type,  1 byte length
+ *   ACL    2 byte handle, 2 byte length (little endian on the wire)
+ *   SCO    2 byte handle, 1 byte length
+ * so the reassembler has to know all three to know when a packet is whole.
+ */
+static ULONG h4bthci_PacketLength(const UBYTE *buf, ULONG have)
+{
+    switch (buf[0])
+    {
+    case H4BTHCI_EVENT:
+        if (have < 3)
+            return 0;
+        return 3 + buf[2];
+
+    case H4BTHCI_ACL:
+        if (have < 5)
+            return 0;
+        return 5 + buf[3] + (((ULONG)buf[4]) << 8);
+
+    case H4BTHCI_SCO:
+        if (have < 4)
+            return 0;
+        return 4 + buf[3];
+
+    default:
+        /*
+         * Not a type this transport knows. Resynchronising by guessing where
+         * the next packet starts would invent data; dropping the byte and
+         * saying so is the only honest recovery, and a controller that does
+         * this is broken in a way worth seeing in the log.
+         */
+        bug("[h4bthci] unknown H4 packet type 0x%02x, dropping a byte\n",
+            buf[0]);
+        return (ULONG)-1;
+    }
+}
+
+/* Hand a complete event to whoever is waiting, and to every listener. */
+static void h4bthci_DeliverEvent(struct H4BTHCIUnit *unit,
+                                   const UBYTE *packet, ULONG length)
+{
+    struct IOBTHCIReq *ioreq = NULL;
+    struct MinNode *mn;
+
+    ObtainSemaphore(&unit->hu_QueueLock);
+    if (unit->hu_EventQueue.mlh_Head->mln_Succ)
+        ioreq = (struct IOBTHCIReq *)RemHead((struct List *)&unit->hu_EventQueue);
+    ReleaseSemaphore(&unit->hu_QueueLock);
+
+    if (ioreq)
+    {
+        ULONG payload = length - 1;     /* without the H4 type byte */
+
+        if (payload > ioreq->iobt_Length)
+        {
+            ioreq->iobt_Actual = ioreq->iobt_Length;
+            ioreq->iobt_Req.io_Error = BTIOERR_OVERFLOW;
+        }
+        else
+        {
+            ioreq->iobt_Actual = payload;
+            ioreq->iobt_Req.io_Error = 0;
+        }
+        if (ioreq->iobt_Data && ioreq->iobt_Actual)
+            CopyMem((APTR)(packet + 1), ioreq->iobt_Data, ioreq->iobt_Actual);
+
+        ReplyMsg(&ioreq->iobt_Req.io_Message);
+    }
+
+    /*
+     * Listeners registered through BTCMD_ADDMSGPORT get a copy. They are not
+     * consumers in the request sense -- the stack uses them to watch events it
+     * did not ask for -- so a missing listener is not an error and a listener
+     * that cannot be allocated for is dropped rather than blocking the wire.
+     */
+    ObtainSemaphore(&unit->hu_QueueLock);
+    for (mn = unit->hu_Listeners.mlh_Head; mn->mln_Succ; mn = mn->mln_Succ)
+    {
+        struct H4BTHCIListener *listener = (struct H4BTHCIListener *)mn;
+        struct BTHCIEventMsg *msg;
+
+        msg = AllocVec(sizeof(struct BTHCIEventMsg), MEMF_PUBLIC | MEMF_CLEAR);
+        if (!msg)
+            continue;
+
+        msg->bem_Msg.mn_Node.ln_Type = NT_MESSAGE;
+        msg->bem_Msg.mn_Length = sizeof(struct BTHCIEventMsg);
+        CopyMem((APTR)(packet + 1), &msg->bem_Event,
+                (length - 1) > sizeof(struct BTHCIEvent)
+                    ? sizeof(struct BTHCIEvent) : (length - 1));
+        PutMsg(listener->hl_Port, &msg->bem_Msg);
+    }
+    ReleaseSemaphore(&unit->hu_QueueLock);
+}
+
+static void h4bthci_DeliverACL(struct H4BTHCIUnit *unit,
+                                 const UBYTE *packet, ULONG length)
+{
+    struct IOBTHCIReq *ioreq = NULL;
+
+    ObtainSemaphore(&unit->hu_QueueLock);
+    if (unit->hu_ACLQueue.mlh_Head->mln_Succ)
+        ioreq = (struct IOBTHCIReq *)RemHead((struct List *)&unit->hu_ACLQueue);
+    ReleaseSemaphore(&unit->hu_QueueLock);
+
+    if (!ioreq)
+        return;         /* nothing waiting: the packet is dropped, as USB does */
+
+    {
+        ULONG payload = length - 1;
+
+        if (payload > ioreq->iobt_Length)
+        {
+            ioreq->iobt_Actual = ioreq->iobt_Length;
+            ioreq->iobt_Req.io_Error = BTIOERR_OVERFLOW;
+        }
+        else
+        {
+            ioreq->iobt_Actual = payload;
+            ioreq->iobt_Req.io_Error = 0;
+        }
+        if (ioreq->iobt_Data && ioreq->iobt_Actual)
+            CopyMem((APTR)(packet + 1), ioreq->iobt_Data, ioreq->iobt_Actual);
+    }
+
+    ReplyMsg(&ioreq->iobt_Req.io_Message);
+}
+
+static void h4bthci_Reassemble(struct H4BTHCIUnit *unit)
+{
+    while (unit->hu_RXLen > 0)
+    {
+        ULONG want = h4bthci_PacketLength(unit->hu_RX, unit->hu_RXLen);
+
+        if (want == (ULONG)-1)
+        {
+            memmove(unit->hu_RX, unit->hu_RX + 1, --unit->hu_RXLen);
+            continue;
+        }
+        if (want == 0 || want > unit->hu_RXLen)
+            break;                      /* incomplete: wait for more bytes */
+
+        switch (unit->hu_RX[0])
+        {
+        case H4BTHCI_EVENT:
+            h4bthci_DeliverEvent(unit, unit->hu_RX, want);
+            break;
+        case H4BTHCI_ACL:
+            h4bthci_DeliverACL(unit, unit->hu_RX, want);
+            break;
+        default:
+            break;                      /* SCO is accepted and discarded */
+        }
+
+        unit->hu_RXLen -= want;
+        if (unit->hu_RXLen)
+            memmove(unit->hu_RX, unit->hu_RX + want, unit->hu_RXLen);
+    }
+}
+
+/*
+ * Send one packet, type byte first.
+ *
+ * PL011BTWrite() returns the number of bytes it accepted, not a status: a
+ * successful one-byte write returns 1. This compared that against PL011BT_OK,
+ * which is 0, so every successful write was read as a failure and every HCI
+ * command came back as "HCI transmission failed, host error (3)" -- the
+ * transport being up made that look like the radio not answering.
+ *
+ * It is also a non-blocking write that stops at TXFF, so a full FIFO means a
+ * short write rather than an error. The caller has to push the remainder,
+ * which nothing did.
+ */
+static LONG h4bthci_WriteAll(struct H4BTHCIUnit *unit, const UBYTE *data,
+                               ULONG length)
+{
+    ULONG done = 0;
+    ULONG spins = 0;
+
+    while (done < length)
+    {
+        LONG n = PL011BTWrite(unit, data + done, length - done);
+
+        if (n < 0)
+        {
+            bug("[h4bthci] PL011BTWrite failed, rc=%ld\n", (LONG)n);
+            return BTIOERR_HOSTERROR;
+        }
+        if (n == 0)
+        {
+            /* FIFO full: give it room rather than spinning forever. */
+            if (++spins > 100000)
+            {
+                bug("[h4bthci] transmit FIFO stayed full, %lu of %lu sent\n",
+                    done, length);
+                return BTIOERR_HOSTERROR;
+            }
+            continue;
+        }
+        spins = 0;
+        done += (ULONG)n;
+    }
+    return 0;
+}
+
+static LONG h4bthci_Send(struct H4BTHCIUnit *unit, UBYTE type,
+                           const UBYTE *data, ULONG length)
+{
+    UBYTE hdr = type;
+    LONG err = h4bthci_WriteAll(unit, &hdr, 1);
+
+    if (err)
+        return err;
+    if (length)
+        return h4bthci_WriteAll(unit, data, length);
+
+    return 0;
+}
+
+LONG h4bthci_QueueRequest(struct H4BTHCIUnit *unit, struct IOBTHCIReq *ioreq)
+{
+    switch (ioreq->iobt_Req.io_Command)
+    {
+    case BTCMD_QUERYDEVICE:
+    {
+        struct TagItem *tags = (struct TagItem *)ioreq->iobt_Data;
+        struct TagItem *tag;
+
+        while (tags && (tag = NextTagItem(&tags)))
+        {
+            switch (tag->ti_Tag)
+            {
+            case BTA_Author:
+                *((STRPTR *)tag->ti_Data) = "The AROS Development Team";
+                break;
+            case BTA_ProductName:
+                *((STRPTR *)tag->ti_Data) = "Raspberry Pi onboard Bluetooth";
+                break;
+            case BTA_Description:
+                *((STRPTR *)tag->ti_Data) =
+                    "H4 HCI transport over the BCM283x PL011";
+                break;
+            case BTA_Copyright:
+                *((STRPTR *)tag->ti_Data) = "(C) 2026 The AROS Development Team";
+                break;
+            case BTA_Version:
+                *((ULONG *)tag->ti_Data) = 45;
+                break;
+            case BTA_Revision:
+                *((ULONG *)tag->ti_Data) = 1;
+                break;
+            case BTA_DriverVersion:
+                *((ULONG *)tag->ti_Data) = 1;
+                break;
+            }
+        }
+        ioreq->iobt_Req.io_Error = 0;
+        return 0;
+    }
+
+    case BTCMD_WRITEHCI:
+        ioreq->iobt_Req.io_Error =
+            h4bthci_Send(unit, H4BTHCI_COMMAND,
+                           ioreq->iobt_Data, ioreq->iobt_Length);
+        ioreq->iobt_Actual = ioreq->iobt_Req.io_Error ? 0 : ioreq->iobt_Length;
+        return 0;
+
+    case BTCMD_WRITEACL:
+        ioreq->iobt_Req.io_Error =
+            h4bthci_Send(unit, H4BTHCI_ACL,
+                           ioreq->iobt_Data, ioreq->iobt_Length);
+        ioreq->iobt_Actual = ioreq->iobt_Req.io_Error ? 0 : ioreq->iobt_Length;
+        return 0;
+
+    case BTCMD_READEVENT:
+        ObtainSemaphore(&unit->hu_QueueLock);
+        AddTail((struct List *)&unit->hu_EventQueue,
+                (struct Node *)&ioreq->iobt_Req.io_Message.mn_Node);
+        ReleaseSemaphore(&unit->hu_QueueLock);
+        return -1;                      /* queued; the unit task replies */
+
+    case BTCMD_READACL:
+        ObtainSemaphore(&unit->hu_QueueLock);
+        AddTail((struct List *)&unit->hu_ACLQueue,
+                (struct Node *)&ioreq->iobt_Req.io_Message.mn_Node);
+        ReleaseSemaphore(&unit->hu_QueueLock);
+        return -1;
+
+    case BTCMD_ADDMSGPORT:
+    {
+        struct H4BTHCIListener *listener =
+            AllocVec(sizeof(struct H4BTHCIListener), MEMF_PUBLIC | MEMF_CLEAR);
+
+        if (!listener)
+        {
+            ioreq->iobt_Req.io_Error = BTIOERR_OUTOFMEMORY;
+            return 0;
+        }
+        listener->hl_Port = (struct MsgPort *)ioreq->iobt_Data;
+        ObtainSemaphore(&unit->hu_QueueLock);
+        AddTail((struct List *)&unit->hu_Listeners, (struct Node *)listener);
+        ReleaseSemaphore(&unit->hu_QueueLock);
+        ioreq->iobt_Req.io_Error = 0;
+        return 0;
+    }
+
+    case BTCMD_REMMSGPORT:
+    {
+        struct MinNode *mn;
+
+        ObtainSemaphore(&unit->hu_QueueLock);
+        for (mn = unit->hu_Listeners.mlh_Head; mn->mln_Succ; mn = mn->mln_Succ)
+        {
+            struct H4BTHCIListener *listener = (struct H4BTHCIListener *)mn;
+
+            if (listener->hl_Port == (struct MsgPort *)ioreq->iobt_Data)
+            {
+                Remove((struct Node *)mn);
+                FreeVec(listener);
+                break;
+            }
+        }
+        ReleaseSemaphore(&unit->hu_QueueLock);
+        ioreq->iobt_Req.io_Error = 0;
+        return 0;
+    }
+
+    /*
+     * SCO is not wired. The onboard controller supports it, but routing audio
+     * needs a PCM path this port does not have, and answering the request as
+     * though it worked would be worse than refusing it.
+     */
+    case BTCMD_SETUPSCO:
+    case BTCMD_READSCO:
+    case BTCMD_WRITESCO:
+        ioreq->iobt_Req.io_Error = IOERR_NOCMD;
+        return 0;
+
+    default:
+        ioreq->iobt_Req.io_Error = IOERR_NOCMD;
+        return 0;
+    }
+}
+
+void h4bthci_UnitTask(void)
+{
+    struct Task *self = FindTask(NULL);
+    struct H4BTHCIUnit *unit = (struct H4BTHCIUnit *)
+        ((struct Process *)self)->pr_Task.tc_UserData;
+    struct Task *waiter;
+
+    /*
+     * Say which step failed.
+     *
+     * There are four of them and none of them said anything, so a failure
+     * arrived at AddBTHardware as the single word "failed" -- with the
+     * resource itself reporting "[PL011BT] ready" a moment earlier, which
+     * makes the two impossible to tell apart from a log. Each step now names
+     * itself and its return code.
+     */
+    PL011BTBase = OpenResource("pl011bt.resource");
+    if (!PL011BTBase)
+        bug("[h4bthci] pl011bt.resource not available\n");
+    else
+    {
+        LONG rc = PL011BTClaim(unit);
+
+        if (rc != PL011BT_OK)
+            bug("[h4bthci] PL011BTClaim failed, rc=%ld\n", (LONG)rc);
+        else
+        {
+            rc = PL011BTSetPower(unit, 1);
+            if (rc != PL011BT_OK)
+                bug("[h4bthci] PL011BTSetPower failed, rc=%ld\n", (LONG)rc);
+            else
+            {
+                rc = PL011BTConfigure(unit, H4BTHCI_BAUD,
+                        PL011BT_CONFIG_RTS_CTS);
+                if (rc != PL011BT_OK)
+                    bug("[h4bthci] PL011BTConfigure(%lu baud) failed,"
+                        " rc=%ld\n", (ULONG)H4BTHCI_BAUD, (LONG)rc);
+                else
+                {
+                    bug("[h4bthci] transport up at %lu baud\n",
+                        (ULONG)H4BTHCI_BAUD);
+                    unit->hu_Task = self;
+                }
+            }
+            if (!unit->hu_Task)
+                PL011BTRelease(unit);
+        }
+    }
+
+    /* Tell the opener whether there is a controller, either way. */
+    Forbid();
+    waiter = unit->hu_ReadySigTask;
+    if (waiter)
+        Signal(waiter, 1L << unit->hu_ReadySignal);
+    Permit();
+
+    if (!unit->hu_Task)
+        return;
+
+    /* %lu, not %u: kprintf fetches a %u as a 16-bit UWORD, and 115200
+     * does not fit in one -- it would report 49664 baud. */
+    bug("[h4bthci] claimed the PL011 at %lu baud\n",
+        (ULONG)H4BTHCI_BAUD);
+
+    /*
+     * Polled, and that is a known cost rather than a design.
+     * pl011bt.resource's capability bits say whether RX and TX interrupts are
+     * available (PL011BT_CAP_RX_INTERRUPT), and they are zero until that path
+     * is proven -- so until then the honest thing is a poll with a delay
+     * rather than a wait that would never be signalled.
+     */
+    for (;;)
+    {
+        LONG got;
+
+        if (SetSignal(0, 0) & SIGBREAKF_CTRL_C)
+            break;
+
+        got = PL011BTRead(unit, unit->hu_RX + unit->hu_RXLen,
+                         H4BTHCI_RXBUF - unit->hu_RXLen);
+        if (got > 0)
+        {
+            unit->hu_RXLen += got;
+            h4bthci_Reassemble(unit);
+        }
+        else
+            Delay(1);
+    }
+
+    PL011BTSetPower(unit, 0);
+    PL011BTRelease(unit);
+
+    Forbid();
+    unit->hu_Task = NULL;
+    waiter = unit->hu_ReadySigTask;
+    if (waiter)
+        Signal(waiter, 1L << unit->hu_ReadySignal);
+    Permit();
+}

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/h4bthci/mmakefile.src
@@ -1,0 +1,28 @@
+include $(SRCDIR)/config/aros.cfg
+
+#
+# The HCI transport for the Pi's on-board controller.
+#
+# AROS's Bluetooth stack talks to HCI devices in DEVS:Bluetooth. Upstream
+# ships exactly one, vbthci, and it is virtual -- so on real hardware the
+# stack has nothing to talk to. This is the other half: H:4 framing over the
+# PL011 that pl011bt.resource owns.
+#
+# It deliberately knows nothing about the board. Pin muxing, the LPO on
+# GPCLK2, BT_REG_EN, the baud rate and flow control all belong to that
+# resource, and what is here would work over any transport that can move
+# bytes. Firmware upload is not here either: a BCM43438 runs from ROM until
+# something sends it a patchram image, and that protocol is brcmbt.fwl.
+#
+FILES := h4bthci_device h4bthci_unit
+
+USER_INCLUDES := -I$(SRCDIR)/rom/bluetooth/stack/include
+
+#MM kernel-h4bthci-bcm2708 : kernel-bluetooth-library-includes kernel-pl011bt-bcm2708-includes
+
+%build_module mmake=kernel-h4bthci-bcm2708 \
+    modname=h4bthci modtype=device \
+    moduledir=Devs/Bluetooth \
+    files="$(FILES)"
+
+%common

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/mmakefile.src
@@ -1,0 +1,16 @@
+include $(SRCDIR)/config/aros.cfg
+
+#
+# The PL011 that the BCM283x wires to the on-board Bluetooth radio.
+#
+# It routes the pins through gpio.resource and asks the firmware for the UART
+# clock and for BT_REG_EN through mbox.resource, so it needs both of their
+# generated headers before it compiles.
+#
+#MM kernel-pl011bt-bcm2708 : kernel-gpio-bcm2708-includes kernel-mbox-bcm2708-includes
+
+%build_module mmake=kernel-pl011bt-bcm2708 \
+    modname=pl011bt modtype=resource \
+    files="pl011bt_init"
+
+%common

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt.conf
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt.conf
@@ -1,0 +1,38 @@
+##begin config
+version 0.1
+residentpri 87
+libbase PL011BTBase
+libbasetype struct PL011BTBase
+##end config
+##begin cdef
+#define PL011BT_API_VERSION 1
+
+/* Capabilities are zero until the corresponding hardware path is safe. */
+#define PL011BT_CAP_PRESENT       (1UL << 0)
+#define PL011BT_CAP_RX_INTERRUPT  (1UL << 1)
+#define PL011BT_CAP_TX_INTERRUPT  (1UL << 2)
+#define PL011BT_CAP_BAUD_CHANGE   (1UL << 3)
+#define PL011BT_CAP_POWER_CONTROL (1UL << 4)
+
+#define PL011BT_CONFIG_RTS_CTS    (1UL << 0)
+
+#define PL011BT_OK                 0
+#define PL011BT_ERR_ARGUMENT      -1
+#define PL011BT_ERR_UNAVAILABLE   -2
+#define PL011BT_ERR_BUSY          -3
+#define PL011BT_ERR_NOT_OWNER     -4
+#define PL011BT_ERR_TIMEOUT       -5
+##end cdef
+##begin cdefprivate
+#include "pl011bt_private.h"
+##end cdefprivate
+##begin functionlist
+unsigned int PL011BTGetAPIVersion() ()
+unsigned long PL011BTGetCapabilities() ()
+long PL011BTClaim(void *owner) (A0)
+void PL011BTRelease(void *owner) (A0)
+long PL011BTConfigure(void *owner, unsigned long baud, unsigned long flags) (A0, D0, D1)
+long PL011BTSetPower(void *owner, unsigned long enabled) (A0, D0)
+long PL011BTWrite(void *owner, const void *data, unsigned long length) (A0, A1, D0)
+long PL011BTRead(void *owner, void *data, unsigned long capacity) (A0, A1, D0)
+##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt_init.c
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt_init.c
@@ -1,0 +1,623 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: pl011bt.resource -- the PL011 wired to the on-board Bluetooth radio.
+
+    The BCM283x has two UARTs. On a Raspberry Pi 3 and later the firmware
+    routes the PL011 to the on-board Bluetooth controller and leaves the AUX
+    mini-UART on the GPIO header, which is where the serial console lives.
+    This resource owns that PL011 -- the pin mux, the controller's 32.768 kHz
+    low-power oscillator on GPCLK2, BT_REG_EN, the baud divisor and the
+    receive interrupt -- and nothing above it.
+
+    It is deliberately the transport and only the transport: H:4 framing is
+    h4bthci.device beside this, the protocols are rom/bluetooth, and the
+    Broadcom patchram upload is brcmbt.fwl.
+
+    Resident initialisation stays side-effect free. It discovers the
+    peripheral window and asks the firmware for the UART clock; the PL011 is
+    not touched until a client claims the resource and configures it, so a
+    machine that never opens Bluetooth is left exactly as the firmware set
+    it up.
+*/
+
+#define DEBUG 0
+
+#include <aros/debug.h>
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+#include <aros/macros.h>
+#include <aros/symbolsets.h>
+
+#include <proto/exec.h>
+#include <proto/kernel.h>
+#include <proto/gpio.h>
+#include <proto/mbox.h>
+#include <proto/pl011bt.h>
+
+#include "pl011bt_private.h"
+
+/*
+ * The Bluetooth pins. GPIO 30-33 are CTS/RTS/TXD/RXD of the PL011 in ALT3,
+ * and GPIO 43 carries GPCLK2 in ALT0, which the controller uses as its LPO.
+ */
+#define BT_GPIO_CTS             30
+#define BT_GPIO_RXD             33
+#define BT_GPIO_LPO             43
+
+/* Mailbox property tags for the firmware-owned GPIO expander. BT_REG_EN is
+ * expander pin 128 and is not addressable through the SoC GPIO block. */
+#define FW_SET_GPIO_STATE       0x00038041
+#define FW_SET_GPIO_CONFIG      0x00038043
+#define FW_GPIO_BT_REG_EN       128
+#define FW_GPIO_DIR_OUTPUT      1
+
+/* Answer when the firmware will not say. The PL011 reference clock is 48 MHz
+ * on every Pi that has an on-board radio. */
+#define UART_CLOCK_FALLBACK_HZ  48000000
+
+/* proto/kernel.h, proto/mbox.h and proto/gpio.h declare the conventional
+ * library bases as extern APTR. Define them here so their inline calls use
+ * the resources this one opened. */
+APTR KernelBase;
+APTR MBoxBase;
+APTR GPIOBase;
+
+static inline ULONG pl011bt_rd(IPTR addr)
+{
+    return AROS_LE2LONG(*(volatile ULONG *)addr);
+}
+
+static inline void pl011bt_wr(IPTR addr, ULONG value)
+{
+    *(volatile ULONG *)addr = AROS_LONG2LE(value);
+}
+
+/*
+ * Route the four PL011 signals to the radio.
+ *
+ * Through gpio.resource rather than by hand: GPIOSetFunc() preserves the
+ * other pins in the same GPFSEL, and on a BCM2712 it knows to go through the
+ * RP1 instead. Both matter here -- GPFSEL3 also carries the WiFi SDIO bus on
+ * GPIO 34-39, and clearing that from under sdio.resource is not recoverable.
+ */
+static void route_bluetooth_uart(void)
+{
+    unsigned int pin;
+
+    for (pin = BT_GPIO_CTS; pin <= BT_GPIO_RXD; pin++)
+        GPIOSetFunc(pin, GPIO_FSEL_ALT3);
+
+    D(bug("[PL011BT] GPIO %lu-%lu -> ALT3\n",
+          (ULONG)BT_GPIO_CTS, (ULONG)BT_GPIO_RXD));
+}
+
+/*
+ * Drive the controller's low-power oscillator: 32.768 kHz out of GPCLK2.
+ *
+ * Stop the generator by clearing ENAB *and nothing else*.
+ *
+ * Writing the password alone clears ENAB, but in the same store also drives
+ * SRC to 0 (GND) and MASH to 0. The BCM283x peripherals datasheet is explicit
+ * that the source and the divisor must not change while the generator runs:
+ * clear ENAB, wait for BUSY to fall, and only then reprogram. Changing SRC in
+ * the stop write leaves BUSY set and the wait below never completes.
+ *
+ * On a Pi the firmware has already started GPCLK2 for the radio, so the bad
+ * write lands on a running generator every time. It passes anywhere the
+ * register is not modelled and BUSY reads back 0.
+ */
+static LONG setup_lpo_clock(struct PL011BTBase *PL011BTBase)
+{
+    ULONG wait = PL011BT_WAIT_LIMIT;
+    ULONG ctl;
+
+    GPIOSetFunc(BT_GPIO_LPO, GPIO_FSEL_ALT0);
+
+    ctl = pl011bt_rd(CM_GP2CTL) & (CM_SRC_MASK | CM_MASH_MASK);
+    pl011bt_wr(CM_GP2CTL, CM_PASSWORD | ctl);
+    while ((pl011bt_rd(CM_GP2CTL) & CM_BUSY) && --wait != 0)
+        ;
+    if (wait == 0)
+        return PL011BT_ERR_TIMEOUT;
+
+    /* 19.2 MHz / 585.9375 = 32768 Hz. The fractional field is in 1/4096. */
+    pl011bt_wr(CM_GP2DIV, CM_PASSWORD | (585 << 12) | 3840);
+    pl011bt_wr(CM_GP2CTL,
+               CM_PASSWORD | CM_MASH(1) | CM_SRC_OSC | CM_ENAB);
+
+    D(bug("[PL011BT] GPCLK2 -> 32768 Hz on GPIO %lu\n", (ULONG)BT_GPIO_LPO));
+    return PL011BT_OK;
+}
+
+/*
+ * BT_REG_EN, the radio's enable line, sits on the firmware's GPIO expander
+ * rather than on the SoC, so it is reachable only through the mailbox.
+ * Caller holds pl011bt_Sem: the message buffer is shared.
+ */
+static LONG firmware_gpio_set(struct PL011BTBase *PL011BTBase, ULONG gpio,
+                              ULONG enabled)
+{
+    ULONG *msg = PL011BTBase->pl011bt_MBoxMsg;
+    LONG result = PL011BT_ERR_UNAVAILABLE;
+
+    if (MBoxBase == NULL || msg == NULL)
+    {
+        bug("[PL011BT] power: mbox.resource unavailable\n");
+        return result;
+    }
+
+    msg[0] = AROS_LONG2LE(12 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(FW_SET_GPIO_CONFIG);
+    msg[3] = AROS_LONG2LE(24);
+    msg[4] = 0;
+    msg[5] = AROS_LONG2LE(gpio);
+    msg[6] = AROS_LONG2LE(FW_GPIO_DIR_OUTPUT);
+    msg[7] = 0;
+    msg[8] = 0;
+    msg[9] = 0;
+    msg[10] = AROS_LONG2LE(enabled != 0);
+    msg[11] = 0;
+    if (MBoxCall((APTR)(IPTR)VCMB_BASE, VCMB_PROPCHAN, msg) == msg &&
+        (AROS_LE2LONG(msg[1]) & VCTAG_RESP))
+        result = PL011BT_OK;
+
+    if (result == PL011BT_OK)
+    {
+        msg[0] = AROS_LONG2LE(8 * 4);
+        msg[1] = AROS_LONG2LE(VCTAG_REQ);
+        msg[2] = AROS_LONG2LE(FW_SET_GPIO_STATE);
+        msg[3] = AROS_LONG2LE(8);
+        msg[4] = 0;
+        msg[5] = AROS_LONG2LE(gpio);
+        msg[6] = AROS_LONG2LE(enabled != 0);
+        msg[7] = 0;
+        if (MBoxCall((APTR)(IPTR)VCMB_BASE, VCMB_PROPCHAN, msg) != msg ||
+            !(AROS_LE2LONG(msg[1]) & VCTAG_RESP))
+            result = PL011BT_ERR_UNAVAILABLE;
+    }
+
+    D(bug("[PL011BT] power: GPIO %lu -> %lu, result %ld\n",
+          (ULONG)gpio, (ULONG)(enabled != 0), (LONG)result));
+    return result;
+}
+
+static ULONG query_uart_clock(struct PL011BTBase *PL011BTBase)
+{
+    ULONG *msg = PL011BTBase->pl011bt_MBoxMsg;
+
+    if (MBoxBase == NULL || msg == NULL)
+        return UART_CLOCK_FALLBACK_HZ;
+
+    msg[0] = AROS_LONG2LE(8 * 4);
+    msg[1] = AROS_LONG2LE(VCTAG_REQ);
+    msg[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);
+    msg[3] = AROS_LONG2LE(8);
+    msg[4] = AROS_LONG2LE(4);
+    msg[5] = AROS_LONG2LE(VCCLOCK_UART);
+    msg[6] = 0;
+    msg[7] = 0;
+
+    if (MBoxCall((APTR)(IPTR)VCMB_BASE, VCMB_PROPCHAN, msg) != msg)
+        return UART_CLOCK_FALLBACK_HZ;
+    if (AROS_LE2LONG(msg[6]) == 0)
+        return UART_CLOCK_FALLBACK_HZ;
+    return AROS_LE2LONG(msg[6]);
+}
+
+/*
+ * Drain the FIFO into the ring. Runs in interrupt context.
+ *
+ * Plain void(void *, void *), which is what KrnAddIRQHandler() calls. Writing
+ * it as AROS_INTH1 produces the struct Interrupt server convention instead,
+ * and being called as a plain pointer through that mismatch corrupts
+ * registers.
+ *
+ * Everything here is a store to MMIO or to the ring: no allocation, no lock,
+ * no call back into exec. The reader synchronises on the head alone, which
+ * this is the only writer of.
+ */
+static void pl011bt_rx_handler(void *data, void *unused)
+{
+    struct PL011BTBase *PL011BTBase = data;
+    ULONG head;
+
+    (void)unused;
+    head = PL011BTBase->pl011bt_RXHead;
+
+    while (!(pl011bt_rd(PL011_0_BASE + PL011_FR) & PL011_FR_RXFE))
+    {
+        ULONG dr = pl011bt_rd(PL011_0_BASE + PL011_DR);
+        ULONG next = (head + 1) & (PL011BT_RX_RING - 1);
+
+        if ((dr & PL011_DR_ERR) != 0 && PL011BTBase->pl011bt_RXErrors < 8)
+        {
+            PL011BTBase->pl011bt_RXErrors++;
+            bug("[PL011BT] rx status 0x%lx%s\n", (ULONG)((dr >> 8) & 0xF),
+                (dr & PL011_DR_OE) ? " OVERRUN" : "");
+        }
+        if (next == PL011BTBase->pl011bt_RXTail)
+        {
+            /* The reader is too far behind. Dropping here is still better
+             * than letting the FIFO overrun, because it is counted. */
+            PL011BTBase->pl011bt_RXDropped++;
+            break;
+        }
+        PL011BTBase->pl011bt_RXRing[head] = (UBYTE)(dr & 0xFF);
+        head = next;
+    }
+    PL011BTBase->pl011bt_RXHead = head;
+
+    /* Acknowledge receive and receive-timeout; overrun goes with them so a
+     * single lost byte does not latch the condition forever. */
+    pl011bt_wr(PL011_0_BASE + PL011_ICR,
+               PL011_INT_RX | PL011_INT_RT | PL011_INT_OE);
+}
+
+static int pl011bt_init(struct PL011BTBase *PL011BTBase)
+{
+    IPTR periiobase;
+
+    InitSemaphore(&PL011BTBase->pl011bt_Sem);
+    PL011BTBase->pl011bt_Owner = NULL;
+    PL011BTBase->pl011bt_Caps = 0;
+
+    KernelBase = OpenResource("kernel.resource");
+    if (KernelBase == NULL)
+        return FALSE;
+
+    /*
+     * Held as an IPTR for the test, because the BCM2712 window does not fit
+     * in the unsigned int the resource stores -- truncating first would let
+     * a 64-bit base alias onto one of the windows accepted below.
+     */
+    periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
+
+    /*
+     * Bind to the SoCs this has been run on, by naming them rather than by
+     * excluding the others.
+     *
+     * The arrangement this drives -- PL011 on GPIO 30-33 to the radio, the
+     * console pushed onto the AUX mini-UART, the LPO on GPCLK2, BT_REG_EN on
+     * the firmware's GPIO expander -- is the BCM2835/6/7 one, and IRQ_VC_UART
+     * below is the legacy interrupt controller's numbering. A BCM2711 wires
+     * its radio the same way but presents the GPU interrupts through the GIC
+     * at BCM2711_GPUIRQ_OFFSET, and a BCM2712 does not use this UART for
+     * Bluetooth at all. Neither has been tested, so the resource stands down
+     * there: absent is a state h4bthci.device already handles, present and
+     * wrong is not.
+     */
+    if (periiobase != BCM2835_PERIPHYSBASE &&
+        periiobase != BCM2836_PERIPHYSBASE)
+    {
+        D(bug("[PL011BT] peripheral window 0x%p is not a BCM283x, standing"
+              " down\n", (void *)periiobase));
+        return FALSE;
+    }
+    PL011BTBase->pl011bt_periiobase = (unsigned int)periiobase;
+
+    GPIOBase = OpenResource("gpio.resource");
+    if (GPIOBase == NULL)
+    {
+        bug("[PL011BT] gpio.resource unavailable, cannot route the UART\n");
+        return FALSE;
+    }
+    MBoxBase = OpenResource("mbox.resource");
+
+    PL011BTBase->pl011bt_MBoxRaw = AllocMem(64 + (MBOX_MSG_ALIGN - 1),
+                                            MEMF_PUBLIC | MEMF_CLEAR);
+    if (PL011BTBase->pl011bt_MBoxRaw == NULL)
+        return FALSE;
+    PL011BTBase->pl011bt_MBoxMsg = (ULONG *)
+        (((IPTR)PL011BTBase->pl011bt_MBoxRaw + (MBOX_MSG_ALIGN - 1))
+         & ~(IPTR)(MBOX_MSG_ALIGN - 1));
+
+    PL011BTBase->pl011bt_ClockHz = query_uart_clock(PL011BTBase);
+    PL011BTBase->pl011bt_Caps = PL011BT_CAP_PRESENT |
+        PL011BT_CAP_BAUD_CHANGE | PL011BT_CAP_POWER_CONTROL;
+
+    bug("[PL011BT] ready: PL011=0x%08lx clock=%lu mbox=%s\n",
+        (ULONG)PL011_0_BASE, (ULONG)PL011BTBase->pl011bt_ClockHz,
+        MBoxBase != NULL ? "yes" : "no");
+
+    return TRUE;
+}
+
+AROS_LH0(unsigned int, PL011BTGetAPIVersion,
+    struct PL011BTBase *, PL011BTBase, 1, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    return PL011BT_API_VERSION;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH0(unsigned long, PL011BTGetCapabilities,
+    struct PL011BTBase *, PL011BTBase, 2, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    return PL011BTBase->pl011bt_Caps;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH1(long, PL011BTClaim,
+    AROS_LHA(void *, owner, A0),
+    struct PL011BTBase *, PL011BTBase, 3, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    LONG result = PL011BT_OK;
+
+    if (owner == NULL)
+        return PL011BT_ERR_ARGUMENT;
+
+    ObtainSemaphore(&PL011BTBase->pl011bt_Sem);
+    if (PL011BTBase->pl011bt_Owner != NULL)
+        result = PL011BT_ERR_BUSY;
+    else
+        PL011BTBase->pl011bt_Owner = owner;
+    ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+
+    return result;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH1(void, PL011BTRelease,
+    AROS_LHA(void *, owner, A0),
+    struct PL011BTBase *, PL011BTBase, 4, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    ObtainSemaphore(&PL011BTBase->pl011bt_Sem);
+    if (owner != NULL && PL011BTBase->pl011bt_Owner == owner)
+    {
+        pl011bt_wr(PL011_0_BASE + PL011_IMSC, 0);
+        pl011bt_wr(PL011_0_BASE + PL011_CR, 0);
+        PL011BTBase->pl011bt_Owner = NULL;
+        PL011BTBase->pl011bt_Baud = 0;
+        PL011BTBase->pl011bt_ConfigFlags = 0;
+    }
+    ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH3(long, PL011BTConfigure,
+    AROS_LHA(void *, owner, A0),
+    AROS_LHA(unsigned long, baud, D0),
+    AROS_LHA(unsigned long, flags, D1),
+    struct PL011BTBase *, PL011BTBase, 5, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    ULONG divisor, integer, fraction, control;
+    ULONG wait = PL011BT_WAIT_LIMIT;
+    ULONG guard;
+
+    if (owner == NULL || baud == 0)
+        return PL011BT_ERR_ARGUMENT;
+
+    ObtainSemaphore(&PL011BTBase->pl011bt_Sem);
+    if (PL011BTBase->pl011bt_Owner != owner)
+    {
+        ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+        return PL011BT_ERR_NOT_OWNER;
+    }
+
+    if (setup_lpo_clock(PL011BTBase) != PL011BT_OK)
+    {
+        bug("[PL011BT] configure: LPO clock timeout\n");
+        ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+        return PL011BT_ERR_TIMEOUT;
+    }
+    route_bluetooth_uart();
+
+    pl011bt_wr(PL011_0_BASE + PL011_CR, 0);
+    while ((pl011bt_rd(PL011_0_BASE + PL011_FR) & PL011_FR_BUSY) && --wait != 0)
+        ;
+    if (wait == 0)
+    {
+        bug("[PL011BT] configure: PL011 busy timeout\n");
+        ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+        return PL011BT_ERR_TIMEOUT;
+    }
+
+    pl011bt_wr(PL011_0_BASE + PL011_LCRH, 0);
+    pl011bt_wr(PL011_0_BASE + PL011_IMSC, 0);
+    pl011bt_wr(PL011_0_BASE + PL011_ICR, PL011_INT_ALL);
+
+    /*
+     * Start from an empty receive path, not from whatever the line held.
+     *
+     * Clearing the interrupt status says nothing about the FIFO's contents.
+     * Powering the controller through BT_REG_EN and reprogramming the baud
+     * divisor both put transitions on the wire, and whatever the receiver
+     * made of those sits in the FIFO waiting to be read as if it were HCI. On
+     * hardware that shows up as an OVERRUN before a single command has been
+     * sent, followed by the H:4 framer reporting unknown packet types -- it
+     * is not desynchronised by a lost reply, it never had synchronisation.
+     */
+    guard = PL011BT_RX_RING;
+    while (guard-- &&
+           !(pl011bt_rd(PL011_0_BASE + PL011_FR) & PL011_FR_RXFE))
+        (void)pl011bt_rd(PL011_0_BASE + PL011_DR);
+
+    PL011BTBase->pl011bt_RXHead = 0;
+    PL011BTBase->pl011bt_RXTail = 0;
+    PL011BTBase->pl011bt_RXDropped = 0;
+    pl011bt_wr(PL011_0_BASE + PL011_ICR, PL011_INT_ALL);
+
+    divisor = (PL011BTBase->pl011bt_ClockHz * 4 + baud / 2) / baud;
+    integer = divisor >> 6;
+    fraction = divisor & 0x3F;
+    if (integer == 0 || integer > 0xFFFF)
+    {
+        ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+        return PL011BT_ERR_ARGUMENT;
+    }
+    pl011bt_wr(PL011_0_BASE + PL011_IBRD, integer);
+    pl011bt_wr(PL011_0_BASE + PL011_FBRD, fraction);
+    pl011bt_wr(PL011_0_BASE + PL011_LCRH,
+               PL011_LCRH_WLEN8 | PL011_LCRH_FEN);
+
+    control = PL011_CR_UARTEN | PL011_CR_TXE | PL011_CR_RXE;
+    if (flags & PL011BT_CONFIG_RTS_CTS)
+        control |= PL011_CR_RTSEN | PL011_CR_CTSEN;
+    pl011bt_wr(PL011_0_BASE + PL011_CR, control);
+
+    /*
+     * Arm receive interrupts once, after the port is configured.
+     *
+     * Order matters: the watermark and the mask are cleared by the LCRH write
+     * above, and enabling the interrupt before UARTEN would deliver on a port
+     * that is not receiving. Registration is idempotent because a second
+     * Configure by the same owner is legitimate -- a baud change, for one.
+     */
+    pl011bt_wr(PL011_0_BASE + PL011_IFLS, PL011_IFLS_RX18);
+    if (PL011BTBase->pl011bt_RXIRQ == NULL)
+    {
+        PL011BTBase->pl011bt_RXIRQ = KrnAddIRQHandler(IRQ_VC_UART,
+            pl011bt_rx_handler, PL011BTBase, SysBase);
+        if (PL011BTBase->pl011bt_RXIRQ != NULL)
+        {
+            PL011BTBase->pl011bt_Caps |= PL011BT_CAP_RX_INTERRUPT;
+            D(bug("[PL011BT] rx interrupt armed on irq %lu\n",
+                  (ULONG)IRQ_VC_UART));
+        }
+        else
+            bug("[PL011BT] KrnAddIRQHandler(%lu) failed -- receive stays"
+                " polled\n", (ULONG)IRQ_VC_UART);
+    }
+    pl011bt_wr(PL011_0_BASE + PL011_ICR, PL011_INT_ALL);
+    if (PL011BTBase->pl011bt_RXIRQ != NULL)
+        pl011bt_wr(PL011_0_BASE + PL011_IMSC, PL011_INT_RX | PL011_INT_RT);
+
+    PL011BTBase->pl011bt_Baud = baud;
+    PL011BTBase->pl011bt_ConfigFlags = flags;
+
+    D(bug("[PL011BT] configure: baud=%lu clock=%lu divisor=%lu/%lu"
+          " flags=0x%lx\n",
+          (ULONG)baud, (ULONG)PL011BTBase->pl011bt_ClockHz,
+          (ULONG)integer, (ULONG)fraction, (ULONG)flags));
+
+    ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+    return PL011BT_OK;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH2(long, PL011BTSetPower,
+    AROS_LHA(void *, owner, A0),
+    AROS_LHA(unsigned long, enabled, D0),
+    struct PL011BTBase *, PL011BTBase, 6, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    LONG result;
+
+    if (owner == NULL)
+        return PL011BT_ERR_ARGUMENT;
+
+    ObtainSemaphore(&PL011BTBase->pl011bt_Sem);
+    if (PL011BTBase->pl011bt_Owner != owner)
+        result = PL011BT_ERR_NOT_OWNER;
+    else
+        result = firmware_gpio_set(PL011BTBase, FW_GPIO_BT_REG_EN, enabled);
+    ReleaseSemaphore(&PL011BTBase->pl011bt_Sem);
+
+    return result;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH3(long, PL011BTWrite,
+    AROS_LHA(void *, owner, A0),
+    AROS_LHA(const void *, data, A1),
+    AROS_LHA(unsigned long, length, D0),
+    struct PL011BTBase *, PL011BTBase, 7, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    const UBYTE *bytes = data;
+    ULONG written = 0;
+
+    if (owner == NULL || (data == NULL && length != 0))
+        return PL011BT_ERR_ARGUMENT;
+    if (PL011BTBase->pl011bt_Owner != owner)
+        return PL011BT_ERR_NOT_OWNER;
+
+    /* Returns what the FIFO accepted, not a status: a caller with more to
+     * send comes back rather than blocking the transport here. */
+    while (written < length &&
+           !(pl011bt_rd(PL011_0_BASE + PL011_FR) & PL011_FR_TXFF))
+    {
+        pl011bt_wr(PL011_0_BASE + PL011_DR, bytes[written]);
+        written++;
+    }
+    return (LONG)written;
+
+    AROS_LIBFUNC_EXIT
+}
+
+AROS_LH3(long, PL011BTRead,
+    AROS_LHA(void *, owner, A0),
+    AROS_LHA(void *, data, A1),
+    AROS_LHA(unsigned long, capacity, D0),
+    struct PL011BTBase *, PL011BTBase, 8, Pl011bt)
+{
+    AROS_LIBFUNC_INIT
+
+    UBYTE *bytes = data;
+    ULONG read = 0;
+
+    if (owner == NULL || (data == NULL && capacity != 0))
+        return PL011BT_ERR_ARGUMENT;
+    if (PL011BTBase->pl011bt_Owner != owner)
+        return PL011BT_ERR_NOT_OWNER;
+
+    /*
+     * From the ring, not from the FIFO.
+     *
+     * Reading the FIFO here would make the caller's scheduling the deadline
+     * for the hardware, and no schedule is fast enough: OVERRUN was reported
+     * on real hardware even at a one-millisecond poll. The interrupt owns the
+     * FIFO and this owns the tail, so a slow reader costs latency, not data.
+     */
+    while (read < capacity &&
+           PL011BTBase->pl011bt_RXTail != PL011BTBase->pl011bt_RXHead)
+    {
+        bytes[read] = PL011BTBase->pl011bt_RXRing[PL011BTBase->pl011bt_RXTail];
+        PL011BTBase->pl011bt_RXTail =
+            (PL011BTBase->pl011bt_RXTail + 1) & (PL011BT_RX_RING - 1);
+        read++;
+    }
+
+    if (PL011BTBase->pl011bt_RXDropped != 0)
+    {
+        bug("[PL011BT] rx ring overflow, %lu byte(s) dropped\n",
+            (ULONG)PL011BTBase->pl011bt_RXDropped);
+        PL011BTBase->pl011bt_RXDropped = 0;
+    }
+    return (LONG)read;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*
+ * Register the init with genmodule's INITLIB set.
+ *
+ * Without this line pl011bt_init() is a static function nobody references, so
+ * the compiler drops it along with everything only it calls -- and genmodule,
+ * having no init to run, adds the resource anyway. OpenResource() then hands
+ * out a base whose fields are all zero, which is worse than a missing
+ * resource because it looks like a working one: PL011BTGetAPIVersion()
+ * answers from a constant, and the first call that touches the base hangs.
+ * ObtainSemaphore() on a zeroed SignalSemaphore blocks forever, because
+ * InitSemaphore() sets ss_QueueCount to -1 and zero reads as "already owned".
+ */
+ADD2INITLIB(pl011bt_init, 0)

--- a/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt_private.h
+++ b/arch/arm-native/soc/broadcom/2708/bluetooth/pl011bt_private.h
@@ -1,0 +1,82 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Private state for pl011bt.resource: the PL011 UART that the BCM283x wires
+    to the on-board Bluetooth controller on the Raspberry Pi 3, 3B+, Zero 2 W
+    and 4.
+
+    The resource owns the transport and nothing above it. HCI framing is
+    h4bthci.device beside this, the protocols are rom/bluetooth, and the
+    Broadcom patchram upload is brcmbt.fwl.
+*/
+
+#ifndef PL011BT_PRIVATE_H_
+#define PL011BT_PRIVATE_H_
+
+#include <exec/nodes.h>
+#include <exec/semaphores.h>
+#include <exec/types.h>
+#include <inttypes.h>
+
+/*
+ * Receive ring, filled by the PL011 interrupt and drained by PL011BTRead().
+ * A power of two, so the index arithmetic masks rather than divides.
+ *
+ * Sized against the traffic, not against a tick period. The BCM43430A1 does
+ * not send one advertising report per event: during an LE scan it batches
+ * every advert it heard into a single HCI event of up to 1220 bytes. Two of
+ * those back to back overflow a 2 KB ring, and an overflow costs the H:4
+ * framer its synchronisation just as a FIFO overrun does. 8 KB holds six.
+ */
+#define PL011BT_RX_RING         8192
+
+/*
+ * Bound on the BUSY spins. Both places that wait -- the clock generator
+ * stopping and the UART draining -- are microseconds on working hardware, so
+ * this is a bound on a fault rather than a timeout anyone should reach.
+ */
+#define PL011BT_WAIT_LIMIT      1000000
+
+struct PL011BTBase
+{
+    struct Node                 pl011bt_Node;
+    struct SignalSemaphore      pl011bt_Sem;
+    unsigned int                pl011bt_periiobase;
+
+    ULONG                       pl011bt_Caps;
+    APTR                        pl011bt_Owner;
+    ULONG                       pl011bt_ClockHz;    /* UART reference clock */
+    ULONG                       pl011bt_Baud;
+    ULONG                       pl011bt_ConfigFlags;
+    ULONG                       pl011bt_RXErrors;   /* status reports emitted */
+
+    /*
+     * One mailbox message buffer for the life of the resource, allocated and
+     * aligned once. The firmware writes its reply straight to memory, so the
+     * buffer has to own its cache lines exclusively -- see the MBOX_MSG_ALIGN
+     * comment in mbox.conf. Both users hold pl011bt_Sem.
+     */
+    APTR                        pl011bt_MBoxRaw;
+    ULONG                      *pl011bt_MBoxMsg;
+
+    /*
+     * The FIFO holds sixteen bytes, which at 115200 baud is 1.4 ms. Nothing
+     * scheduled can be relied on to visit it that often: polling at 10 ms lost
+     * data on every burst, and polling at 1 ms still reported OVERRUN on real
+     * hardware during an LE scan. The interrupt owns the FIFO and the ring,
+     * PL011BTRead() owns the tail, so a late reader costs latency rather than
+     * bytes. A single producer and a single consumer need no interlock.
+     */
+    volatile ULONG              pl011bt_RXHead;     /* written by the handler */
+    volatile ULONG              pl011bt_RXTail;     /* written by the reader  */
+    volatile ULONG              pl011bt_RXDropped;
+    APTR                        pl011bt_RXIRQ;      /* KrnAddIRQHandler handle */
+    UBYTE                       pl011bt_RXRing[PL011BT_RX_RING];
+};
+
+#define ARM_PERIIOBASE PL011BTBase->pl011bt_periiobase
+#include <hardware/bcm2708.h>
+#include <hardware/pl011uart.h>
+#include <hardware/videocore.h>
+
+#endif /* PL011BT_PRIVATE_H_ */

--- a/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/gpio/gpio_init.c
@@ -111,6 +111,8 @@ AROS_LH2(void, GPIOSetFunc,
     }
     else if (GPIOBase->gpio_periiobase && (pin <= 53))
     {
+        unsigned int val;
+
         reg = GPFSEL0;
         while (pin >= 10) {
             pin -= 10;
@@ -118,11 +120,18 @@ AROS_LH2(void, GPIOSetFunc,
         }
 
         pin += (pin << 1);
-        func <<= pin;
 
         ObtainSemaphore(&GPIOBase->gpio_Sem);
 
-        *(volatile unsigned int *)reg = AROS_LONG2LE(func);
+        /*
+         * Read-modify-write: one GPFSEL selects the function of ten pins,
+         * three bits each, so a plain store of this pin's field sets the
+         * other nine to input.
+         */
+        val = AROS_LE2LONG(*(volatile unsigned int *)reg);
+        val &= ~(7 << pin);
+        val |= (func & 7) << pin;
+        *(volatile unsigned int *)reg = AROS_LONG2LE(val);
 
         ReleaseSemaphore(&GPIOBase->gpio_Sem);
     }

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -106,6 +106,25 @@
 #define CM_ENAB                                         (1 << 4)
 #define CM_MASH(x)                                      (((x) & 3) << 9)
 
+/*
+ * Clock Manager GPCLK2. On a Raspberry Pi 3 this drives the Bluetooth
+ * controller's 32.768 kHz low-power oscillator out of GPIO 43 in ALT0.
+ * GPCLK0 and GPCLK1 are the two register pairs below it, at 0x70 and 0x78.
+ */
+#define CM_GP2CTL                                       (CLOCK_BASE + 0x80)
+#define CM_GP2DIV                                       (CLOCK_BASE + 0x84)
+
+/*
+ * The fields of a CTL register worth carrying across a stop. Everything else
+ * in it is status (BUSY), a one-shot (KILL, FLIP) or undefined, and the
+ * datasheet forbids changing the source or the divisor while the generator
+ * runs -- so stopping one is a read, a mask down to these, and a write with
+ * ENAB clear. Writing the password alone would clear ENAB but also drive SRC
+ * to GND in the same store, which leaves BUSY set forever.
+ */
+#define CM_SRC_MASK                                     0x0000000F
+#define CM_MASH_MASK                                    0x00000600
+
 /* DMA controller */
 #define DMA_CH_BASE(ch)                                 (DMA0_BASE + (ch) * 0x100)
 #define DMA_CS(ch)                                      (DMA_CH_BASE(ch) + 0x00)
@@ -368,6 +387,16 @@
 #define GPIO_PADS_0_27                                  0x002c
 #define GPIO_PADS_28_45                                 0x0030
 #define GPIO_PADS_46_53                                 0x0034
+
+/* GPFSEL function codes: three bits per pin, ten pins per register. */
+#define GPIO_FSEL_INPUT                                 0
+#define GPIO_FSEL_OUTPUT                                1
+#define GPIO_FSEL_ALT0                                  4
+#define GPIO_FSEL_ALT1                                  5
+#define GPIO_FSEL_ALT2                                  6
+#define GPIO_FSEL_ALT3                                  7
+#define GPIO_FSEL_ALT4                                  3
+#define GPIO_FSEL_ALT5                                  2
 
 #define GPFSEL0                                         (GPIO_BASE + 0x0)               // GPIO Function Selectors..
 #define GPFSEL1                                         (GPIO_BASE + 0x4)

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/pl011uart.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/pl011uart.h
@@ -73,4 +73,43 @@
 #define PL011_ICR_BEIC           (1 << 9)
 #define PL011_ICR_OEIC           (1 << 10)
 
+/*
+ * The receive status the PL011 reports per byte, in the high bits of the data
+ * register. OE means the FIFO overflowed and bytes were lost before this one;
+ * a framer downstream then reads payload as a header and invents packets, so
+ * it is worth reporting rather than masking away.
+ */
+#define PL011_DR_DATA            (0xFF)
+#define PL011_DR_FE              (1 << 8)
+#define PL011_DR_PE              (1 << 9)
+#define PL011_DR_BE              (1 << 10)
+#define PL011_DR_OE              (1 << 11)
+#define PL011_DR_ERR             (0xF << 8)
+
+/*
+ * IMSC, RIS, MIS and ICR share one bit layout, so these name the interrupt
+ * rather than the register. The PL011_ICR_* names above stay for callers that
+ * only ever clear.
+ *
+ * RT is the receive timeout, and it is what delivers the tail of a burst: RX
+ * alone fires at the watermark, so the last few bytes of a packet would sit
+ * in the FIFO until the next packet arrived.
+ */
+#define PL011_INT_RX             (1 << 4)
+#define PL011_INT_TX             (1 << 5)
+#define PL011_INT_RT             (1 << 6)
+#define PL011_INT_FE             (1 << 7)
+#define PL011_INT_PE             (1 << 8)
+#define PL011_INT_BE             (1 << 9)
+#define PL011_INT_OE             (1 << 10)
+#define PL011_INT_ALL            (0x7FF)
+
+/* FIFO level selects: how full the FIFO gets before the interrupt is raised. */
+#define PL011_IFLS_TX18          (0 << 0)
+#define PL011_IFLS_TX14          (1 << 0)
+#define PL011_IFLS_TX12          (2 << 0)
+#define PL011_IFLS_RX18          (0 << 3)
+#define PL011_IFLS_RX14          (1 << 3)
+#define PL011_IFLS_RX12          (2 << 3)
+
 #endif /* PL011UART_H */

--- a/arch/arm-native/soc/broadcom/2708/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/mmakefile.src
@@ -15,6 +15,9 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 #MM kernel-dma-bcm2708 \
 #MM kernel-sdio-bcm2708 \
 #MM kernel-bwfm-bcm2708 \
+#MM kernel-pl011bt-bcm2708 \
+#MM kernel-h4bthci-bcm2708 \
+#MM kernel-brcmbt-bcm2708 \
 #MM kernel-sdcard \
 #MM hidd-i2c-bcm2708 \
 #MM hidd-vcgfx \
@@ -25,7 +28,7 @@ BCM2708_SP := aros-$(AROS_TARGET_CPU)-bcm2708.rom
 
 PKG_LIBS      :=
 PKG_LIBS_ARCH :=
-PKG_RSRC      := gpio mbox dma sdio bwfm
+PKG_RSRC      := gpio mbox dma sdio bwfm pl011bt
 PKG_RSRC_ARCH :=
 PKG_DEVS      := sdcard USBHardware/usb2otg
 PKG_DEVS_ARCH := timer


### PR DESCRIPTION
AROS has a Bluetooth stack, two firmware loaders and one HCI device -- and that device is `vbthci`, which is virtual. On real hardware the stack has nothing to talk to. This adds the missing half for the boards whose radio hangs off the SoC's PL011: the Raspberry Pi 3, 3B+ and Zero 2 W.

### The three modules

| module | where it lands | what it owns |
|---|---|---|
| `pl011bt.resource` | in the ROM package | the PL011: pin mux, the 32.768 kHz LPO on GPCLK2, `BT_REG_EN`, the baud divisor, the receive interrupt |
| `h4bthci.device` | `DEVS:Bluetooth/` | H:4 framing, and the device the stack opens |
| `brcmbt.fwl` | `DEVS:Bluetooth/FWLoaders/` | the Broadcom patchram upload, beside `rtlbtv1`/`rtlbtv2` |

The split is the one the stack already assumes: `BTStackLoader` opens every `*.fwl`, `AddBTHardware` opens the device, and the device reaches the wire through the resource.

### Three decisions worth stating

**Resident initialisation is side-effect free.** It finds the peripheral window and asks the firmware for the UART clock, then stops. The PL011 is not written until a client claims the resource and configures it, so a machine that never opens Bluetooth is left exactly as the firmware set it up.

**It binds to the BCM2835/6/7 windows by naming them, not by excluding others.** The arrangement it drives -- PL011 on GPIO 30-33, console pushed onto the AUX mini-UART, LPO on GPCLK2, `BT_REG_EN` on the firmware's GPIO expander -- is that family's, and `IRQ_VC_UART` is the legacy controller's numbering. A BCM2711 wires its radio the same way but delivers GPU interrupts through the GIC at `BCM2711_GPUIRQ_OFFSET`; a BCM2712 does not use this UART for Bluetooth at all. Neither is tested here, so the resource stands down rather than being present and wrong. Extending it to the Pi 4 should be a small change for someone with the hardware.

**The receive path cannot be polled.** The FIFO holds sixteen bytes, 1.4 ms at 115200 baud. Polling at 10 ms lost data on every burst and polling at 1 ms still reported OVERRUN during an LE scan. The interrupt owns the FIFO and fills an 8 KB ring sized against the traffic rather than against a tick: a BCM43430A1 batches every advert it heard into a single HCI event of up to 1220 bytes, and a ring overflow costs the H:4 framer its synchronisation exactly as a FIFO overrun does.

### The four preparatory commits

`gpio: preserve the other pins when selecting a function` is a bug fix that stands on its own. `GPIOSetFunc()` stores this pin's three bits into a GPFSEL without reading it first, so the other nine pins that register selects for are set to input; selecting four consecutive pins undoes the first three. The pins in one register are not unrelated -- GPFSEL3 covers GPIO 30-39, which is the four PL011 signals *and* the six that carry the WiFi SDIO bus, so routing either group silently unroutes the other. `sdio.resource` already works around it in `sdio_gpio_mux()`, opening GPFSEL3 by hand rather than calling the resource that exists to do this. Nothing else in the tree calls `GPIOSetFunc` at all, which is how it survived and also why the fix has no other callers to regress.

The two header commits add what callers were each defining privately: the GPCLK2 registers beside the PWM pair already in `bcm2708.h`, the GPFSEL function codes (worth spelling once -- ALT4 is 3 and ALT5 is 2), and the PL011 receive-status, interrupt-mask and FIFO-level bits.

`raspi-aarch64: package gpio.resource` closes a gap this ran into: the aarch64 package takes `mbox`, `dma`, `sdio` and `bwfm` out of the bcm2708 tree and skips `gpio`, so that target has had no pin-mux API at all.

### Testing

Built for `raspi-aarch64` with the LLVM toolchain; all three modules compile and link. The remaining `-Wformat` warnings on the `bug()` calls are deliberate: `kprintf` formats through `VNewRawDoFmt`, where `%lu` is the 32-bit `ULONG` and a bare `%u` is a 16-bit `UWORD`, which is why `compiler/arossupport/include/debug.h` writes `%ld` and `%lx` too. Using the specifiers clang asks for would truncate.

The driver has run on Raspberry Pi 3 hardware in the form it was developed in, where the controller completes bring-up, reports its version and features, and is registered with the stack. It has not yet been run in this arm-native form, which is the review risk I would most like a second pair of eyes on.
