### PR TITLE
 m68k: Fix stack alignment and minimum process stack size

### DIFF
--- a/arch/m68k-all/include/aros/cpu.h
+++ b/arch/m68k-all/include/aros/cpu.h
@@ -24,6 +24,7 @@
 #define AROS_IPTRALIGN             2 /* Alignment for IPTR */
 #define AROS_DOUBLEALIGN           2 /* Alignment for double */
 #define AROS_WORSTALIGN            4 /* Worst case alignment */
+#define AROS_STACKALIGN            8 /* Required for aligned(8) stack objects */
 
 #define AROS_SLOWSTACKFORMAT 1
 

--- a/arch/m68k-amiga/dos/dos_platform.h
+++ b/arch/m68k-amiga/dos/dos_platform.h
@@ -2,9 +2,9 @@
 #define DOS_PLATFORM_H
 
 /* Amiga interrupts and exceptions use the supervisor stack.  Keep a
- * conservative default for arbitrary applications while allowing measured
- * system processes to request the classic 4 KiB process stack. */
+ * conservative default for arbitrary applications.  A 4 KiB process stack
+ * is not sufficient for all legacy CLI paths through AROS DOS/Exec. */
 #define PROC_STACKSIZE     8192
-#define PROC_MINSTACKSIZE  4096
+#define PROC_MINSTACKSIZE  PROC_STACKSIZE
 
 #endif


### PR DESCRIPTION
Fix m68k process-stack allocation by enforcing the required stack alignment and an 8 KiB minimum stack size.

This prevents stack corruption and crashes affecting programs that open CON: windows. The larger minimum stack slightly reduces available memory on constrained systems; further memory-footprint reductions will be handled separately.