### PR TITLE
Shell: preserve bufferCopy cursor on failure

### DIFF
--- a/workbench/c/Shell/buffer.c
+++ b/workbench/c/Shell/buffer.c
@@ -73,7 +73,8 @@ LONG bufferCopy(Buffer *in, Buffer *out, ULONG size, ShellState *ss)
 {
     STRPTR s = in->buf + in->cur;
     LONG ret = bufferAppend(s, size, out, ss);
-    in->cur += size;
+    if (ret == 0)
+        in->cur += size;
     return ret;
 }
 


### PR DESCRIPTION
`bufferCopy()` advances its input cursor even when the underlying `bufferAppend()` fails. An allocation failure can therefore consume input that was not copied.

Advance the input cursor only after a successful append. Successful copies retain the existing behavior.

Verified failure and success cursor state, repeated boundary cases, and pc-i386 compilation of the affected translation unit.