### PR TITLE
Shell: finalize embedded interpreter state

### DIFF
--- a/workbench/c/Shell/convertBackTicks.c
+++ b/workbench/c/Shell/convertBackTicks.c
@@ -111,6 +111,9 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
 
 cleanup:
     Redirection_release(&ess);
+    while (ess.stack)
+        popInterpreterState(&ess);
+    popInterpreterState(&ess);
     /* TODO: delete generated file */
 freebufs:
     bufferFree(&embedIn, ss);


### PR DESCRIPTION
Embedded commands use a local `ShellState` that can acquire interpreter-owned resources while parsing the embedded command. The backtick cleanup currently releases redirection state but does not finalize that local interpreter state, leaving ReadArgs data, argument defaults, and saved interpreter frames allocated.

After releasing redirection resources, unwind all saved interpreter states and finalize the remaining local state using the existing interpreter-state cleanup path.

Verified nested interpreter-state cleanup, argument-default and ReadArgs ownership, cleanup ordering, and pc-i386 compilation of the affected Shell translation units.
