### PR TITLE
Raspi5 bringup

### DIFF
--- a/arch/aarch64-native/kernel/kernel_arch.h
+++ b/arch/aarch64-native/kernel/kernel_arch.h
@@ -6,11 +6,12 @@
 #include <kernel_irqtypes.h>   /* irqid_t - this header may be reached without kernel_base.h */
 
 /* Number of IRQs used in the machine. Needed by kernel_base.h.
-   A GIC presents shared peripheral interrupts well above the range of the
-   earlier Broadcom controller: the SD host lands at 158 and PCIe legacy
-   interrupts at 175, and a handler for anything beyond this count is
-   silently refused. */
-#define IRQ_COUNT 256
+   A GIC presents SPIs well above the earlier Broadcom controller's range
+   (BCM2712: SD host at 305, RP1/PCIe higher still), and KrnAddIRQHandler
+   silently refuses anything at or above the count - HW_IRQ_COUNT must be
+   set explicitly, or kernel_base.h defaults it to 256 - INTB_KERNEL. */
+#define IRQ_COUNT       384
+#define HW_IRQ_COUNT    IRQ_COUNT
 
 /*
  * Interrupt controller functions.

--- a/arch/aarch64-native/kernel/kernel_startup.c
+++ b/arch/aarch64-native/kernel/kernel_startup.c
@@ -124,9 +124,10 @@ static void __attribute__((used)) __clear_bss(struct TagItem *msg)
     }
 }
 
-/* PL011 base for the early bring-up prints. The Pi 2/3 puts it at
-   0x3f201000, the Pi 4 (BCM2711) at 0xfe201000; it is selected from the
-   platform id before the first character goes out. */
+/* PL011 base for the early bring-up prints. The bootstrap passes the address
+   it printed through itself in KRN_DebugUartBase; the platform id only serves
+   as a fallback for a bootstrap that predates that tag. Either way it is
+   settled before the first character goes out. */
 static uintptr_t dbg_uart = 0x3f201000;
 
 static inline void uart_putc(char c)
@@ -153,9 +154,24 @@ void __attribute__((used)) kernel_cstart(struct TagItem *msg)
     uint64_t fb_base = 0;
     uint32_t fb_w = 0, fb_h = 0, fb_depth = 0, fb_pitch = 0;
 
-    for (struct TagItem *t = msg; t->ti_Tag != TAG_DONE; t++)
-        if (t->ti_Tag == KRN_Platform && t->ti_Data == 0xc44)
-            dbg_uart = 0xfe201000;
+    {
+        IPTR uartbase = 0, plat = 0;
+
+        for (struct TagItem *t = msg; t->ti_Tag != TAG_DONE; t++)
+        {
+            if (t->ti_Tag == KRN_DebugUartBase)
+                uartbase = t->ti_Data;
+            else if (t->ti_Tag == KRN_Platform)
+                plat = t->ti_Data;
+        }
+
+        if (uartbase)
+            dbg_uart = uartbase;
+        else if (plat == 0xc44)
+            dbg_uart = 0xfe201000;      /* BCM2711 PL011 */
+        else if (plat == 0x2712)
+            dbg_uart = 0x1c00030000;    /* BCM2712: RP1 UART0 */
+    }
 
     uart_puts("[Kernel] kernel_cstart entered\n");
     BootMsg = msg;

--- a/arch/aarch64-native/kernel/mmu.c
+++ b/arch/aarch64-native/kernel/mmu.c
@@ -47,26 +47,6 @@
 #define MAIR_IDX_NORMAL_WB  1   /* Normal, Write-Back Cacheable */
 #define MAIR_IDX_NORMAL_NC  2   /* Normal, Non-Cacheable */
 
-/* MAIR register value */
-#define MAIR_VALUE  ( \
-    (0x00UL << (MAIR_IDX_DEVICE * 8))    | \
-    (0xFFUL << (MAIR_IDX_NORMAL_WB * 8)) | \
-    (0x44UL << (MAIR_IDX_NORMAL_NC * 8))   \
-)
-
-/* TCR_EL1 configuration: 4KB granule, 35-bit VA (T0SZ=29), 36-bit PA.
-   Must match the boot MMU setup. */
-#define TCR_VALUE ( \
-    (29UL << 0)      | /* T0SZ = 29 (32GB VA space) */ \
-    (0UL  << 7)      | /* EPD0 = 0 (TTBR0 enabled) */ \
-    (1UL  << 8)      | /* IRGN0 = Write-Back */ \
-    (1UL  << 10)     | /* ORGN0 = Write-Back */ \
-    (3UL  << 12)     | /* SH0 = Inner Shareable */ \
-    (0UL  << 14)     | /* TG0 = 4KB granule */ \
-    (1UL  << 23)     | /* EPD1 = 1 (TTBR1 disabled) */ \
-    (1UL  << 31)       /* RES1 */ \
-)
-
 /* Translation levels for a 4KB granule. The VA size is read from TCR_EL1
    at runtime, since boot picks it. */
 #define MMU_L1_SHIFT        30

--- a/arch/aarch64-native/kernel/platform_bcm2712.c
+++ b/arch/aarch64-native/kernel/platform_bcm2712.c
@@ -40,7 +40,7 @@
 
 /* BCM2712 Peripheral Base and PL011 UART */
 #define BCM2712_PERIBASE        0x107C000000UL
-#define BCM2712_UART_BASE       (BCM2712_PERIBASE + 0x201000UL)
+#define BCM2712_UART_BASE       0x107D001000UL
 
 #define PL011_DR                0x00
 #define PL011_FR                0x18

--- a/arch/aarch64-native/kernel/platform_bcm2712.c
+++ b/arch/aarch64-native/kernel/platform_bcm2712.c
@@ -38,9 +38,9 @@
 
 #define DTIMER(x)
 
-/* BCM2712 Peripheral Base and PL011 UART */
+/* BCM2712 Peripheral Base and PL011 UART. PI5 use D0, Pi500 use C1 */
 #define BCM2712_PERIBASE        0x107C000000UL
-#define BCM2712_UART_BASE       0x107D001000UL
+#define BCM2712_UART_BASE       0x1C00030000UL
 
 #define PL011_DR                0x00
 #define PL011_FR                0x18
@@ -79,9 +79,11 @@ static int bcm2712_ser_getc(void)
     return -1;
 }
 
-/* ---- GIC-400 (GICv2), Pi 5 physical addresses ---- */
-#define GICD_BASE   0xFF841000UL
-#define GICC_BASE   0xFF842000UL
+/* ---- GIC-400 (GICv2) ---- */
+/* From the DT: /soc/interrupt-controller@7fff9000, i.e. 0x10_0000_0000 +
+   0x7fff9000. */
+#define GICD_BASE   0x107FFF9000UL
+#define GICC_BASE   0x107FFFA000UL
 #define GICD(o)     (*(volatile uint32_t *)(GICD_BASE + (o)))
 #define GICC(o)     (*(volatile uint32_t *)(GICC_BASE + (o)))
 
@@ -226,6 +228,7 @@ static APTR bcm2712_init_gentimer(APTR _kernelBase)
 static IPTR bcm2712_probe(struct ARM_Implementation *krnARMImpl, struct TagItem *msg)
 {
     void *bootPutC = NULL;
+    IPTR periibase = 0;
     uint64_t midr;
 
     while (msg->ti_Tag != TAG_DONE)
@@ -235,7 +238,11 @@ static IPTR bcm2712_probe(struct ARM_Implementation *krnARMImpl, struct TagItem 
         case KRN_FuncPutC:
             bootPutC = (void *)msg->ti_Data;
             break;
+        case KRN_PeripheralBase:
+            periibase = (IPTR)msg->ti_Data;
+            break;
         }
+
         msg++;
     }
 
