### PR TITLE
Shell: fix ReadArgs ownership across interpreter state

### DIFF
--- a/workbench/c/Shell/interpreter.c
+++ b/workbench/c/Shell/interpreter.c
@@ -2,6 +2,7 @@
     Copyright (C) 1995-2011, The AROS Development Team. All rights reserved.
  */
 
+#include <proto/dos.h>
 #include <proto/exec.h>
 
 #include "Shell.h"
@@ -29,6 +30,8 @@ void initDefaultInterpreterState(ShellState *ss)
 
         ss->arg[i]  = 0;
     }
+
+    ss->arg_rd = NULL;
 
     ss->bra    = '<';
     ss->ket    = '>';
@@ -66,6 +69,9 @@ void popInterpreterState(ShellState *ss)
         if (a->def)
             FreeMem((APTR) a->def, a->deflen + 1);
     }
+
+    if (ss->arg_rd)
+        FreeDosObject(DOS_RDARGS, ss->arg_rd);
 
     if (tmp_ss)
     {


### PR DESCRIPTION
Interpreter state pushes copy the current `RDArgs` pointer along with the rest of `ShellState`. The new active state currently keeps that same pointer, so a subsequent `.key` can free the saved state's `RDArgs`. Popping the interpreter state then restores a stale pointer. The active state's replacement `RDArgs` is also not released when popping.

Treat `arg_rd` like the other state-owned resources: start a newly pushed interpreter state with no `RDArgs`, and release the current state's `RDArgs` before restoring the saved state.

Verified nested `.key` / push / pop ownership transitions and pc-i386 compilation of the changed translation unit.
