### PR TITLE
posixc: fix unsafe terminal error paths, preserve action compatibility

### DIFF
--- a/compiler/crt/posixc/ioctl.c
+++ b/compiler/crt/posixc/ioctl.c
@@ -6,97 +6,12 @@
 
 #include <unistd.h>
 
-#include <devices/conunit.h>
-#include <dos/dosextens.h>
 #include <sys/ioctl.h>
-#include <proto/dos.h>
 
 #include <errno.h>
 
 #include <libraries/fd.h>
 #include "__fdesc.h"
-
-static int send_action_packet(struct MsgPort *port, BPTR arg)
-{
-    struct MsgPort *replyport;
-    struct StandardPacket *packet;
-    SIPTR ret;
-
-    replyport = CreatePort(NULL,0L);
-    if(!replyport)
-    {
-        return 0;
-    }
-    packet = (struct StandardPacket *) AllocMem(sizeof(struct StandardPacket),
-                                                MEMF_PUBLIC|MEMF_CLEAR);
-    if(!packet)
-    {
-        DeletePort(replyport);
-        return 0;
-    }
-
-    packet->sp_Msg.mn_Node.ln_Name = (char *)&(packet->sp_Pkt);
-    packet->sp_Pkt.dp_Link         = &(packet->sp_Msg);
-    packet->sp_Pkt.dp_Port         = replyport;
-    packet->sp_Pkt.dp_Type         = ACTION_DISK_INFO;
-    packet->sp_Pkt.dp_Arg1         = (SIPTR) arg;
-
-    PutMsg(port, (struct Message *) packet);
-    WaitPort(replyport);
-    GetMsg(replyport);
-
-    ret = packet->sp_Pkt.dp_Res1;
-
-    FreeMem(packet, sizeof(struct StandardPacket));
-    DeletePort(replyport);
-
-    return ret;
-}
-
-static int fill_consize(APTR fd, struct winsize *ws)
-{
-    struct ConUnit *console_unit = NULL;
-    struct InfoData *info_data;
-    BPTR action_disk_info_arg;
-    void *console = ((struct FileHandle *) BADDR(fd))->fh_Type;
-
-    if(!console)
-    {
-        return 0;
-    }
-
-    info_data = AllocMem(sizeof(*info_data), MEMF_PUBLIC);
-    if(info_data == NULL)
-    {
-        /* no memory, ouch */
-        return 0;
-    }
-
-    action_disk_info_arg = MKBADDR(info_data);
-    if(send_action_packet((struct MsgPort *) console, action_disk_info_arg))
-    {
-        console_unit = (void *) ((struct IOStdReq *) info_data->id_InUse)->io_Unit;
-    }
-
-    /* info_data not required anymore */
-    FreeMem(info_data, sizeof(*info_data));
-
-    if (console_unit == NULL)
-    {
-        return 0;
-    }
-
-    ws->ws_row    = (unsigned short) console_unit->cu_YMax+1;
-    ws->ws_col    = (unsigned short) console_unit->cu_XMax+1;
-    if(console_unit->cu_Window)
-    {
-        /* does a console always have a window? might be iconified? */
-        ws->ws_xpixel = (unsigned short) console_unit->cu_Window->Width;
-        ws->ws_ypixel = (unsigned short) console_unit->cu_Window->Height;
-    }
-
-    return 1;
-}
 
 /*****************************************************************************
 
@@ -127,12 +42,17 @@ static int fill_consize(APTR fd, struct winsize *ws)
         ...     - Other arguments for the specified request
 
     RESULT
-        EBADF   - fd is not valid
-        EFAULT  - no valid argument
-        ENOTTY  - fd is not of required type
+        DOS handles return -1 with errno set to EBADF (invalid descriptor)
+        or ENOTTY (unsupported operation). Foreign hooks define their own
+        return values and errors.
 
     NOTES
-        Width and height are the width and height of the intuition window.
+        DOS terminal geometry is currently unsupported. ACTION_DISK_INFO
+        does not provide a validated geometry contract: mainline CON stores
+        a use count in id_InUse, not a console.device IO request pointer.
+        See rom/filesys/console_handler/con_handler.c, ACTION_DISK_INFO:
+        id->id_InUse = fh->usecount;
+        Foreign descriptor hooks retain their own request handling.
 
     EXAMPLE
         #include <stdio.h>
@@ -157,7 +77,8 @@ static int fill_consize(APTR fd, struct winsize *ws)
         }
 
     BUGS
-        Only the requests listed above are implemented.
+        TIOCGWINSZ on DOS handles returns ENOTTY until a terminal-control
+        protocol is available. The output structure is left unchanged.
 
     SEE ALSO
 
@@ -165,13 +86,11 @@ static int fill_consize(APTR fd, struct winsize *ws)
 
 ******************************************************************************/
 {
-    va_list args;
-    struct winsize *ws;
-    fdesc *desc;
+    fdesc *desc = __getfdesc(fd);
 
     /* Descriptor owned by another subsystem (e.g. a bsdsocket socket):
        dispatch the ioctl (FIONBIO/FIONREAD/...) through its hook. */
-    if (__getfdesc(fd) == NULL)
+    if (desc == NULL)
     {
         APTR data;
         const struct fd_hooks *hooks = __getfdhooks(fd, &data);
@@ -192,40 +111,18 @@ static int fill_consize(APTR fd, struct winsize *ws)
                 errno = err;
             return r;
         }
+        errno = hooks ? ENOTTY : EBADF;
+        return -1;
     }
 