@@ -246,8 +253,9 @@ static IPTR bcm2712_probe(struct ARM_Implementation *krnARMImpl, struct TagItem 
         return FALSE;
 
     krnARMImpl->ARMI_Family = 8;
+    // TODO: Remove
     krnARMImpl->ARMI_Platform = 0x2712;
-    krnARMImpl->ARMI_PeripheralBase = (APTR)BCM2712_PERIBASE;
+    krnARMImpl->ARMI_PeripheralBase = (periibase ? periibase : (APTR)BCM2712_PERIBASE);
     krnARMImpl->ARMI_InitCore = &bcm27xx_init_cpu;
     krnARMImpl->ARMI_FIQProcess = &bcm27xx_fiq_process;
     krnARMImpl->ARMI_SendIPI = &bcm27xx_send_ipi;

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -36,12 +36,14 @@
 uintptr_t __arm_periiobase = 0;
 unsigned int __arm_socid = 0;
 uintptr_t __vcmb_base = 0;
+uintptr_t __rp1_base = 0;
 
 extern void mem_init(void);
 extern unsigned int uartclock;
 extern unsigned int uartdivint;
 extern unsigned int uartdivfrac;
 extern unsigned int uartbaud;
+extern uintptr_t __uart_base;
 
 void boot_exception_handler(uint64_t esr, uint64_t elr, uint64_t far) __attribute__((used));
 void boot_exception_handler(uint64_t esr, uint64_t elr, uint64_t far)
@@ -255,6 +257,94 @@ void query_memory()
     }
 }
 
+/*
+ * The RP1 southbridge hangs off one of the BCM2712 PCIe host bridges.
+ * The CPU address of that window is not fixed across board and firmware revisions
+ * (0x1f_0000_0000 and 0x1c_0000_0000 both occur)
+ */
+static void query_rp1(void)
+{
+    of_node_t *axi = dt_find_node("/axi");
+    of_node_t *bridge;
+    of_property_t *p;
+    uint32_t parent_ac;
+
+    if (!axi)
+        return;
+
+    p = dt_find_property(axi, "#address-cells");
+    parent_ac = p ? AROS_BE2LONG(*(uint32_t *)p->op_value) : 2;
+
+    ForeachNode(&axi->on_children, bridge)
+    {
+        of_node_t *child;
+        uint32_t child_ac, child_sc, entry_cells;
+        volatile uint32_t *ranges;
+        int32_t cells;
+        int has_rp1 = 0;
+        uintptr_t win32 = 0, win64 = 0;
+
+        if (strncmp(bridge->on_name, "pcie", 4))
+            continue;
+
+        ForeachNode(&bridge->on_children, child)
+        {
+            if (!strncmp(child->on_name, "rp1", 4))
+                has_rp1 = 1;
+        }
+        if (!has_rp1)
+            continue;
+
+        p = dt_find_property(bridge, "#address-cells");
+        child_ac = p ? AROS_BE2LONG(*(uint32_t *)p->op_value) : 3;
+        p = dt_find_property(bridge, "#size-cells");
+        child_sc = p ? AROS_BE2LONG(*(uint32_t *)p->op_value) : 2;
+        entry_cells = child_ac + parent_ac + child_sc;
+
+        p = dt_find_property(bridge, "ranges");
+        if (!p)
+            return;
+
+        ranges = p->op_value;
+        cells = p->op_length / 4;
+
+        while (cells >= (int32_t)entry_cells)
+        {
+            /* The first child cell is the PCI space code, not an address. */
+            uint32_t space = AROS_BE2LONG(ranges[0]);
+            uint64_t addr_cpu = 0, addr_len = 0;
+            uint32_t i;
+
+            ranges += child_ac;
+            for (i = 0; i < parent_ac; i++)
+                addr_cpu = (addr_cpu << 32) | AROS_BE2LONG(*ranges++);
+            for (i = 0; i < child_sc; i++)
+                addr_len = (addr_len << 32) | AROS_BE2LONG(*ranges++);
+
+            kprintf("[BOOT] RP1 window: space %08x -> %p, %p bytes\n",
+                    space, addr_cpu, addr_len);
+
+            mmu_map_section(addr_cpu, addr_cpu, addr_len, 0, 0, 3, 0);
+
+            if (!win32 && ((space >> 24) & 0x03) == 0x02)
+                win32 = (uintptr_t)addr_cpu;
+            if (!win64 && ((space >> 24) & 0x03) == 0x03)
+                win64 = (uintptr_t)addr_cpu;
+
+            cells -= entry_cells;
+        }
+        /*
+            * Take the prefetchable window: the firmware allocates RP1's BAR1
+            * from it (UART0 answers at win64 + 0x30000), while the MEM32 entry
+            * describes where Linux will move RP1 once it re-enumerates PCIe.
+            * Both windows are the same on C1 and D0 - the d0 overlay does not
+            * touch them - so this is stepping-independent.
+            */
+        __rp1_base = win64;
+        kprintf("[BOOT] RP1 windows: mem32 %p, mem64 %p\n", win32, win64);
+        return;
+    }
+}
 
 void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3)
 {
@@ -276,10 +366,10 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     mem_init();
 
     int dt_mem_usage = mem_avail();
-    
+
     /* Parse device tree */
     dt_parse((void *)(uintptr_t)dtb_addr);
-    
+
     /*
      * The SoC id gates the UART and mailbox register offsets, so it has to
      * be known before serInit(). The tag itself is emitted further down.
@@ -313,8 +403,6 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         __arm_socid = plat;
     }
 
-    __vcmb_base = __arm_periiobase + (__arm_socid == 0x2712 ? 0x7C013880 : 0xB880);
-    
     dt_mem_usage -= mem_avail();
 
     /* Prepare mapping for peripherals. Use the data from device tree here */
@@ -372,6 +460,8 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     else
         while(1) asm volatile("wfe");
 
+    __vcmb_base = __arm_periiobase + (__arm_socid == 0x2712 ? 0x7C013880 : 0xB880);
+
     /*
      * The Pi 4 describes additional MMIO windows on the /scb bus: the full
      * 0xFC000000 peripheral block (which contains the PCIe host bridge
@@ -418,7 +508,13 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         }
     }
 
+    query_rp1();
+
     serInit();
+
+    boottag->ti_Tag = KRN_DebugUartBase;
+    boottag->ti_Data = __uart_base;   /* the address serInit() actually used */
+    boottag++;
 
     kprintf("\n\n[BOOT] AROS %s\n", bootstrapName);
     {
@@ -435,9 +531,15 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
      */
     boottag->ti_Tag = KRN_Platform;
     boottag->ti_Data = __arm_socid;
-    
+
     kprintf("[BOOT] SoC platform id 0x%x\n", __arm_socid);
-    
+
+    boottag++;
+
+    boottag->ti_Tag = KRN_PeripheralBase;
+    /* BCM2712 keeps the legacy block at bus 0x7C000000 into the window */
+    boottag->ti_Data = __arm_periiobase +
+                       (__arm_socid == 0x2712 ? 0x7C000000 : 0);
     boottag++;
 
     /*
@@ -486,7 +588,7 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
              * pokes below would land blindly in the /soc window. */
             if (__arm_socid == 0x2712)
                 continue;
-            
+
             of_property_t *p = dt_find_property(led, "gpios");
             of_property_t *st = dt_find_property(led, "status");
             int32_t gpio = 0;

--- a/arch/aarch64-raspi/boot/boot.c
+++ b/arch/aarch64-raspi/boot/boot.c
@@ -34,6 +34,8 @@
 #define ARM_PERIIOBASE (__arm_periiobase)
 
 uintptr_t __arm_periiobase = 0;
+unsigned int __arm_socid = 0;
+uintptr_t __vcmb_base = 0;
 
 extern void mem_init(void);
 extern unsigned int uartclock;
@@ -78,8 +80,8 @@ void query_vmem()
     vc_msg[6] = 0;
     vc_msg[7] = 0;
 
-    vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vc_msg);
-    vc_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+    vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vc_msg);
+    vc_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
 
     if (!vc_msg)
     {
@@ -135,8 +137,8 @@ void setup_arm_clock()
     vc_msg[5] = AROS_LONG2LE(3);            /* clock id 3 = ARM */
     vc_msg[6] = 0;
     vc_msg[7] = 0;
-    vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vc_msg);
-    vc_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+    vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vc_msg);
+    vc_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
     if (!vc_msg)
         return;
     arm_cur = AROS_LE2LONG(vc_msg[6]);
