### PR TITLE
Shell: clean up failed append redirection

### DIFF
--- a/workbench/c/Shell/convertRedir.c
+++ b/workbench/c/Shell/convertRedir.c
@@ -63,7 +63,14 @@ LONG convertRedir(ShellState *ss, Buffer *in, Buffer *out)
             return IoErr();
 
         if (append && Seek(ss->newOut, 0, OFFSET_END) == -1)
-            return IoErr();
+        {
+            LONG error = IoErr();
+
+            Close(ss->newOut);
+            ss->newOut = BNULL;
+            SetIoErr(error);
+            return error;
+        }
 
         ss->oldOut = SelectOutput(ss->newOut);
     }


### PR DESCRIPTION
Append redirection stores the newly opened output handle before seeking it to the end of the file. If that seek fails, the half-initialized redirection state is left behind and later cleanup can restore an output handle that was never committed.

On seek failure, close the newly opened handle, clear the pending output state, preserve the original DOS error, and return it. Successful output redirection is unchanged.

Verified the failure-state lifecycle, error preservation, successful-state contract, and pc-i386 compilation of the affected translation unit.