### PR TITLE
v3d mesa26

### DIFF
--- a/arch/aarch64-raspi/boot/vc_fb.c
+++ b/arch/aarch64-raspi/boot/vc_fb.c
@@ -146,8 +146,9 @@ int vcfb_init(void)
         scr_FrameBuffer = (void*)((intptr_t)scr_FrameBuffer & ~0xc0000000);
 
         /* The firmware echoes back what it actually configured, in place.
-         * The Pi 5 keeps its native mode rather than honouring the request,
-         * so never trust the values we asked for. */
+         * Never trust the values we asked for: on the Pi 5 the surface is
+         * locked to the firmware's mode and SETRES acknowledges without
+         * reprogramming. TESTRES answers honestly, GETEDID is unimplemented. */
         if (AROS_LE2LONG(vcmb_msg[5]))
             fb_width  = AROS_LE2LONG(vcmb_msg[5]);
         if (AROS_LE2LONG(vcmb_msg[6]))

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm-uapi/drm_fourcc.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm-uapi/drm_fourcc.h
@@ -5,8 +5,26 @@
 #define fourcc_code(a, b, c, d) ((uint32_t)(a) | ((uint32_t)(b) << 8) | ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24))
 #define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL
 #define DRM_FORMAT_MOD_LINEAR 0
-#define DRM_FORMAT_MOD_BROADCOM_UIF (((uint64_t)0x09) << 56 | 2)
-#define DRM_FORMAT_MOD_BROADCOM_SAND128 (((uint64_t)0x09) << 56 | 3)
+
+/* Real DRM encoding: vendor in the top 8 bits, 48 bits of parameter above an
+ * 8 bit type. The driver both compares against these and takes them apart. */
+#define DRM_FORMAT_MOD_VENDOR_BROADCOM 0x07
+#define fourcc_mod_code(vendor, val) \
+    ((((uint64_t)DRM_FORMAT_MOD_VENDOR_##vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
+
+#define __fourcc_mod_broadcom_param_shift 8
+#define __fourcc_mod_broadcom_param_bits 48
+#define fourcc_mod_broadcom_code(val, params) \
+    fourcc_mod_code(BROADCOM, ((((uint64_t)(params)) << __fourcc_mod_broadcom_param_shift) | (val)))
+#define fourcc_mod_broadcom_param(m) \
+    ((int)(((m) >> __fourcc_mod_broadcom_param_shift) & \
+           ((1ULL << __fourcc_mod_broadcom_param_bits) - 1)))
+#define fourcc_mod_broadcom_mod(m) \
+    ((m) & ~(((1ULL << __fourcc_mod_broadcom_param_bits) - 1) << \
+             __fourcc_mod_broadcom_param_shift))
+
+#define DRM_FORMAT_MOD_BROADCOM_UIF fourcc_mod_code(BROADCOM, 6)
+#define DRM_FORMAT_MOD_BROADCOM_SAND128 fourcc_mod_broadcom_code(4, 0)
 #define DRM_FORMAT_ARGB8888 fourcc_code('A','R','2','4')
 #define DRM_FORMAT_XRGB8888 fourcc_code('X','R','2','4')
 #define DRM_FORMAT_ABGR8888 fourcc_code('A','B','2','4')

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm-uapi/v3d_drm.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm-uapi/v3d_drm.h
@@ -24,6 +24,10 @@
 #ifndef _V3D_DRM_H_
 #define _V3D_DRM_H_
 
+/* Vendored from Mesa's include/drm-uapi/v3d_drm.h. It has to be refreshed
+ * together with the Mesa port: the driver uses whatever the UAPI of its own
+ * generation defines. "drm.h" resolves to the AROS core stub one directory
+ * up, not to Mesa's Linux one, which is the point of shadowing it here. */
 #include <stdint.h>
 #include "drm.h"
 
@@ -39,6 +43,12 @@ extern "C" {
 #define DRM_V3D_GET_BO_OFFSET                     0x05
 #define DRM_V3D_SUBMIT_TFU                        0x06
 #define DRM_V3D_SUBMIT_CSD                        0x07
+#define DRM_V3D_PERFMON_CREATE                    0x08
+#define DRM_V3D_PERFMON_DESTROY                   0x09
+#define DRM_V3D_PERFMON_GET_VALUES                0x0a
+#define DRM_V3D_SUBMIT_CPU                        0x0b
+#define DRM_V3D_PERFMON_GET_COUNTER               0x0c
+#define DRM_V3D_PERFMON_SET_GLOBAL                0x0d
 
 #define DRM_IOCTL_V3D_SUBMIT_CL           DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_CL, struct drm_v3d_submit_cl)
 #define DRM_IOCTL_V3D_WAIT_BO             DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_WAIT_BO, struct drm_v3d_wait_bo)
@@ -48,8 +58,87 @@ extern "C" {
 #define DRM_IOCTL_V3D_GET_BO_OFFSET       DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_GET_BO_OFFSET, struct drm_v3d_get_bo_offset)
 #define DRM_IOCTL_V3D_SUBMIT_TFU          DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_TFU, struct drm_v3d_submit_tfu)
 #define DRM_IOCTL_V3D_SUBMIT_CSD          DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_CSD, struct drm_v3d_submit_csd)
+#define DRM_IOCTL_V3D_PERFMON_CREATE      DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_PERFMON_CREATE, \
+						   struct drm_v3d_perfmon_create)
+#define DRM_IOCTL_V3D_PERFMON_DESTROY     DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_PERFMON_DESTROY, \
+						   struct drm_v3d_perfmon_destroy)
+#define DRM_IOCTL_V3D_PERFMON_GET_VALUES  DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_PERFMON_GET_VALUES, \
+						   struct drm_v3d_perfmon_get_values)
+#define DRM_IOCTL_V3D_SUBMIT_CPU          DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_SUBMIT_CPU, struct drm_v3d_submit_cpu)
+#define DRM_IOCTL_V3D_PERFMON_GET_COUNTER DRM_IOWR(DRM_COMMAND_BASE + DRM_V3D_PERFMON_GET_COUNTER, \
+						   struct drm_v3d_perfmon_get_counter)
+#define DRM_IOCTL_V3D_PERFMON_SET_GLOBAL  DRM_IOW(DRM_COMMAND_BASE + DRM_V3D_PERFMON_SET_GLOBAL, \
+						   struct drm_v3d_perfmon_set_global)
 
 #define DRM_V3D_SUBMIT_CL_FLUSH_CACHE             0x01
