### PR TITLE
fd.library: hook the module into workbench-libs-complete so it is built

### DIFF
--- a/workbench/libs/fd/mmakefile.src
+++ b/workbench/libs/fd/mmakefile.src
@@ -5,7 +5,7 @@ FILES:= fd_alloc fd_hooks fd_init
 
 USER_LDFLAGS := -static
 
-#MM- workbench-libs : workbench-libs-fd
+#MM- workbench-libs-complete : workbench-libs-fd
 %build_module mmake=workbench-libs-fd \
     modname=fd modtype=library \
     files="$(FILES)"


### PR DESCRIPTION
`workbench/libs/fd/mmakefile.src` hooks the module into the metatarget `workbench-libs`, which nothing in the tree depends on; the Libs modules are collected by `workbench-libs-complete` (glu, gl, translator, mesa do that). The includes are copied because `includes-copy` runs on its own, but the library is never compiled: `fd.library` is absent from `Libs/` in a full pc-x86_64 build and from the ISO.

Without it both sides of the descriptor bridge fall back silently to private tables. posixc's `__fdlib_available()` is false, AROSTCP's `FDBase` stays NULL, and the two number spaces overlap from the bottom.

Measured on an installed pc-x86_64 system built from 675bd114, AROSTCP started by hand, with a small probe:

| | without fd.library | with fd.library in SYS:Libs |
|---|---|---|
| posixc `open()` | 3 | 5 |
| bsdsocket `socket()` | 0 | 6 |
| posixc `open()` again | 4 | 7 |
| posixc `read()` on the socket | blocks on the console, returns what is typed | returns the HTTP reply |
| `recv()` right after | returns the HTTP reply | continues the same stream |

So on a build without the library a program that uses `read()`/`write()` on a socket, as OpenSSL's generic socket code does, talks to stdin/stdout instead of the network and sees garbage rather than an error. With contrib OpenSSL 4.0.1 this surfaced as `wrong version number` in `tls_validate_record_header`, which is the report this PR follows up on.

With the metatarget corrected the module builds with the rest of Libs: verified by deleting `Libs/fd.library` and running `workbench-libs-complete`, which rebuilt it. Every ISO built so far, and every install from one, lacks the library until rebuilt.
