### PR TITLE
Run: fix redirected output duplication and preserve append position

### DIFF
--- a/developer/debug/test/dos/README.run
+++ b/developer/debug/test/dos/README.run
@@ -1,0 +1,46 @@
+Run redirection regression
+==========================
+
+run_redirection takes an explicit path to a standalone Run executable.
+Build it through test-dos-common, or directly with the AROS target compiler.
+Build Run.c in standalone form with -nostartfiles -static and an ADATE string.
+Do not replace the installed/resident command for this test.
+
+    run_redirection RAM:Run-fixed
+
+The probe creates a unique directory in RAM:, verifies a successful launch
+and exact output for both > and >>, including a pre-existing PREFIX line.
+It waits up to 250 ticks for each asynchronous Echo. On success it removes
+its files and empty directory; after failure it retains them, without
+reusing a possibly still-active background command's output pathname.
+
+The unmodified Run is expected to fail these output checks on the tested
+RAM-handler. Comparing baseline/fixed executables by explicit path avoids
+accidentally running a resident command instead of the patched binary.
+
+Fault injection (host only)
+---------------------------
+From this directory:
+
+    cc -std=c99 -Wall -Wextra -Werror -fsanitize=address,undefined \
+       run_handle_host.c -o /tmp/run_handle_host
+    /tmp/run_handle_host
+
+This compiles the actual production run_handle.h with DOS boundary doubles.
+It checks source seek failures and unrepresentable positions, unsupported
+seeks, exclusive-to-shared retry, failed OpenFromLock cleanup, failed copy
+seek cleanup, and interactive handles. It is not a native handler test or
+allocation-failure test of the entire Run command.
+
+Compatibility limits
+--------------------
+The duplication helper uses the existing LONG-based Seek API. Negative
+positions other than -1/ERROR_ACTION_NOT_KNOWN are rejected rather than
+silently reopening a seekable output at offset zero. Positions above
+LONG_MAX are not supported by this path. Only interactive handles and
+explicitly unsupported Seek operations are duplicated without a position.
+
+Exclusive output is changed to SHARED_LOCK only after DupLockFromFH reports
+ERROR_OBJECT_IN_USE. That mode change is not rolled back if a later operation
+fails. Concurrent append atomicity, other filesystems and allocation-failure
+injection across the entire Shell launch are outside this regression.

--- a/developer/debug/test/dos/mmakefile.src
+++ b/developer/debug/test/dos/mmakefile.src
@@ -37,6 +37,7 @@ FILES := \
     readitem \
     readitemloop \
     runcommand \
+    run_redirection \
     rwverify \
     scantest \
     scanvarstest \

