### PR TITLE
Shell: match dot argument names exactly

### DIFF
--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -22,7 +22,7 @@ static LONG getArgumentIdx(ShellState *ss, STRPTR name, LONG len)
     {
         a = ss->args + i;
 
-        if (strncmp(a->name, name, len) == 0)
+        if (a->namelen == len && strncmp(a->name, name, len) == 0)
             return i;
     }
 


### PR DESCRIPTION
`getArgumentIdx()` compares only the requested prefix length, so a shorter argument name can match an existing longer name.

Require the stored argument-name length to match before comparing the name bytes.

Verified exact-name reuse, prefix separation, and pc-i386 compilation of the affected translation unit.