### PR TITLE
nvme fixes

### DIFF
--- a/rom/devs/nvme/nvme_busclass.c
+++ b/rom/devs/nvme/nvme_busclass.c
@@ -538,12 +538,16 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
                         bug ("[NVME:Bus] NVMEBus_Start: ns#%u           nlb %08x%08x\n", nn + 1, (rt->nlb >> 32), rt->nlb & 0xFFFFFFFF);
                     )
 
-                    if (!(rt->attributes & NVME_LBART_ATTRIB_HIDE)) {
+                    if (rt->attributes & NVME_LBART_ATTRIB_HIDE) {
+                        D(bug ("[NVME:Bus] NVMEBus_Start:      Skipping hidden namespace\n");)
+                        lbaEnd = 0;
+                    } else if (rt->nlb) {
                         lbaStart = rt->slba;
                         lbaEnd =  rt->slba + rt->nlb;
                     } else {
-                        D(bug ("[NVME:Bus] NVMEBus_Start:      Skipping hidden namespace\n");)
-                        lbaEnd = 0;
+                        /* Optional feature - no ranges defined still reports success. */
+                        D(bug ("[NVME:Bus] NVMEBus_Start:      No LBA range reported, using nsze\n");)
+                        lbaEnd = id_ns->nsze << (id_ns->lbaf[lbaf].ds - 9);
                     }
                 } else
                     lbaEnd = id_ns->nsze << (id_ns->lbaf[lbaf].ds - 9);

--- a/rom/devs/nvme/nvme_busclass.c
+++ b/rom/devs/nvme/nvme_busclass.c
@@ -509,7 +509,8 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
                 for (i = 0; i < id_ns->nlbaf + 1; i++) {
                     D(bug ("[NVME:Bus] NVMEBus_Start: ns#%u       lbaf[%u], ms = %u, ds = %u, rp = %u\n", nn + 1, i, id_ns->lbaf[i].ms, id_ns->lbaf[i].ds, id_ns->lbaf[i].rp);)
                 }
-                struct nvme_lba_range_type *rt = (struct nvme_lba_range_type *)(IPTR)buffer + 4096;
+                /* Second page of the buffer - casting first would scale the offset. */
+                struct nvme_lba_range_type *rt = (struct nvme_lba_range_type *)((IPTR)buffer + 4096);
 
                 D(bug ("[NVME:Bus] NVMEBus_Start: ns#%u lba_range_type buffer @ 0x%p\n", nn + 1, rt);)
 

--- a/rom/devs/nvme/nvme_init.c
+++ b/rom/devs/nvme/nvme_init.c
@@ -329,13 +329,10 @@ static int NVME_Probe(struct NVMEBase *NVMEBase)
     return TRUE;
 }
 
-/*
- * nvme.device main code has two init routines with 0 and 127 priorities.
- * All bus scanners must run between them.
- */
+/* Init routines run in ascending numeric priority, so NVME_Init at 0 runs
+   before NVME_Probe at 30. */
 ADD2INITLIB(NVME_Probe, 30)
 
 ADD2INITLIB(NVME_Init, 0)
 ADD2OPENDEV(NVME_Open, 0)
 ADD2CLOSEDEV(NVME_Close, 0)
-

--- a/rom/devs/nvme/nvme_io.c
+++ b/rom/devs/nvme/nvme_io.c
@@ -158,13 +158,16 @@ static BOOL nvme_sector_rw(struct IORequest *io, UQUAD off64, BOOL is_write)
      * Watching for work instead would run the count out every time on
      * a controller whose interrupt is doing its job, since the queue
      * it is looking at has already been emptied.
+     *
+     * ceh_Reply is cleared again by the queue's task after it replies, so
+     * watch the slot ceasing to be ours too - that does not come back.
      */
     {
         struct completionevent_handler *slot =
             &nvmeq->ce_entries[cmdio.common.op.command_id];
         ULONG spins = 4096;
 
-        while (spins-- && !slot->ceh_Reply)
+        while (spins-- && !slot->ceh_Reply && (slot->ceh_Msg == (APTR)io))
             nvme_process_cq(nvmeq);
     }
 


### PR DESCRIPTION
Three independent fixes to nvme.device, found bringing up an NVMe disk on a Pi 500+.

- **LBA range descriptor pointer arithmetic**: the cast bound to the buffer
  rather than the sum, so `+ 4096` scaled by the 64-byte descriptor size and
  the controller wrote 256KB past the buffer. Affects any controller that
  answers Get Features for LBA Range Type.
- **Fall back to the namespace size when no LBA range is reported**: LBA Range
  Type is optional; a controller with no ranges defined answers successfully
  with an empty descriptor, which gave a zero-length namespace and no unit.
- **Do not wait on a flag the queue task clears**: the drain loop waited on
  `ceh_Reply`, which the queue task clears again after replying. Losing that
  race spun the count out on a finished request. It now also watches the slot
  ceasing to be ours, which does not come back.