--- a/developer/debug/test/dos/run_handle_host.c
+++ b/developer/debug/test/dos/run_handle_host.c
@@ -1,0 +1,84 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+/* Host-only fault injection around the actual production duplication helper.
+   cc -std=c99 -Wall -Wextra -Werror run_handle_host.c -o run_handle_host */
+#include <stdint.h>
+#include <assert.h>
+#include <stdio.h>
+typedef intptr_t BPTR;
+typedef int32_t LONG;
+struct DosLibrary { int unused; };
+#define BNULL 0
+#define OFFSET_CURRENT 0
+#define OFFSET_BEGINNING -1
+#define CHANGE_FH 1
+#define SHARED_LOCK -2
+#define ERROR_INVALID_LOCK 211
+#define ERROR_OBJECT_IN_USE 202
+#define ERROR_ACTION_NOT_KNOWN 209
+#define ERROR_SEEK_ERROR 219
+static LONG error, position, seek_error;
+static int interactive, exclusive, share_ok, open_ok, restore_ok;
+static unsigned seeks, duplicates, shares, unlocks, closes;
+static LONG get_error(struct DosLibrary *base) { (void)base;return error; }
+static void set_error(LONG e,struct DosLibrary *base) { (void)base;error=e; }
+static int is_interactive(BPTR f,struct DosLibrary *base)
+{ (void)base;assert(f==1);return interactive; }
+static LONG seek_file(BPTR f,LONG offset,LONG mode,struct DosLibrary *base)
+{
+    (void)base;++seeks;
+    if(f==1) { assert(offset==0 && mode==OFFSET_CURRENT);error=seek_error;return position; }
+    assert(f==3 && offset==position && mode==OFFSET_BEGINNING);
+    error=ERROR_SEEK_ERROR;return restore_ok?0:-1;
+}
+static BPTR duplicate(BPTR f,struct DosLibrary *base)
+{
+    (void)base;assert(f==1);++duplicates;
+    if(exclusive && !shares) { error=ERROR_OBJECT_IN_USE;return 0; }
+    return 2;
+}
+static int change_mode(LONG type,BPTR f,LONG mode,struct DosLibrary *base)
+{ (void)base;assert(type==CHANGE_FH && f==1 && mode==SHARED_LOCK);++shares;error=223;return share_ok; }
+static BPTR open_lock(BPTR l,struct DosLibrary *base)
+{ (void)base;assert(l==2);error=103;return open_ok?3:0; }
+static void unlock(BPTR l,struct DosLibrary *base)
+{ (void)base;assert(l==2);++unlocks;error=0; }
+static void close_file(BPTR f,struct DosLibrary *base)
+{ (void)base;assert(f==3);++closes;error=0; }
+#define IoErr() get_error(DOSBase)
+#define SetIoErr(e) set_error((e),DOSBase)
+#define IsInteractive(f) is_interactive((f),DOSBase)
+#define Seek(f,p,m) seek_file((f),(p),(m),DOSBase)
+#define DupLockFromFH(f) duplicate((f),DOSBase)
+#define ChangeMode(t,f,m) change_mode((t),(f),(m),DOSBase)
+#define OpenFromLock(l) open_lock((l),DOSBase)
+#define UnLock(l) unlock((l),DOSBase)
+#define Close(f) close_file((f),DOSBase)
+#include "../../../../workbench/c/shellcommands/run_handle.h"
+static void reset(void)
+{
+    error=seek_error=0;position=7;interactive=exclusive=0;
+    share_ok=open_ok=restore_ok=1;
+    seeks=duplicates=shares=unlocks=closes=0;
+}
+int main(void)
+{
+    reset();position=-1;seek_error=ERROR_SEEK_ERROR;
+    assert(DuplicateRunHandle(1,NULL)==0 && error==ERROR_SEEK_ERROR && !duplicates);
+    reset();position=INT32_MIN;
+    assert(DuplicateRunHandle(1,NULL)==0 && error==ERROR_SEEK_ERROR && !duplicates);
+    reset();position=-1;seek_error=ERROR_ACTION_NOT_KNOWN;
+    assert(DuplicateRunHandle(1,NULL)==3 && seeks==1);
+    reset();exclusive=1;
+    assert(DuplicateRunHandle(1,NULL)==3 && shares==1 && duplicates==2 && seeks==2);
+    reset();exclusive=1;share_ok=0;
+    assert(DuplicateRunHandle(1,NULL)==0 && error==223 && duplicates==1);
+    reset();open_ok=0;
+    assert(DuplicateRunHandle(1,NULL)==0 && error==103 && unlocks==1 && !closes);
+    reset();restore_ok=0;
+    assert(DuplicateRunHandle(1,NULL)==0 && error==ERROR_SEEK_ERROR && closes==1 && !unlocks);
+    reset();interactive=1;
+    assert(DuplicateRunHandle(1,NULL)==3 && !seeks);
+    reset();assert(DuplicateRunHandle(0,NULL)==0 && error==ERROR_INVALID_LOCK && !duplicates);
+    puts("RUN HANDLE PASS: seek failures, range rejection, nonseekable, sharing, ownership");
+    return 0;
+}

