### PR TITLE
 dosboot/cd.device: Fix delayed CD32 disc insertion

### DIFF
--- a/arch/m68k-amiga/devs/cd/cd.c
+++ b/arch/m68k-amiga/devs/cd/cd.c
@@ -14,8 +14,6 @@
 
 #include <dos/filehandler.h>
 
-#include <resources/filesysres.h>
-
 #include <devices/cd.h>
 
 #include "cd_intern.h"
@@ -28,15 +26,13 @@ struct cdUnit {
     const struct cdUnitOps   *cu_UnitOps;
     struct Task        *cu_Task;
     struct MsgPort     *cu_MsgPort;
-    const struct DosEnvec *cu_Envec;
 };
 
-static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
-                             const struct DosEnvec *de);
+static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de);
 
 /* Each cd.device unit has a task which dispatches requests and services
  * backend hardware completions. */
-static VOID cdTask(IPTR base, IPTR unit)
+static VOID cdTask(IPTR unit)
 {
     struct cdUnit *cu = (APTR)unit;
     struct IOStdReq *io;
@@ -44,25 +40,6 @@ static VOID cdTask(IPTR base, IPTR unit)
     BOOL running = TRUE;
 
     D(bug("%s.%d Task, Port %p\n", cu->cu_UnitOps->uo_Name, cu->cu_Unit, cu->cu_MsgPort));
-
-    /* The boot node registers from here rather than from resident init:
-     * the DosType scan in cdRegisterVolume needs FileSystem.resource
-     * populated, and the filesystem modules init at lower resident
-     * priority than this device does. It must also happen before the
-     * disc probe below - the probe can take seconds with a disc in the
-     * drive, and dosboot expects its boot nodes in place by the time it
-     * runs.
-     */
-    cdRegisterVolume((struct cdBase *)base, cu, cu->cu_Envec);
-
-    /* cdSelectDosType() may have to wait for FileSystem.resource while the
-     * resident initializers are still running.  Do that bootstrap work at
-     * the normal task priority so it cannot starve the initializers and
-     * make dosboot conclude temporarily that there is no boot medium.
-     * Once the boot node exists, match Commodore's priority-15 CDUITask so
-     * asynchronous requests still make progress when an application polls
-     * CheckIO() without yielding. */
-    SetTaskPri(FindTask(NULL), 15);
 
     /* Blocking drive probes belong here, not in resident init: a
      * misbehaving drive must cost a failed mount, not a wedged boot
@@ -124,47 +101,8 @@ static VOID cdTask(IPTR base, IPTR unit)
     /* Terminate by fallthough */
 }
 
-/* Ask FileSystem.resource which CD filesystem the ROM actually carries
- * rather than hard-coding one: the boot node's DosType must match a
- * registered filesystem or CliInit never finds a handler for CD0:,
- * which is how the 2019 switch from cdfs to CDVDFS broke CD boot.
- * Registration order is not guaranteed against this unit task, so poll
- * briefly before falling back to CDVDFS's type.
- */
-static IPTR cdSelectDosType(struct cdBase *cb)
-{
-    static const ULONG types[] = {
-        AROS_MAKE_ID('C','D','V','D'),  /* CDVDFS */
-        AROS_MAKE_ID('C','D','F','S'),  /* the older cdfs handler */
-    };
-    int attempt, i;
-
-    for (attempt = 0; attempt < 20; attempt++) {
-        struct FileSysResource *fsr = OpenResource(FSRNAME);
-        if (fsr) {
-            for (i = 0; i < (int)(sizeof(types) / sizeof(types[0])); i++) {
-                struct FileSysEntry *fse;
-                IPTR found = 0;
-                Forbid();
-                ForeachNode(&fsr->fsr_FileSysEntries, fse) {
-                    if (fse->fse_DosType == types[i]) {
-                        found = types[i];
-                        break;
-                    }
-                }
-                Permit();
-                if (found)
-                    return found;
-            }
-        }
-        cdDelayMS(cb, 100);
-    }
-    return types[0];
-}
-
 /* Add a bootnode using expansion.library */
