### PR TITLE
console.handler: bound completion trailing-space append

### DIFF
--- a/rom/filesys/console_handler/completion.c
+++ b/rom/filesys/console_handler/completion.c
@@ -232,7 +232,7 @@ static void DoFileReq(struct filehandle *fh, struct completioninfo *ci)
                         c = ci->match[strlen(ci->match) - 1];
                         if ((c != '/') && (c != ':'))
                         {
-                            strncat(ci->match, " ", sizeof(ci->match));
+                            Strlcat(ci->match, " ", sizeof(ci->match));
                         }
 
                         InsertIntoConBuffer(ci, ci->match);
@@ -788,7 +788,7 @@ void Completion(struct filehandle *fh, BOOL withinfo)
                     c = ci->match[strlen(ci->match) - 1];
                     if ((c != '/') && (c != ':'))
                     {
-                        strncat(ci->match, " ", sizeof(ci->match));
+                        Strlcat(ci->match, " ", sizeof(ci->match));
                     }
 
                     InsertIntoConBuffer(ci, ci->match);


### PR DESCRIPTION
Two console completion paths append a trailing space with `strncat()` using the destination buffer size as the append limit. With a 255-byte match, the added space and terminator extend past the 256-byte buffer.

Use `utility.library/Strlcat()` for the optional trailing-space append. A complete 255-byte match is now preserved without the trailing space when no capacity remains.

Verified the 254/255-byte boundary, both completion paths, repeated boundary cases, and pc-i386 compilation of the affected translation unit.