### PR TITLE
Shell: propagate .pushis state push failure

### DIFF
--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -222,7 +222,11 @@ LONG convertLineDot(ShellState *ss, Buffer *in)
     }
     else if (strncasecmp(s, "pushis", 6) == 0)
     {
-        pushInterpreterState(ss);
+        LONG error = pushInterpreterState(ss);
+
+        if (error)
+            return error;
+
         res = s;
     }
 #else /* this ugly version is 424 bytes smaller on x64 */
@@ -295,7 +299,11 @@ LONG convertLineDot(ShellState *ss, Buffer *in)
         }
         else if (*s == 'u' && s[1] == 's' && s[2] == 'h') /* .pushis */
         {
-            pushInterpreterState(ss);
+            LONG error = pushInterpreterState(ss);
+
+            if (error)
+                return error;
+
             res = s;
         }
     }


### PR DESCRIPTION
`.pushis` calls `pushInterpreterState()` but ignores its error result. If allocating the new interpreter state fails, the command therefore continues as if the state had been pushed.

Propagate the error returned by `pushInterpreterState()` from both parser implementations. Successful pushes retain the existing behavior.

Verified successful and failed push behavior with deterministic failure injection and pc-i386 compilation of the affected translation unit.