### PR TITLE
ata.device: add HIDD include dependencies

### DIFF
--- a/rom/devs/ata/mmakefile.src
+++ b/rom/devs/ata/mmakefile.src
@@ -1,7 +1,7 @@
 
 include $(SRCDIR)/config/aros.cfg
 
-#MM- kernel-ata-includes : kernel-scsi-includes
+#MM- kernel-ata-includes : kernel-scsi-includes kernel-hidd-bus-includes kernel-hidd-storage-includes
 #MM- kernel-ata-kobj-includes : kernel-scsi--kobj-includes
 
 USER_CPPFLAGS := \


### PR DESCRIPTION
A clean `kernel-ata` build can reach ATA compilation before the generated bus and storage HIDD interface headers exist.

Add the corresponding HIDD include dependencies to `kernel-ata-includes`.

`kernel-ata` then builds successfully from a clean pc-i386 build tree.
