### PR TITLE
console-handler: allow full input line termination

### DIFF
--- a/rom/filesys/console_handler/support.c
+++ b/rom/filesys/console_handler/support.c
@@ -1011,7 +1011,7 @@ BOOL process_input(struct filehandle *fh)
             /* fall through */
 
         case INP_RETURN:
-            if (fh->inputsize < INPUTBUFFER_SIZE)
+            if (fh->inputsize <= INPUTBUFFER_SIZE)
             {
                 if (inp != INP_EOF)
                 {


### PR DESCRIPTION
The console input buffer accepts 256 characters, but Return is only processed while the current input size is below 256. Once the line reaches the full supported payload size, Return is therefore ignored and the line cannot be submitted.

Allow the termination path at exactly `INPUTBUFFER_SIZE`. The input buffer already reserves extra storage for the line terminator, while normal character input remains limited to 256 bytes.

Verified the 255-, 256-, and 257-byte boundaries, read-buffer compaction, and pc-i386 compilation of the changed translation unit.