-static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
-                             const struct DosEnvec *de)
+static BOOL cdRegisterVolume(struct cdUnit *unit, const struct DosEnvec *de)
 {
     struct ExpansionBase *ExpansionBase;
     struct DeviceNode *devnode;
@@ -191,7 +129,7 @@ static BOOL cdRegisterVolume(struct cdBase *cb, struct cdUnit *unit,
         pp[2]                   = unit->cu_Unit;
         pp[DE_TABLESIZE    + 4] = DE_BOOTBLOCKS;
         pp[DE_BOOTPRI      + 4] = -10;
-        pp[DE_DOSTYPE      + 4] = cdSelectDosType(cb);
+        pp[DE_DOSTYPE      + 4] = de->de_DosType;
         pp[DE_BAUD         + 4] = 0;
         pp[DE_CONTROL      + 4] = 0;
         pp[DE_BOOTBLOCKS   + 4] = 0;
@@ -234,11 +172,12 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
     if (cu) {
         cu->cu_Private = priv;
         cu->cu_UnitOps = ops;
-        cu->cu_Envec   = de;
         /* Assigned before the task starts: it names the boot node */
         cu->cu_Unit    = cb->cb_MaxUnit++;
         cu->cu_Task = NewCreateTask(TASKTAG_PC, cdTask,
                                     TASKTAG_NAME, ops->uo_Name,
+                                    /* Match Commodore's CDUITask. */
+                                    TASKTAG_PRI, 15,
                                     /*
                                      * The unit task runs the drive
                                      * protocol and sector delivery;
@@ -247,11 +186,16 @@ LONG cdAddUnit(struct cdBase *cb, const struct cdUnitOps *ops, APTR priv, const 
                                      * chip RAM on a stock CD32.
                                      */
                                     TASKTAG_STACKSIZE, 4096,
-                                    TASKTAG_ARG1, cb,
-                                    TASKTAG_ARG2, cu,
+                                    TASKTAG_ARG1, cu,
                                     TASKTAG_TASKMSGPORT, &cu->cu_MsgPort,
                                     TAG_END);
         if (cu->cu_Task) {
+            /* Boot-node creation is deterministic initialization work, not
+             * part of the priority-15 hardware service task.  The backend
+             * supplies the filesystem type carried by this ROM, so this
+             * does not depend on FileSystem.resource registration timing. */
+            cdRegisterVolume(cu, de);
+
             ObtainSemaphore(&cb->cb_UnitsLock);
             ADDTAIL(&cb->cb_Units, &cu->cu_Node);
             ReleaseSemaphore(&cb->cb_UnitsLock);

--- a/arch/m68k-amiga/devs/cd/cd32.c
+++ b/arch/m68k-amiga/devs/cd/cd32.c
@@ -105,6 +105,8 @@ struct CD32Unit {
     union CDTOC cu_CDTOC[100];
     ULONG cu_IntEnable;
     ULONG cu_ChangeNum;
+    BOOL cu_MediaKnown;
+    BOOL cu_MediaPresent;
     struct CD32XLTransfer cu_XL;
     struct CDXL *cu_XLCallbackNode;
     volatile ULONG cu_XLProgress;
@@ -361,14 +363,18 @@ static BOOL CD32_HandleUnsolicited(struct CD32Unit *cu, UBYTE RxHead)
     case CHCD_MEDIA:
         RxHead++;
         if (cu->cu_Misc->Response[RxHead] == 0x83) {
-            if (!(cu->cu_CDInfo.Status & CDSTSF_DISK)) {
+            if (!cu->cu_MediaPresent)
                 cu->cu_ChangeNum++;
-                cu->cu_CDInfo.Status |= CDSTSF_CLOSED | CDSTSF_DISK |
-                    CDSTSF_SPIN;
-            }
-        } else if (cu->cu_CDInfo.Status & CDSTSF_DISK) {
-            cu->cu_ChangeNum++;
+            cu->cu_CDInfo.Status = CDSTSF_CLOSED | CDSTSF_DISK |
+                CDSTSF_SPIN;
+            cu->cu_MediaKnown = FALSE;
+            cu->cu_MediaPresent = FALSE;
+        } else {
+            if (cu->cu_MediaPresent)
+                cu->cu_ChangeNum++;
             cu->cu_CDInfo.Status = 0;
+            cu->cu_MediaKnown = TRUE;
+            cu->cu_MediaPresent = FALSE;
         }
         return TRUE;
 
@@ -930,7 +936,8 @@ static UBYTE CD32_Status(struct CD32Unit *cu)
     D(bug("%s: %p\n", __func__, cu));
     cmd[0] = CHCD_STATUS;
     res[1] = 0x80;
-    CD32_Cmd(cu, cmd, 1, res, 20);
+    if (CD32_Cmd(cu, cmd, 1, res, 20) != 0)
+        return cu->cu_CDInfo.Status;
     res[20] = 0;
     D(bug("%s: Drive \"%s\", state 0x%02x\n", __func__, &res[2], res[1]));
 
@@ -939,6 +946,8 @@ static UBYTE CD32_Status(struct CD32Unit *cu)
             cu->cu_ChangeNum++;
             cu->cu_CDInfo.Status = 0;
         }
+        cu->cu_MediaKnown = TRUE;
+        cu->cu_MediaPresent = FALSE;
     } else if (res[1] & CHERR_DISKPRESENT) {
         if (!(cu->cu_CDInfo.Status & CDSTSF_DISK)) {
             cu->cu_ChangeNum++;
@@ -987,16 +996,31 @@ static VOID CD32_ReadTOC(struct CD32Unit *cu)
     D(bug("%s: TotalSectors = %d\n", __func__, cu->cu_TotalSectors));
 }
 
-static LONG CD32_IsCDROM(struct CD32Unit *cu)
+static BOOL CD32_RefreshMedia(struct CD32Unit *cu)
 {
+    if (cu->cu_MediaKnown)
+        return cu->cu_MediaPresent;
+
     if ((cu->cu_CDInfo.Status & CDSTSF_DISK) == 0) {
         if ((CD32_Status(cu) & CDSTSF_DISK) == 0)
-            return CDERR_NoDisk;
+            goto done;
     }
 
-    if ((cu->cu_CDInfo.Status & CDSTSF_TOC) == 0) {
+    if ((cu->cu_CDInfo.Status & CDSTSF_TOC) == 0)
         CD32_ReadTOC(cu);
-    }
+
+done:
+    cu->cu_MediaPresent =
+        (cu->cu_CDInfo.Status & CDSTSF_TOC) != 0;
+    cu->cu_MediaKnown = TRUE;
+    CD32_ArmAsyncResponse(cu);
+    return cu->cu_MediaPresent;
+}
+
+static LONG CD32_IsCDROM(struct CD32Unit *cu)
+{
+    if (!CD32_RefreshMedia(cu))
+        return CDERR_NoDisk;
 
     if ((cu->cu_CDInfo.Status & CDSTSF_CDROM) == 0) {
         return CDERR_SeekError;
@@ -1073,7 +1097,12 @@ static LONG CD32_DoIO(struct IOStdReq *io, APTR priv)
         err = 0;
         break;
     case CD_CHANGESTATE:
-        io->io_Actual = (cu->cu_CDInfo.Status & CDSTSF_TOC) ? 0 : 1;
+        /* Report current media state, not the state cached by the last
+         * command.  In particular, dosboot polls this command while the
+         * no-media screen is open; a disc inserted after power-on must
+         * cause the drive status and TOC to be refreshed here. */
+        io->io_Actual = CD32_RefreshMedia(cu) ? 0 : 1;
+        CD32_ArmAsyncResponse(cu);
         D(bug("CD_CHANGESTATE: %d\n", io->io_Actual));
         err = 0;
         break;
@@ -1391,7 +1420,6 @@ static VOID CD32_UnitInit(APTR priv)
     struct CD32Unit *cu = priv;
 
     cu->cu_Task = FindTask(NULL);
-    CD32_IsCDROM(cu);
 }
 
 static const struct cdUnitOps CD32Ops = {
@@ -1404,7 +1432,7 @@ static const struct cdUnitOps CD32Ops = {
 };
 
 static const struct DosEnvec CD32Envec = {
-    .de_TableSize = DE_MASK,
+    .de_TableSize = DE_DOSTYPE,
     .de_SizeBlock = 2048 >> 2,
     .de_Surfaces  = 1,
     .de_SectorPerBlock = 1,
@@ -1427,6 +1455,7 @@ static const struct DosEnvec CD32Envec = {
     .de_BufMemType = MEMF_24BITDMA,
     .de_MaxTransfer = 32 * 2048,
     .de_Mask = 0x00fffffe,
+    .de_DosType = AROS_MAKE_ID('C', 'D', 'V', 'D'),
 };
 
 

--- a/rom/dosboot/bootanim.c
+++ b/rom/dosboot/bootanim.c
@@ -88,7 +88,7 @@ void anim_Stop(struct DOSBootBase *DOSBootBase)
     {
         if (ad->ad_State & STATEF_POINTERHIDE)
         {
-            FreeMem(DOSBootBase->blank_pointer, 6*2);
+            FreeMem(DOSBootBase->blank_pointer, BOOT_POINTER_SIZE);
             DOSBootBase->blank_pointer = NULL;
         }
         banm_Dispose(DOSBootBase);

--- a/rom/dosboot/bootanim.h
+++ b/rom/dosboot/bootanim.h
@@ -3,6 +3,10 @@
 
 #include "dosboot_intern.h"
 
+#define BOOT_POINTER_HEIGHT 16
+#define BOOT_POINTER_SIZE \
+    ((BOOT_POINTER_HEIGHT + 2) * 2 * sizeof(UWORD))
+
 struct AnimData
 {
     struct Library      *OOPBase;

--- a/rom/dosboot/bootscreen.c
+++ b/rom/dosboot/bootscreen.c
@@ -13,7 +13,7 @@
 #include <proto/graphics.h>
 #include <proto/intuition.h>
 
-#include "dosboot_intern.h"
+#include "bootanim.h"
 
 /*
  * 'quiet' asks for NULL rather than an alert when the display database
@@ -123,9 +123,11 @@ struct Screen *NoBootMediaScreen(struct DOSBootBase *DOSBootBase)
            setup runs, so the default arrow doesn't linger over the screen. */
         if (DOSBootBase->bm_Window)
         {
-            DOSBootBase->blank_pointer = AllocMem(6 * 2, MEMF_CHIP | MEMF_CLEAR);
+            DOSBootBase->blank_pointer = AllocMem(BOOT_POINTER_SIZE,
+                                                   MEMF_CHIP | MEMF_CLEAR);
             if (DOSBootBase->blank_pointer)
-                SetPointer(DOSBootBase->bm_Window, DOSBootBase->blank_pointer, 1, 16, 0, 0);
+                SetPointer(DOSBootBase->bm_Window, DOSBootBase->blank_pointer,
+                           BOOT_POINTER_HEIGHT, 16, 0, 0);
         }
 
         if (!anim_Init(scr, DOSBootBase))
@@ -145,10 +147,22 @@ void CloseBootScreen(struct Screen *scr, struct DOSBootBase *DOSBootBase)
     if (DOSBootBase->bm_Window)
     {
         CloseWindow(DOSBootBase->bm_Window);
+        DOSBootBase->bm_Window = NULL;
     }
 
     CloseScreen(scr);
 
     CloseLibrary(&IntuitionBase->LibNode);
     CloseLibrary(&GfxBase->LibNode);
+}
+
+void CloseNoBootMediaScreen(struct DOSBootBase *DOSBootBase)
+{
+    if (DOSBootBase->bm_Screen)
+    {
+        CloseBootScreen(DOSBootBase->bm_Screen, DOSBootBase);
+        DOSBootBase->bm_Screen = NULL;
+    }
+
+    anim_Stop(DOSBootBase);
 }

--- a/rom/dosboot/bootstrap.c
+++ b/rom/dosboot/bootstrap.c
@@ -37,6 +37,10 @@
 #include "dosboot_intern.h"
 #include "../expansion/expansion_intern.h"
 
+#define DOSBOOT_RETRY_NOW 1
+
+extern void CloseNoBootMediaScreen(struct DOSBootBase *DOSBootBase);
+
 #ifdef __mc68000
 
 /* These two functions are implemented in arch/m68k/all/dosboot/bootcode.c */
@@ -89,10 +93,8 @@ static BOOL GetBootNodeDeviceUnit(struct BootNode *bn, BPTR *device, IPTR *unit,
     }
     *bootblocks = de->de_BootBlocks * de->de_SizeBlock * sizeof(ULONG);
     if (*bootblocks == 0)
-    {
-        D(bug("[DOSBoot:bootstrap] %s: No bootblocks\n", __func__));
-        return FALSE;
-    }
+        D(bug("[DOSBoot:bootstrap] %s: Device does not use bootblocks\n", __func__));
+
     return TRUE;
 }
 
@@ -346,6 +348,23 @@ LONG dosboot_BootStrap(LIBBASETYPEPTR LIBBASE)
                 BootNodeDeviceUnit = GetBootNodeDeviceUnit(bn, &device, &unit, &bootblock_size);
                 if (!BootNodeDeviceUnit || (dosboot_DevicePresent((struct IORequest*)io, device, unit)))
                 {
+                    /* A screen opened while no medium was present owns large
+                     * Chip RAM allocations. Do not start the filesystem or
+                     * boot code while those allocations are live: allocations
+                     * made by the boot path would become interleaved with the
+                     * screen bitmap and leave Chip RAM fragmented after the
+                     * screen is eventually closed. Tear down both the screen
+                     * and this probe, then retry immediately from a clean
+                     * allocation layout. */
+                    if (BootNodeDeviceUnit && LIBBASE->bm_Screen)
+                    {
+                        CloseDevice((struct IORequest *)io);
+                        DeleteIORequest((struct IORequest *)io);
+                        DeleteMsgPort(msgport);
+                        CloseNoBootMediaScreen(LIBBASE);
+                        return DOSBOOT_RETRY_NOW;
+                    }
+
                     /* First try as a BootBlock.
                      * dosboot_BootBlock does not return at all if
                      * the boot block booted. TRUE (always, on m68k)
@@ -356,7 +375,8 @@ LONG dosboot_BootStrap(LIBBASETYPEPTR LIBBASE)
                      */
                     
                     D(bug("[DOSBoot:bootstrap] %s: Attempting %b\n",__func__, ((struct DeviceNode *)bn->bn_DeviceNode)->dn_Name));
-                    if (!BootNodeDeviceUnit || !dosboot_BootBlock(&io, &msgport, bn, ExpansionBase, bootblock_size)) {
+                    if (!BootNodeDeviceUnit || bootblock_size == 0 ||
+                        !dosboot_BootBlock(&io, &msgport, bn, ExpansionBase, bootblock_size)) {
                         if (io)
                         {
                             if (BootNodeDeviceUnit)

--- a/rom/dosboot/cleanup.c
+++ b/rom/dosboot/cleanup.c
@@ -14,6 +14,7 @@
 
 extern const char Dosboot_LibID[];
 extern const int Dosboot_End;
+extern void CloseNoBootMediaScreen(struct DOSBootBase *DOSBootBase);
 
 AROS_UFP3(static APTR, dosboot_Cleanup,
           AROS_UFPA(void *, dummy, D0),
@@ -50,12 +51,8 @@ AROS_UFH3(static APTR, dosboot_Cleanup,
     }
 
     D(bug("[dosboot cleanup] Boot screen 0x%p\n", base->bm_Screen));
-    if (base->bm_Screen)
-    {
-        /* Close "No boot media" screen. This is actually what we are here for. */
-        CloseBootScreen(base->bm_Screen, base);
-    }
-    anim_Stop(base);
+    /* Close "No boot media" screen. This is actually what we are here for. */
+    CloseNoBootMediaScreen(base);
 
     /* Well, since we are here, let's completely expunge. :) */
     CloseLibrary(&base->bm_ExpansionBase->LibNode);

--- a/rom/dosboot/dosboot_init.c
+++ b/rom/dosboot/dosboot_init.c
@@ -296,7 +296,8 @@ int dosboot_Init(LIBBASETYPEPTR LIBBASE)
     /* Attempt to boot until we succeed */
     for (;;)
     {
-        dosboot_BootStrap(LIBBASE);
+        if (dosboot_BootStrap(LIBBASE) == 1)
+            continue;
 
         if (!LIBBASE->bm_Screen)
             LIBBASE->bm_Screen = NoBootMediaScreen(LIBBASE);

--- a/rom/graphics/gfxfuncsupport.c
+++ b/rom/graphics/gfxfuncsupport.c
@@ -43,7 +43,7 @@ OOP_Object *get_planarbm_object(struct BitMap *bitmap, struct GfxBase *GfxBase)
 
         if(!HIDD_PlanarBM_SetBitMap(pbm_obj, bitmap)) {
             DEBUG_PLANARBM(bug("!!! get_planarbm_object: HIDD_PlanarBM_SetBitMap FAILED !!!\n"));
-            release_cache_object(CDD(GfxBase)->planarbm_cache, pbm_obj, GfxBase);
+            release_planarbm_object(pbm_obj, GfxBase);
             pbm_obj = NULL;
         }
 
@@ -52,6 +52,14 @@ OOP_Object *get_planarbm_object(struct BitMap *bitmap, struct GfxBase *GfxBase)
     }
 
     return pbm_obj;
+}
+
+/****************************************************************************************/
+
+VOID release_planarbm_object(OOP_Object *pbm_obj, struct GfxBase *GfxBase)
+{
+    HIDD_PlanarBM_SetBitMap(pbm_obj, NULL);
+    release_cache_object(CDD(GfxBase)->planarbm_cache, pbm_obj, GfxBase);
 }
 
 /****************************************************************************************/

--- a/rom/graphics/gfxfuncsupport.h
+++ b/rom/graphics/gfxfuncsupport.h
@@ -45,7 +45,7 @@
 do                                                                             \
 {                                                                              \
     if(! IS_HIDD_BM(bitmap))                                                   \
-        release_cache_object(CDD(GfxBase)->planarbm_cache, (bm_obj), GfxBase); \
+        release_planarbm_object((bm_obj), GfxBase);                            \
 } while (0)
 
 
@@ -165,6 +165,7 @@ typedef LONG(*PIXELFUNC)(APTR, OOP_Object *, OOP_Object *, WORD, WORD, struct Gf
 /****************************************************************************************/
 
 OOP_Object *get_planarbm_object(struct BitMap *bitmap, struct GfxBase *GfxBase);
+VOID release_planarbm_object(OOP_Object *pbm_obj, struct GfxBase *GfxBase);
 
 ULONG do_render_func(struct RastPort *rp, Point *src, struct Rectangle *rr,
                      RENDERFUNC render_func, APTR funcdata,

--- a/rom/hidds/gfx/gfx_bitmapclass.c
+++ b/rom/hidds/gfx/gfx_bitmapclass.c
@@ -5233,7 +5233,7 @@ void BM__Hidd_BitMap__SetPixFmt(OOP_Class *cl, OOP_Object *o, OOP_Object *pf)
      * It increases number of pixfmt users, so we'll need to release it when
      * not used any more.
      */
-    data->pf_registered = TRUE;
+    data->pf_registered = (pf != NULL);
 }
 
 /*

--- a/rom/hidds/gfx/gfx_planarbitmapclass.c
+++ b/rom/hidds/gfx/gfx_planarbitmapclass.c
@@ -289,6 +289,20 @@ static BOOL PBM_SetBitMap(OOP_Class *cl, OOP_Object *o, struct BitMap *bm)
     struct planarbm_data *data = OOP_INST_DATA(cl, o);
     OOP_Object *pf;
 
+    /* Detach from a caller-owned bitmap when a cached wrapper is released.
+     * Besides avoiding a stale bitmap pointer, this releases the registered
+     * pixel format while the wrapper is idle. */
+    if (!bm)
+    {
+        PBM_FreeBitMap(data);
+        data->bitmap = NULL;
+        data->planes_alloced = FALSE;
+
+        BM__Hidd_BitMap__SetBitMapTags(CSD(cl)->bitmapclass, o, bmtags);
+        BM__Hidd_BitMap__SetPixFmt(CSD(cl)->bitmapclass, o, NULL);
+        return TRUE;
+    }
+
     /* First we attempt to register a pixelformat */
     pftags[0].ti_Data = bm->Depth;      /* PixFmt_Depth */
     pftags[1].ti_Data = bm->Depth;      /* PixFmt_BitsPerPixel */


### PR DESCRIPTION
Fixes booting CD32 discs inserted after the no-media screen appears.

The change refreshes the drive state and TOC when polling for media, then fully releases the boot screen and its cached planar resources before retrying the boot. This prevents Chip RAM fragmentation that could break memory-sensitive games. CD boot-node registration is also made deterministic without filesystem polling.

Verified with Chaos Engine on a stock 2 MiB Chip-only CD32 configuration: inserting the disc after 25 seconds boots successfully, reaches the demo, and preserves continuous CD audio playback.