### PR TITLE
console.device: protect unit lifetime during input handling

### DIFF
--- a/rom/devs/console/cdinputhandler.c
+++ b/rom/devs/console/cdinputhandler.c
@@ -23,7 +23,7 @@
 /* protos */
 static Object *obtainconunit(struct Window *window,
     struct ConsoleBase *ConsoleDevice);
-static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
+static VOID releaseconunit(struct ConsoleBase *ConsoleDevice);
 
 /*************************************************************************
 
@@ -117,7 +117,7 @@ static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice);
                 }
 
                 /* deletion of unit is now allowed */
-                releaseconunit(unit, ConsoleDevice);
+                releaseconunit(ConsoleDevice);
 
             } /* if (RAWKEY event was meant for a console window) */
         }
@@ -187,41 +187,26 @@ static Object *obtainconunit(struct Window *window,
         if (CU(o)->cu_Window == activewin)
         {
             D(bug("Unit found: %p\n", o));
-            /* Delay deltion of this console object */
-            ICU(o)->conFlags |= CF_DELAYEDDISPOSE;
+            /* Keep the shared unit-list lock until the caller is done
+               using this console object. */
             break;
         }
     }
 
-    /* Unlock the console list */
-    ReleaseSemaphore(&ConsoleDevice->unitListLock);
+    /*
+     * A found unit remains protected by the shared list lock until
+     * releaseconunit().  CloseDevice() takes this lock exclusively before
+     * removing a unit, so it cannot dispose the object while this caller
+     * still uses it.
+     */
+    if (!o)
+        ReleaseSemaphore(&ConsoleDevice->unitListLock);
 
     ReturnPtr("obtainconunit", Object *, o);
 }
 
-static VOID releaseconunit(Object *o, struct ConsoleBase *ConsoleDevice)
+static VOID releaseconunit(struct ConsoleBase *ConsoleDevice)
 {
-    struct IntuitionBase *IntuitionBase =
-        (APTR) ConsoleDevice->cb_IntuitionBase;
-
-    /* Lock all units */
-    ObtainSemaphore(&ConsoleDevice->unitListLock);
-
-    /* Needn't prevent the unit from being disposed anymore */
-    ICU(o)->conFlags &= ~CF_DELAYEDDISPOSE;
-
-    /* If unit is scheduled for deletion, then delete it */
-    if (ICU(o)->conFlags & CF_DISPOSE)
-    {
-        ULONG mID = OM_REMOVE;
-
-        /* Remove from list */
-        DoMethodA(o, (Msg) &mID);
-
-        /* Delete it */
-        DisposeObject(o);
-    }
-
     ReleaseSemaphore(&ConsoleDevice->unitListLock);
 }
 

--- a/rom/devs/console/consoletask.c
+++ b/rom/devs/console/consoletask.c
@@ -58,7 +58,7 @@ VOID con_inject(struct ConsoleBase *ConsoleDevice, struct ConUnit *cu,
 }
 
 /* Protos */
-static BOOL checkconunit(Object *unit, struct ConsoleBase *ConsoleDevice);
+static BOOL lockconunit(Object *unit, struct ConsoleBase *ConsoleDevice);
 static void answer_read_request(struct IOStdReq *req,
     struct ConsoleBase *ConsoleDevice);
 
@@ -282,7 +282,7 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                 /* Check that the ConUnit has not been disposed,
                    while the message was passed
                  */
-                if (checkconunit(cdihmsg->unit, ConsoleDevice))
+                if (lockconunit(cdihmsg->unit, ConsoleDevice))
                 {
                     BOOL rawEvent = report_raw_event(cdihmsg->unit,
                         &cdihmsg->ie, ConsoleDevice);
@@ -435,7 +435,14 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
                         D(bug("cdihmsg->ie.ie_Class = %d\n",
                                 cdihmsg->ie.ie_Class));
                     } /* switch(cdihmsg->ie.ie_Class) */
-                } /* if (checkconunit(cdihmsg->unit, ConsoleDevice)) */
+
+                    /*
+                     * CloseDevice() needs the unit-list lock exclusively
+                     * before removing the unit.  Keep our shared lock until
+                     * all accesses through cdihmsg->unit are complete.
+                     */
+                    ReleaseSemaphore(&ConsoleDevice->unitListLock);
+                } /* if (lockconunit(cdihmsg->unit, ConsoleDevice)) */
 
                 /* The input handler sent this asynchronously (it must never
                    wait for us, see CDInputHandler); we own the message. */
@@ -487,10 +494,14 @@ VOID consoleTaskEntry(struct ConsoleBase *ConsoleDevice)
 /* FIXME: Do cleanup here */
 }
 
-/********** checkconunit()  *******************************/
+/********** lockconunit()  *******************************/
 
-/* Checks that the supplied unit has not been disposed */
-static BOOL checkconunit(Object *unit, struct ConsoleBase *ConsoleDevice)
+/*
+ * Checks that the supplied unit is still in the console list.  If found,
+ * the shared unit-list lock remains held so the object cannot be removed or
+ * disposed until the caller has finished using it.
+ */
+static BOOL lockconunit(Object *unit, struct ConsoleBase *ConsoleDevice)
 {
     Object *o, *ostate;
     BOOL found = FALSE;
@@ -506,7 +517,9 @@ static BOOL checkconunit(Object *unit, struct ConsoleBase *ConsoleDevice)
         }
     }
 
-    ReleaseSemaphore(&ConsoleDevice->unitListLock);
+    if (!found)
+        ReleaseSemaphore(&ConsoleDevice->unitListLock);
+
     return found;
 }
 


### PR DESCRIPTION
`CloseDevice()` removes and disposes a console unit under `unitListLock`, but the input paths currently release their shared lock after lookup while continuing to use the unit pointer. A concurrent close can therefore dispose the unit while either the input handler or console task is still using it.

Keep the shared `unitListLock` held for the duration of each unit use. The input handler releases it after the asynchronous event handoff, while the console task releases it after processing the event. `CloseDevice()` remains synchronous and exclusive, and the input handler still never waits for the console task.

Verified forced close/input interleavings and pc-i386 compilation of both changed translation units.