@@ -149,8 +151,8 @@ void setup_arm_clock()
     vc_msg[5] = AROS_LONG2LE(3);
     vc_msg[6] = 0;
     vc_msg[7] = 0;
-    vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vc_msg);
-    vc_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+    vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vc_msg);
+    vc_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
     if (!vc_msg)
         return;
     arm_max = AROS_LE2LONG(vc_msg[6]);
@@ -168,8 +170,8 @@ void setup_arm_clock()
         vc_msg[6] = AROS_LONG2LE(arm_max);
         vc_msg[7] = 0;                      /* skip_setting_turbo = 0 */
         vc_msg[8] = 0;
-        vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vc_msg);
-        vc_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+        vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vc_msg);
+        vc_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
         if (vc_msg)
             kprintf("[BOOT] ARM clock set to %u Hz\n", AROS_LE2LONG(vc_msg[6]));
     }
@@ -274,8 +276,45 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     mem_init();
 
     int dt_mem_usage = mem_avail();
+    
     /* Parse device tree */
     dt_parse((void *)(uintptr_t)dtb_addr);
+    
+    /*
+     * The SoC id gates the UART and mailbox register offsets, so it has to
+     * be known before serInit(). The tag itself is emitted further down.
+     */
+    {
+        of_node_t *r = dt_find_node("/");
+        of_property_t *compat = r ? dt_find_property(r, "compatible") : NULL;
+        IPTR plat = 0xc43; /* default: BCM2836/2837 (Raspberry Pi 2/3) */
+        if (compat)
+        {
+            const char *s = (const char *)compat->op_value;
+            int n = (int)compat->op_length, i;
+            for (i = 0; i + 7 <= n; i++)
+            {
+                if (s[i] == 'b' && s[i+1] == 'c' && s[i+2] == 'm' &&
+                    s[i+3] == '2' && s[i+4] == '7' && s[i+5] == '1' &&
+                    s[i+6] == '2')
+                {
+                    plat = 0x2712; /* BCM2712 (Raspberry Pi 5) */
+                    break;
+                }
+                if (s[i] == 'b' && s[i+1] == 'c' && s[i+2] == 'm' &&
+                    s[i+3] == '2' && s[i+4] == '7' && s[i+5] == '1' &&
+                    s[i+6] == '1')
+                {
+                    plat = 0xc44; /* BCM2711 (Raspberry Pi 4) */
+                    break;
+                }
+            }
+        }
+        __arm_socid = plat;
+    }
+
+    __vcmb_base = __arm_periiobase + (__arm_socid == 0x2712 ? 0x7C013880 : 0xB880);
+    
     dt_mem_usage -= mem_avail();
 
     /* Prepare mapping for peripherals. Use the data from device tree here */
@@ -391,40 +430,14 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
     /*
      * Store the SoC id for the kernel's platform probe. The peripheral base
      * itself is taken from the device tree (/soc ranges) above, so it is
-     * already correct for either SoC; here we only distinguish the interrupt
-     * controller / timer family: BCM2836/2837 (Pi 2/3, legacy controller) vs
-     * BCM2711 (Pi 4, GIC-400), by scanning the root "compatible" list.
+     * already correct; this only tells the kernel which interrupt controller
+     * and timer family to expect. Scanned near the top of boot().
      */
     boottag->ti_Tag = KRN_Platform;
-    {
-        of_node_t *r = dt_find_node("/");
-        of_property_t *compat = r ? dt_find_property(r, "compatible") : NULL;
-        IPTR plat = 0xc43; /* default: BCM2836/2837 (Raspberry Pi 2/3) */
-        if (compat)
-        {
-            const char *s = (const char *)compat->op_value;
-            int n = (int)compat->op_length, i;
-            for (i = 0; i + 7 <= n; i++)
-            {
-                if (s[i] == 'b' && s[i+1] == 'c' && s[i+2] == 'm' &&
-                    s[i+3] == '2' && s[i+4] == '7' && s[i+5] == '1' &&
-                    s[i+6] == '2')
-                {
-                    plat = 0x2712; /* BCM2712 (Raspberry Pi 5) */
-                    break;
-                }
-                if (s[i] == 'b' && s[i+1] == 'c' && s[i+2] == 'm' &&
-                    s[i+3] == '2' && s[i+4] == '7' && s[i+5] == '1' &&
-                    s[i+6] == '1')
-                {
-                    plat = 0xc44; /* BCM2711 (Raspberry Pi 4) */
-                    break;
-                }
-            }
-        }
-        boottag->ti_Data = plat;
-        kprintf("[BOOT] SoC platform id 0x%x\n", (unsigned)plat);
-    }
+    boottag->ti_Data = __arm_socid;
+    
+    kprintf("[BOOT] SoC platform id 0x%x\n", __arm_socid);
+    
     boottag++;
 
     /*
@@ -468,6 +481,12 @@ void boot(uintptr_t dtb_addr, uintptr_t arch, uintptr_t dummy2, uintptr_t dummy3
         kprintf("[BOOT] Configuring LEDs\n");
         ForeachNode(&e->on_children, led)
         {
+            /* BCM2712 has no BCM283x GPIO block: the ACT LED sits on a
+             * brcmstb controller and the PWR LED behind RP1. The GPFSEL
+             * pokes below would land blindly in the /soc window. */
+            if (__arm_socid == 0x2712)
+                continue;
+            
             of_property_t *p = dt_find_property(led, "gpios");
             of_property_t *st = dt_find_property(led, "status");
             int32_t gpio = 0;

--- a/arch/aarch64-raspi/boot/include/bcm2708_boot.h
+++ b/arch/aarch64-raspi/boot/include/bcm2708_boot.h
@@ -32,11 +32,6 @@
 #define PGD_SIZE                        4096     /* Level 0: 512 entries x 8 bytes */
 #define PUD_SIZE                        4096     /* Level 1: 512 entries x 8 bytes */
 #define PMD_SIZE                        (4*4096) /* Level 2: 4 pages for 4GB coverage */
