### PR TITLE
Console handler: widen cursor movement distance

### DIFF
--- a/rom/filesys/console_handler/support.c
+++ b/rom/filesys/console_handler/support.c
@@ -399,9 +399,9 @@ void do_write(struct filehandle *fh, APTR data, ULONG length)
 
 /******************************************************************************************/
 
-void do_movecursor(struct filehandle *fh, UBYTE direction, UBYTE howmuch)
+void do_movecursor(struct filehandle *fh, UBYTE direction, UWORD howmuch)
 {
-    UBYTE seq[6]; /* 9B <N> <N> <N> <dir> <0> */
+    UBYTE seq[8]; /* 9B <N...> <dir> <0> */
     ULONG size;
 
     if (howmuch > 0)

--- a/rom/filesys/console_handler/support.h
+++ b/rom/filesys/console_handler/support.h
@@ -80,7 +80,7 @@
 BOOL parse_filename(struct filehandle *fh, char *filename, struct NewWindow *nw);
 
 void do_write(struct filehandle *fh, APTR data, ULONG length);
-void do_movecursor(struct filehandle *fh, UBYTE direction, UBYTE howmuch);
+void do_movecursor(struct filehandle *fh, UBYTE direction, UWORD howmuch);
 void do_cursorvisible(struct filehandle *fh, BOOL on);
 void do_deletechar(struct filehandle *fh);
 void do_eraseinline(struct filehandle *fh);


### PR DESCRIPTION
The console handler supports 256-byte input lines, but its cursor movement helper accepts the movement distance as UBYTE. A movement of exactly 256 therefore becomes zero, so callers can update the logical input position without moving the displayed cursor.

Use UWORD for the cursor movement distance and enlarge the local formatting buffer to cover the complete UWORD range. Existing movements from 0 through 255 remain unchanged.

Verified the reachable 256-byte boundary, all 13 callers, byte-identical behavior for the existing range, the corrected 256 movement, full UWORD formatting capacity, and pc-i386 compilation.