### PR TITLE
posixc: zero-extend the ioctl request before handing it to an fd hook

### DIFF
--- a/compiler/crt/posixc/ioctl.c
+++ b/compiler/crt/posixc/ioctl.c
@@ -183,7 +183,11 @@ static int fill_consize(APTR fd, struct winsize *ws)
             va_start(ap, request);
             arg = va_arg(ap, APTR);
             va_end(ap);
-            r = hooks->fdh_ioctl(data, (IPTR)request, arg, &err);
+            /* request is an int but the codes are unsigned 32-bit values
+               with bit 31 set (FIONBIO = _IOW('f', 126, long) = 0x8008667e),
+               so on 64-bit targets a plain (IPTR) cast sign-extends and no
+               hook's switch can match it. Zero-extend instead. */
+            r = hooks->fdh_ioctl(data, (IPTR)(ULONG)request, arg, &err);
             if (r < 0)
                 errno = err;
             return r;


### PR DESCRIPTION
Companion to #1122. That one makes fd.library exist, so posixc dispatches socket descriptors to bsdsocket's hooks; this one makes `ioctl()` on such a descriptor work on 64-bit targets.

`ioctl()` takes the request as an `int`, but the request codes are unsigned 32-bit values with bit 31 set: `FIONBIO` is `_IOW('f', 126, long)` = `0x8008667e`. The hook dispatch in `compiler/crt/posixc/ioctl.c` casts it with `(IPTR)`, which on x86_64 and aarch64 sign-extends to `0xffffffff8008667e`, so `fdh_sock_ioctl()` in AROSTCP never matches its `case FIONBIO` and returns `EINVAL`. On 32-bit targets `int` and `IPTR` have the same width and it cannot happen.

Observed on an installed pc-x86_64 system from 675bd114 with fd.library installed and AROSTCP started by hand. A client built against stock contrib OpenSSL 4.0.1 failed before the handshake:

```
FAIL: connect
error:80000016:system library:BIO_socket_ioctl:Invalid argument:crypto/bio/bio_sock.c:248:calling ioctlsocket()
error:80000016:system library:conn_state:Invalid argument:crypto/bio/bss_conn.c:215:calling connect(example.com, 443)
```

With this change (posixc.library rebuilt and installed, guest rebooted) the same binary passes:

```
handshake OK: TLSv1.3 TLS_AES_256_GCM_SHA384, verify=0
reply 269 bytes: HTTP/1.1 200 OK
```

That is chain and hostname verification against `ENV:SYS/Certificates/ca-bundle.crt` (the one from #1123) and an HTTP reply, all through posixc's generic `read()`/`write()`/`ioctl()` path with no OpenSSL patch. Both fixes are needed; fd.library alone still fails at `ioctlsocket()`.

The prototype could instead be widened to `unsigned long request`, which matches POSIX better, but that changes a public signature, so this patch keeps to the cast.
