### PR TITLE
console-handler: bound AppWindow path insertion

### DIFF
--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -781,19 +781,23 @@ LONG CONMain(struct ExecBase *SysBase)
                                         if (insertedlen <= (INPUTBUFFER_SIZE - 1))
                                             iconpath[insertedlen++] = ' ';
 
-                                        currentpos = fh->inputpos;
-                                        currentrest = fh->inputsize - fh->inputpos;
-                                        memmove(&fh->inputbuffer[currentpos + insertedlen],
-                                                &fh->inputbuffer[currentpos],
-                                                currentrest);
-                                        CopyMem(iconpath, &fh->inputbuffer[currentpos],
-                                                insertedlen);
-                                        fh->inputsize += insertedlen;
-                                        fh->inputpos += insertedlen;
+                                        if (fh->inputsize <= INPUTBUFFER_SIZE &&
+                                            insertedlen <= (ULONG)(INPUTBUFFER_SIZE - fh->inputsize))
+                                        {
+                                            currentpos = fh->inputpos;
+                                            currentrest = fh->inputsize - fh->inputpos;
+                                            memmove(&fh->inputbuffer[currentpos + insertedlen],
+                                                    &fh->inputbuffer[currentpos],
+                                                    currentrest);
+                                            CopyMem(iconpath, &fh->inputbuffer[currentpos],
+                                                    insertedlen);
+                                            fh->inputsize += insertedlen;
+                                            fh->inputpos += insertedlen;
 
-                                        do_write(fh, &fh->inputbuffer[currentpos],
-                                                 insertedlen + currentrest);
-                                        do_movecursor(fh, CUR_LEFT, currentrest);
+                                            do_write(fh, &fh->inputbuffer[currentpos],
+                                                     insertedlen + currentrest);
+                                            do_movecursor(fh, CUR_LEFT, currentrest);
+                                        }
                                     }
                                 }
                             } while (++i < fh->appmsg->am_NumArgs);


### PR DESCRIPTION
Dropped AppWindow paths are inserted directly into the current console input line. The insertion currently does not account for the amount of input already buffered, so a sufficiently full line can cause the shifted tail and inserted path to extend past the input buffer.

Only insert a dropped path when the complete token fits within the normal input payload capacity. If it does not fit, leave the current command line unchanged for that argument.

Verified exact-fit and over-capacity insertion boundaries, insertion in the middle of an existing line, repeated multi-argument insertion, and pc-i386 compilation of the changed translation unit.
