### PR TITLE
m68k: Restore classic CON: ACTION_DISK_INFO compatibility

### DIFF
--- a/rom/filesys/console_handler/con_handler.c
+++ b/rom/filesys/console_handler/con_handler.c
@@ -1157,10 +1157,16 @@ LONG CONMain(struct ExecBase *SysBase)
                         id->id_VolumeNode = (fh->flags & FHFLG_DEVICEMODE)
                                                 ? (BPTR)(SIPTR)-1
                                                 : (BPTR)fh->window;
-                        /* Anyone still holding a stream on us. Reporting the
-                           IORequest here made us look busy for as long as we
-                           were alive, so DISMOUNT could never proceed. */
-                        id->id_InUse = fh->usecount;
+                        if (fh->flags & FHFLG_DEVICEMODE) {
+                            /* Device-backed consoles are shared and can be
+                               dismounted, so report their open count. */
+                            id->id_InUse = fh->usecount;
+                        } else {
+                            /* Classic console handlers return their read
+                               IORequest here. Old programs such as the 1.3
+                               SetMap command use it to find the console unit. */
+                            id->id_InUse = (IPTR)fh->conreadio;
+                        }
                         replypkt(dp, DOSTRUE);
                     }
                     break;


### PR DESCRIPTION
Restore the classic id_InUse value for window-backed CON: handlers while retaining the open count for shared device backed consoles.

Workbench 1.3’s SetMap command expects ACTION_DISK_INFO to return the console read IORequest through id_InUse. Returning the open count instead caused it to dereference an invalid pointer and crash during startup.

Verified by booting Workbench 1.3 to the desktop and opening a CLI.