-#define PMD_HI_SIZE                     4096     /* Level 2: 1 page for the PCIe window at 24GB */
-
-/* CPU-side PCIe outbound window on BCM2711 (fixed in the SoC address map) */
-#define BCM2711_PCIE_WIN_BASE           0x600000000UL
-#define BCM2711_PCIE_WIN_SIZE           0x40000000UL
 
 struct bcm2708bootmem
 {
@@ -52,7 +47,6 @@ struct bcm2708bootmem
     uint8_t     bm_pgd[PGD_SIZE];                                        /* Level 0 page table */
     uint8_t     bm_pud[PUD_SIZE];                                        /* Level 1 page table */
     uint8_t     bm_pmd[PMD_SIZE];                                        /* Level 2 page tables (2MB blocks) */
-    uint8_t     bm_pmd_hi[PMD_HI_SIZE];                                  /* Level 2 page table for the PCIe window */
 }  __attribute__((packed));
 
 #define BOOTMEMADDR(offset) (&(((struct bcm2708bootmem *)0x0)->offset))

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -183,6 +183,13 @@ RASPIFW_FILES     := LICENCE.broadcom bootcode.bin fixup.dat start.elf \
                      bcm2712-rpi-5-b.dtb bcm2712-rpi-500.dtb \
                      bcm2712-d-rpi-5-b.dtb bcm2712d0-rpi-5-b.dtb
 
+# The Pi 500(+) has no D0-specific dtb; the firmware patches the base dtb at
+# boot with the bcm2712d0.dtbo overlay (selected via overlay_map.dtb). D0
+# boards use a different address map (RP1 PCIe window at 0x1c_0000_0000, not
+# 0x1f_...), so without these files the bootstrap sees C1 addresses on D0
+# hardware.
+RASPIFW_OVERLAYS  := overlay_map.dtb bcm2712d0.dtbo
+
 RASPIWIFIFW_BRANCH := buster
 RASPIWIFIFW_URI    := https://github.com/RPi-Distro/firmware-nonfree/blob/$(RASPIWIFIFW_BRANCH)
 # 43455 and 43456 are both chip id 0x4345 and cannot share a blob: bwfm.device
@@ -217,6 +224,11 @@ PKG_CLASSES   := USB/hub USB/hubss USB/massstorage
 #MM
 distfiles-raspi-aarch64-fw:
 	$(foreach file, $(RASPIFW_FILES), $(shell wget -4 -t 5 -T 15 -c "$(addprefix $(RASPIFW_URI)/, $(file))" -O "$(addprefix $(AROSDIR)/, $(file))"))
+	@$(MKDIR) $(AROSDIR)/overlays
+	@for f in $(RASPIFW_OVERLAYS) ; do \
+	    wget -4 -t 5 -T 15 -c "$(RASPIFW_URI)/overlays/$$f" -O "$(AROSDIR)/overlays/$$f" \
+	        || $(ECHO) "WARNING: could not fetch overlay $$f" ; \
+	done
 
 #MM
 distfiles-raspi-aarch64-wifi-fw:
@@ -236,7 +248,7 @@ distfiles-raspi-aarch64le-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-rasp
 # framebuffer + overlay page ring + BO pools); 64 (the firmware default)
 # runs out during a full-screen GL session. 128 is the working minimum.
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\nenable_uart=1\narm_64bit=1\ngpu_mem=128\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=1\ngpu_mem=128\nenable_uart=1\n[pi5]\nenable_rp1_uart=1\npciex4_reset=0\n" > $@
 
 # .d depfiles are only generated for C sources, not startup64.S
 $(AROSDIR)/aros-aarch64-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $(foreach f, $(filter-out startup64,$(FILES)), $(TARGETDIR)/$(f).d)

--- a/arch/aarch64-raspi/boot/mmakefile.src
+++ b/arch/aarch64-raspi/boot/mmakefile.src
@@ -248,7 +248,7 @@ distfiles-raspi-aarch64le-bootimg-quick: $(AROSDIR)/aros-$(AROS_TARGET_CPU)-rasp
 # framebuffer + overlay page ring + BO pools); 64 (the firmware default)
 # runs out during a full-screen GL session. 128 is the working minimum.
 $(AROSDIR)/config.txt: $(AROSDIR)/$(ARM_BSP)
-	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=1\ngpu_mem=128\nenable_uart=1\n[pi5]\nenable_rp1_uart=1\npciex4_reset=0\n" > $@
+	@printf "kernel=aros-$(AROS_TARGET_CPU)-raspi.img\nkernel_address=0x80000\ninitramfs $(ARM_BSP) 0x00800000\narm_64bit=1\ngpu_mem=128\nenable_uart=1\nframebuffer_depth=32\nframebuffer_ignore_alpha=1\n[pi5]\nenable_rp1_uart=1\npciex4_reset=0\nframebuffer_swap=0\n" > $@
 
 # .d depfiles are only generated for C sources, not startup64.S
 $(AROSDIR)/aros-aarch64-raspi.img: $(TARGETDIR)/core.bin.o $(foreach f, $(FILES), $(TARGETDIR)/$(f).o) $(foreach f, $(filter-out startup64,$(FILES)), $(TARGETDIR)/$(f).d)

--- a/arch/aarch64-raspi/boot/mmu.c
+++ b/arch/aarch64-raspi/boot/mmu.c
@@ -73,75 +73,69 @@
 #define ATTR_NORMAL_NC  ATTR_IDX(2)
 
 /* Page table pointers */
-static uint64_t *pgd;
 static uint64_t *pud;
 static uint64_t *pmd;
