### PR TITLE
bcm2708: bring dma.resource up on the BCM2712

### DIFF
--- a/arch/arm-native/soc/broadcom/2708/dma/dma.conf
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma.conf
@@ -1,5 +1,5 @@
 ##begin config
-version 0.1
+version 0.2
 residentpri 88
 libbase DMABase
 libbasetype struct DMABase
@@ -14,4 +14,5 @@ libbasetype struct DMABase
 int DMAAllocChannel(unsigned int flags) (D0)
 void DMAFreeChannel(int channel) (D0)
 int DMAWaitChannel(int channel, unsigned int timeout_us) (D0, D1)
+int DMAStopChannel(int channel) (D0)
 ##end functionlist

--- a/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_init.c
@@ -48,10 +48,13 @@
 #define DMA_POOL_DMA4_BCM2711  ((1 << 11) | (1 << 12) | (1 << 13) | (1 << 14))
 
 /*
- * BCM2712 DMA channel allocation.
+ * BCM2712, from brcm,dma-channel-mask: 0-5 legacy (all treated as full,
+ * unverified), 6-10 DMA4, 11 is the firmware's.
  */
-#define DMA_POOL_FULL_BCM2712  ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3))
-#define DMA_POOL_LITE_BCM2712  ((1 << 4) | (1 << 5) | (1 << 6) | (1 << 7))
+#define DMA_POOL_FULL_BCM2712  0x3f
+#define DMA_POOL_LITE_BCM2712  0
+#define DMA_POOL_DMA4_BCM2712  ((1 << 6) | (1 << 7) | (1 << 8) | (1 << 9) | \
+                                (1 << 10))
 
 APTR KernelBase __attribute__((used)) = NULL;
 
@@ -122,41 +125,56 @@ static inline IPTR dma_debug_reg(struct DMABase *DMABase, int channel)
     return DMA_DEBUG(channel);
 }
 
-/* Stop the channel and leave the engine idle with its flags clear. */
-static void dma_channel_quiesce(struct DMABase *DMABase, int channel)
+/* Stop the channel and leave it idle. FALSE if it would not come to rest. */
+static BOOL dma_channel_quiesce(struct DMABase *DMABase, int channel)
 {
     volatile ULONG *cs = (volatile ULONG *)DMA_CS(channel);
     int try = 10000;
 
     if (BCM2708_DMA_IS_DMA4(DMABase->dma_periiobase, channel))
     {
-        /*
-         * DMA4 has no reset bit in CS - bit 31 is HALT there - and resetting
-         * while the AXI bus still has transactions in flight is documented as
-         * probably fatal. So halt, let the engine drain, then reset via DEBUG.
-         */
-        *cs = AROS_LONG2LE(DMA4_CS_HALT);
-        while (try-- > 0)
+        ULONG v = AROS_LE2LONG(*cs);
+        ULONG dbg;
+
+        /* No reset bit in CS: halt a running engine, drain, reset via DEBUG.
+         * HALT is sticky and reports DMA_BUSY, so never halt an idle one. */
+        if (v & DMA4_CS_ACTIVE)
         {
-            if (!(AROS_LE2LONG(*cs) & (DMA4_CS_HALT | DMA4_CS_DMA_BUSY)))
-                break;
+            *cs = AROS_LONG2LE(DMA4_CS_HALT);
+            while (try-- > 0)
+            {
+                v = AROS_LE2LONG(*cs);
+                if (!(v & (DMA4_CS_ACTIVE | DMA4_CS_OUTSTANDING_TRANSACTIONS)))
+                    break;
+            }
+            *cs = AROS_LONG2LE(DMA4_CS_INT | DMA4_CS_END);
+            v = AROS_LE2LONG(*cs);
         }
 
-        /* The DMA4 error latches are read-to-clear, not W1C - and they
-         * must be cleared, or CS.ERROR stays up and the engine
-         * misbehaves on later transfers. */
-        (void)*(volatile ULONG *)DMA4_DEBUG(channel);
+        /* Error latches are read-to-clear */
+        dbg = AROS_LE2LONG(*(volatile ULONG *)DMA4_DEBUG(channel));
 
-        if (AROS_LE2LONG(*cs) & (DMA4_CS_HALT | DMA4_CS_DMA_BUSY))
-            /* Still draining: a DEBUG reset now is documented as
-             * "probably fatal", so leave the engine as it stands. */
-            bug("[DMA] channel %d would not halt (cs=0x%08x) - "
-                "reset skipped\n", channel, AROS_LE2LONG(*cs));
-        else
-            *(volatile ULONG *)DMA4_DEBUG(channel) =
-                AROS_LONG2LE(DMA4_DEBUG_RESET);
+        /* Reset is only unsafe with AXI traffic in flight; BUSY alone is a
+         * paused DREQ write the reset clears. */
+        if (v & (DMA4_CS_ACTIVE | DMA4_CS_OUTSTANDING_TRANSACTIONS))
+        {
+            bug("[DMA] channel %d would not halt (cs=0x%08x debug=0x%08x) - "
+                "reset skipped\n", channel, v, dbg);
+            return FALSE;
+        }
+
+        *(volatile ULONG *)DMA4_DEBUG(channel) =
+            AROS_LONG2LE(DMA4_DEBUG_RESET);
         *cs = AROS_LONG2LE(DMA4_CS_INT | DMA4_CS_END);
-        return;
+
+        v = AROS_LE2LONG(*cs);
+        if (v & (DMA4_CS_ACTIVE | DMA4_CS_DMA_BUSY))
+        {
+            bug("[DMA] channel %d still busy after reset (cs=0x%08x)\n",
+                channel, v);
+            return FALSE;
+        }
+        return TRUE;
     }
 
     *cs = AROS_LONG2LE(DMA_CS_RESET);
@@ -165,17 +183,27 @@ static void dma_channel_quiesce(struct DMABase *DMABase, int channel)
         if (!(AROS_LE2LONG(*cs) & DMA_CS_RESET))
             break;
     }
