### PR TITLE
ata.device: stop ATAPI IRQ handling after completion

### DIFF
--- a/rom/devs/ata/lowlevel.c
+++ b/rom/devs/ata/lowlevel.c
@@ -284,7 +284,10 @@ static void ata_IRQPIOReadAtapi(struct ata_Unit *unit, UBYTE status)
 
     /* have we failed yet? */
     if (0 == (status & (ATAF_BUSY | ATAF_DATAREQ)))
+    {
         ata_IRQNoData(unit, status);
+        return;
+    }
     if (status & ATAF_ERROR)
     {
         ata_IRQNoData(unit, status);
@@ -330,13 +333,12 @@ static void ata_IRQPIOWriteAtapi(struct ata_Unit *unit, UBYTE status)
 
     DIRQ(bug("[ATAPI] %s: Current status: %ld during WRITE\n", __func__, reason));
 
-    /*
-     * have we failed yet?
-     * CHECKME: This sequence actually can trigger ata_IRQNoData() twice.
-     * Is this correct ?
-     */
+    /* have we failed yet? */
     if (0 == (status & (ATAF_BUSY | ATAF_DATAREQ)))
+    {
         ata_IRQNoData(unit, status);
+        return;
+    }
     if (status & ATAF_ERROR)
     {
         ata_IRQNoData(unit, status);


### PR DESCRIPTION
`ata_IRQPIOReadAtapi()` and `ata_IRQPIOWriteAtapi()` can continue processing after `ata_IRQNoData()` has already completed the command and cleared the IRQ state.

In the write path, a terminal status combined with `ATAF_ERROR` can also call `ata_IRQNoData()` twice; the existing source comment already notes this case.

Return immediately after terminal completion in both ATAPI PIO IRQ handlers. This also removes the now-resolved CHECKME comment.

Validation:

* `kernel-ata` builds successfully for pc-i386
* baseline/candidate A/B build performed in the same buildroot
* candidate rebuild is byte-identical
* object-level disassembly confirms that terminal completion exits the handlers instead of continuing through the ATAPI data path