-static uint64_t *pmd_hi;
 
 void mmu_init(void)
 {
     int i;
 
-    pgd = (uint64_t *)BOOTMEMADDR(bm_pgd);
-    pud = (uint64_t *)BOOTMEMADDR(bm_pud);
+    /*
+     * The level-1 table lives in the bm_pgd page (0x7000): level 0 is unused
+     * with T0SZ=25, and the bm_pud page (0x8000) turned out to be written by
+     * another agent on the BCM2712 (the built-in armstub parking the
+     * secondary cores, by all evidence: constant content, invisible to a
+     * verified CPU watchpoint). 0x8000 is left as a sentinel-filled honeypot
+     * so its writes stay observable.
+     */
+    pud = (uint64_t *)BOOTMEMADDR(bm_pgd);
     pmd = (uint64_t *)BOOTMEMADDR(bm_pmd);
-    pmd_hi = (uint64_t *)BOOTMEMADDR(bm_pmd_hi);
 
-    /* Clear all page table levels */
-    for (i = 0; i < 512; i++)
-        pgd[i] = 0;
-
+    /* Clear the tables; sentinel-fill the ceded 0x8000 page */
     for (i = 0; i < 512; i++)
         pud[i] = 0;
+
+    for (i = 0; i < 512; i++)
+        ((uint64_t *)BOOTMEMADDR(bm_pud))[i] = 0xDEADBEEF00000000UL | i;
 
     /* Clear PMD: 4 pages covering 4GB (4 * 512 = 2048 entries) */
     for (i = 0; i < 2048; i++)
         pmd[i] = 0;
 
-    for (i = 0; i < 512; i++)
-        pmd_hi[i] = 0;
-
     /*
      * Set up the page table hierarchy:
-     * PGD[0] -> PUD (covers first 512GB, only first entry used)
      * PUD[0] -> PMD page 0 (covers 0x00000000 - 0x3FFFFFFF, 1GB)
      * PUD[1] -> PMD page 1 (covers 0x40000000 - 0x7FFFFFFF, 1GB)
      * PUD[2] -> PMD page 2 (covers 0x80000000 - 0xBFFFFFFF, 1GB)
      * PUD[3] -> PMD page 3 (covers 0xC0000000 - 0xFFFFFFFF, 1GB)
-     * PUD[24] -> PMD high page (0x600000000 - 0x63FFFFFFF, the BCM2711
-     *            PCIe outbound window; unused and harmless on Pi 2/3)
+     * Entries >= 4 get 1GB blocks on demand (mmu_map_section high path).
      */
-    pgd[0] = (uint64_t)(uintptr_t)pud | DESC_TABLE;
-
     pud[0] = (uint64_t)(uintptr_t)&pmd[0 * 512] | DESC_TABLE;
     pud[1] = (uint64_t)(uintptr_t)&pmd[1 * 512] | DESC_TABLE;
     pud[2] = (uint64_t)(uintptr_t)&pmd[2 * 512] | DESC_TABLE;
     pud[3] = (uint64_t)(uintptr_t)&pmd[3 * 512] | DESC_TABLE;
-    pud[BCM2711_PCIE_WIN_BASE >> 30] = (uint64_t)(uintptr_t)pmd_hi | DESC_TABLE;
 
     /*
-     * Raspberry Pi 5 (BCM2712): Map BCM2712 peripheral space (0x107C000000)
-     * and RP1 PCIe peripheral window (0x1F00000000) as 1GB device blocks.
+     * The RP1 windows sit under /axi/pcie, which no DT walk touches, so
+     * they stay hardcoded. The boot UART lives behind them - without
+     * these, serial dies the moment the MMU loads.
      */
-    pud[0x107C000000UL >> 30] = DESC_BLOCK | (0x1040000000UL) |
-                                 ATTR_DEVICE | ATTR_AF | ATTR_AP_RW_EL1 |
-                                 ATTR_SH_NON | ATTR_PXN | ATTR_UXN;
-    pud[0x1F00000000UL >> 30] = DESC_BLOCK | (0x1F00000000UL) |
-                                 ATTR_DEVICE | ATTR_AF | ATTR_AP_RW_EL1 |
-                                 ATTR_SH_NON | ATTR_PXN | ATTR_UXN;
+    pud[0x1C00000000UL >> 30] = DESC_BLOCK | 0x1C00000000UL | ATTR_DEVICE |
+                                ATTR_AF | ATTR_AP_RW_EL1 | ATTR_SH_NON |
+                                ATTR_PXN | ATTR_UXN;   /* BCM2712 D0 */
+    pud[0x1F00000000UL >> 30] = DESC_BLOCK | 0x1F00000000UL | ATTR_DEVICE |
+                                ATTR_AF | ATTR_AP_RW_EL1 | ATTR_SH_NON |
+                                ATTR_PXN | ATTR_UXN;   /* BCM2712 C1 */
 }
 
 /*
  * Return the level-2 slot for a virtual address, or NULL if the address
- * is outside the translated ranges (first 4GB + the PCIe window).
+ * is outside the translated ranges (first 4GB).
  */
 static uint64_t *mmu_slot(uintptr_t virt)
 {
     if (virt < 0x100000000UL)
         return &pmd[virt >> 21];
-    if (virt >= BCM2711_PCIE_WIN_BASE &&
-        virt < BCM2711_PCIE_WIN_BASE + BCM2711_PCIE_WIN_SIZE)
-        return &pmd_hi[(virt - BCM2711_PCIE_WIN_BASE) >> 21];
     return (uint64_t *)0;
 }
 