+    if (AROS_LE2LONG(*cs) & DMA_CS_RESET)
+    {
+        bug("[DMA] channel %d would not reset (cs=0x%08x)\n",
+            channel, AROS_LE2LONG(*cs));
+        return FALSE;
+    }
     *cs = AROS_LONG2LE(DMA_CS_INT | DMA_CS_END);
+    return TRUE;
 }
 
 /* Enable the channel and bring the engine to a clean, idle state. */
-static void dma_channel_reset(struct DMABase *DMABase, int channel)
+static BOOL dma_channel_reset(struct DMABase *DMABase, int channel)
 {
-    volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
+    if (BCM2708_DMA_HAS_GLOBAL_REGS(DMABase->dma_periiobase))
+    {
+        volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
 
-    *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) | (1 << channel));
+        *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) | (1 << channel));
+    }
 
-    dma_channel_quiesce(DMABase, channel);
+    return dma_channel_quiesce(DMABase, channel);
 }
 
 AROS_LH1(int, DMAAllocChannel,
@@ -201,7 +229,12 @@ AROS_LH1(int, DMAAllocChannel,
         /* DMA4 is a distinct programming model, so it is exactly what was
          * asked for or nothing - never a substitute from another pool. */
         if (flags & DMACHF_DMA4)
-            avail = is2711 ? (DMA_POOL_DMA4_BCM2711 & ~DMABase->dma_InUse) : 0;
+        {
+            ULONG dma4 = is2712 ? DMA_POOL_DMA4_BCM2712
+                                : (is2711 ? DMA_POOL_DMA4_BCM2711 : 0);
+
+            avail = dma4 & ~DMABase->dma_InUse;
+        }
         /* Prefer lite channels so the scarce full engines stay available
          * for users that need TDMODE. */
         else if (flags & DMACHF_TDMODE)
@@ -214,19 +247,24 @@ AROS_LH1(int, DMAAllocChannel,
         }
     }
 
-    if (avail != 0)
+    /* A channel that will not come to rest never completes; skip it. */
+    for (ch = 0; ch < 15; ch++)
     {
-        for (ch = 0; ch < 15; ch++)
+        if (!(avail & (1 << ch)))
+            continue;
+
+        if (dma_channel_reset(DMABase, ch))
         {
-            if (avail & (1 << ch))
-            {
-                channel = ch;
-                break;
-            }
+            channel = ch;
+            break;
         }
 
+        bug("[DMA] channel %d is not usable, trying the next one\n", ch);
+    }
+
+    if (channel >= 0)
+    {
         DMABase->dma_InUse |= (1 << channel);
-        dma_channel_reset(DMABase, channel);
 
         /* Completion IRQ for DMAWaitChannel — opt-in: drivers that run
          * their own handler on the channel's line (the AHI drivers, with
@@ -265,11 +303,14 @@ AROS_LH1(void, DMAFreeChannel,
 
     if (DMABase->dma_InUse & (1 << channel))
     {
-        volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
-
         dma_channel_quiesce(DMABase, channel);
 
-        *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) & ~(1 << channel));
+        if (BCM2708_DMA_HAS_GLOBAL_REGS(DMABase->dma_periiobase))
+        {
+            volatile ULONG *enable = (volatile ULONG *)DMA_ENABLE_REG;
+
+            *enable = AROS_LONG2LE(AROS_LE2LONG(*enable) & ~(1 << channel));
+        }
         DMABase->dma_InUse &= ~(1 << channel);
 
         if (DMABase->dma_Wait[channel].irq_handle)
@@ -452,6 +493,24 @@ AROS_LH2(int, DMAWaitChannel,
     }
 
     return ret;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/* Stop the channel without freeing it. 0, or -1 if it would not stop. */
+AROS_LH1(int, DMAStopChannel,
+                AROS_LHA(int, channel, D0),
+                struct DMABase *, DMABase, 4, Dma)
+{
+    AROS_LIBFUNC_INIT
+
+    D(bug("[DMA] %s(%d)\n", __PRETTY_FUNCTION__, channel));
+
+    if ((channel < 0) || (channel > 14) ||
+        !(DMABase->dma_InUse & (1 << channel)))
+        return -1;
+
+    return dma_channel_quiesce(DMABase, channel) ? 0 : -1;
 
     AROS_LIBFUNC_EXIT
 }

--- a/arch/arm-native/soc/broadcom/2708/dma/dma_private.h
+++ b/arch/arm-native/soc/broadcom/2708/dma/dma_private.h
@@ -36,6 +36,8 @@ struct DMABase {
 };
 
 #define ARM_PERIIOBASE DMABase->dma_periiobase
+#define DMA0_BASE      BCM2708_DMA_BASE(DMABase->dma_periiobase)
+#include <hardware/bcm2708_dma.h>
 #include <hardware/bcm2708.h>
 
 #endif /* DMA_PRIVATE_H_ */

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708.h
@@ -50,7 +50,10 @@
 #define SPI0_BASE                                       (ARM_PERIIOBASE + 0x204000)
 #define BSC0_BASE                                       (ARM_PERIIOBASE + 0x205000)
 #define GPIO_PWM                                        (ARM_PERIIOBASE + 0x20C000)
+/* Overridable: the BCM2712 controller is outside the peripheral window */
+#ifndef DMA0_BASE
 #define DMA0_BASE                                       (ARM_PERIIOBASE + 0x007000)
+#endif
 #define V3D_BASE                                        (ARM_PERIIOBASE + 0xc00000)
 
 /* PWM registers */

--- a/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708_dma.h
+++ b/arch/arm-native/soc/broadcom/2708/include/hardware/bcm2708_dma.h
@@ -32,6 +32,10 @@
                                                  * the request fails on other SoCs. DMA4 does
                                                  * 2D as well, so TDMODE need not be set. */
 
+/* Kept here so the header stays self-contained for the AHI drivers */
+#define BCM2708_DMA_PERIIOBASE_2711 0xFE000000
+#define BCM2708_DMA_PERIIOBASE_2712 0x107C000000ULL
+
 /* DMA control block — hardware-defined layout, must be 32-byte aligned.
  * All fields are little-endian; callers convert with AROS_LONG2LE. */
 struct BCM2708DMACB
@@ -66,9 +70,37 @@ struct BCM2711DMA4CB
     ULONG   reserved;
 };
 
-/* Channels 11-14 on the BCM2711 are DMA4; nothing on the other SoCs is. */
-#define BCM2708_DMA_IS_DMA4(periiobase, ch) \
-    (((periiobase) == BCM2708_DMA_PERIIOBASE_2711) && ((ch) >= 11) && ((ch) <= 14))
+/*
+ * The BCM2712 controller is on the AXI bus: channels 0-5 at +0, 6-11 at
+ * +0x600, so the 0x100 stride holds. It has no global ENABLE/INT_STATUS.
+ */
+#define BCM2712_DMA_BASE            0x1000010000ULL
+
+static inline IPTR BCM2708_DMA_BASE(IPTR periiobase)
+{
+    if (periiobase == BCM2708_DMA_PERIIOBASE_2712)
+        return BCM2712_DMA_BASE;
+
+    return periiobase + 0x007000;
+}
+
+#define BCM2708_DMA_CH_BASE(periiobase, ch) \
+    (BCM2708_DMA_BASE(periiobase) + (ch) * 0x100)
+
+#define BCM2708_DMA_HAS_GLOBAL_REGS(periiobase) \
+    ((periiobase) != BCM2708_DMA_PERIIOBASE_2712)
+
+/* DMA4 engines: 11-14 on the BCM2711, 6-11 on the BCM2712 */
+static inline int BCM2708_DMA_IS_DMA4(IPTR periiobase, unsigned int channel)
+{
+    if (periiobase == BCM2708_DMA_PERIIOBASE_2711)
+        return (channel >= 11) && (channel <= 14);
+
+    if (periiobase == BCM2708_DMA_PERIIOBASE_2712)
+        return (channel >= 6) && (channel <= 11);
+
+    return 0;
+}
 
 /*
  * What a DMA4 caller must know, all measured on a Pi 400 (v3d bring-up
@@ -100,6 +132,16 @@ struct BCM2711DMA4CB
  *   suggests. Linear only.
  */
 #define BCM2711_DMA4_SDRAM(x)   (0x400000000ULL | (UQUAD)(IPTR)(x))
+
+/* Per SoC: the BCM2712's DMA4 address map is identity, no alias */
+static inline UQUAD BCM2708_DMA4_SDRAM(IPTR periiobase, IPTR phys)
+{
+    if (periiobase == BCM2708_DMA_PERIIOBASE_2712)
+        return (UQUAD)phys;
+
+    return BCM2711_DMA4_SDRAM(phys);
+}
+
 #define BCM2711_DMA4_CS_PROT    (3UL << 8)
 #define BCM2711_DMA4_CS_RUN     (BCM2708_DMA_CS_RUN | BCM2711_DMA4_CS_PROT)
 #define BCM2711_DMA4_CS_ACK     (BCM2708_DMA_CS_ACK | BCM2711_DMA4_CS_PROT)
@@ -149,7 +191,6 @@ struct BCM2711DMA4CB
  * as a handler checks its own channel's CS.INT.
  */
 #define BCM2708_DMA_IRQ_BASE        16          /* GPU IRQ of channel 0 */
-#define BCM2708_DMA_PERIIOBASE_2711 0xFE000000
 #define BCM2708_DMA_GPUIRQ_OFFSET   96
 
 static inline unsigned int BCM2708_DMA_IRQ(IPTR periiobase, unsigned int channel)
@@ -158,6 +199,10 @@ static inline unsigned int BCM2708_DMA_IRQ(IPTR periiobase, unsigned int channel
      * DMA4 engines get a line each again, so the sharing stops after 10. */
     static const UBYTE spi[] = { 80, 81, 82, 83, 84, 85, 86, 87, 87, 88, 88,
                                  89, 90, 91, 92 };
+
+    /* BCM2712: SPI 80-91, one per channel */
+    if (periiobase == BCM2708_DMA_PERIIOBASE_2712)
+        return 32 + 80 + channel;
 
     if (periiobase != BCM2708_DMA_PERIIOBASE_2711)
         return BCM2708_DMA_IRQ_BASE + channel;


### PR DESCRIPTION
- Adds BCM2712 support to dma.resources. Channels 0-5 legacy and 6-10 DMA4, one SPI each. 
- Adds DMAStopChannel method so drivers with their own control block chains stop through the resource.