### PR TITLE
MetaMake: fail on unknown requested targets

### DIFF
--- a/tools/MetaMake/mmake.c
+++ b/tools/MetaMake/mmake.c
@@ -112,6 +112,7 @@ main (int argc, char ** argv)
     char * targets[64];
     int targetc;
     int doenv = 0;
+    int retval = 0;
 
     currdir = getcwd (NULL, 1024);
 
@@ -250,7 +251,8 @@ main (int argc, char ** argv)
         }
     
         debug(printf("MMAKE:mmake.c->main: calling maketarget '%s'\n", tname));
-        maketarget (deplogfh, prj, tname, 0, 0);
+        if (!maketarget (deplogfh, prj, tname, 0, 0))
+            retval = 20;
 
         if (deplogfh)
             fclose (deplogfh);
@@ -268,6 +270,6 @@ main (int argc, char ** argv)
 
     free (currdir);
 
-    return 0;
+    return retval;
 }
 

--- a/tools/MetaMake/project.c
+++ b/tools/MetaMake/project.c
@@ -606,7 +606,7 @@ execute (struct Project * prj,
 
 #define VOUT(x)
 
-void
+int
 maketarget (FILE * deplogfh, struct Project * prj, char * tname, unsigned int depth, unsigned int offset)
 {
     struct Target * target, * subtarget;
@@ -639,7 +639,7 @@ maketarget (FILE * deplogfh, struct Project * prj, char * tname, unsigned int de
             fputs(tname, mm_faillogfh);
             fputs("\n", mm_faillogfh);
         }
-        return;
+        return 0;
     }
 
     target->updated = 1;
@@ -777,4 +777,5 @@ maketarget (FILE * deplogfh, struct Project * prj, char * tname, unsigned int de
             }
         }
     }
+    return 1;
 }

--- a/tools/MetaMake/project.h
+++ b/tools/MetaMake/project.h
@@ -58,7 +58,7 @@ void initprojects (void);
 void expungeprojects (void);
 struct Project * findproject (const char * pname);
 struct Project * getfirstproject (void);
-void maketarget (FILE * deplogfh,
+int maketarget (FILE * deplogfh,
         struct Project * prj,
         char * tname,
         unsigned int depth,


### PR DESCRIPTION
MetaMake currently reports an explicitly requested unknown target but still exits successfully.

Propagate whether the requested root target was found back to `main()` and return the existing failure status 20 when it was not.

Verified with a standalone MetaMake host build:

* known target: `0` → `0`
* unknown requested target: `0` → `20`
* unknown project: `20` → `20`

Unknown subtarget handling is unchanged.