@@ -149,10 +143,8 @@ void mmu_load(void)
 {
     uint64_t tmp;
 
-    aarch64_flush_cache((uintptr_t)pgd, PGD_SIZE);
     aarch64_flush_cache((uintptr_t)pud, PUD_SIZE);
     aarch64_flush_cache((uintptr_t)pmd, PMD_SIZE);
-    aarch64_flush_cache((uintptr_t)pmd_hi, PMD_HI_SIZE);
 
     /* Set MAIR_EL1 */
     tmp = MAIR_VALUE;
@@ -249,6 +241,45 @@ void mmu_map_section(uintptr_t phys, uintptr_t virt, uintptr_t length, int norma
 
     DMMU(kprintf("[BOOT] MMU map %p:%p->%p:%p, normal=%d, cacheable=%d, ap=%x, tex=%x\n",
             phys, phys+length-1, virt, virt+length-1, normal, cacheable, ap, tex));
+
+    /*
+     * Above 4GB everything on these boards is large, uniform and
+     * GB-aligned (peripheral windows, high RAM), and the static boot
+     * tables have no PMD pages to spare - use 1GB PUD blocks. Below
+     * 4GB the 2MB PMD path stays: the first four PUD slots are table
+     * pointers and must not be clobbered.
+     */
+    if (virt >= 0x100000000UL)
+    {
+        if ((virt | phys) & ((1UL << 30) - 1))
+        {
+            kprintf("[BOOT] MMU: unaligned high mapping %p dropped\n", virt);
+            return;
+        }
+
+        while (length)
+        {
+            uint64_t *slot = &pud[virt >> 30];
+            uint64_t desc = DESC_BLOCK | ATTR_AF | (uint64_t)phys;
+
+            /* same attributelogic as the 2MB-way */
+            if (normal && (cacheable || tex))
+                desc |= ATTR_NORMAL | ATTR_SH_INNER;
+            else if (normal)
+                desc |= ATTR_NORMAL_NC | ATTR_SH_INNER;
+            else
+                desc |= ATTR_DEVICE | ATTR_SH_NON | ATTR_PXN | ATTR_UXN;
+            desc |= (ap == 2) ? ATTR_AP_RO_EL1 : ATTR_AP_RW_EL1;
+
+            if ((*slot & 3) != DESC_TABLE)     /* never overwrite a table */
+                *slot = desc;
+
+            virt   += (1UL << 30);
+            phys   += (1UL << 30);
+            length -= (length > (1UL << 30)) ? (1UL << 30) : length;
+        }
+        return;
+    }
 
     while (count--)
     {

--- a/arch/aarch64-raspi/boot/mmu.c
+++ b/arch/aarch64-raspi/boot/mmu.c
@@ -160,16 +160,20 @@ void mmu_load(void)
 
     /*
      * Set TCR_EL1:
-     *   T0SZ = 29  (35-bit VA space = 32GB, bits [5:0]; reaches the BCM2711
-     *               PCIe outbound window at 0x6_0000_0000. Lookup still
-     *               starts at level 1 for T0SZ 25-33 with a 4KB granule.)
+     *   T0SZ = 25  (39-bit VA space = 512GB, bits [5:0]; reaches the BCM2711
+     *               PCIe outbound window at 0x6_0000_0000 and the BCM2712
+     *               peripheral and RP1 windows at 0x10_7C00_0000 and
+     *               0x1F_0000_0000. Lookup still starts at level 1 for
+     *               T0SZ 25-33 with a 4KB granule, so TTBR0 holds the
+     *               level-1 table.)
      *   IRGN0 = 01 (Inner Write-Back Write-Allocate Cacheable, bits [9:8])
      *   ORGN0 = 01 (Outer Write-Back Write-Allocate Cacheable, bits [11:10])
      *   SH0 = 11   (Inner Shareable, bits [13:12])
      *   TG0 = 00   (4KB granule, bits [15:14])
-     *   IPS = 001   (36-bit physical address space, bits [34:32])
+     *   IPS = 010  (40-bit physical address space, bits [34:32]; the BCM2712
+     *               windows need 37 PA bits, and 40 is Cortex-A76's PARange)
      */
-    tmp = (29UL << 0)       /* T0SZ = 29 -> 32GB VA space */
+    tmp = (25UL << 0)       /* T0SZ = 25 -> 512GB VA space */
         | (0x1UL << 8)      /* IRGN0 = 01 */
         | (0x1UL << 10)     /* ORGN0 = 01 */
         | (0x3UL << 12)     /* SH0 = 11 (inner shareable) */
@@ -177,13 +181,13 @@ void mmu_load(void)
         | (0x1UL << 23)     /* EPD1 = 1: TTBR1 walks disabled (TTBR1 is
                              * never programmed; leaving it enabled with
                              * T1SZ=0 is CONSTRAINED UNPREDICTABLE) */
-        | (0x1UL << 32);    /* IPS = 001 (36-bit PA) */
+        | (0x2UL << 32);    /* IPS = 010 (40-bit PA) */
     asm volatile ("msr TCR_EL1, %0" :: "r"(tmp));
     asm volatile ("isb");
 
     /*
      * Set TTBR0_EL1 to the Level 1 (PUD) table.
-     * With T0SZ=29 (35-bit VA) and 4KB granule, the initial lookup
+     * With T0SZ=25 (39-bit VA) and 4KB granule, the initial lookup
      * level is 1, so TTBR0 must point to the Level 1 table directly.
      * Level 0 (PGD) is not used.
      */

--- a/arch/aarch64-raspi/boot/serialdebug.c
+++ b/arch/aarch64-raspi/boot/serialdebug.c
@@ -23,20 +23,17 @@
 #define ARM_PERIIOBASE (__arm_periiobase)
 extern uintptr_t __arm_periiobase;
 extern unsigned int __arm_socid;
+extern uintptr_t __rp1_base;
+uintptr_t __uart_base = 0;
 
 /*
  * BCM2712 has no BCM283x UART at +0x201000. The debug connector is uart10
  * (/soc/serial@7d001000, a PL011), 0x7D001000 into the peripheral window.
  */
-#define RP1_UART0_BASE_5 0x1f00030000ULL
-#define RP1_UART0_BASE_500_PLUSS 0x1c00030000ULL
+#define RP1_UART0_BASE (__rp1_base ? __rp1_base + 0x30000 : 0x1c00030000ULL)
 
-#define UART_BASE (__arm_socid == 0x2712 \
-                    ? RP1_UART0_BASE_500_PLUSS \
-                    : PL011_0_BASE)
+#define UART_BASE (__arm_socid == 0x2712 ? RP1_UART0_BASE : PL011_0_BASE)
 
-// #define UART_BASE   (__arm_socid == 0x2712 ? (ARM_PERIIOBASE + 0x7D001000) \
-//                                            : PL011_0_BASE)
 #define PL011_ICR_FLAGS (PL011_ICR_RXIC|PL011_ICR_TXIC|PL011_ICR_RTIC|PL011_ICR_FEIC|PL011_ICR_PEIC|PL011_ICR_BEIC|PL011_ICR_OEIC|PL011_ICR_RIMIC|PL011_ICR_CTSMIC|PL011_ICR_DSRMIC|PL011_ICR_DCDMIC)
 
 #define DEF_BAUD 115200
@@ -78,16 +75,11 @@ void serInit(void)
 
     uartbaud = DEF_BAUD;
 
+    __uart_base = UART_BASE;
+
     /* BCM2712 has no BCM283x GPIO block, and uart10's pins are dedicated.
-     * Firmware has already set this up. 
+     * Firmware has already set this up.
      */
-    // if (__arm_socid == 0x2712) 
-    // {
-    //     uartclock   = 9216000;    /* /clocks/clk-uart */
-    //     uartdivint  = PL011_BAUDINT(uartbaud, uartclock);
-    //     uartdivfrac = PL011_BAUDFRAC(uartbaud, uartclock);
-    //     return;
-    // }
     if (__arm_socid == 0x2712)
     {
         /*
@@ -103,12 +95,10 @@ void serInit(void)
          * 115200 8N1
          */
         uartbaud = 115200;
-        // uartdivint  = PL011_BAUDINT(uartbaud, uartclock);
-        // uartdivfrac = PL011_BAUDFRAC(uartbaud, uartclock);
-    
+
         return;
-    } 
-    
+    }
+
     uart_msg[0] = AROS_LONG2LE(8 * 4);
     uart_msg[1] = AROS_LONG2LE(VCTAG_REQ);
     uart_msg[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);

--- a/arch/aarch64-raspi/boot/serialdebug.c
+++ b/arch/aarch64-raspi/boot/serialdebug.c
@@ -22,7 +22,21 @@
 #undef ARM_PERIIOBASE
 #define ARM_PERIIOBASE (__arm_periiobase)
 extern uintptr_t __arm_periiobase;
+extern unsigned int __arm_socid;
 
+/*
+ * BCM2712 has no BCM283x UART at +0x201000. The debug connector is uart10
+ * (/soc/serial@7d001000, a PL011), 0x7D001000 into the peripheral window.
+ */
+#define RP1_UART0_BASE_5 0x1f00030000ULL
+#define RP1_UART0_BASE_500_PLUSS 0x1c00030000ULL
+
+#define UART_BASE (__arm_socid == 0x2712 \
+                    ? RP1_UART0_BASE_500_PLUSS \
+                    : PL011_0_BASE)
+
+// #define UART_BASE   (__arm_socid == 0x2712 ? (ARM_PERIIOBASE + 0x7D001000) \
+//                                            : PL011_0_BASE)
 #define PL011_ICR_FLAGS (PL011_ICR_RXIC|PL011_ICR_TXIC|PL011_ICR_RTIC|PL011_ICR_FEIC|PL011_ICR_PEIC|PL011_ICR_BEIC|PL011_ICR_OEIC|PL011_ICR_RIMIC|PL011_ICR_CTSMIC|PL011_ICR_DSRMIC|PL011_ICR_DCDMIC)
 
 #define DEF_BAUD 115200
@@ -40,7 +54,7 @@ inline void waitSerOUT()
 {
     while(1)
     {
-       if ((rd32le(PL011_0_BASE + PL011_FR) & PL011_FR_TXFF) == 0) break;
+       if ((rd32le(UART_BASE + PL011_FR) & PL011_FR_TXFF) == 0) break;
     }
 }
 
@@ -50,10 +64,10 @@ inline void putByte(uint8_t chr)
 
     if (chr == '\n')
     {
-        wr32le(PL011_0_BASE + PL011_DR, '\r');
+        wr32le(UART_BASE + PL011_DR, '\r');
         waitSerOUT();
     }
-    wr32le(PL011_0_BASE + PL011_DR, chr);
+    wr32le(UART_BASE + PL011_DR, chr);
 }
 
 void serInit(void)
@@ -64,6 +78,37 @@ void serInit(void)
 
     uartbaud = DEF_BAUD;
 
+    /* BCM2712 has no BCM283x GPIO block, and uart10's pins are dedicated.
+     * Firmware has already set this up. 
+     */
+    // if (__arm_socid == 0x2712) 
+    // {
+    //     uartclock   = 9216000;    /* /clocks/clk-uart */
+    //     uartdivint  = PL011_BAUDINT(uartbaud, uartclock);
+    //     uartdivfrac = PL011_BAUDFRAC(uartbaud, uartclock);
+    //     return;
+    // }
+    if (__arm_socid == 0x2712)
+    {
+        /*
+         * RP1 UART0 has already been initialised by firmware:
+         *
+         * config.txt:
+         *   enable_uart=1
+         *   enable_rp1_uart=1
+         *   pciex4_reset=0
+         *
+         * GPIO14 = TX
+         * GPIO15 = RX
+         * 115200 8N1
+         */
+        uartbaud = 115200;
+        // uartdivint  = PL011_BAUDINT(uartbaud, uartclock);
+        // uartdivfrac = PL011_BAUDFRAC(uartbaud, uartclock);
+    
+        return;
+    } 
+    
     uart_msg[0] = AROS_LONG2LE(8 * 4);
     uart_msg[1] = AROS_LONG2LE(VCTAG_REQ);
     uart_msg[2] = AROS_LONG2LE(VCTAG_GETCLKRATE);
