### PR TITLE
ata.device: fix inverted SMART media presence check

### DIFF
--- a/rom/devs/ata/ata.c
+++ b/rom/devs/ata/ata.c
@@ -540,7 +540,7 @@ static void cmd_SMART(struct IORequest *io, LIBBASETYPEPTR LIBBASE)
 #endif
     D(bug("[ATA%02ld] %s()\n", ((struct ata_Unit*)io->io_Unit)->au_UnitNum, __func__));
 
-    if (unit->au_Flags & AF_DiscPresent)
+    if (!(unit->au_Flags & AF_DiscPresent))
     {
         io->io_Error = IOERR_OPENFAIL;
         return;


### PR DESCRIPTION
`cmd_SMART()` rejects a unit when `AF_DiscPresent` is set, although that flag denotes media being present.

Invert the check so `IOERR_OPENFAIL` is returned only when no media is present.

`kernel-ata` builds successfully for pc-i386.
