### PR TITLE
mesa26 macos llvm build fixes

### DIFF
--- a/workbench/libs/mesa/libcompiler/mmakefile.src
+++ b/workbench/libs/mesa/libcompiler/mmakefile.src
@@ -36,6 +36,12 @@ SPIRV_FILES := $(filter-out \
 
 LIBGLCPP_FILES := $(patsubst $(top_srcdir)/$(CUR_MESADIR)/%,%,$(wildcard \
 	$(top_srcdir)/$(CUR_MESADIR)/glsl/glcpp/*.c))
+# glcpp.c is the standalone preprocessor's main, and the scaffolding stubs
+# clash with the real ones in libmesa.a.
+LIBGLCPP_FILES := $(filter-out \
+	glsl/glcpp/glcpp.c \
+	glsl/glcpp/pp_standalone_scaffolding.c, \
+	$(LIBGLCPP_FILES))
 
 LIBCOMPILER_FILES := \
 	glsl_types.c \

--- a/workbench/libs/mesa/libglapi/gen_public_glapi_wrappers.sh
+++ b/workbench/libs/mesa/libglapi/gen_public_glapi_wrappers.sh
@@ -17,7 +17,7 @@ tmp_c="${out_c}.tmp"
     echo "#define MAPI_TMP_DEFINES"
     echo "#include \"shared_glapi_mapi_tmp.h\""
     echo
-    awk '
+    ${AWK:-awk} '
         function trim(s) {
             gsub(/^[ \t]+|[ \t]+$/, "", s)
             return s

--- a/workbench/libs/mesa/libglapi/mmakefile.src
+++ b/workbench/libs/mesa/libglapi/mmakefile.src
@@ -136,7 +136,7 @@ $(top_builddir)/$(CUR_MESADIR)/shared-glapi/public_glapi_wrappers.c: \
 		$(SRCDIR)/$(CURDIR)/gen_public_glapi_wrappers.sh
 	%mkdir_q dir="$(dir $@)"
 	$(Q)$(ECHO) "Generating $(if $(filter /%,$@),$(if $(filter $(SRCDIR)/%,$(abspath $@)),$(patsubst $(SRCDIR)/%,%,$(abspath $@)),$(patsubst $(TOP)/%,%,$(abspath $@))),$(patsubst $(SRCDIR)/%,%,$(abspath $(SRCDIR)/$(CURDIR)/$@)))"
-	$(Q)$(SHELL) $(SRCDIR)/$(CURDIR)/gen_public_glapi_wrappers.sh \
+	$(Q)AWK="$(AWK)" $(SHELL) $(SRCDIR)/$(CURDIR)/gen_public_glapi_wrappers.sh \
 		$(top_builddir)/$(CUR_MESADIR)/shared-glapi/shared_glapi_mapi_tmp.h \
 		$(SRCDIR)/$(CURDIR)/public_glapi_required_symbols.txt \
 		$@

--- a/workbench/libs/mesa/mesa-26.0.0-aros.diff
+++ b/workbench/libs/mesa/mesa-26.0.0-aros.diff
@@ -301,16 +301,10 @@ diff --git a/src/gallium/auxiliary/nir/nir_to_tgsi.c b/src/gallium/auxiliary/nir
 diff -ruN mesa-26.0.0/include/math.h mesa-26.0.0.aros/include/math.h
 --- /dev/null	2026-03-29 00:00:00.000000000 +0000
 +++ mesa-26.0.0.aros/include/math.h	2026-03-29 00:00:00.000000000 +0000
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,4 @@
 +#ifndef AROS_MESA_LOCAL_MATH_H
 +#define AROS_MESA_LOCAL_MATH_H
-+
-+#if defined(__AROS__) && defined(__cplusplus)
-+#include <aros/stdc/math.h>
-+#else
 +#include_next <math.h>
-+#endif
-+
 +#endif
 diff -ruN mesa-26.0.0/include/stdlib.h mesa-26.0.0.aros/include/stdlib.h
 --- /dev/null	2026-03-29 00:00:00.000000000 +0000

--- a/workbench/libs/mesa/mmakefile.src
+++ b/workbench/libs/mesa/mmakefile.src
@@ -123,11 +123,12 @@ USER_LDFLAGS += $(TARGET_CXX_LDFLAGS) -L$(top_libdir)
 $(AROS_ENVARC)/SYS:
 	%mkdir_q dir=$@
 
-$(AROS_ENVARC)/SYS/GL.default: | $(AROS_ENVARC)/SYS
-	@$(ECHO) "mesa3dgl$(MESAGLBUILD)" > $(AROS_ENVARC)/SYS/GL.default
-
+# Rewritten on every build: as a file target it would survive an
+# OPT_MESAGL change, and gl.library would keep opening the old
+# mesa3dgl against freshly built drivers.
 #MM
-mesa3dgl-library-env : $(AROS_ENVARC)/SYS/GL.default
+mesa3dgl-library-env : | $(AROS_ENVARC)/SYS
+	@$(ECHO) "mesa3dgl$(MESAGLBUILD)" > $(AROS_ENVARC)/SYS/GL.default
 
 #
 # mesa3d includes...


### PR DESCRIPTION
- Uses gawk instead of awk on macos
- Don't build llvmpipe for raspi targets even tough llvm toolchain is used, gated to only be compiled on pc targets!
- Lets the local math.h shim forward to the C++ library's own
- Keep the standalone glcpp sources out of libcompiler.a