@@ -81,7 +126,7 @@ void serInit(void)
     else
         uartclock = 48000000;   /* firmware default UART clock */
 
-    wr32le(PL011_0_BASE + PL011_CR, 0);
+    wr32le(UART_BASE + PL011_CR, 0);
 
     uartvar = rd32le(GPFSEL1);
     uartvar &= ~(7<<12);                        // TX on GPIO14
@@ -101,13 +146,13 @@ void serInit(void)
 
     wr32le(GPPUDCLK0, 0);
 
-    wr32le(PL011_0_BASE + PL011_ICR, PL011_ICR_FLAGS);
+    wr32le(UART_BASE + PL011_ICR, PL011_ICR_FLAGS);
     uartdivint = PL011_BAUDINT(uartbaud, uartclock);
-    wr32le(PL011_0_BASE + PL011_IBRD, uartdivint);
+    wr32le(UART_BASE + PL011_IBRD, uartdivint);
     uartdivfrac = PL011_BAUDFRAC(uartbaud, uartclock);
-    wr32le(PL011_0_BASE + PL011_FBRD, uartdivfrac);
-    wr32le(PL011_0_BASE + PL011_LCRH, PL011_LCRH_WLEN8|PL011_LCRH_FEN);           // 8N1, Fifo enabled
-    wr32le(PL011_0_BASE + PL011_CR, PL011_CR_UARTEN|PL011_CR_TXE|PL011_CR_RXE);   // enable the uart, tx and rx
+    wr32le(UART_BASE + PL011_FBRD, uartdivfrac);
+    wr32le(UART_BASE + PL011_LCRH, PL011_LCRH_WLEN8|PL011_LCRH_FEN);           // 8N1, Fifo enabled
+    wr32le(UART_BASE + PL011_CR, PL011_CR_UARTEN|PL011_CR_TXE|PL011_CR_RXE);   // enable the uart, tx and rx
 
     for (uartvar = 0; uartvar < 150; uartvar++) asm volatile ("nop\n");
 }

--- a/arch/aarch64-raspi/boot/vc_fb.c
+++ b/arch/aarch64-raspi/boot/vc_fb.c
@@ -144,6 +144,16 @@ int vcfb_init(void)
             D(kprintf("[VCFB] Buffer uncached\n"));
         }
         scr_FrameBuffer = (void*)((intptr_t)scr_FrameBuffer & ~0xc0000000);
+
+        /* The firmware echoes back what it actually configured, in place.
+         * The Pi 5 keeps its native mode rather than honouring the request,
+         * so never trust the values we asked for. */
+        if (AROS_LE2LONG(vcmb_msg[5]))
+            fb_width  = AROS_LE2LONG(vcmb_msg[5]);
+        if (AROS_LE2LONG(vcmb_msg[6]))
+            fb_height = AROS_LE2LONG(vcmb_msg[6]);
+        if (AROS_LE2LONG(vcmb_msg[15]))
+            fb_depth  = AROS_LE2LONG(vcmb_msg[15]);
     }
 
     /* query the framebuffer pitch */
@@ -175,6 +185,12 @@ int vcfb_init(void)
     vcfb_height = fb_height;
     vcfb_depth  = fb_depth;
     vcfb_pitch  = fb_pitch;
+
+    /* The firmware may place the fb outside both the reported VC region
+     * and the RAM ranges (Pi 5: carveout at 0x3f800000) - map it
+     * explicitly instead of relying on query_vmem()'s coverage.
+     * Normal-NC: framebuffer wants write-combining, not Device. */
+    mmu_map_section(vcfb_base, vcfb_base, vcfb_pitch * vcfb_height, 1, 0, 3, 0);
 
     fb_Init(fb_width, fb_height, fb_depth, fb_pitch);
 

--- a/arch/aarch64-raspi/boot/vc_fb.c
+++ b/arch/aarch64-raspi/boot/vc_fb.c
@@ -7,6 +7,7 @@
 #include <aros/macros.h>
 
 #include <hardware/bcm2708.h>
+#include <stdint.h>
 #undef ARM_PERIIOBASE
 
 #include <hardware/videocore.h>
@@ -20,6 +21,7 @@
 #undef ARM_PERIIOBASE
 #define ARM_PERIIOBASE (__arm_periiobase)
 extern uintptr_t __arm_periiobase;
+extern uintptr_t __vcmb_base;
 
 #define D(x) /* x */
 
@@ -49,8 +51,8 @@ int vcfb_init(void)
         vcmb_msg[6] = 0;
         vcmb_msg[7] = 0;                        // terminate tag
 
-        vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vcmb_msg);
-        vcmb_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+        vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vcmb_msg);
+        vcmb_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
 
         if (!vcmb_msg || (vcmb_msg[1] != AROS_LONG2LE(VCTAG_RESP)))
             return 0;
@@ -104,8 +106,8 @@ int vcfb_init(void)
 
         vcmb_msg[0] = AROS_LONG2LE((c << 2));                 // fill in request size
 
-        vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vcmb_msg);
-        vcmb_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+        vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vcmb_msg);
+        vcmb_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
 
         if (!vcmb_msg || (vcmb_msg[1] != AROS_LONG2LE(VCTAG_RESP)))
             return 0;
@@ -154,8 +156,8 @@ int vcfb_init(void)
         vcmb_msg[5] = 0;
         vcmb_msg[6] = 0;                        // terminate tag
 
-        vcmb_write(VCMB_BASE, VCMB_PROPCHAN, (void *)vcmb_msg);
-        vcmb_msg = vcmb_read(VCMB_BASE, VCMB_PROPCHAN);
+        vcmb_write(__vcmb_base, VCMB_PROPCHAN, (void *)vcmb_msg);
+        vcmb_msg = vcmb_read(__vcmb_base, VCMB_PROPCHAN);
 
         if (!vcmb_msg || (vcmb_msg[4] != AROS_LONG2LE(VCTAG_RESP + 4)))
             return 0;

--- a/arch/aarch64-raspi/timer/timer_init.c
+++ b/arch/aarch64-raspi/timer/timer_init.c
@@ -19,6 +19,7 @@
 #include <exec/execbase.h>
 #include <exec/interrupts.h>
 #include <hardware/intbits.h>
+#include <hardware/bcm2708.h>
 #include <proto/arossupport.h>
 #include <proto/bootloader.h>
 #include <proto/exec.h>
@@ -105,10 +106,16 @@ static int Timer_Init(struct TimerBase *TimerBase)
 
     TimerBase->tb_Platform.tbp_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
+    /* BCM2711 and BCM2712 both present the legacy GPU interrupts through
+     * the GIC at +96, and both want the VBlank-driven MicroHZ fallback:
+     * the systimer compare SPI is not guaranteed to be delivered. */
+    int isGIC = (TimerBase->tb_Platform.tbp_periiobase == BCM2711_PERIIOBASE ||
+                 TimerBase->tb_Platform.tbp_periiobase == BCM2712_PERIIOBASE);
+
     /* Install timer IRQ handler */
     timerIRQ = IRQ_TIMER0 + TICK_TIMER;
-    if (TimerBase->tb_Platform.tbp_periiobase == BCM2711_PERIIOBASE)
-        timerIRQ += BCM2711_GPUIRQ_OFFSET;
+    if (isGIC)
+        timerIRQ += BCM271X_GPUIRQ_OFFSET;
 
     TimerBase->tb_TimerIRQHandle = KrnAddIRQHandler(timerIRQ, Timer1Tick, TimerBase, SysBase);
     if (!TimerBase->tb_TimerIRQHandle)
