### PR TITLE
Shell: propagate variable buffer errors - pt. 2

### DIFF
--- a/workbench/c/Shell/convertVar.c
+++ b/workbench/c/Shell/convertVar.c
@@ -18,7 +18,7 @@ LONG convertVar(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
     LONG bra = (*s == '{' ? 2 : 0);
     TEXT varName[257];
     TEXT varValue[256];
-    LONG i, len;
+    LONG i, len, error;
     struct Process *me;
     APTR orig_WindowPtr;
 
@@ -66,16 +66,19 @@ LONG convertVar(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
     if ((bra != 1) && (i > 0) && ((len = GetVar(varName, varValue, 256, LV_VAR)) != -1))
     {
         D(bug("[Shell] found var: %s = %s\n", varName, varValue));
-        bufferAppend(varValue, len, out, ss);
+        error = bufferAppend(varValue, len, out, ss);
     }
     else
     {
         D(bug("[Shell] var not found: %s\n", varName));
-        bufferAppend(p, ++i + bra, out, ss);
+        error = bufferAppend(p, ++i + bra, out, ss);
     }
 
     /* Restore original pr_WindowPtr */
     me->pr_WindowPtr = orig_WindowPtr;
+
+    if (error)
+        return error;
 
     in->cur = s - in->buf;
     return 0;


### PR DESCRIPTION
Variable substitution uses buffer helpers that can fail when growing the output buffer, but both append paths ignore those errors and continue as successful conversions.

Capture the buffer error, restore the temporary `pr_WindowPtr` state unconditionally, and then propagate the failure. The input position is advanced only after a successful output mutation.

Verified both failure paths, `pr_WindowPtr` restoration, successful substitution behavior, execution containment, and pc-i386 compilation of the affected translation unit.