+#define DRM_V3D_SUBMIT_EXTENSION		  0x02
+
+/* struct drm_v3d_extension - ioctl extensions
+ *
+ * Linked-list of generic extensions where the id identify which struct is
+ * pointed by ext_data. Therefore, DRM_V3D_EXT_ID_* is used on id to identify
+ * the extension type.
+ */
+struct drm_v3d_extension {
+	__u64 next;
+	__u32 id;
+#define DRM_V3D_EXT_ID_MULTI_SYNC			0x01
+#define DRM_V3D_EXT_ID_CPU_INDIRECT_CSD		0x02
+#define DRM_V3D_EXT_ID_CPU_TIMESTAMP_QUERY		0x03
+#define DRM_V3D_EXT_ID_CPU_RESET_TIMESTAMP_QUERY	0x04
+#define DRM_V3D_EXT_ID_CPU_COPY_TIMESTAMP_QUERY	0x05
+#define DRM_V3D_EXT_ID_CPU_RESET_PERFORMANCE_QUERY	0x06
+#define DRM_V3D_EXT_ID_CPU_COPY_PERFORMANCE_QUERY	0x07
+	__u32 flags; /* mbz */
+};
+
+/* struct drm_v3d_sem - wait/signal semaphore
+ *
+ * If binary semaphore, it only takes syncobj handle and ignores flags and
+ * point fields. Point is defined for timeline syncobj feature.
+ */
+struct drm_v3d_sem {
+	__u32 handle; /* syncobj */
+	/* rsv below, for future uses */
+	__u32 flags;
+	__u64 point;  /* for timeline sem support */
+	__u64 mbz[2]; /* must be zero, rsv */
+};
+
+/* Enum for each of the V3D queues. */
+enum v3d_queue {
+	V3D_BIN,
+	V3D_RENDER,
+	V3D_TFU,
+	V3D_CSD,
+	V3D_CACHE_CLEAN,
+	V3D_CPU,
+};
+
+/**
+ * struct drm_v3d_multi_sync - ioctl extension to add support multiples
+ * syncobjs for commands submission.
+ *
+ * When an extension of DRM_V3D_EXT_ID_MULTI_SYNC id is defined, it points to
+ * this extension to define wait and signal dependencies, instead of single
+ * in/out sync entries on submitting commands. The field flags is used to
+ * determine the stage to set wait dependencies.
+ */
+struct drm_v3d_multi_sync {
+	struct drm_v3d_extension base;
+	/* Array of wait and signal semaphores */
+	__u64 in_syncs;
+	__u64 out_syncs;
+
+	/* Number of entries */
+	__u32 in_sync_count;
+	__u32 out_sync_count;
+
+	/* set the stage (v3d_queue) to sync */
+	__u32 wait_stage;
+
+	__u32 pad; /* mbz */
+};
 
 /**
  * struct drm_v3d_submit_cl - ioctl argument for submitting commands to the 3D
@@ -127,7 +216,16 @@ struct drm_v3d_submit_cl {
 	/* Number of BO handles passed in (size is that times 4). */
 	__u32 bo_handle_count;
 
+	/* DRM_V3D_SUBMIT_* properties */
 	__u32 flags;
+
+	/* ID of the perfmon to attach to this job. 0 means no perfmon. */
+	__u32 perfmon_id;
+
+	__u32 pad;
+
+	/* Pointer to an array of ioctl extensions*/
+	__u64 extensions;
 };
 
 /**
@@ -196,6 +294,13 @@ enum drm_v3d_param {
 	DRM_V3D_PARAM_SUPPORTS_TFU,
 	DRM_V3D_PARAM_SUPPORTS_CSD,
 	DRM_V3D_PARAM_SUPPORTS_CACHE_FLUSH,
+	DRM_V3D_PARAM_SUPPORTS_PERFMON,
+	DRM_V3D_PARAM_SUPPORTS_MULTISYNC_EXT,
+	DRM_V3D_PARAM_SUPPORTS_CPU_QUEUE,
+	DRM_V3D_PARAM_MAX_PERF_COUNTERS,
+	DRM_V3D_PARAM_SUPPORTS_SUPER_PAGES,
+        DRM_V3D_PARAM_GLOBAL_RESET_COUNTER,
+        DRM_V3D_PARAM_CONTEXT_RESET_COUNTER,
 };
 
 struct drm_v3d_get_param {
@@ -234,6 +339,16 @@ struct drm_v3d_submit_tfu {
 	__u32 in_sync;
 	/* Sync object to signal when the TFU job is done. */
 	__u32 out_sync;
+
+	__u32 flags;
+
+	/* Pointer to an array of ioctl extensions*/
+	__u64 extensions;
+
+	struct {
+		__u32 ioc;
+		__u32 pad;
+	} v71;
 };
 
 /* Submits a compute shader for dispatch.  This job will block on any
@@ -259,6 +374,421 @@ struct drm_v3d_submit_csd {
 	__u32 in_sync;
 	/* Sync object to signal when the CSD job is done. */
 	__u32 out_sync;
