### PR TITLE
Shell: require full .pushis and .popis names

### DIFF
--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -292,12 +292,12 @@ LONG convertLineDot(ShellState *ss, Buffer *in)
     }
     else if (*s == 'p')
     {
-        if (*++s == 'o' && s[1] == 'p') /* .popis */
+        if (*++s == 'o' && s[1] == 'p' && s[2] == 'i' && s[3] == 's') /* .popis */
         {
             popInterpreterState(ss);
             res = s;
         }
-        else if (*s == 'u' && s[1] == 's' && s[2] == 'h') /* .pushis */
+        else if (*s == 'u' && s[1] == 's' && s[2] == 'h' && s[3] == 'i' && s[4] == 's') /* .pushis */
         {
             LONG error = pushInterpreterState(ss);
 

--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 1995-2021, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
  */
 
 #include <exec/memory.h>


### PR DESCRIPTION
The size-optimized dot-command parser recognizes `.popis` after only `pop` and `.pushis` after only `push`, unlike the libc implementation retained in the same function.

Require the remaining `is` characters before performing the interpreter-state operation.

Verified truncated-command rejection, complete-command preservation, unchanged suffix/case behavior, and pc-i386 compilation of the affected translation unit.