### PR TITLE
Shell: propagate backtick buffer errors

### DIFF
--- a/workbench/c/Shell/convertBackTicks.c
+++ b/workbench/c/Shell/convertBackTicks.c
@@ -39,17 +39,18 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
         if (p == '*')
         {
             c = 0;
-            bufferCopy(in, &embedIn, 1, ss);
+            if ((error = bufferCopy(in, &embedIn, 1, ss)))
+                goto freebufs;
         }
         else if (c == '`')
             break;
-        else
-            bufferCopy(in, &embedIn, 1, ss);
+        else if ((error = bufferCopy(in, &embedIn, 1, ss)))
+            goto freebufs;
     }
 
     if (c != '`')
     {
-        bufferCopy(&embedIn, out, embedIn.len, ss);
+        error = bufferCopy(&embedIn, out, embedIn.len, ss);
         goto freebufs;
     }
 
@@ -104,7 +105,8 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
                 if (size <= 0 && buf[i] == '\n')
                     --len;
 
-                bufferAppend(buf, len, out, ss);
+                if ((error = bufferAppend(buf, len, out, ss)))
+                    goto cleanup;
             }
         }
 


### PR DESCRIPTION
Backtick conversion uses Shell buffer helpers that can fail while collecting the embedded command, copying an unmatched backtick sequence, or integrating embedded command output. Those errors are currently ignored, so a partial transformation can still be reported as successful.

Propagate all four buffer mutation failures through the appropriate existing exit path. Pre-resource failures free the temporary buffers directly; failures while collecting embedded command output pass through the full cleanup path so redirected output, the temporary file, interpreter state, and buffers are released.

Verified all four failure sites, cleanup routing, successful conversion behavior, execution containment, and pc-i386 compilation of the affected translation unit.