### PR TITLE
ata.device: document DMA serialization contract

### DIFF
--- a/rom/devs/ata/lowlevel.c
+++ b/rom/devs/ata/lowlevel.c
@@ -5,8 +5,8 @@
 */
 
 /*
- * TODO:
- * - put a critical section around DMA transfers (shared dma channels)
+ * DMA requests are serialized per ATA bus. Providers with shared DMA state
+ * must serialize across buses; ata_pci disables secondary DMA on simplex hardware.
  */
 
 #include <aros/debug.h>


### PR DESCRIPTION
The old comment in `lowlevel.c` suggests adding a critical section around shared DMA channels.

Reviewing the current ATA request and PCI DMA paths shows that DMA requests are already serialized within each ATA bus by its bus task. The PCI provider gives normal primary and secondary channels independent DMA register/state, while simplex controllers are handled by disabling DMA on the secondary channel.

Replace the stale TODO with a short description of this serialization contract so that the existing design and the responsibility of future DMA providers are explicit.

No executable code is changed.