-    if(request != TIOCGWINSZ)
+    if (!desc->fcb)
     {
-        /* FIXME: Implement missing ioctl() parameters */
-        AROS_FUNCTION_NOT_IMPLEMENTED("posixc");
-        errno = ENOSYS;
-        return EFAULT;
+        errno = EBADF;
+        return -1;
     }
-
-    switch(fd)
-    {
-        case STDIN_FILENO:  desc=BADDR(Input());
-           break;
-        case STDOUT_FILENO: desc=BADDR(Output());
-           break;
-        default:
-           desc=__getfdesc(fd); /* FIXME: is this correct? why does it not work for STDOUT/STDIN? */
-    }
-
-    if(!desc || !IsInteractive(desc))
-    {
-        return EBADF;
-    }
-
-    va_start(args, request);
-    ws=(struct winsize *) va_arg(args, struct winsize *);
-    va_end(args);
-
-    if(!ws || !fill_consize(desc, ws))
-    {
-        return EFAULT;
-    }
-
-    return 0;
+    /* Never reinterpret handler-private InfoData fields as pointers.
+       No DOS request is supported here yet, so do not consume its varargs
+       or inspect its handle (which may be a directory FileLock). */
+    errno = ENOTTY;
+    return -1;
 }
-

--- a/compiler/crt/posixc/tcgetattr.c
+++ b/compiler/crt/posixc/tcgetattr.c
@@ -47,9 +47,22 @@
 {
     fdesc *fdesc = __getfdesc(fd);
 
-    if (!fdesc)
+    if (!fdesc || !fdesc->fcb)
     {
         errno = EBADF;
+        return -1;
+    }
+
+    if (!t)
+    {
+        errno = EFAULT;
+        return -1;
+    }
+    /* Directory descriptors contain a FileLock, not a DOS FileHandle. */
+    if ((fdesc->fcb->privflags & _FCB_ISDIR) ||
+        !IsInteractive(fdesc->fcb->handle))
+    {
+        errno = ENOTTY;
         return -1;
     }
 

--- a/compiler/crt/posixc/tcsetattr.c
+++ b/compiler/crt/posixc/tcsetattr.c
@@ -34,8 +34,10 @@
         -1      - error
 
     NOTES
-        Will return success, if *any* of the changes were successful.
-        Currently supports only ICANON flag
+        Currently supports only ICANON. For compatibility, TCSANOW,
+        TCSADRAIN and TCSAFLUSH all apply the mode immediately. Output drain
+        and input flush are not implemented; accepting these actions does
+        not provide their full POSIX semantics.
 
     EXAMPLE
 
@@ -50,25 +52,38 @@
 {
     fdesc *fdesc = __getfdesc(fd);
 
-    if (!fdesc)
+    if (!fdesc || !fdesc->fcb)
     {
         errno = EBADF;
         return -1;
     }
 
-    if (IsInteractive(fdesc->fcb->handle))
+    if (!t)
     {
-        if (t->c_lflag & ICANON)
-        {
-            SetMode(fdesc->fcb->handle, 0);
-            fdesc->fcb->privflags &= ~_FCB_CONSOLERAW;
-        }
-        else
-        {
-            SetMode(fdesc->fcb->handle, 1);
-            fdesc->fcb->privflags |= _FCB_CONSOLERAW;
-        }
+        errno = EFAULT;
+        return -1;
     }
-
+    if (opt != TCSANOW && opt != TCSADRAIN && opt != TCSAFLUSH)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((fdesc->fcb->privflags & _FCB_ISDIR) ||
+        !IsInteractive(fdesc->fcb->handle))
+    {
+        errno = ENOTTY;
+        return -1;
+    }
+    if (!SetMode(fdesc->fcb->handle, (t->c_lflag & ICANON) ? 0 : 1))
+    {
+        errno = __stdc_ioerr2errno(IoErr());
+        if (!errno) errno = EIO;
+        return -1;
+    }
+    /* Do not claim a mode transition that the handler rejected. */
+    if (t->c_lflag & ICANON)
+        fdesc->fcb->privflags &= ~_FCB_CONSOLERAW;
+    else
+        fdesc->fcb->privflags |= _FCB_CONSOLERAW;
     return 0;
 }

--- a/developer/debug/test/crt/posixc/README.terminal
+++ b/developer/debug/test/crt/posixc/README.terminal
@@ -1,0 +1,49 @@
+Terminal safety and compatibility tests
+=======================================
+
+Build through test-crt-posixc-general, or compile ioctl_tty.c and
+termios_tty.c individually with the mainline target compiler and SDK.
+Run with interactive DOS stdin (native CON or another interactive handler):
+
+    ioctl_tty
+    termios_tty
+
+Redirecting stdout to SER: is supported. The tests create separate RAM:
+temporary files using O_EXCL and only remove files they created. Do not
+run two instances of the same test concurrently. termios_tty restores the
+initial ICANON mode, including on failures after a successful mode change.
+
+Scope
+-----
+ioctl_tty checks invalid descriptors, DOS stdin/stdout and ordinary files,
+ENOTTY for unsupported geometry (including a NULL argument), and unchanged
+winsize output. This is an explicit failure contract, not working geometry.
+
+termios_tty checks invalid descriptors, pointers and action values, ordinary
+file rejection, and raw/cooked roundtrips through dup for TCSANOW, TCSADRAIN
+and TCSAFLUSH. Passing does not establish drain/flush behavior: all three
+actions retain the legacy immediate ICANON-only mode change. It does not
+test a full termios snapshot, independent opens, signals, timed reads or PTY.
+
+Source-level reason for removing legacy geometry
+----------------------------------------------
+At mainline base 74a2d80b7f4cf023184fd53be1e506484f5e4c38,
+rom/filesys/console_handler/con_handler.c:1156-1159, ACTION_DISK_INFO,
+stores id->id_InUse = fh->usecount. The adjacent comment explains that
+reporting an IORequest there prevented DISMOUNT. A nonzero value is not
+evidence of an IOStdReq pointer. Neither a NULL check nor an address-range
+heuristic can validate it. A safe geometry implementation needs an explicit
+terminal-control contract rather than interpretation of private InfoData.
+
+The removed path could perform an invalid read (reproduced at address 1 in
+a source-level sanitizer test). These changes do not claim an arbitrary-write
+exploit or complete POSIX terminal support.
+
+Compatibility policy
+--------------------
+Do not couple descriptor/error-path safety fixes with newly rejecting valid
+tcsetattr actions. Keeping the immediate compatibility approximation does
+not make it POSIX-compliant: TCSADRAIN must wait for output and TCSAFLUSH must
+also discard unread input when these semantics are implemented. The tty
+service must eventually supply those operations. No compatibility switch or
+private XTerm packet protocol is introduced here.

--- a/developer/debug/test/crt/posixc/ioctl_tty.c
+++ b/developer/debug/test/crt/posixc/ioctl_tty.c
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+/* DOS geometry is intentionally unsupported until a public tty ABI exists. */
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+
+int main(void)
+{
+    struct winsize w = {1, 2, 3, 4};
+    int fd = -1, failed = 0, error = 0;
+#define CHECK(x) do { if (!(x)) { failed = __LINE__; error = errno; goto done; } } while (0)
+    CHECK(ioctl(-1, TIOCGWINSZ, &w) == -1 && errno == EBADF);
+    CHECK(ioctl(STDIN_FILENO, TIOCGWINSZ, &w) == -1 && errno == ENOTTY);
+    CHECK(ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1 && errno == ENOTTY);
+    CHECK(ioctl(STDIN_FILENO, TIOCGWINSZ, NULL) == -1 && errno == ENOTTY);
+    fd = open("RAM:ioctl-tty-test.tmp", O_CREAT | O_EXCL | O_RDWR, 0600);
+    CHECK(fd >= 0);
+    CHECK(ioctl(fd, TIOCGWINSZ, &w) == -1 && errno == ENOTTY);
+    CHECK(ioctl(fd, 123, &w) == -1 && errno == ENOTTY);
+    CHECK(w.ws_row == 1 && w.ws_col == 2 && w.ws_xpixel == 3 && w.ws_ypixel == 4);
+done:
+    if (fd >= 0)
+    {
+        if (close(fd)) { failed = __LINE__; error = errno; }
+        if (unlink("RAM:ioctl-tty-test.tmp")) { failed = __LINE__; error = errno; }
+    }
+    if (failed) printf("IOCTL TTY FAIL line=%d errno=%d\n", failed, error);
+    else puts("IOCTL TTY PASS: descriptor errors, unsupported geometry, unchanged output");
+    return failed ? 20 : 0;
+}

--- a/developer/debug/test/crt/posixc/mmakefile.src
+++ b/developer/debug/test/crt/posixc/mmakefile.src
@@ -24,6 +24,7 @@ POSIXCTESTFILES := \
         statfs \
         strptime \
         strtok_r \
+        termios_tty \
         time_r \
         uname \
         usleep \

--- a/developer/debug/test/crt/posixc/mmakefile.src
+++ b/developer/debug/test/crt/posixc/mmakefile.src
@@ -15,6 +15,7 @@ POSIXCTESTFILES := \
         flock \
         getfsstat \
         getpass \
+        ioctl_tty \
         lseek \
         mnt_names \
         open \
@@ -141,4 +142,3 @@ USER_CPPFLAGS = -D_XOPEN_SOURCE=700
 
 %build_progs mmake=test-crt-posixc-2k8 \
     files="$(POSIXC2K8TESTFILES)" targetdir=$(EXEDIR)
-

--- a/developer/debug/test/crt/posixc/termios_tty.c
+++ b/developer/debug/test/crt/posixc/termios_tty.c
@@ -1,0 +1,50 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+/* Run with interactive DOS stdin. Tests ICANON compatibility, not full termios. */
+#include <termios.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    struct termios t, before, saved;
+    const int actions[] = {TCSANOW, TCSADRAIN, TCSAFLUSH};
+    int fd = -1, copy = -1, changed = 0, failed = 0, error = 0;
+    unsigned i;
+#define CHECK(x) do { if (!(x)) { failed = __LINE__; error = errno; goto done; } } while (0)
+    memset(&t, 0x55, sizeof t); before = t;
+    CHECK(tcgetattr(-1, &t) == -1 && errno == EBADF);
+    CHECK(tcsetattr(-1, TCSANOW, &t) == -1 && errno == EBADF);
+    fd = open("RAM:termios-tty-test.tmp", O_CREAT | O_EXCL | O_RDWR, 0600);
+    CHECK(fd >= 0);
+    CHECK(tcgetattr(fd, &t) == -1 && errno == ENOTTY && !memcmp(&t, &before, sizeof t));
+    CHECK(tcsetattr(fd, TCSANOW, &t) == -1 && errno == ENOTTY);
+    CHECK(tcgetattr(STDIN_FILENO, NULL) == -1 && errno == EFAULT);
+    CHECK(tcsetattr(STDIN_FILENO, TCSANOW, NULL) == -1 && errno == EFAULT);
+    memset(&saved, 0, sizeof saved);
+    CHECK(tcgetattr(STDIN_FILENO, &saved) == 0);
+    CHECK(tcsetattr(STDIN_FILENO, 99, &saved) == -1 && errno == EINVAL);
+    copy = dup(STDIN_FILENO); CHECK(copy >= 0);
+    for (i = 0; i < sizeof actions / sizeof actions[0]; ++i)
+    {
+        t = saved; t.c_lflag &= ~ICANON;
+        CHECK(tcsetattr(copy, actions[i], &t) == 0); changed = 1;
+        t.c_lflag = ICANON;
+        CHECK(tcgetattr(STDIN_FILENO, &t) == 0 && !(t.c_lflag & ICANON));
+        CHECK(tcsetattr(STDIN_FILENO, actions[i], &saved) == 0); changed = 0;
+        CHECK(tcgetattr(copy, &t) == 0 && (t.c_lflag & ICANON) == (saved.c_lflag & ICANON));
+    }
+done:
+    if (changed && tcsetattr(STDIN_FILENO, TCSANOW, &saved)) { failed = __LINE__; error = errno; }
+    if (copy >= 0 && close(copy)) { failed = __LINE__; error = errno; }
+    if (fd >= 0)
+    {
+        if (close(fd)) { failed = __LINE__; error = errno; }
+        if (unlink("RAM:termios-tty-test.tmp")) { failed = __LINE__; error = errno; }
+    }
+    if (failed) printf("TERMIOS TTY FAIL line=%d errno=%d\n", failed, error);
+    else puts("TERMIOS TTY PASS: errors, all legacy actions, dup ICANON roundtrips");
+    return failed ? 20 : 0;
+}


