### PR TITLE
Shell: fix buffer reallocation free size

### DIFF
--- a/workbench/c/Shell/buffer.c
+++ b/workbench/c/Shell/buffer.c
@@ -32,7 +32,7 @@ static BOOL bufferExpand(Buffer *out, LONG size, ShellState *ss)
             CopyMem(out->buf, tmp, out->len);
 
         if (out->mem > 0)
-            FreeMem(out->buf, out->mem);
+            FreeMem(out->buf, out->mem + 1);
 
         out->buf = tmp;
         out->mem = newSize;


### PR DESCRIPTION
`bufferExpand()` allocates `newSize + 1` bytes but frees the previous buffer with `out->mem`, unlike `bufferFree()` which includes the extra byte.

Free the previous allocation with `out->mem + 1` as well.

A focused before/after check reproduces a 513-byte allocation being freed as 512 bytes on the baseline and 513 bytes after the change. The updated `buffer.c` also compiles with the pc-i386 AROS cross-compiler.
