### PR TITLE
mesa26 gl

### DIFF
--- a/workbench/hidds/llvmpipe/llvmpipe_galliumclass.c
+++ b/workbench/hidds/llvmpipe/llvmpipe_galliumclass.c
@@ -3,7 +3,7 @@
 */
 
 #ifndef DEBUG
-#define DEBUG 1
+#define DEBUG 0
 #endif
 #include <aros/debug.h>
 
@@ -90,9 +90,9 @@ HiddLlvmpipe_CreateDisplaytarget( struct sw_winsys *ws,
     }
     spdt->fmt = format;
 
-    bug("[LLVMPipe] %s: step 1 create dt fmt=%d size=%ux%u stride=%u align=%u front=%p dt=%p data=%p\n",
+    D(bug("[LLVMPipe] %s: step 1 create dt fmt=%d size=%ux%u stride=%u align=%u front=%p dt=%p data=%p\n",
         __PRETTY_FUNCTION__, format, width, height, *stride, alignment, front_private, spdt,
-        spdt ? spdt->data : NULL);
+        spdt ? spdt->data : NULL));
 
     return (struct sw_displaytarget *)spdt;
 }
@@ -114,8 +114,8 @@ HiddLlvmpipe_MapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt,
     unsigned flags)
 {
     struct HiddLlvmpipeDisplaytarget * spdt = HiddLlvmpipe_Displaytarget(dt);
-    bug("[LLVMPipe] %s: step 2 map dt=%p flags=0x%x data=%p\n",
-        __PRETTY_FUNCTION__, dt, flags, spdt ? spdt->data : NULL);
+    D(bug("[LLVMPipe] %s: step 2 map dt=%p flags=0x%x data=%p\n",
+        __PRETTY_FUNCTION__, dt, flags, spdt ? spdt->data : NULL));
     if (!spdt)
     {
         bug("[LLVMPipe] %s: ERROR - map called with NULL displaytarget\n", __PRETTY_FUNCTION__);
@@ -127,7 +127,8 @@ HiddLlvmpipe_MapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt,
 static void
 HiddLlvmpipe_UnMapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt)
 {
-    bug("[LLVMPipe] %s: step 3 unmap dt=%p\n", __PRETTY_FUNCTION__, dt);
+    D(bug("[LLVMPipe] %s: step 3 unmap dt=%p\n", __PRETTY_FUNCTION__, dt));
+    return;
 }
 
 /*  Displaytarget support code ends */

--- a/workbench/hidds/llvmpipe/mmakefile.src
+++ b/workbench/hidds/llvmpipe/mmakefile.src
@@ -13,14 +13,15 @@ USER_LDFLAGS := $(TARGET_CXX_LDFLAGS) \
             -lgalliumvm \
             -Wl,--no-whole-archive \
             -lcompiler \
+            -lgalliumdrawllvm \
+            -lgalliumtess \
             -lgalliumauxiliary \
             -lmesautil \
             $(LLVM_LIBS) \
             -lz \
             -lpthread \
             -lposixc_rel \
-            -lstdc_rel \
-            -lsupc++
+            -lstdc_rel
 ifneq ($(TARGET_LIBATOMIC),)
 USER_LDFLAGS += $(TARGET_CXX_LIBS)
 endif
@@ -37,7 +38,7 @@ LLVMPIPE_HIDD_FILES := \
 #MM- workbench-hidds : hidd-llvmpipe-$(AROS_TOOLCHAIN)-$(AROS_TARGET_TOOLCHAIN)
 #MM- hidd-llvmpipe-llvm-yes : hidd-llvmpipe
 
-#MM hidd-llvmpipe : includes hidd-gallium mesa3dgl-linklibs linklibs-libatomic mesa3d-linklib-llvmpipe
+#MM hidd-llvmpipe : includes hidd-gallium mesa3dgl-linklibs linklibs-libatomic mesa3d-linklib-llvmpipe mesa3d-linklib-galliumdrawllvm mesa3d-linklib-galliumtess
 
 USER_INCLUDES += \
             -iquote $(SRCDIR)/$(CURDIR) \

--- a/workbench/hidds/softpipe/softpipe_galliumclass.c
+++ b/workbench/hidds/softpipe/softpipe_galliumclass.c
@@ -3,7 +3,7 @@
 */
 
 #ifndef DEBUG
-#define DEBUG 1
+#define DEBUG 0
 #endif
 #include <aros/debug.h>
 
@@ -91,9 +91,9 @@ HiddSoftpipe_CreateDisplaytarget( struct sw_winsys *ws,
     }
     spdt->fmt = format;
 
-    bug("[SoftPipe] %s: step 1 create dt fmt=%d size=%ux%u stride=%u align=%u front=%p dt=%p data=%p\n",
+    D(bug("[SoftPipe] %s: step 1 create dt fmt=%d size=%ux%u stride=%u align=%u front=%p dt=%p data=%p\n",
         __PRETTY_FUNCTION__, format, width, height, *stride, alignment, front_private, spdt,
-        spdt ? spdt->data : NULL);
+        spdt ? spdt->data : NULL));
 
     return (struct sw_displaytarget *)spdt;
 }