+
+	/* ID of the perfmon to attach to this job. 0 means no perfmon. */
+	__u32 perfmon_id;
+
+	/* Pointer to an array of ioctl extensions*/
+	__u64 extensions;
+
+	__u32 flags;
+
+	__u32 pad;
+};
+
+/**
+ * struct drm_v3d_indirect_csd - ioctl extension for the CPU job to create an
+ * indirect CSD
+ *
+ * When an extension of DRM_V3D_EXT_ID_CPU_INDIRECT_CSD id is defined, it
+ * points to this extension to define a indirect CSD submission. It creates a
+ * CPU job linked to a CSD job. The CPU job waits for the indirect CSD
+ * dependencies and, once they are signaled, it updates the CSD job config
+ * before allowing the CSD job execution.
+ */
+struct drm_v3d_indirect_csd {
+	struct drm_v3d_extension base;
+
+	/* Indirect CSD */
+	struct drm_v3d_submit_csd submit;
+
+	/* Handle of the indirect BO, that should be also attached to the
+	 * indirect CSD.
+	 */
+	__u32 indirect;
+
+	/* Offset within the BO where the workgroup counts are stored */
+	__u32 offset;
+
+	/* Workgroups size */
+	__u32 wg_size;
+
+	/* Indices of the uniforms with the workgroup dispatch counts
+	 * in the uniform stream. If the uniform rewrite is not needed,
+	 * the offset must be 0xffffffff.
+	 */
+	__u32 wg_uniform_offsets[3];
+};
+
+/**
+ * struct drm_v3d_timestamp_query - ioctl extension for the CPU job to calculate
+ * a timestamp query
+ *
+ * When an extension DRM_V3D_EXT_ID_TIMESTAMP_QUERY is defined, it points to
+ * this extension to define a timestamp query submission. This CPU job will
+ * calculate the timestamp query and update the query value within the
+ * timestamp BO. Moreover, it will signal the timestamp syncobj to indicate
+ * query availability.
+ */
+struct drm_v3d_timestamp_query {
+	struct drm_v3d_extension base;
+
+	/* Array of queries' offsets within the timestamp BO for their value */
+	__u64 offsets;
+
+	/* Array of timestamp's syncobjs to indicate its availability */
+	__u64 syncs;
+
+	/* Number of queries */
+	__u32 count;
+
+	/* mbz */
+	__u32 pad;
+};
+
+/**
+ * struct drm_v3d_reset_timestamp_query - ioctl extension for the CPU job to
+ * reset timestamp queries
+ *
+ * When an extension DRM_V3D_EXT_ID_CPU_RESET_TIMESTAMP_QUERY is defined, it
+ * points to this extension to define a reset timestamp submission. This CPU
+ * job will reset the timestamp queries based on value offset of the first
+ * query. Moreover, it will reset the timestamp syncobj to reset query
+ * availability.
+ */
+struct drm_v3d_reset_timestamp_query {
+	struct drm_v3d_extension base;
+
+	/* Array of timestamp's syncobjs to indicate its availability */
+	__u64 syncs;
+
+	/* Offset of the first query within the timestamp BO for its value */
+	__u32 offset;
+
+	/* Number of queries */
+	__u32 count;
+};
+
+/**
+ * struct drm_v3d_copy_timestamp_query - ioctl extension for the CPU job to copy
+ * query results to a buffer
+ *
+ * When an extension DRM_V3D_EXT_ID_CPU_COPY_TIMESTAMP_QUERY is defined, it
+ * points to this extension to define a copy timestamp query submission. This
+ * CPU job will copy the timestamp queries results to a BO with the offset
+ * and stride defined in the extension.
+ */
+struct drm_v3d_copy_timestamp_query {
+	struct drm_v3d_extension base;
+
+	/* Define if should write to buffer using 64 or 32 bits */
+	__u8 do_64bit;
+
+	/* Define if it can write to buffer even if the query is not available */
+	__u8 do_partial;
+
+	/* Define if it should write availability bit to buffer */
+	__u8 availability_bit;
+
+	/* mbz */
+	__u8 pad;
+
+	/* Offset of the buffer in the BO */
+	__u32 offset;
+
+	/* Stride of the buffer in the BO */
+	__u32 stride;
+
+	/* Number of queries */
+	__u32 count;
+
+	/* Array of queries' offsets within the timestamp BO for their value */
+	__u64 offsets;
+
+	/* Array of timestamp's syncobjs to indicate its availability */
+	__u64 syncs;
+};
+
+/**
+ * struct drm_v3d_reset_performance_query - ioctl extension for the CPU job to
+ * reset performance queries
+ *
+ * When an extension DRM_V3D_EXT_ID_CPU_RESET_PERFORMANCE_QUERY is defined, it
+ * points to this extension to define a reset performance submission. This CPU
+ * job will reset the performance queries by resetting the values of the
+ * performance monitors. Moreover, it will reset the syncobj to reset query
+ * availability.
+ */
+struct drm_v3d_reset_performance_query {
+	struct drm_v3d_extension base;
+
+	/* Array of performance queries's syncobjs to indicate its availability */
+	__u64 syncs;
+
+	/* Number of queries */
+	__u32 count;
+
+	/* Number of performance monitors */
+	__u32 nperfmons;
+
+	/* Array of u64 user-pointers that point to an array of kperfmon_ids */
+	__u64 kperfmon_ids;
+};
+
+/**
+ * struct drm_v3d_copy_performance_query - ioctl extension for the CPU job to copy
+ * performance query results to a buffer
+ *
+ * When an extension DRM_V3D_EXT_ID_CPU_COPY_PERFORMANCE_QUERY is defined, it
+ * points to this extension to define a copy performance query submission. This
+ * CPU job will copy the performance queries results to a BO with the offset
+ * and stride defined in the extension.
+ */
+struct drm_v3d_copy_performance_query {
+	struct drm_v3d_extension base;
+
+	/* Define if should write to buffer using 64 or 32 bits */
+	__u8 do_64bit;
+
+	/* Define if it can write to buffer even if the query is not available */
+	__u8 do_partial;
+
+	/* Define if it should write availability bit to buffer */
+	__u8 availability_bit;
+
+	/* mbz */
+	__u8 pad;
+
+	/* Offset of the buffer in the BO */
+	__u32 offset;
+
+	/* Stride of the buffer in the BO */
+	__u32 stride;
+
+	/* Number of performance monitors */
+	__u32 nperfmons;
+
+	/* Number of performance counters related to this query pool */
+	__u32 ncounters;
+
+	/* Number of queries */
+	__u32 count;
+
+	/* Array of performance queries's syncobjs to indicate its availability */
+	__u64 syncs;
+
+	/* Array of u64 user-pointers that point to an array of kperfmon_ids */
+	__u64 kperfmon_ids;
+};
+
+struct drm_v3d_submit_cpu {
+	/* Pointer to a u32 array of the BOs that are referenced by the job.
+	 *
+	 * For DRM_V3D_EXT_ID_CPU_INDIRECT_CSD, it must contain only one BO,
+	 * that contains the workgroup counts.
+	 *
+	 * For DRM_V3D_EXT_ID_TIMESTAMP_QUERY, it must contain only one BO,
+	 * that will contain the timestamp.
+	 *
+	 * For DRM_V3D_EXT_ID_CPU_RESET_TIMESTAMP_QUERY, it must contain only
+	 * one BO, that contains the timestamp.
+	 *
+	 * For DRM_V3D_EXT_ID_CPU_COPY_TIMESTAMP_QUERY, it must contain two
+	 * BOs. The first is the BO where the timestamp queries will be written
+	 * to. The second is the BO that contains the timestamp.
+	 *
+	 * For DRM_V3D_EXT_ID_CPU_RESET_PERFORMANCE_QUERY, it must contain no
+	 * BOs.
+	 *
+	 * For DRM_V3D_EXT_ID_CPU_COPY_PERFORMANCE_QUERY, it must contain one
+	 * BO, where the performance queries will be written.
+	 */
+	__u64 bo_handles;
+
+	/* Number of BO handles passed in (size is that times 4). */
+	__u32 bo_handle_count;
+
+	__u32 flags;
+
+	/* Pointer to an array of ioctl extensions*/
+	__u64 extensions;
+};
+
+/* The performance counters index represented by this enum are deprecated and
+ * must no longer be used. These counters are only valid for V3D 4.2.
+ *
+ * In order to check for performance counter information,
+ * use DRM_IOCTL_V3D_PERFMON_GET_COUNTER.
+ *
+ * Don't use V3D_PERFCNT_NUM to retrieve the maximum number of performance
+ * counters. You should use DRM_IOCTL_V3D_GET_PARAM with the following
+ * parameter: DRM_V3D_PARAM_MAX_PERF_COUNTERS.
+ */
+enum {
+	V3D_PERFCNT_FEP_VALID_PRIMTS_NO_PIXELS,
+	V3D_PERFCNT_FEP_VALID_PRIMS,
+	V3D_PERFCNT_FEP_EZ_NFCLIP_QUADS,
+	V3D_PERFCNT_FEP_VALID_QUADS,
+	V3D_PERFCNT_TLB_QUADS_STENCIL_FAIL,
+	V3D_PERFCNT_TLB_QUADS_STENCILZ_FAIL,
+	V3D_PERFCNT_TLB_QUADS_STENCILZ_PASS,
+	V3D_PERFCNT_TLB_QUADS_ZERO_COV,
+	V3D_PERFCNT_TLB_QUADS_NONZERO_COV,
+	V3D_PERFCNT_TLB_QUADS_WRITTEN,
+	V3D_PERFCNT_PTB_PRIM_VIEWPOINT_DISCARD,
+	V3D_PERFCNT_PTB_PRIM_CLIP,
+	V3D_PERFCNT_PTB_PRIM_REV,
+	V3D_PERFCNT_QPU_IDLE_CYCLES,
+	V3D_PERFCNT_QPU_ACTIVE_CYCLES_VERTEX_COORD_USER,
+	V3D_PERFCNT_QPU_ACTIVE_CYCLES_FRAG,
+	V3D_PERFCNT_QPU_CYCLES_VALID_INSTR,
+	V3D_PERFCNT_QPU_CYCLES_TMU_STALL,
+	V3D_PERFCNT_QPU_CYCLES_SCOREBOARD_STALL,
+	V3D_PERFCNT_QPU_CYCLES_VARYINGS_STALL,
+	V3D_PERFCNT_QPU_IC_HIT,
+	V3D_PERFCNT_QPU_IC_MISS,
+	V3D_PERFCNT_QPU_UC_HIT,
+	V3D_PERFCNT_QPU_UC_MISS,
+	V3D_PERFCNT_TMU_TCACHE_ACCESS,
+	V3D_PERFCNT_TMU_TCACHE_MISS,
+	V3D_PERFCNT_VPM_VDW_STALL,
+	V3D_PERFCNT_VPM_VCD_STALL,
+	V3D_PERFCNT_BIN_ACTIVE,
+	V3D_PERFCNT_RDR_ACTIVE,
+	V3D_PERFCNT_L2T_HITS,
+	V3D_PERFCNT_L2T_MISSES,
+	V3D_PERFCNT_CYCLE_COUNT,
+	V3D_PERFCNT_QPU_CYCLES_STALLED_VERTEX_COORD_USER,
+	V3D_PERFCNT_QPU_CYCLES_STALLED_FRAGMENT,
+	V3D_PERFCNT_PTB_PRIMS_BINNED,
+	V3D_PERFCNT_AXI_WRITES_WATCH_0,
+	V3D_PERFCNT_AXI_READS_WATCH_0,
+	V3D_PERFCNT_AXI_WRITE_STALLS_WATCH_0,
+	V3D_PERFCNT_AXI_READ_STALLS_WATCH_0,
+	V3D_PERFCNT_AXI_WRITE_BYTES_WATCH_0,
+	V3D_PERFCNT_AXI_READ_BYTES_WATCH_0,
+	V3D_PERFCNT_AXI_WRITES_WATCH_1,
+	V3D_PERFCNT_AXI_READS_WATCH_1,
+	V3D_PERFCNT_AXI_WRITE_STALLS_WATCH_1,
+	V3D_PERFCNT_AXI_READ_STALLS_WATCH_1,
+	V3D_PERFCNT_AXI_WRITE_BYTES_WATCH_1,
+	V3D_PERFCNT_AXI_READ_BYTES_WATCH_1,
+	V3D_PERFCNT_TLB_PARTIAL_QUADS,
+	V3D_PERFCNT_TMU_CONFIG_ACCESSES,
+	V3D_PERFCNT_L2T_NO_ID_STALL,
+	V3D_PERFCNT_L2T_COM_QUE_STALL,
+	V3D_PERFCNT_L2T_TMU_WRITES,
+	V3D_PERFCNT_TMU_ACTIVE_CYCLES,
+	V3D_PERFCNT_TMU_STALLED_CYCLES,
+	V3D_PERFCNT_CLE_ACTIVE,
+	V3D_PERFCNT_L2T_TMU_READS,
+	V3D_PERFCNT_L2T_CLE_READS,
+	V3D_PERFCNT_L2T_VCD_READS,
+	V3D_PERFCNT_L2T_TMUCFG_READS,
+	V3D_PERFCNT_L2T_SLC0_READS,
+	V3D_PERFCNT_L2T_SLC1_READS,
+	V3D_PERFCNT_L2T_SLC2_READS,
+	V3D_PERFCNT_L2T_TMU_W_MISSES,
+	V3D_PERFCNT_L2T_TMU_R_MISSES,
+	V3D_PERFCNT_L2T_CLE_MISSES,
+	V3D_PERFCNT_L2T_VCD_MISSES,
+	V3D_PERFCNT_L2T_TMUCFG_MISSES,
+	V3D_PERFCNT_L2T_SLC0_MISSES,
+	V3D_PERFCNT_L2T_SLC1_MISSES,
+	V3D_PERFCNT_L2T_SLC2_MISSES,
+	V3D_PERFCNT_CORE_MEM_WRITES,
+	V3D_PERFCNT_L2T_MEM_WRITES,
+	V3D_PERFCNT_PTB_MEM_WRITES,
+	V3D_PERFCNT_TLB_MEM_WRITES,
+	V3D_PERFCNT_CORE_MEM_READS,
+	V3D_PERFCNT_L2T_MEM_READS,
+	V3D_PERFCNT_PTB_MEM_READS,
+	V3D_PERFCNT_PSE_MEM_READS,
+	V3D_PERFCNT_TLB_MEM_READS,
+	V3D_PERFCNT_GMP_MEM_READS,
+	V3D_PERFCNT_PTB_W_MEM_WORDS,
+	V3D_PERFCNT_TLB_W_MEM_WORDS,
+	V3D_PERFCNT_PSE_R_MEM_WORDS,
+	V3D_PERFCNT_TLB_R_MEM_WORDS,
+	V3D_PERFCNT_TMU_MRU_HITS,
+	V3D_PERFCNT_COMPUTE_ACTIVE,
+	V3D_PERFCNT_NUM,
+};
+
+#define DRM_V3D_MAX_PERF_COUNTERS                 32
+
+struct drm_v3d_perfmon_create {
+	__u32 id;
+	__u32 ncounters;
+	__u8 counters[DRM_V3D_MAX_PERF_COUNTERS];
+};
+
+struct drm_v3d_perfmon_destroy {
+	__u32 id;
+};
+
+/*
+ * Returns the values of the performance counters tracked by this
+ * perfmon (as an array of ncounters u64 values).
+ *
+ * No implicit synchronization is performed, so the user has to
+ * guarantee that any jobs using this perfmon have already been
+ * completed  (probably by blocking on the seqno returned by the
+ * last exec that used the perfmon).
+ */
+struct drm_v3d_perfmon_get_values {
+	__u32 id;
+	__u32 pad;
+	__u64 values_ptr;
+};
+
+#define DRM_V3D_PERFCNT_MAX_NAME 64
+#define DRM_V3D_PERFCNT_MAX_CATEGORY 32
+#define DRM_V3D_PERFCNT_MAX_DESCRIPTION 256
+
+/**
+ * struct drm_v3d_perfmon_get_counter - ioctl to get the description of a
+ * performance counter
+ *
+ * As userspace needs to retrieve information about the performance counters
+ * available, this IOCTL allows users to get information about a performance
+ * counter (name, category and description).
+ */
+struct drm_v3d_perfmon_get_counter {
+	/*
+	 * Counter ID
+	 *
+	 * Must be smaller than the maximum number of performance counters, which
+	 * can be retrieve through DRM_V3D_PARAM_MAX_PERF_COUNTERS.
+	 */
+	__u8 counter;
+
+	/* Name of the counter */
+	__u8 name[DRM_V3D_PERFCNT_MAX_NAME];
+
+	/* Category of the counter */
+	__u8 category[DRM_V3D_PERFCNT_MAX_CATEGORY];
+
+	/* Description of the counter */
+	__u8 description[DRM_V3D_PERFCNT_MAX_DESCRIPTION];
+
+	/* mbz */
+	__u8 reserved[7];
+};
+
+#define DRM_V3D_PERFMON_CLEAR_GLOBAL    0x0001
+
+/**
+ * struct drm_v3d_perfmon_set_global - ioctl to define a global performance
+ * monitor
+ *
+ * The global performance monitor will be used for all jobs. If a global
+ * performance monitor is defined, jobs with a self-defined performance
+ * monitor won't be allowed.
+ */
+struct drm_v3d_perfmon_set_global {
+	__u32 flags;
+	__u32 id;
 };
 
 #if defined(__cplusplus)

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/drm.h
@@ -1,12 +1,7 @@
 /*
- * DRM core stub for AROS. Only what Mesa's v3d driver actually reaches
- * for: the GEM handle calls and the ioctl numbering they travel on.
- *
- * The numbering convention here is "the nr, nothing else": core calls
- * occupy 0x00-0x3f and a driver's own start at DRM_COMMAND_BASE. Real DRM
- * packs direction and struct size into the value as well, which nothing on
- * this side needs, and leaving them out keeps the numbers readable in the
- * shim that dispatches them.
+ * DRM core stub for AROS: the GEM handle calls and the ioctl numbering they
+ * travel on. These are the nr only - real DRM also packs direction and struct
+ * size into the value, which nothing on this side needs.
  */
 #ifndef DRM_H
 #define DRM_H
