### PR TITLE
console.device: reset snip buffer when clearing

### DIFF
--- a/rom/devs/console/setconsnip.c
+++ b/rom/devs/console/setconsnip.c
@@ -23,6 +23,7 @@ AROS_LH1(LONG, SetConSnip,
 
     FreeMem((APTR) ConsoleDevice->copyBuffer,
         ConsoleDevice->copyBufferSize);
+    ConsoleDevice->copyBuffer = NULL;
     ConsoleDevice->copyBufferSize = 0;
     if (data)
     {


### PR DESCRIPTION
`SetConSnip()` clears `copyBufferSize` but leaves `copyBuffer` non-NULL when the snip is cleared. `GetConSnip()` checks the pointer, so a cleared snip is returned as an allocated empty string instead of no snip.

Reset `copyBuffer` when clearing the old buffer.

Verified both NULL and empty-string clears return no snip after the change. The updated source also compiles with the pc-i386 AROS cross-compiler.
