### PR TITLE
camdusbmidi: build the class on arm and aarch64

### DIFF
--- a/rom/usb/classes/camdmidi/camd/mmakefile.src
+++ b/rom/usb/classes/camdmidi/camd/mmakefile.src
@@ -6,7 +6,6 @@ CAMDOBJDIR := $(OBJDIR)/../camdusbmidi/arch
 
 SRCFILE := poseidonusb
 
-USER_LDFLAGS := -static
 USER_INCLUDES := -I$(OBJDIR)/../include -iquote $(SRCDIR)/$(CURDIR)/..
 
 #MM kernel-usb-classes-camdusbmidi-object : kernel-usb-classes-camd-usbmidi-includes
@@ -15,16 +14,18 @@ USER_INCLUDES := -I$(OBJDIR)/../include -iquote $(SRCDIR)/$(CURDIR)/..
 $(OBJDIR)/%.o : $(SRCDIR)/$(CURDIR)/%.c | $(OBJDIR)
 	%compile_q
 
-ifeq ($(AROS_TOOLCHAIN),llvm)
-BINLDFLAGS := -m elf_$(AROS_TARGET_CPU)
-endif
-BINLDFLAGS += $(LDFLAGS)
- 
-%rule_link_binary ldflags=$(BINLDFLAGS) file=$(CAMDOBJDIR)/$(SRCFILE).bin.o name=$(SRCFILE) objs=$(OBJDIR)/$(SRCFILE).o
+# The class writes this blob to DEVS:Midi/ and camd.library LoadSeg()s it, so
+# it has to stay a relocatable ELF: OpenMidiDevice() only accepts the driver
+# if MidiDeviceData.Init points inside the loaded seglist, which needs the
+# relocations intact.
+$(CAMDOBJDIR)/$(SRCFILE).bin.o : $(OBJDIR)/$(SRCFILE).o | $(OBJDIR) $(CAMDOBJDIR)
+	$(Q)$(ECHO) "Embedding  $(SRCFILE)..."
+	$(Q)$(CP) $< $(OBJDIR)/$(SRCFILE)
+	$(Q)cd $(OBJDIR) && $(AROS_LD) -r --format binary $(SRCFILE) -o $@
 
 #MM
 kernel-usb-classes-camdusbmidi-object : $(CAMDOBJDIR)/$(SRCFILE).bin.o
 
-GLOB_MKDIRS += $(OBJDIR)
+GLOB_MKDIRS += $(OBJDIR) $(CAMDOBJDIR)
 
 %common

--- a/rom/usb/classes/camdmidi/camd/poseidonusb.c
+++ b/rom/usb/classes/camdmidi/camd/poseidonusb.c
@@ -30,7 +30,9 @@ char name[], vers[];
 
 #define CAMDPORTCOUNT   16
 
-static struct MidiDeviceData MidiDeviceData =
+/* Nothing here references it -- camd.library finds it by scanning the loaded
+ * seglist for MDD_Magic -- so the compiler has to be told to keep it. */
+static struct MidiDeviceData MidiDeviceData __attribute__((used)) =
 {
   MDD_Magic,
   name,

--- a/rom/usb/classes/camdmidi/mmakefile.src
+++ b/rom/usb/classes/camdmidi/mmakefile.src
@@ -6,7 +6,8 @@ include $(SRCDIR)/config/aros.cfg
 
 #MM- kernel-usb-classes-camdusbmidi-i386 : kernel-usb-classes-camd-usbmidi
 #MM- kernel-usb-classes-camdusbmidi-x86_64 : kernel-usb-classes-camd-usbmidi
-##MM- kernel-usb-classes-camdusbmidi-arm : kernel-usb-classes-camd-usbmidi
+#MM- kernel-usb-classes-camdusbmidi-arm : kernel-usb-classes-camd-usbmidi
+#MM- kernel-usb-classes-camdusbmidi-aarch64 : kernel-usb-classes-camd-usbmidi
 #MM- kernel-usb-classes-camdusbmidi-ppc : kernel-usb-classes-camd-usbmidi
 
 USER_CPPFLAGS := -DMUIMASTER_YES_INLINE_STDARG


### PR DESCRIPTION
The arm rule was disabled in e4b16b1210 because the CAMD driver blob would not link. It was also the wrong artefact: the class writes it to DEVS:Midi/ for camd.library to LoadSeg(), and OpenMidiDevice() only accepts a driver whose MidiDeviceData.Init points inside the loaded seglist, so the relocations have to survive. %rule_link_binary flattened it with --oformat binary, which drops every relocation and which the ARM and AArch64 BFD backends refuse outright. The object is self-contained, so embed it as it is. MidiDeviceData needs __attribute__((used)): only camd's MDD_Magic scan refers to it, so the compiler had dropped it.

Compile-tested on arm and aarch64