### PR TITLE
Fix build_archspecific target build IDs

### DIFF
--- a/config/make.tmpl
+++ b/config/make.tmpl
@@ -3273,7 +3273,7 @@ ifneq (%(cxxfiles),)
     $(error cxx support is TODO)
 endif
 
-%buildid targets="%(mainmmake)-%(arch)"
+%buildid targets="%(mainmmake)-%(arch) %(mainmmake)-%(arch)-quick %(mainmmake)-%(arch)-linklib"
 
 #MM %(mainmmake)-%(arch) : %(mainmmake)-%(arch)-includes
 #MM %(mainmmake)-%(arch)-linklib : %(mainmmake)-%(arch)-includes


### PR DESCRIPTION
%build_archspecific only associates its build ID with the base target.
The -quick and -linklib variants therefore lose the build-specific variable namespace.

Fix: Associate base, -quick and -linklib targets with the same build ID.

Verified with the i386 and x86_64 stdc build_archspecific targets.