@@ -160,7 +167,7 @@ static int Timer_Init(struct TimerBase *TimerBase)
 
     vblank_Init(TimerBase);
 
-    if (TimerBase->tb_Platform.tbp_periiobase == BCM2711_PERIIOBASE)
+    if (isGIC)
     {
         TimerBase->tb_Platform.tbp_MicroHZInt.is_Node.ln_Pri  = 0;
         TimerBase->tb_Platform.tbp_MicroHZInt.is_Node.ln_Type = NT_INTERRUPT;
@@ -170,7 +177,7 @@ static int Timer_Init(struct TimerBase *TimerBase)
 
         AddIntServer(INTB_VERTB, &TimerBase->tb_Platform.tbp_MicroHZInt);
 
-        D(bug("[Timer] Timer_Init: microhz driven from VBlank (BCM2711)\n"));
+        D(bug("[Timer] Timer_Init: microhz driven from VBlank (BCM2711/BCM2712)\n"));
     }
 
     D(bug("[Timer] Timer_Init: configured GPU timer %d\n", TICK_TIMER));

--- a/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_init.c
+++ b/arch/arm-native/soc/broadcom/2708/bwfm/bwfm_init.c
@@ -1481,7 +1481,10 @@ static int bwfm_init(struct BWFMBase *BWFMBase)
 
     SDIOBase = OpenResource("sdio.resource");
     if (!SDIOBase)
+    {
         D(bug("[bwfm] sdio.resource not available\n"));
+        return FALSE;
+    }
 
     /* Chip bring-up (power + enumeration) is deferred to the first BWFMAttach(),
      * which bwfm.device calls when it is opened - so the WiFi chip stays

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/arasan.h
@@ -14,11 +14,13 @@
 #define EMMC2_BASE                      (ARM_PERIIOBASE + 0x340000)
 
 /* BCM2712 (Raspberry Pi 5) eMMC2 controller */
-#define BCM2712_EMMC2_BASE              (ARM_PERIIOBASE + 0x100000)
+/* BCM2712: the SD slot is sdio1 (mmc@fff000), not an offset from the
+ * VC-legacy block - /soc child 0xfff000 + window base 0x10_0000_0000. */
+#define BCM2712_EMMC2_BASE              0x1000FFF000UL
 
 /* Both windows share one interrupt line on the BCM2711 (GIC SPI 126). */
 #define IRQ_BCM2711_SDHCI               158
-#define IRQ_BCM2712_SDHCI               300
+#define IRQ_BCM2712_SDHCI               305     /* GIC SPI 273 + 32 */
 
 /* Identification clock, used until the card reports what it can take. */
 #define BCM2708SDCLOCK_MIN              400000

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -38,7 +38,7 @@
  * INTID n + 96. Anything using an IRQ_* number below has to add it when
  * running on that SoC.
  */
-#define BCM2711_GPUIRQ_OFFSET                           96
+#define BCM271X_GPUIRQ_OFFSET                           96
 
 #define SYSTIMER_BASE                                   (ARM_PERIIOBASE + 0x003000)
 #define ARMTIMER_BASE                                   (ARM_PERIIOBASE + 0x00b000)

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_bcm2708init.c
@@ -18,6 +18,11 @@
 #include <hardware/arasan.h>
 #include <hardware/videocore.h>
 
+/* The BCM2712 mailbox sits at +0x13880, not the BCM283x/2711 +0xB880 */
+#undef VCMB_BASE
+#define VCMB_BASE ((IPTR)__arm_periiobase + \
+    (((IPTR)__arm_periiobase == BCM2712_PERIIOBASE) ? 0x13880 : 0xB880))
+
 extern APTR     MBoxBase;
 extern IPTR     __arm_periiobase;
 

--- a/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdcard/sdcard_sdhost_init.c
@@ -139,10 +139,10 @@ static int FNAME_SDHOST(SDHostInit)(struct SDCardBase *SDCardBase)
     __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
     /*
-     * On the BCM2711 the card slot is wired to EMMC2, not to this controller.
+     * On the BCM2711/BCM2712 the card slot is wired to EMMC2, not to this controller.
      * Report success so the remaining init functions still run.
      */
-    if (__arm_periiobase == BCM2711_PERIIOBASE)
+    if (__arm_periiobase == BCM2711_PERIIOBASE || __arm_periiobase == BCM2712_PERIIOBASE)
     {
         D(bug("[SDHost] %s: not the card controller on this SoC\n", __PRETTY_FUNCTION__));
         if (MBoxMessage_)

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_init.c
@@ -988,7 +988,7 @@ static int sdio_do_probe(struct SDIOBase *SDIOBase)
         unsigned int irq = IRQ_VC_ARASANSDIO;
 
         if (SDIOBase->sdio_periiobase == BCM2711_PERIIOBASE)
-            irq += BCM2711_GPUIRQ_OFFSET;
+            irq += BCM271X_GPUIRQ_OFFSET;
 
         SDIOBase->sdio_IRQHandle = KrnAddIRQHandler(irq,
                                                     sdio_irq_handler, SDIOBase, NULL);
@@ -1043,6 +1043,13 @@ static int sdio_init(struct SDIOBase *SDIOBase)
         return FALSE;
 
     if ((SDIOBase->sdio_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase)) == 0)
+        return FALSE;
+
+    /* BCM2712 wires the WiFi to its own SDHCI block, not the Arasan; the
+     * partial iobase redirect below is not enough (GPIO mux and wdelay's
+     * timeout-less SYSTIMER spin still assume BCM283x). Bail until a real
+     * 2712 SDIO path exists. */
+    if (SDIOBase->sdio_periiobase == BCM2712_PERIIOBASE)
         return FALSE;
 
     InitSemaphore(&SDIOBase->sdio_Sem);

--- a/arch/arm-native/soc/broadcom/2708/sdio/sdio_private.h
+++ b/arch/arm-native/soc/broadcom/2708/sdio/sdio_private.h
@@ -20,8 +20,8 @@ struct SDIOBase
 {
     struct Node             sdio_Node;
     struct SignalSemaphore  sdio_Sem;       /* Serialises command issue */
-    unsigned int            sdio_periiobase;
-    unsigned int            sdio_iobase;    /* Arasan SDHCI MMIO base */
+    IPTR                    sdio_periiobase;
+    IPTR                    sdio_iobase;    /* Arasan SDHCI MMIO base */
     unsigned int            sdio_ClockMax;  /* Controller base clock (Hz) */
     uint16_t                sdio_RCA;       /* Relative card address (CMD3) */
     uint32_t                sdio_OCR;       /* I/O OCR from CMD5 */

--- a/compiler/include/aros/kernel.h
+++ b/compiler/include/aros/kernel.h
@@ -76,7 +76,7 @@ typedef enum
 #define KRN_FrameBufferDepth    (KRN_Dummy + 36) /* Framebuffer bits per pixel			*/
 #define KRN_FrameBufferPitch    (KRN_Dummy + 37) /* Framebuffer bytes per line			*/
 #define KRN_PeripheralBase      (KRN_Dummy + 38) /* SoC peripheral IO physical base address */
-
+#define KRN_DebugUartBase       (KRN_Dummy + 39) /* CPU address of the boot debug UART */
 /*
  * KRN_MEMLower/KRN_MEMUpper may appear more than once, one pair per physical
  * memory range the bootstrap found, lower first. The first pair describes the


### PR DESCRIPTION
Enables AROS to boot to Wanderer on Raspberry Pi 5 (only tested on 500+)

Debug serial is routed to GPIO 14/15 as on the Pi 3 and Pi 4, so one wiring
works across all boards, rather than the Pi 5's dedicated debug connector.
