### PR TITLE
Shell: bound .key and .def argument names

### DIFF
--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -15,6 +15,9 @@ static LONG getArgumentIdx(ShellState *ss, STRPTR name, LONG len)
     struct SArg *a;
     LONG i;
 
+    if (len > MAXARGLEN)
+        return -1;
+
     for (i = 0; i < ss->argcount; ++i)
     {
         a = ss->args + i;
@@ -47,6 +50,9 @@ static LONG dotDef(ShellState *ss, STRPTR szz, Buffer *in, LONG len)
     if ((result = bufferReadItem(buf, sizeof(buf), in, ss)) == ITEM_UNQUOTED)
     {
         len = in->cur - i;
+
+        if (len > MAXARGLEN)
+            return ERROR_LINE_TOO_LONG;
 
         i = getArgumentIdx(ss, buf, len);
         if (i < 0)
@@ -116,7 +122,13 @@ static LONG dotKey(ShellState *ss, STRPTR s, Buffer *in)
         for (len = 0; *s != '/' && *s != ',' && *s != '\n' && *s != '\0'; ++s)
             ++len;
 
+        if (len > MAXARGLEN)
+            return ERROR_LINE_TOO_LONG;
+
         j = getArgumentIdx(ss, s - len, len);
+        if (j < 0)
+            return ERROR_TOO_MANY_ARGS;
+
         arg = (STRPTR) ss->arg[j];
         a = ss->args + j;
 

--- a/workbench/c/Shell/state.h
+++ b/workbench/c/Shell/state.h
@@ -16,7 +16,7 @@
 
 struct SArg
 {
-    TEXT   name[MAXARGLEN];
+    TEXT   name[MAXARGLEN + 1];
     LONG   namelen;
     LONG   len;
     IPTR   def;


### PR DESCRIPTION
`.key` and `.def` argument names are stored in a fixed `SArg.name` buffer. A 32-character name currently writes its terminator past the end of that buffer, while longer names can access still farther beyond it.

Keep the existing 32-character argument-name limit, reserve space for the terminator, and reject longer names with `ERROR_LINE_TOO_LONG` before lookup or copying.

Verified the 31/32/33-character boundaries for both `.key` and `.def`; the updated source also compiles with the pc-i386 AROS cross-compiler.