### PR DESCRIPTION
This series fixes unsafe terminal error paths in posixc. It does **not** implement PTY, complete termios, or working DOS terminal geometry.

## 1. Reject unsafe DOS geometry queries

The old `TIOCGWINSZ` path treats `InfoData.id_InUse` as an `IOStdReq *` and dereferences its `io_Unit`. However, the mainline console handler stores a use count there:

[`rom/filesys/console_handler/con_handler.c`, ACTION_DISK_INFO, lines 1156–1159 at the tested base](https://github.com/aros-development-team/AROS/blob/74a2d80b7f4cf023184fd53be1e506484f5e4c38/rom/filesys/console_handler/con_handler.c#L1156-L1159):

```c
id->id_InUse = fh->usecount;
```

The adjacent comment explains why reporting an IORequest prevented DISMOUNT. A nonzero use count is not a valid pointer contract. A source-level sanitizer probe reproduced an invalid read at address 1; a NULL check is insufficient. This is an invalid-read finding, not a claim of an arbitrary-write exploit.

Remove that fallback. **DOS `ioctl` requests now return `-1/ENOTTY`, including `TIOCGWINSZ`; output remains unchanged.** This is an explicit compatibility limitation until a supported terminal-control query exists. No request varargs or DOS handle internals are examined in this unsupported path.

Also resolve stdin/stdout through the descriptor table instead of casting DOS Input()/Output() handles to `fdesc *`, and return `-1/EBADF` for invalid descriptors instead of positive errno values. Foreign descriptor hooks and the request zero-extension from #1124 remain intact.

## 2. Validate termios operations without changing valid-action compatibility

- Reject invalid descriptors, NULL pointers and invalid action values.
- Reject ordinary files with ENOTTY; check `_FCB_ISDIR` before treating a FileLock as a FileHandle.
- Propagate failed `SetMode` calls and update the shared fcb mode cache only after success.
- **Preserve immediate ICANON application for TCSANOW, TCSADRAIN and TCSAFLUSH.** No new ENOTSUP policy is introduced. Drain/flush remain unimplemented, explicitly documented compatibility approximations.

`tcgetattr` still updates only ICANON in the caller's structure. This is not a complete initialized snapshot or authoritative tty state across independent opens.

## Tests and limits

The series adds `ioctl_tty.c`, `termios_tty.c`, build registration, and `README.terminal` under `developer/debug/test/crt/posixc/`. The tests can be compiled independently with the mainline target compiler/SDK and run with interactive DOS stdin. Stdout may be redirected to SER:.

Verified on the tested base above:

- Rebuilt a staged `posixc.library`; strict x86_64 cross-compilation of both probes with GNU99, O2, Wall/Wextra/Werror.
- Installed the staged library in a disposable x86_64 AROS guest (`pc,accel=tcg`) and rebooted before testing.
- Both probes passed on native CON and again through XTerm's interactive DOS handler. The termios test exercises all three actions through dup and restores the initial mode.
- An additional local host harness compiling the actual modified libc sources with DOS/fd test doubles passed ASan/UBSan. That supplementary harness is outside this PR; the standalone native probes are included.

Native log, first pair CON and second pair XTerm:

```text
IOCTL TTY PASS: descriptor errors, unsupported geometry, unchanged output
TERMIOS TTY PASS: errors, all legacy actions, dup ICANON roundtrips
IOCTL TTY PASS: descriptor errors, unsupported geometry, unchanged output
TERMIOS TTY PASS: errors, all legacy actions, dup ICANON roundtrips
```

These are focused functional tests, not a soak, concurrent-I/O test or terminal conformance certification. No aarch64 runtime test was performed. The original guest library was restored afterwards.

Current master was checked before submission: the files changed by this series have not changed since the tested base, and the handler still reports `fh->usecount`. The two commits deliberately keep ioctl safety separate from termios validation/compatibility for review.
