### PR TITLE
Shell: propagate PIPE buffer insertion errors

### DIFF
--- a/workbench/c/Shell/readLine.c
+++ b/workbench/c/Shell/readLine.c
@@ -54,7 +54,7 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
     BOOL comment = FALSE;
     BOOL quoted = FALSE;
     BOOL escaped = FALSE;
-    LONG c, i, j, len;
+    LONG c, i, j, len, error;
     TEXT pchar[3], mchar[3];
 
     len = GetVar("_pchar", pchar, sizeof pchar, GVF_LOCAL_ONLY | LV_VAR);
@@ -118,7 +118,10 @@ LONG readLine(ShellState *ss, struct CommandLineInterface *cli, Buffer *out, WOR
     bufferAppend(buf, j, out, ss);
 
     if (checkPipe(pchar, mchar, buf, j))
-        bufferInsert(PIPE_NAME, strlen(PIPE_NAME), out, ss);
+    {
+        if ((error = bufferInsert(PIPE_NAME, sizeof(PIPE_NAME) - 1, out, ss)))
+            return error;
+    }
 
     *moreLeft = (c != ENDSTREAMCH);
 


### PR DESCRIPTION
`readLine()` may prepend `PIPE ` to a complete command line. For lines near the current 512-byte buffer limit this insertion can require buffer growth, but an allocation failure is currently ignored and the unprefixed line is still reported as successfully read.

Propagate the `bufferInsert()` error so a failed PIPE transformation does not continue into normal command processing. The existing initial line append remains unchanged because the current caller preallocates enough storage for every valid `readLine()` input.

Verified the 508–512-byte expansion boundary, allocation-failure containment, successful PIPE insertion, and pc-i386 compilation of the affected translation unit.