### PR TITLE
console.handler: bound ASL drawer copy

### DIFF
--- a/rom/filesys/console_handler/completion.c
+++ b/rom/filesys/console_handler/completion.c
@@ -219,8 +219,10 @@ static void DoFileReq(struct filehandle *fh, struct completioninfo *ci)
                 {
                     UBYTE c;
 
-                    strcpy(ci->match, fr->fr_Drawer);
-                    AddPart(ci->match, fr->fr_File, sizeof(ci->match));
+                    if (Strlcpy(ci->match, fr->fr_Drawer, sizeof(ci->match)) >= sizeof(ci->match))
+                        ci->match[0] = '\0';
+                    else
+                        AddPart(ci->match, fr->fr_File, sizeof(ci->match));
 
                     if (ci->match[0])
                     {


### PR DESCRIPTION
The console file requester copies `fr_Drawer` into a fixed 256-byte completion buffer before calling `AddPart()`. The ASL requester can return drawer paths larger than that buffer.

Reject requester results whose drawer component does not fit before copying it. Fitting paths retain the existing behavior and oversized paths are not truncated.

Verified the 255/256-byte boundary, oversized drawer rejection, and pc-i386 compilation of the affected translation unit.