@@ -14,6 +9,8 @@
 #include <stdint.h>
 
 #ifndef __u32
+typedef unsigned char __u8;
+typedef unsigned short __u16;
 typedef unsigned int __u32;
 typedef unsigned long long __u64;
 typedef int __s32;
@@ -54,5 +51,11 @@ struct drm_gem_open {
 #define DRM_IOCTL_GEM_CLOSE     DRM_IOW(0x09, struct drm_gem_close)
 #define DRM_IOCTL_GEM_FLINK     DRM_IOWR(0x0a, struct drm_gem_flink)
 #define DRM_IOCTL_GEM_OPEN      DRM_IOWR(0x0b, struct drm_gem_open)
+
+/* Real DRM values. Nothing here exports dma-bufs or waits on a syncobj, but
+ * the driver names them. */
+#define DRM_CLOEXEC                         0x80000
+#define DRM_RDWR                            0x00002
+#define DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL     (1 << 0)
 
 #endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/poll.h
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/drm-stubs/poll.h
@@ -1,0 +1,33 @@
+/*
+ * AROS stub for poll.h, which Mesa's util/libsync.h needs for sync_wait().
+ * There are no fence fds here - jobs are waited on through the v3d shim - so
+ * the call is never reached; ENOSYS guards a caller that does.
+ */
+#ifndef POLL_H_AROS
+#define POLL_H_AROS
+
+#include <errno.h>
+
+#define POLLIN      0x0001
+#define POLLPRI     0x0002
+#define POLLOUT     0x0004
+#define POLLERR     0x0008
+#define POLLHUP     0x0010
+#define POLLNVAL    0x0020
+
+typedef unsigned long nfds_t;
+
+struct pollfd
+{
+    int   fd;
+    short events;
+    short revents;
+};
+
+static inline int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+#endif

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/mmakefile.src
@@ -6,70 +6,83 @@ include $(SRCDIR)/workbench/libs/mesa/mesa.cfg
 # Only build for the aarch64 RasPi target: the BCM2711 is the only SoC
 # with a V3D 4.2, and the driver has never been built for arm.
 #
-# The glue here targets the Mesa 20.x gallium driver API, and Mesa 26 both
-# rearranged the driver and dropped the hardware versions it is written for
-# (33 and 41; 26 carries 42 and 71). Hook it in only for the Mesa version
-# it has been ported to, as the vc4 driver next door does.
-#MM- workbench-hidds-raspi-aarch64 : hidd-v3d-mesa$(OPT_MESAGL)
-#MM- hidd-v3d-mesa20.0.8 : hidd-v3d
-#MM- linklibs-gallium_v3d-mesa20.0.8 : linklibs-gallium_v3d
+# Upstream gates this on OPT_MESAGL for the Mesa 20.x gallium API. Dropped
+# here: the driver is ported to 26 - generations 42 and 71, merged packet.xml.
+#MM- workbench-hidds-raspi-aarch64 : hidd-v3d
 
 MESA_V3D_DIR = $(top_srcdir)/src/gallium/drivers/v3d
 MESA_BROADCOM_DIR = $(top_srcdir)/src/broadcom
 MESA_GALLIUM_DIR = $(top_srcdir)/src/gallium
 
-# V3D Gallium driver sources (excluding simulator)
+# V3D Gallium driver sources (files_libv3d in meson.build, minus the
+# simulator). v3d_tiling.c moved to broadcom/common in Mesa 26.
 V3D_SOURCES := \
     $(MESA_V3D_DIR)/v3d_blit \
     $(MESA_V3D_DIR)/v3d_bufmgr \
     $(MESA_V3D_DIR)/v3d_cl \
     $(MESA_V3D_DIR)/v3d_context \
+    $(MESA_V3D_DIR)/v3d_disk_cache \
     $(MESA_V3D_DIR)/v3d_fence \
     $(MESA_V3D_DIR)/v3d_formats \
     $(MESA_V3D_DIR)/v3d_job \
     $(MESA_V3D_DIR)/v3d_program \
     $(MESA_V3D_DIR)/v3d_query \
+    $(MESA_V3D_DIR)/v3d_query_perfcnt \
+    $(MESA_V3D_DIR)/v3d_query_pipe \
     $(MESA_V3D_DIR)/v3d_resource \
     $(MESA_V3D_DIR)/v3d_screen \
-    $(MESA_V3D_DIR)/v3d_tiling \
     $(MESA_V3D_DIR)/v3d_uniforms
 
-#
-# The v3dx_ sources are compiled once per hardware generation, exactly as
-# Mesa's own build does: v3d_context.c dispatches on devinfo.ver and calls
-# both the v3d33_ and the v3d41_ entry points by name, so both sets have to
-# exist or the link fails. Mesa 20.0.8 builds 33 and 41 only - a V3D 4.2
-# part like the BCM2711 runs the 41 path - so there is no 42 here.
-#
-# Generated wrappers rather than two linklibs, because the version has to
-# reach the compiler as a macro and %build_linklib takes one set of flags.
-#
-V3DX_BASE   := draw emit format_table job rcl state
+# The v3dx_ sources are compiled once per generation: v3d_util.h's v3d_X()
+# dispatches on devinfo.ver and names both the v3d42_ and v3d71_ entry points,
+# so both sets must exist or the link fails. Generated wrappers rather than a
+# linklib per generation - the version has to reach the compiler as a macro.
+V3D_GENS    := 42 71
 V3DX_GENDIR := $(OBJDIR)/v3dx-gen
 
-V3DX_SOURCES := \
-    $(patsubst %,$(V3DX_GENDIR)/v3d33_%,$(V3DX_BASE)) \
-    $(patsubst %,$(V3DX_GENDIR)/v3d41_%,$(V3DX_BASE))
+# Basenames are unique across the three source directories, so one vpath does.
+V3DX_BASE := draw emit format_table job rcl state tfu dump counter
 
-$(V3DX_GENDIR)/v3d33_%.c : $(MESA_V3D_DIR)/v3dx_%.c
+vpath v3dx_%.c \
+    $(MESA_V3D_DIR) \
+    $(MESA_BROADCOM_DIR)/clif \
+    $(MESA_BROADCOM_DIR)/perfcntrs
+
+V3DX_SOURCES := $(foreach gen,$(V3D_GENS), \
+    $(patsubst %,$(V3DX_GENDIR)/v3d$(gen)_%,$(V3DX_BASE)))
+
+$(V3DX_GENDIR)/v3d42_%.c : v3dx_%.c
 	%mkdir_q dir="$(V3DX_GENDIR)"
 	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
-	$(Q)printf '#define V3D_VERSION 33\n#include "%s"\n' $< > $@
+	$(Q)printf '#define V3D_VERSION 42\n#include "%s"\n' $< > $@
 
-$(V3DX_GENDIR)/v3d41_%.c : $(MESA_V3D_DIR)/v3dx_%.c
+$(V3DX_GENDIR)/v3d71_%.c : v3dx_%.c
 	%mkdir_q dir="$(V3DX_GENDIR)"
 	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
-	$(Q)printf '#define V3D_VERSION 41\n#include "%s"\n' $< > $@
+	$(Q)printf '#define V3D_VERSION 71\n#include "%s"\n' $< > $@
 
 #MM
 linklibs-gallium_v3d-gen-v3dx : $(addsuffix .c,$(V3DX_SOURCES))
 
-# Broadcom compiler sources
+V3D_NIR_GENDIR := $(OBJDIR)/nir-gen
+V3D_NIR_ALGEBRAIC := $(V3D_NIR_GENDIR)/v3d_nir_lower_algebraic
+
+$(V3D_NIR_ALGEBRAIC).c : $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_algebraic.py
+	%mkdir_q dir="$(V3D_NIR_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $< -p $(top_srcdir)/src/compiler/nir > $@.tmp \
+	    && mv -f $@.tmp $@
+
+#MM
+linklibs-gallium_v3d-gen-nir : $(V3D_NIR_ALGEBRAIC).c
+
+# Broadcom compiler sources (libbroadcom_compiler_files in meson.build)
 BROADCOM_COMPILER_SOURCES := \
     $(MESA_BROADCOM_DIR)/compiler/nir_to_vir \
     $(MESA_BROADCOM_DIR)/compiler/vir \
     $(MESA_BROADCOM_DIR)/compiler/vir_dump \
     $(MESA_BROADCOM_DIR)/compiler/vir_live_variables \
+    $(MESA_BROADCOM_DIR)/compiler/vir_opt_constant_alu \
     $(MESA_BROADCOM_DIR)/compiler/vir_opt_copy_propagate \
     $(MESA_BROADCOM_DIR)/compiler/vir_opt_dead_code \
     $(MESA_BROADCOM_DIR)/compiler/vir_opt_redundant_flags \
@@ -78,22 +91,31 @@ BROADCOM_COMPILER_SOURCES := \
     $(MESA_BROADCOM_DIR)/compiler/vir_to_qpu \
     $(MESA_BROADCOM_DIR)/compiler/qpu_schedule \
     $(MESA_BROADCOM_DIR)/compiler/qpu_validate \
-    $(MESA_BROADCOM_DIR)/compiler/v3d40_tex \
-    $(MESA_BROADCOM_DIR)/compiler/v3d33_tex \
-    $(MESA_BROADCOM_DIR)/compiler/v3d33_vpm_setup \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_tex \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_packing \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_blend \
     $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_io \
     $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_image_load_store \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_line_smooth \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_load_output \
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_load_store_bitsize \
     $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_logic_ops \
     $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_scratch \
-    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_txf_ms
+    $(MESA_BROADCOM_DIR)/compiler/v3d_nir_lower_txf_ms \
+    $(V3D_NIR_ALGEBRAIC)
 
-# Broadcom common sources
+# Broadcom common, clif, qpu and perfcntrs sources (libbroadcom_v3d,
+# libbroadcom_qpu and libbroadcom_perfcntrs in meson.build)
 BROADCOM_COMMON_SOURCES := \
     $(MESA_BROADCOM_DIR)/common/v3d_debug \
     $(MESA_BROADCOM_DIR)/common/v3d_device_info \
+    $(MESA_BROADCOM_DIR)/common/v3d_tiling \
+    $(MESA_BROADCOM_DIR)/common/v3d_util \
+    $(MESA_BROADCOM_DIR)/clif/clif_dump \
     $(MESA_BROADCOM_DIR)/qpu/qpu_instr \
     $(MESA_BROADCOM_DIR)/qpu/qpu_pack \
-    $(MESA_BROADCOM_DIR)/qpu/qpu_disasm
+    $(MESA_BROADCOM_DIR)/qpu/qpu_disasm \
+    $(MESA_BROADCOM_DIR)/perfcntrs/v3d_perfcntrs
 
 # V3D HIDD sources
 V3D_HIDD_SOURCES := \
@@ -110,29 +132,31 @@ V3D_HIDD_SOURCES := \
 # these never race with vc4gallium's identical rules. Two include roots
 # because the sources reach them both ways: "cle/x.h" and "broadcom/cle/x.h".
 #
+# One v3d_packet.xml for every generation (vc4_packet.xml for the 21), with the
+# generation passed to the generator rather than picking a versioned XML.
 CLE_SRCDIR  := $(MESA_BROADCOM_DIR)/cle
 CLE_GENROOT := $(OBJDIR)/cle-gen
 CLE_GENDIR  := $(CLE_GENROOT)/broadcom/cle
 
-$(CLE_GENDIR)/v3d_packet_v33_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/v3d_packet_v33.xml
+$(CLE_GENDIR)/v3d_packet_v21_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/vc4_packet.xml
 	%mkdir_q dir="$(CLE_GENDIR)"
 	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
-	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 33 > $@
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 21 > $@
 
-$(CLE_GENDIR)/v3d_packet_v41_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/v3d_packet_v33.xml
-	%mkdir_q dir="$(CLE_GENDIR)"
-	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
-	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 41 > $@
-
-$(CLE_GENDIR)/v3d_packet_v42_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/v3d_packet_v33.xml
+$(CLE_GENDIR)/v3d_packet_v42_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/v3d_packet.xml
 	%mkdir_q dir="$(CLE_GENDIR)"
 	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
 	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 42 > $@
 
+$(CLE_GENDIR)/v3d_packet_v71_pack.h: $(CLE_SRCDIR)/gen_pack_header.py $(CLE_SRCDIR)/v3d_packet.xml
+	%mkdir_q dir="$(CLE_GENDIR)"
+	$(Q)$(ECHO) "Generating $(patsubst $(TOP)/%,%,$@)"
+	$(Q)$(PYTHON) $(PYTHON_FLAGS) $^ 71 > $@
+
 CLE_GEN_HEADERS := \
-    $(CLE_GENDIR)/v3d_packet_v33_pack.h \
-    $(CLE_GENDIR)/v3d_packet_v41_pack.h \
-    $(CLE_GENDIR)/v3d_packet_v42_pack.h
+    $(CLE_GENDIR)/v3d_packet_v21_pack.h \
+    $(CLE_GENDIR)/v3d_packet_v42_pack.h \
+    $(CLE_GENDIR)/v3d_packet_v71_pack.h
 
 #MM
 linklibs-gallium_v3d-gen-cle : $(CLE_GEN_HEADERS)
@@ -160,11 +184,25 @@ USER_INCLUDES := \
     -I $(MESA_GALLIUM_DIR)/drivers \
     -I $(top_srcdir)/src \
     -I $(top_srcdir)/src/compiler/nir \
-    -I $(top_builddir)/src/compiler/nir
+    -I $(top_builddir)/src/compiler/nir \
+    -iquote $(MESA_BROADCOM_DIR)/compiler \
+    -iquote $(MESA_BROADCOM_DIR)/common \
+    -iquote $(top_srcdir)/src/compiler \
+    -iquote $(top_builddir)/src/compiler \
+    -iquote $(top_builddir)/src/compiler/glsl \
+    -iquote $(top_srcdir)/src/util \
+    -I $(top_srcdir)/src/util \
+    -iquote $(top_builddir)/src \
+    -iquote $(top_builddir)/src/util \
+    -iquote $(top_builddir)/src/util/format
 
+# USE_V3D_SIMULATOR is the Mesa 26 spelling; keep the older names so the
+# AROS override header still matches on either.
 USER_CPPFLAGS += \
+    -DUSE_V3D_SIMULATOR=0 \
     -DUSING_V3D_SIMULATOR=0 \
     -Dusing_v3d_simulator=0 \
+    -DV3D_BUILD_NEON \
     -UHAVE_VALGRIND \
     -DGCA_CONSUMER_MODULE \
     -include $(SRCDIR)/$(CURDIR)/v3d_aros_override.h
@@ -175,7 +213,7 @@ USER_CFLAGS += $(NOWARN_CFLAGS)
 # Build combined Mesa V3D driver archive
 COMBINED_V3D_SOURCES := $(V3D_SOURCES) $(V3DX_SOURCES) $(BROADCOM_COMPILER_SOURCES) $(BROADCOM_COMMON_SOURCES)
 
-#MM linklibs-gallium_v3d : linklibs-gallium_v3d-gen-cle linklibs-gallium_v3d-gen-v3dx
+#MM linklibs-gallium_v3d : linklibs-gallium_v3d-gen-cle linklibs-gallium_v3d-gen-v3dx linklibs-gallium_v3d-gen-nir
 
 %build_linklib mmake=linklibs-gallium_v3d libname=gallium_v3d libdir=$(top_libdir) \
     objdir=$(top_builddir)/gallium_v3d files="$(COMBINED_V3D_SOURCES)"

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/v3d_drm_shim.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/v3d_drm_shim.c
@@ -575,6 +575,22 @@ void renderonly_scanout_destroy(struct renderonly_scanout *scanout,
     (void)scanout; (void)ro;
 }
 
+/* driconf: mesa.cfg leaves xmlconfig.c out of libmesautil, so v3d_screen.c's
+ * option handling has to be answered here. Every option reads as unset, which
+ * is what Mesa itself falls back to without a config file. */
+void driParseConfigFiles(void *cache, const void *info,
+                         int screenNum, const char *driverName,
+                         const char *kernelDriverName,
+                         const char *deviceName,
+                         const char *applicationName, uint32_t applicationVersion,
+                         const char *engineName, uint32_t engineVersion)
+{
+    (void)cache; (void)info; (void)screenNum; (void)driverName;
+    (void)kernelDriverName; (void)deviceName;
+    (void)applicationName; (void)applicationVersion;
+    (void)engineName; (void)engineVersion;
+}
+
 unsigned char driCheckOption(const void *cache, const char *name, int type)
 {
     (void)cache; (void)name; (void)type;

--- a/arch/arm-native/soc/broadcom/2708/hidd/v3d/v3d_galliumclass.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/v3d/v3d_galliumclass.c
@@ -35,6 +35,7 @@
 #define NDEBUG 1
 
 #include "pipe/p_state.h"
+#include "pipe/p_screen.h"
 #include "util/u_inlines.h"
 #include "broadcom/common/v3d_limits.h"
 #include "v3d_screen.h"
@@ -42,17 +43,26 @@
 #include "v3d_resource.h"
 #include "v3d_tiling.h"
 
-/* The v3d_bo_unreference inline this file instantiates calls
- * util_hash_table_remove by its plain name; the driver archive reaches
- * that function through the GalliumCoreAPI trampolines (objcopy renames
- * its refs to __gca_*), but this object is compiled outside the archive,
- * so forward the plain name to the same trampoline. */
-struct util_hash_table;
-extern void __gca_util_hash_table_remove(struct util_hash_table *ht,
-                                         void *key);
-void util_hash_table_remove(struct util_hash_table *ht, void *key)
+/* Compiled outside the driver archive, so objcopy does not rename the plain
+ * names the v3d_bo_unreference inline reaches for. Forward each to its
+ * trampoline; a drifted callee list shows up as an undefined plain name. */
+extern void __gca__mesa_hash_table_remove_key(struct hash_table *ht,
+                                              const void *key);
+void _mesa_hash_table_remove_key(struct hash_table *ht, const void *key)
 {
-    __gca_util_hash_table_remove(ht, key);
+    __gca__mesa_hash_table_remove_key(ht, key);
+}
+
+extern int __gca_mtx_lock(mtx_t *mtx);
+int mtx_lock(mtx_t *mtx)
+{
+    return __gca_mtx_lock(mtx);
+}
+
+extern int __gca_mtx_unlock(mtx_t *mtx);
+int mtx_unlock(mtx_t *mtx)
+{
+    return __gca_mtx_unlock(mtx);
 }
 
 #undef HiddGalliumAttrBase
@@ -69,7 +79,6 @@ void util_hash_table_remove(struct util_hash_table *ht, void *key)
 #endif
 
 struct pipe_screen;
-struct pipe_screen_config;
 struct renderonly;
 extern struct pipe_screen *v3d_screen_create(int fd,
     const struct pipe_screen_config *config, struct renderonly *ro);
@@ -432,9 +441,13 @@ APTR HiddV3D__Hidd_Gallium__CreatePipeScreen(OOP_Class *cl, OOP_Object *o,
     }
     ReleaseSemaphore(&sd->bo_lock);
 
-    /* fd is a dummy: the ioctl override never looks at it. No driconf and
-     * no renderonly - we present through the display driver ourselves. */
-    screen = v3d_screen_create(0, NULL, NULL);
+    /* fd is a dummy and there is no renderonly - we present ourselves. The
+     * config must be a real object: v3d_screen_create derefs it for driconf. */
+    {
+        static const struct pipe_screen_config v3d_no_config = { 0 };
+
+        screen = v3d_screen_create(0, &v3d_no_config, NULL);
+    }
     if (!screen)
     {
         bug("[V3D] v3d_screen_create failed\n");
@@ -555,7 +568,7 @@ VOID HiddV3D__Hidd_Gallium__DisplayResource(OOP_Class *cl, OOP_Object *o,
         return;
     }
 
-    if (slice->tiling == VC5_TILING_RASTER)
+    if (slice->tiling == V3D_TILING_RASTER)
     {
         src = base + slice->offset
             + msg->srcy * slice->stride + msg->srcx * rsc->cpp;
@@ -655,7 +668,7 @@ IPTR HiddV3D__Hidd_Gallium__DisplayResourceRP(OOP_Class *cl, OOP_Object *o,
     if (!sd->powered || !rsc || !rsc->bo || !rp)
         return FALSE;
     /* Tiled or exotic sources go through the detiling DisplayResource. */
-    if (rsc->slices[0].tiling != VC5_TILING_RASTER || rsc->cpp != 4
+    if (rsc->slices[0].tiling != V3D_TILING_RASTER || rsc->cpp != 4
         || rsc->slices[0].offset != 0)
         return FALSE;
     if (!(L = rp->Layer))

--- a/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vc4gallium/mmakefile.src
@@ -215,15 +215,12 @@ GCA_ABI_FLAGS := $(TARGET_ISA_CFLAGS) $(USER_CPPFLAGS)
 # gca_bind matches slots positionally, so the slot list is generated from
 # the union of their import sets. A driver added here must also appear in
 # the v3d-side consumption (hidd/v3d) and vice versa.
-# v3d is built only where its glue has been ported, so the union is taken
-# over the drivers this Mesa version actually builds.
-GCA_CONSUMERS := $(top_libdir)/libgallium_vc4.a
-ifeq ($(OPT_MESAGL),20.0.8)
-GCA_CONSUMERS += $(top_libdir)/libgallium_v3d.a
-endif
+# Both drivers are in the union: upstream gates v3d to 20.0.8, this tree ports
+# it to 26 (see hidd/v3d).
+GCA_CONSUMERS := $(top_libdir)/libgallium_vc4.a $(top_libdir)/libgallium_v3d.a
 
-#MM linklibs-gallium_vc4-gca : linklibs-gallium_v3d-mesa$(OPT_MESAGL)
-#MM linklibs-galliumcoreapi : linklibs-gallium_vc4 linklibs-gallium_v3d-mesa$(OPT_MESAGL)
+#MM linklibs-gallium_vc4-gca : linklibs-gallium_v3d
+#MM linklibs-galliumcoreapi : linklibs-gallium_vc4 linklibs-gallium_v3d
 
 # The data the driver reads rather than calls, which the glue carries as
 # objects instead of trampolines. Every data import has to be named here or
@@ -238,8 +235,13 @@ else
 GCA_PRIVATE_DATA += _util_cpu_caps_state \
                     glsl_type_builtin_int \
                     glsl_type_builtin_uint \
-                    glsl_type_builtin_vec4
+                    glsl_type_builtin_vec4 \
+                    util_dynarray_is_data_stack_allocated
 endif
+
+# util_dynarray_is_data_stack_allocated is an address sentinel, so a private
+# copy is only safe while no util_dynarray crosses the module boundary.
+# Re-audit if another one shows up here.
 
 $(GCA_GENDIR)/.gca.stamp : $(GCA_CONSUMERS) $(GCA_CORELIBS) $(GCA_TOOL)
 	%mkdir_q dir="$(GCA_GENDIR)"

--- a/arch/arm-native/soc/broadcom/2708/hidd/vcgfx/vcgfx_init.c
+++ b/arch/arm-native/soc/broadcom/2708/hidd/vcgfx/vcgfx_init.c
@@ -93,6 +93,15 @@ static int FNAME_SUPPORT(Init)(LIBBASETYPEPTR LIBBASE)
     KernelBase = OpenResource("kernel.resource");
     __arm_periiobase = KrnGetSystemAttr(KATTR_PeripheralBase);
 
+    /* BCM2712 is a different display generation. Bail before vc4_hvs_init()
+     * touches anything and leave the Pi 5 display to fbgfx. */
+    if (__arm_periiobase == BCM2712_PERIIOBASE)
+    {
+        D(bug("[VideoCoreGfx] %s: BCM2712 - leaving the display to fbgfx\n",
+            __PRETTY_FUNCTION__));
+        return FALSE;
+    }
+
     /* The mailbox interface is the same on every VideoCore; the HVS is not,
      * so on BCM2711 only the mailbox half of the driver runs. */
     xsd->vcsd_IsBCM2711 = (__arm_periiobase == BCM2711_PERIIOBASE);


### PR DESCRIPTION
## v3d on Mesa 26, and the Pi 5 display

Ports the v3d driver to Mesa 26: generations 42 (BCM2711) and 71 (BCM2712)
replace 33 and 41, the packet headers come from the merged `v3d_packet.xml`,
and the source lists follow Mesa 26's meson. This drops the `OPT_MESAGL` gate
that pinned v3d to 20.0.8, since the driver now targets the version being
built.

Also stops vcgfx registering a display driver on BCM2712 — the HVS is a
different generation, so the Pi 5 panel is left to fbgfx.