--- a/developer/debug/test/dos/run_redirection.c
+++ b/developer/debug/test/dos/run_redirection.c
@@ -1,0 +1,85 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+/* Run an explicit standalone Run executable; never replace resident Run. */
+#include <proto/dos.h>
+#include <proto/exec.h>
+#include <dos/dostags.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    struct Process *me = (struct Process *)FindTask(NULL);
+    char directory[120], path[2][160], command[500], data[128];
+    const char *expected[2] = {"RUN_REDIRECT_OK\n", "PREFIX\nRUN_REDIRECT_OK\n"};
+    BPTR lock, file;
+    unsigned attempt, round, ticks;
+    LONG result, count;
+    int all_ok = 1, matched;
+
+    if (argc != 2 || strlen(argv[1]) > 240 || strpbrk(argv[1], "\"*\r\n"))
+    {
+        puts("Usage: run_redirection <explicit standalone Run executable>");
+        return RETURN_FAIL;
+    }
+    /* CreateDir is the ownership boundary. Never truncate a pre-existing file. */
+    for (attempt = 0; attempt < 100; ++attempt)
+    {
+        snprintf(directory, sizeof directory, "RAM:run-redirection-%lu-%u",
+                 (unsigned long)me->pr_TaskNum, attempt);
+        lock = CreateDir((CONST_STRPTR)directory);
+        if (lock) { UnLock(lock); break; }
+        if (IoErr() != ERROR_OBJECT_EXISTS) return RETURN_FAIL;
+    }
+    if (attempt == 100) return RETURN_FAIL;
+    snprintf(path[0], sizeof path[0], "%s/overwrite", directory);
+    snprintf(path[1], sizeof path[1], "%s/append", directory);
+
+    for (round = 0; round < 2; ++round)
+    {
+        matched = 0;
+        if (round)
+        {
+            file = Open((CONST_STRPTR)path[round], MODE_NEWFILE);
+            if (!file) { all_ok = 0; break; }
+            count = Write(file, "PREFIX\n", 7);
+            if (!Close(file) || count != 7) { all_ok = 0; break; }
+        }
+        snprintf(command, sizeof command, "\"%s\" %s%s Echo RUN_REDIRECT_OK",
+                 argv[1], round ? ">>" : ">", path[round]);
+        result = SystemTags((CONST_STRPTR)command, SYS_Asynch, FALSE, TAG_DONE);
+        for (ticks = 0; result == RETURN_OK && ticks < 250; ++ticks)
+        {
+            file = Open((CONST_STRPTR)path[round], MODE_OLDFILE);
+            if (file)
+            {
+                count = Read(file, data, sizeof data - 1);
+                Close(file);
+                if (count >= 0)
+                {
+                    data[count] = 0;
+                    if ((size_t)count == strlen(expected[round]) &&
+                        !memcmp(data, expected[round], (size_t)count))
+                    { matched = 1; break; }
+                }
+            }
+            Delay(1);
+        }
+        printf("RUN %s %s: launch=%ld exact_output=%d\n",
+               round ? "APPEND" : "REDIRECT", matched ? "PASS" : "FAIL",
+               (long)result, matched);
+        if (!matched) all_ok = 0;
+    }
+    if (all_ok)
+    {
+        /* A background Echo may still be closing its output after the read. */
+        for (round = 0; round < 2; ++round)
+        {
+            for (ticks = 0; ticks < 250 && !DeleteFile((CONST_STRPTR)path[round]); ++ticks) Delay(1);
+            if (ticks == 250) all_ok = 0;
+        }
+        if (all_ok && !DeleteFile((CONST_STRPTR)directory)) all_ok = 0;
+    }
+    if (!all_ok) printf("Test files retained: %s\n", directory);
+    puts(all_ok ? "RUN REDIRECTION PASS: launch status, exact bytes, cleanup" : "RUN REDIRECTION FAIL");
+    return all_ok ? RETURN_OK : RETURN_FAIL;
+}

