### PR TITLE
Shell: inherit CLI number in backtick state

### DIFF
--- a/workbench/c/Shell/convertBackTicks.c
+++ b/workbench/c/Shell/convertBackTicks.c
@@ -31,6 +31,7 @@ LONG convertBackTicks(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
 
     ess.ss_DOSBase = DOSBase;
     ess.ss_SysBase = SysBase;
+    ess.cliNumber = ss->cliNumber;
 
     for (++in->cur; in->cur < n; p = c)
     {


### PR DESCRIPTION
Backtick command conversion creates a separate Shell state without carrying over the current CLI number. `<$$>` inside an embedded command can therefore use zero instead of the current CLI number.

Carry `cliNumber` into the embedded state before command conversion.

Verified current-CLI inheritance and pc-i386 compilation of the affected translation unit.