### PR TITLE
VMM: honor catalog versions

### DIFF
--- a/workbench/system/VMM/MUI/locale.c
+++ b/workbench/system/VMM/MUI/locale.c
@@ -10,7 +10,7 @@
 #include "strings.h"
 
 #define CATALOG_NAME     "System/System/VMM.catalog"
-#define CATALOG_VERSION  1
+#include "cat/catalog_version.h"
 
 /*** Variables **************************************************************/
 struct Catalog *catalog;

--- a/workbench/system/VMM/locale.c
+++ b/workbench/system/VMM/locale.c
@@ -9,8 +9,8 @@
 #define CATCOMP_ARRAY
 #include "strings.h"
 
-#define CATALOG_NAME     "System/System/VMM.catalog"
-#define CATALOG_VERSION  1
+#define CATALOG_NAME     "System/System/VMM-Handler.catalog"
+#include "cat/catalog_version.h"
 
 extern struct Library *LocaleBase;
 


### PR DESCRIPTION
Use the catalog version headers maintained by the VMM translation repositories instead of hardcoded runtime versions.

This keeps the VMM handler and VMM application catalog consumers aligned with their respective translation contracts.