@@ -115,8 +115,8 @@ HiddSoftpipe_MapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt,
     unsigned flags)
 {
     struct HiddSoftpipeDisplaytarget * spdt = HiddSoftpipe_Displaytarget(dt);
-    bug("[SoftPipe] %s: step 2 map dt=%p flags=0x%x data=%p\n",
-        __PRETTY_FUNCTION__, dt, flags, spdt ? spdt->data : NULL);
+    D(bug("[SoftPipe] %s: step 2 map dt=%p flags=0x%x data=%p\n",
+        __PRETTY_FUNCTION__, dt, flags, spdt ? spdt->data : NULL));
     if (!spdt)
     {
         bug("[SoftPipe] %s: ERROR - map called with NULL displaytarget\n", __PRETTY_FUNCTION__);
@@ -128,7 +128,8 @@ HiddSoftpipe_MapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt,
 static void
 HiddSoftpipe_UnMapDisplaytarget(struct sw_winsys *ws, struct sw_displaytarget *dt)
 {
-    bug("[SoftPipe] %s: step 3 unmap dt=%p\n", __PRETTY_FUNCTION__, dt);
+    D(bug("[SoftPipe] %s: step 3 unmap dt=%p\n", __PRETTY_FUNCTION__, dt));
+    return;
 }
 
 /*  Displaytarget support code ends */

--- a/workbench/libs/gallium/gallium_init.c
+++ b/workbench/libs/gallium/gallium_init.c
@@ -5,8 +5,12 @@
 #include <aros/symbolsets.h>
 #include <proto/exec.h>
 #include <proto/oop.h>
+#include <proto/dos.h>
 
+#include <dos/var.h>
 #include <hidd/gfx.h>
+
+#include <string.h>
 
 #include LC_LIBDEFS_FILE
 #include "gallium_intern.h"
@@ -31,6 +35,24 @@ static int Init(LIBBASETYPEPTR LIBBASE)
     LIBBASE->fallback = (char *)softpipe_str;
     LIBBASE->fallbackmodule = NULL;
 
+    /* Which software rasteriser to use when the display has no gallium
+       driver of its own. (llvmpipe, softpipe) */
+    {
+        char buf[64];
+
+        if (GetVar("SYS/Gallium.default", buf, sizeof(buf),
+                   GVF_GLOBAL_ONLY | LV_VAR) > 0)
+        {
+            char *sel = AllocVec(strlen(buf) + 1, MEMF_PUBLIC);
+
+            if (sel)
+            {
+                strcpy(sel, buf);
+                LIBBASE->fallback = sel;
+            }
+        }
+    }
+
     /* cache method id's that we use ..  */
     LIBBASE->galliumMId_UpdateRect = OOP_GetMethodID(IID_Hidd_BitMap, moHidd_BitMap_UpdateRect);
     LIBBASE->galliumMId_DisplayResource = OOP_GetMethodID(IID_Hidd_Gallium, moHidd_Gallium_DisplayResource);
@@ -54,6 +76,9 @@ static int Expunge(LIBBASETYPEPTR LIBBASE)
     if (LIBBASE->fallbackmodule)
         CloseLibrary(LIBBASE->fallbackmodule);
 
+    if ((CONST_STRPTR)LIBBASE->fallback != softpipe_str)
+        FreeVec(LIBBASE->fallback);
+
     return TRUE;
 }
 
@@ -61,3 +86,4 @@ ADD2INITLIB(Init, 0);
 ADD2EXPUNGELIB(Expunge, 0);
 
 ADD2LIBS((STRPTR)"gallium.hidd", 0, static struct Library *, GalliumHiddBase);
+ADD2LIBS((STRPTR)"dos.library", 0, struct DosLibrary *, DOSBase);

--- a/workbench/libs/mesa/libgalliumaux/mmakefile.src
+++ b/workbench/libs/mesa/libgalliumaux/mmakefile.src
@@ -36,7 +36,6 @@ MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES := $(patsubst $(top_srcdir)/$(CUR_MESADIR)/
             $(top_srcdir)/$(CUR_MESADIR)/translate/*.c \
             $(top_srcdir)/$(CUR_MESADIR)/util/*.c))
 MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES := $(filter-out \
-            nir/nir_to_tgsi_info.c \
             indices/u_indices.c \
             indices/u_unfilled_indices.c, \
             $(MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES))
@@ -44,26 +43,15 @@ MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES := $(filter-out \
 MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES += \
             vl/vl_video_buffer.c \
             vl/vl_mpeg12_bitstream.c
-ifneq ($(AROS_TOOLCHAIN),llvm)
-# The gallivm based draw paths need the target-side LLVM libraries, which are
-# only built with the llvm toolchain family. Leave them out otherwise; the weak
-# fallbacks in draw_llvm_aros_stubs.c stand in for them.
+# Every gallium consumer links this archive, so the gallivm draw paths stay out
+# of it and are built again as libgalliumdrawllvm below. nir_to_tgsi_info.c
+# joins them: its header inlines a no-op when DRAW_LLVM_AVAILABLE is unset.
 MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES := $(filter-out \
             draw/draw_llvm.c \
             draw/draw_pt_fetch_shade_pipeline_llvm.c \
-            draw/draw_vs_llvm.c, \
+            draw/draw_vs_llvm.c \
+            nir/nir_to_tgsi_info.c, \
             $(MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES))
-else
-# Mesa only declares the gallivm draw entry points - NUM_TCS_INPUTS in
-# draw_tess.h among them - when DRAW_LLVM_AVAILABLE is set. Set it for just
-# these files: draw_context.c and the rest have to keep their LLVM paths
-# inert, or everything linking libgalliumauxiliary would need gallivm too.
-# struct draw_context is not affected, the macro only guards a forward
-# declaration in draw_private.h, so the layout stays the same either way.
-GALLAUXLLVMOFILES := $(addprefix $(top_builddir)/$(CUR_MESADIR)/draw/,draw_llvm.o draw_pt_fetch_shade_pipeline_llvm.o draw_vs_llvm.o)
-GALLAUXLLVMDFILES := $(patsubst %.o,%.d,$(GALLAUXLLVMOFILES))
-$(GALLAUXLLVMOFILES) $(GALLAUXLLVMDFILES): mesa3d-linklib-galliumauxiliary_MC_EXTRA_CPPFLAGS:=-DDRAW_LLVM_AVAILABLE=1
-endif
 GALLIUM_AUXILIARY_GENERATED_SOURCES := \
             driver_trace/tr_util.c \
             util/u_tracepoints.c \
@@ -82,8 +70,7 @@ endif
 #MM- mesa3d-linklib-galliumauxiliary-genobs : mesa3d-linklib-galliumauxiliary-generated
 
 MESA3DGL_GALLIUM_AUXILIARY_SOURCES_C := \
-            $(addprefix $(top_srcdir)/$(CUR_MESADIR)/,$(MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES:.c=)) \
-            $(SRCDIR)/$(CURDIR)/draw_llvm_aros_stubs
+            $(addprefix $(top_srcdir)/$(CUR_MESADIR)/,$(MESA3DGL_GALLIUM_AUXILIARY_C_SOURCES:.c=))
 
 USER_INCLUDES += \
             -iquote $(top_srcdir)/src/gallium/include \
@@ -195,5 +182,49 @@ mesa3d-linklib-galliumauxiliary_C_FILES := $(MESA3DGL_GALLIUM_AUXILIARY_SOURCES_
     basenames="$(addprefix $(top_builddir)/$(CUR_MESADIR)/,$(GALLIUM_AUXILIARY_GENERATED_SOURCES:.c=))" targetdir="$(top_builddir)/$(CUR_MESADIR)" \
     cppflags=$(mesa3d-linklib-galliumauxiliary_CPPFLAGS) cflags=$(mesa3d-linklib-galliumauxiliary_CFLAGS) dflags=$(mesa3d-linklib-galliumauxiliary_DFLAGS) \
     compiler=target srcdir="$(top_builddir)/$(CUR_MESADIR)" usetree=yes
+
+# A second copy of draw, built with DRAW_LLVM_AVAILABLE. The macro changes
+# draw_vertex_shader and the gs/tess shader layouts, so it cannot be applied to
+# a subset. llvmpipe links this ahead of libgalliumauxiliary.
+ifeq ($(AROS_TOOLCHAIN),llvm)
+GALLIUM_DRAW_LLVM_C := \
+            $(patsubst $(top_srcdir)/$(CUR_MESADIR)/%,%, \
+                $(wildcard $(top_srcdir)/$(CUR_MESADIR)/draw/*.c)) \
+            nir/nir_to_tgsi_info.c
+
+GALLDRAWLLVMOFILES := $(addprefix $(top_builddir)/$(CUR_MESADIR)/draw-llvm/,$(GALLIUM_DRAW_LLVM_C:.c=.o))
+GALLDRAWLLVMDFILES := $(patsubst %.o,%.d,$(GALLDRAWLLVMOFILES))
+$(GALLDRAWLLVMOFILES) $(GALLDRAWLLVMDFILES): mesa3d-linklib-galliumdrawllvm_MC_EXTRA_CPPFLAGS:=-DDRAW_LLVM_AVAILABLE=1
+
+# mmake reads #MM out of the .src text, so the ifeq above cannot hide these.
+# Route through $(AROS_TOOLCHAIN) instead: on gnu the -gnu spelling is never
+# declared, and an undeclared metatarget is simply empty.
+#MM- mesa3dgl-linklibs : mesa3d-linklib-galliumdrawllvm-$(AROS_TOOLCHAIN)
+#MM- mesa3d-linklib-galliumdrawllvm-llvm : mesa3d-linklib-galliumdrawllvm
+#MM mesa3d-linklib-galliumdrawllvm : workbench-libs-llvm mesa3d-linklib-compiler mesa3d-linklib-galliumauxiliary-genobs
+
+# _C_FILES must be absolute - the generated rules put the .c files in an
+# order-only prerequisite. files= stays relative for the object layout.
+mesa3d-linklib-galliumdrawllvm_C_FILES := $(addprefix $(top_srcdir)/$(CUR_MESADIR)/,$(GALLIUM_DRAW_LLVM_C:.c=))
+
+%build_linklib mmake=mesa3d-linklib-galliumdrawllvm libname=galliumdrawllvm \
+    libdir=$(top_libdir) objdir=$(top_builddir)/$(CUR_MESADIR)/draw-llvm srcdir=$(top_srcdir)/$(CUR_MESADIR) \
+    files="$(GALLIUM_DRAW_LLVM_C:.c=)" usetree=yes
+endif
+
+# The tessellator, reached from draw_tess.c under DRAW_LLVM_AVAILABLE. Own
+# linklib because %build_linklib resolves cxxfiles against $(SRCDIR)/$(CURDIR),
+# ignoring its own srcdir= - only the C side honours that.
+ifeq ($(AROS_TOOLCHAIN),llvm)
+GALLIUM_TESS_CXX := $(wildcard $(addprefix $(top_srcdir)/$(CUR_MESADIR)/tessellator/,p_tessellator.cpp tessellator.cpp))
+
+#MM- mesa3dgl-linklibs : mesa3d-linklib-galliumtess-$(AROS_TOOLCHAIN)
+#MM- mesa3d-linklib-galliumtess-llvm : mesa3d-linklib-galliumtess
+#MM mesa3d-linklib-galliumtess : includes
+
+%build_linklib mmake=mesa3d-linklib-galliumtess libname=galliumtess \
+    libdir=$(top_libdir) objdir=$(top_builddir)/$(CUR_MESADIR)/tessellator \
+    cxxfiles="$(GALLIUM_TESS_CXX:.cpp=)"
+endif
 
 %common

--- a/workbench/libs/mesa/libmesautil/mmakefile.src
+++ b/workbench/libs/mesa/libmesautil/mmakefile.src
@@ -82,6 +82,13 @@ MESA_UTIL_NEW_C_FILES += \
             blake3/blake3_portable.c \
             ../c11/impl/time.c \
             ../c11/impl/threads_posix.c
+
+# blake3_impl.h turns BLAKE3_USE_NEON on for little-endian aarch64, so the
+# dispatcher calls blake3_hash_many_neon there. Same gate as upstream meson.
+ifeq ($(CPU),aarch64)
+MESA_UTIL_NEW_C_FILES += blake3/blake3_neon.c
+endif
+
 MESA_UTIL_NEW_C_FILES := $(filter-out \
             cache_ops_aarch64.c \
             cache_ops_x86.c \

--- a/workbench/libs/mesa/mesa-26.0.0-aros.diff
+++ b/workbench/libs/mesa/mesa-26.0.0-aros.diff
@@ -550,3 +550,124 @@ diff -ruN mesa-26.0.0/src/gallium/drivers/nouveau/nouveau_screen.c mesa-26.0.0.a
  #else /*__linux__ */
  #include <sys/endian.h>
  #define CPU_TO_LE32( x ) bswap32( x )
+
+diff -ruN mesa-26.0.0/src/mesa/glapi/glapi/glapi.h mesa-26.0.0.aros/src/mesa/glapi/glapi/glapi.h
+--- mesa-26.0.0/src/mesa/glapi/glapi/glapi.h	2026-02-11 19:07:29
++++ mesa-26.0.0.aros/src/mesa/glapi/glapi/glapi.h	2026-09-07 13:17:48
+@@ -69,10 +69,14 @@
+ 
+ struct _glapi_table;
+ 
++#ifndef __AROS__
+ _GLAPI_EXPORT extern __THREAD_INITIAL_EXEC struct _glapi_table * _mesa_glapi_tls_Dispatch;
+ _GLAPI_EXPORT extern __THREAD_INITIAL_EXEC void * _mesa_glapi_tls_Context;
++#endif
+ 
+-#if DETECT_OS_WINDOWS && !defined(MAPI_MODE_SHARED_GLAPI)
++/* AROS joins the accessor path: it has no TLS the static relocator can
++   handle, so the two slots live in pthread keys inside core.c. */
++#if (DETECT_OS_WINDOWS && !defined(MAPI_MODE_SHARED_GLAPI)) || defined(__AROS__)
+ # define GET_DISPATCH() _mesa_glapi_get_dispatch()
+ # define GET_CURRENT_CONTEXT(C)  struct gl_context *C = (struct gl_context *) _mesa_glapi_get_context()
+ #else
+diff -ruN mesa-26.0.0/src/mesa/glapi/shared-glapi/core.c mesa-26.0.0.aros/src/mesa/glapi/shared-glapi/core.c
+--- mesa-26.0.0/src/mesa/glapi/shared-glapi/core.c	2026-02-11 19:07:29
++++ mesa-26.0.0.aros/src/mesa/glapi/shared-glapi/core.c	2026-09-07 13:17:31
+@@ -148,9 +148,37 @@
+ #endif /* defined(_GLAPI_ENTRY_ARCH_TLS_H) */
+ 
+ /* Current dispatch and current context variables */
++#ifdef __AROS__
++/*
++ * AROS has no thread local storage. LoadSeg() is a static relocator, so
++ * neither the TPREL form of __thread nor the GOT-indirect form that
++ * -femulated-tls emits can be relocated - the loader rejects both. Keep the
++ * two per-thread slots in pthread keys instead, reached only through the
++ * accessors below; glapi.h routes GET_DISPATCH/GET_CURRENT_CONTEXT there.
++ */
++#include <pthread.h>
++
++static pthread_key_t aros_dispatch_key;
++static pthread_key_t aros_context_key;
++
++static void
++aros_glapi_keys_init(void)
++{
++   pthread_key_create(&aros_dispatch_key, NULL);
++   pthread_key_create(&aros_context_key, NULL);
++}
++
++static inline void
++aros_glapi_keys(void)
++{
++   static once_flag flag = ONCE_FLAG_INIT;
++   call_once(&flag, aros_glapi_keys_init);
++}
++#else
+ __THREAD_INITIAL_EXEC struct _glapi_table *_mesa_glapi_tls_Dispatch
+    = (struct _glapi_table *)table_noop_array;
+ __THREAD_INITIAL_EXEC void *_mesa_glapi_tls_Context;
++#endif
+ 
+ static int
+ stub_compare(const void *key, const void *elem)
+@@ -238,7 +266,12 @@
+ void
+ _mesa_glapi_set_context(void *ptr)
+ {
++#ifdef __AROS__
++   aros_glapi_keys();
++   pthread_setspecific(aros_context_key, ptr);
++#else
+    _mesa_glapi_tls_Context = ptr;
++#endif
+ }
+ 
+ /**
+@@ -249,7 +282,12 @@
+ void *
+ _mesa_glapi_get_context(void)
+ {
++#ifdef __AROS__
++   aros_glapi_keys();
++   return pthread_getspecific(aros_context_key);
++#else
+    return _mesa_glapi_tls_Context;
++#endif
+ }
+ 
+ /**
+@@ -263,8 +301,14 @@
+    static once_flag flag = ONCE_FLAG_INIT;
+    call_once(&flag, entry_patch_public);
+ 
++#ifdef __AROS__
++   aros_glapi_keys();
++   pthread_setspecific(aros_dispatch_key,
++      tbl ? tbl : (void *)table_noop_array);
++#else
+    _mesa_glapi_tls_Dispatch =
+       tbl ? tbl : (struct _glapi_table *)table_noop_array;
++#endif
+ }
+ 
+ /**
+@@ -273,5 +317,16 @@
+ struct _glapi_table *
+ _mesa_glapi_get_dispatch(void)
+ {
++#ifdef __AROS__
++   struct _glapi_table *tbl;
++
++   aros_glapi_keys();
++   tbl = pthread_getspecific(aros_dispatch_key);
++
++   /* An unset key reads NULL, where the TLS variable started out holding
++      the no-op table. Callers dispatch through this unchecked. */
++   return tbl ? tbl : (struct _glapi_table *)table_noop_array;
++#else
+    return _mesa_glapi_tls_Dispatch;
++#endif
+ }
+Binary files mesa-26.0.0/src/mesa/main/__pycache__/format_parser.cpython-314.pyc and mesa-26.0.0.aros/src/mesa/main/__pycache__/format_parser.cpython-314.pyc differ
+Binary files mesa-26.0.0/src/mesa/main/__pycache__/get_hash_params.cpython-314.pyc and mesa-26.0.0.aros/src/mesa/main/__pycache__/get_hash_params.cpython-314.pyc differ


### PR DESCRIPTION
Mesa 26's glapi keeps the current context and dispatch table in TLS, which no
AROS target can load —  so route `GET_DISPATCH` and `GET_CURRENT_CONTEXT` 
through the existing accessors and keep the two slots in pthread keys instead.

`DRAW_LLVM_AVAILABLE` changes the layout of `draw_vertex_shader` and the
geometry and tessellation shader structs, so it cannot be applied to part of
`draw`. `libgalliumauxiliary` therefore stays free of it — every gallium
consumer links it — and the module is built once more as `libgalliumdrawllvm`
for llvmpipe alone, on the llvm toolchain only.

Also makes the software rasteriser selectable through `SYS/Gallium.default`
(llvmpipe was unreachable behind a hardcoded `"softpipe"`), gates the
per-frame displaytarget tracing in both hidds behind `DEBUG`, and adds
blake3's NEON path for aarch64.

Built with both the gnu and llvm toolchains. 
Tested both softpipe and llvmpipe on a Pi 500+.