--- a/developer/debug/test/dos/run_redirection.c
+++ b/developer/debug/test/dos/run_redirection.c
@@ -10,13 +10,28 @@ int main(int argc, char **argv)
 {
     struct Process *me = (struct Process *)FindTask(NULL);
     char directory[120], path[2][160], command[500], data[128];
-    const char *expected[2] = {"RUN_REDIRECT_OK\n", "PREFIX\nRUN_REDIRECT_OK\n"};
-    BPTR lock, file;
+    static const char overwrite[] = "RUN_REDIRECT_OK\n";
+    static const char append[] = "PREFIX\nRUN_REDIRECT_OK\n";
+    const char *expected[2] = {overwrite, append};
+    const size_t expected_length[2] = {sizeof overwrite - 1, sizeof append - 1};
+    BPTR file;
     unsigned attempt, round, ticks;
-    LONG result, count;
-    int all_ok = 1, matched;
+    size_t argument_length = 0;
+    LONG count;
+    int all_ok = 1;
 
-    if (argc != 2 || strlen(argv[1]) > 240 || strpbrk(argv[1], "\"*\r\n"))
+    /* Validate the bounded command argument before formatting it as a string. */
+    if (argc == 2)
+    {
+        while (argument_length < 241 && argv[1][argument_length])
+        {
+            char c = argv[1][argument_length];
+            if (c == '"' || c == '*' || c == '\r' || c == '\n')
+                break;
+            ++argument_length;
+        }
+    }
+    if (argc != 2 || argument_length > 240 || argv[1][argument_length])
     {
         puts("Usage: run_redirection <explicit standalone Run executable>");
         return RETURN_FAIL;
@@ -24,6 +39,7 @@ int main(int argc, char **argv)
     /* CreateDir is the ownership boundary. Never truncate a pre-existing file. */
     for (attempt = 0; attempt < 100; ++attempt)
     {
+        BPTR lock;
         snprintf(directory, sizeof directory, "RAM:run-redirection-%lu-%u",
                  (unsigned long)me->pr_TaskNum, attempt);
         lock = CreateDir((CONST_STRPTR)directory);
@@ -36,7 +52,8 @@ int main(int argc, char **argv)
 
     for (round = 0; round < 2; ++round)
     {
-        matched = 0;
+        LONG result;
+        int matched = 0;
         if (round)
         {
             file = Open((CONST_STRPTR)path[round], MODE_NEWFILE);
@@ -57,7 +74,7 @@ int main(int argc, char **argv)
                 if (count >= 0)
                 {
                     data[count] = 0;
-                    if ((size_t)count == strlen(expected[round]) &&
+                    if ((size_t)count == expected_length[round] &&
                         !memcmp(data, expected[round], (size_t)count))
                     { matched = 1; break; }
                 }

--- a/workbench/c/shellcommands/Run.c
+++ b/workbench/c/shellcommands/Run.c
@@ -67,6 +67,8 @@
 
 #include <string.h>
 
+#include "run_handle.h"
+
 AROS_SH2H(Run, 41.3,                  "Start a program as a background process\n",
 AROS_SHAH(BOOL  , ,QUIET  ,/S,FALSE,"\tDon't print the background CLI's number"),
 AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (arguments allowed)\n") )
@@ -86,6 +88,8 @@ AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (argume
         command = "";
 
     cis = Open("NIL:", MODE_OLDFILE);
+    if (!cis)
+        goto error;
     
     /* To support '+' style continuation, we're
      * going to need to be a little tricky. We
@@ -120,7 +124,9 @@ AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (argume
         }
     }
 
-    cos = OpenFromLock(DupLockFromFH(Output()));
+    cos = DuplicateRunHandle(Output(), DOSBase);
+    if (!cos)
+        goto error;
 
     /* All the 'noise' goes to cli_StandardError
      */
@@ -136,9 +142,11 @@ AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (argume
     /* Use a duplicate of the CES lock
      */
     if (ces)
-        ces = OpenFromLock(DupLockFromFH(ces));
+        ces = DuplicateRunHandle(ces, DOSBase);
     else
         ces = Open("NIL:", MODE_OLDFILE);
+    if (!ces)
+        goto error;
 
     if ( command[0] != 0)
     {
@@ -154,22 +162,31 @@ AROS_SHAH(STRPTR, ,COMMAND,/F,NULL ,  "The program (resp. script) to run (argume
 
         if ( SystemTagList((CONST_STRPTR)command,
                            tags                                ) == -1 )
-        {
-            PrintFault(IoErr(), "Run");
-            Close(cis);
-            Close(cos);
-            Close(ces);
-            if (cmdsize > 0)
-                FreeMem(command, cmdsize);
-
-            return RETURN_FAIL;
-        }
+            goto error;
+    }
+    else
+    {
+        Close(cis);
+        Close(cos);
+        Close(ces);
     }
 
     if (cmdsize > 0)
         FreeMem(command, cmdsize);
 
     return RETURN_OK;
+
+error:
+    {
+        LONG error = IoErr();
+        PrintFault(error, "Run");
+        if (cis) Close(cis);
+        if (cos) Close(cos);
+        if (ces) Close(ces);
+        if (cmdsize > 0) FreeMem(command, cmdsize);
+        SetIoErr(error);
+    }
+    return RETURN_FAIL;
 
     AROS_SHCOMMAND_EXIT
 }

--- a/workbench/c/shellcommands/run_handle.h
+++ b/workbench/c/shellcommands/run_handle.h
@@ -1,0 +1,61 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+#ifndef SHELL_RUN_HANDLE_H
+#define SHELL_RUN_HANDLE_H
+/* Run needs its own handle: the parent Shell closes redirections on return.
+ * MODE_NEWFILE may hold an exclusive lock, which cannot be duplicated until
+ * explicitly shared. Preserve a seekable stream's position (notably >>). */
+static BPTR DuplicateRunHandle(BPTR source, struct DosLibrary *DOSBase)
+{
+    BPTR lock, copy;
+    LONG position = -1, error;
+
+    if (!source)
+    {
+        SetIoErr(ERROR_INVALID_LOCK);
+        return BNULL;
+    }
+    if (!IsInteractive(source))
+    {
+        position = Seek(source, 0, OFFSET_CURRENT);
+        if (position < 0)
+        {
+            error = IoErr();
+            /* Only an explicitly unsupported seek permits positionless
+             * duplication. Never turn an I/O error into an append at zero.
+             * This LONG-based path cannot preserve positions above LONG_MAX. */
+            if (position != -1 || error != ERROR_ACTION_NOT_KNOWN)
+            {
+                SetIoErr(position == -1 && error ? error : ERROR_SEEK_ERROR);
+                return BNULL;
+            }
+        }
+    }
+
+    lock = DupLockFromFH(source);
+    if (!lock && IoErr() == ERROR_OBJECT_IN_USE)
+    {
+        if (!ChangeMode(CHANGE_FH, source, SHARED_LOCK))
+            return BNULL;
+        lock = DupLockFromFH(source);
+    }
+    if (!lock)
+        return BNULL;
+
+    copy = OpenFromLock(lock);
+    if (!copy)
+    {
+        error = IoErr();
+        UnLock(lock); /* OpenFromLock consumes the lock only on success. */
+        SetIoErr(error);
+        return BNULL;
+    }
+    if (position >= 0 && Seek(copy, position, OFFSET_BEGINNING) == -1)
+    {
+        error = IoErr();
+        Close(copy);
+        SetIoErr(error);
+        return BNULL;
+    }
+    return copy;
+}
+#endif


### PR DESCRIPTION
Fix background output redirection in `Run`, independently of the posixc terminal changes in #1170.

## Cause and change

`Run` needs independent output/error handles: the parent Shell closes redirections when the command returns. On the tested RAM-handler, `MODE_NEWFILE` holds an exclusive lock and `DupLockFromFH` fails with `ERROR_OBJECT_IN_USE` (202). The old nested `OpenFromLock(DupLockFromFH(Output()))` ignored failure and could report a successful launch with no valid child output.

The new private helper:

- checks both duplication operations, retries with SHARED_LOCK only after ERROR_OBJECT_IN_USE;
- releases a lock if OpenFromLock fails (its ownership-on-failure contract is documented in `rom/dos/openfromlock.c`);
- preserves the position of seekable output, including the existing prefix for `>>`;
- rejects failed or unrepresentable source positions instead of silently duplicating at offset zero. Only an explicitly unsupported Seek permits positionless duplication.

`Run` now checks stream setup, cleans up on failure, and closes handles for an empty command. Successful CLI_RUN stream ownership transfer is unchanged. The helper lives in a private header so the host fault test exercises the production implementation, not a copy.

## Verification

Included in `developer/debug/test/dos/`:

- `run_redirection.c`: native test, registered in the test build; takes an explicit standalone Run executable, checks launch status, exact output length/content for `>` and `>>`, and cleanup. It creates a unique RAM directory and retains evidence after failure.
- `run_handle_host.c`: host fault injection for source/copy seek failures, range rejection, unsupported seek, sharing failure, and lock/handle cleanup. Passed with strict warnings and ASan/UBSan.
- `README.run`: instructions and compatibility limits.

Freshly compiled baseline and fixed Run executables were compared in the same disposable x86_64 AROS guest (`pc,accel=tcg`), first from native CON and then XTerm. Both environments produced:

```text
baseline:
RUN REDIRECT FAIL: launch=0 exact_output=0
RUN APPEND FAIL: launch=0 exact_output=0
RUN REDIRECTION FAIL

fixed:
RUN REDIRECT PASS: launch=0 exact_output=1
RUN APPEND PASS: launch=0 exact_output=1
RUN REDIRECTION PASS: launch status, exact bytes, cleanup
```

The standalone and embedded-command forms both cross-compiled with GNU99, O2, Wall/Wextra/Werror; pre-existing pointer-sign warnings were disabled for Run. The new native regression compiled without that suppression. Testing used the existing mainline x86_64 SDK/guest, not a complete rebuild of the latest OS. Installed/resident Run was never replaced.

## Limits

This remains a LONG-based Seek path, not large-file positioning support. Negative/unrepresentable positions fail rather than silently losing the append position. The change does not establish concurrent append atomicity, other-filesystem coverage, or allocation-failure coverage of the entire Shell launch. A successful switch to SHARED_LOCK is not rolled back if a later step fails. The prior interactive/QUIET checks are not counted as fresh coverage of this revision.
