### PR TITLE
bcm2712 pcie bring up

### DIFF
--- a/arch/aarch64-native/kernel/platform_bcm2712.c
+++ b/arch/aarch64-native/kernel/platform_bcm2712.c
@@ -124,20 +124,31 @@ static void bcm2712_irq_init(void)
 /*
  * MSIs are pulses where everything else on this SoC holds a level, so
  * their SPIs - and only those - need edge triggering.  Which ones comes
- * from the mip node's msi-ranges: <phandle type base flags count>.
+ * from the mip node's msi-ranges: <phandle type base flags count>, plus
+ * brcm,msi-offset - the SPIs raised start at base + offset. Each host
+ * bridge has its own block, so all three are consulted.
  */
-static uint32_t mip_first_intid, mip_msi_count;
+#define MIP_MAX_RANGES  3
+
+static struct
+{
+    uint32_t    first;
+    uint32_t    count;
+} mip_ranges[MIP_MAX_RANGES];
+static int mip_nranges;
 static int mip_queried;
 
-static void bcm2712_msi_range_query(void)
+static void bcm2712_msi_range_add(char *bridge)
 {
     void *node;
     void *prop;
     uint32_t *cells;
+    uint32_t offset = 0;
 
-    mip_queried = 1;
+    if (mip_nranges >= MIP_MAX_RANGES)
+        return;
 
-    node = dt_find_node("/axi/pcie@1000120000");
+    node = dt_find_node(bridge);
     prop = node ? dt_find_property(node, "msi-parent") : NULL;
     if (!prop || (dt_get_prop_len(prop) < 4))
         return;
@@ -153,8 +164,36 @@ static void bcm2712_msi_range_query(void)
     if (AROS_BE2LONG(cells[3]) != 1)
         return;
 
-    mip_first_intid = AROS_BE2LONG(cells[2]) + GIC_FIRST_SPI;
-    mip_msi_count = AROS_BE2LONG(cells[4]);
+    prop = dt_find_property(node, "brcm,msi-offset");
+    if (prop && (dt_get_prop_len(prop) >= 4))
+        offset = AROS_BE2LONG(*(uint32_t *)dt_get_prop_value(prop));
+
+    mip_ranges[mip_nranges].first = AROS_BE2LONG(cells[2]) + offset + GIC_FIRST_SPI;
+    mip_ranges[mip_nranges].count = AROS_BE2LONG(cells[4]);
+    mip_nranges++;
+}
+
+static void bcm2712_msi_range_query(void)
+{
+    mip_queried = 1;
+
+    bcm2712_msi_range_add("/axi/pcie@1000100000");
+    bcm2712_msi_range_add("/axi/pcie@1000110000");
+    bcm2712_msi_range_add("/axi/pcie@1000120000");
+}
+
+static int bcm2712_irq_is_msi(uint32_t irq)
+{
+    int i;
+
+    for (i = 0; i < mip_nranges; i++)
+    {
+        if ((irq >= mip_ranges[i].first) &&
+            (irq < mip_ranges[i].first + mip_ranges[i].count))
+            return 1;
+    }
+
+    return 0;
 }
 
 static void bcm2712_irq_enable(int irq)
@@ -172,8 +211,7 @@ static void bcm2712_irq_enable(int irq)
         *((volatile uint8_t *)(GICD_BASE + GICD_ITARGETSR + irq)) = 0x01;
 
         cfg = GICD(GICD_ICFGR + 4 * (irq / 16));
-        if (mip_msi_count && ((uint32_t)irq >= mip_first_intid) &&
-            ((uint32_t)irq < mip_first_intid + mip_msi_count))
+        if (bcm2712_irq_is_msi((uint32_t)irq))
             cfg |= (2u << ((irq % 16) * 2));
         else
             cfg &= ~(2u << ((irq % 16) * 2));

--- a/arch/aarch64-native/kernel/platform_bcm2712.c
+++ b/arch/aarch64-native/kernel/platform_bcm2712.c
@@ -337,7 +337,7 @@ static IPTR bcm2712_probe(struct ARM_Implementation *krnARMImpl, struct TagItem 
     krnARMImpl->ARMI_Family = 8;
     // TODO: Remove
     krnARMImpl->ARMI_Platform = 0x2712;
-    krnARMImpl->ARMI_PeripheralBase = (periibase ? periibase : (APTR)BCM2712_PERIBASE);
+    krnARMImpl->ARMI_PeripheralBase = (APTR)(periibase ? periibase : BCM2712_PERIBASE);
     krnARMImpl->ARMI_InitCore = &bcm27xx_init_cpu;
     krnARMImpl->ARMI_FIQProcess = &bcm27xx_fiq_process;
     krnARMImpl->ARMI_SendIPI = &bcm27xx_send_ipi;

--- a/arch/arm-native/soc/broadcom/2712/hidd/i2c-dw/i2c_dw.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/i2c-dw/i2c_dw.c
@@ -11,6 +11,8 @@
 #include <proto/kernel.h>
 #include <hidd/i2c.h>
 
+#include "rp1.h"
+
 #include "i2c_dw.h"
 
 #include LC_LIBDEFS_FILE
@@ -94,8 +96,7 @@ void METHOD(I2CDW, Hidd_I2C, WriteRead)
 static int I2CDW_Init(LIBBASETYPEPTR LIBBASE)
 {
     IPTR base;
-    struct Library *rp1base;
-    IPTR *fields;
+    struct RP1Base *rp1;
 
     D(bug("[I2C-DW] Init\n"));
 
@@ -109,16 +110,12 @@ static int I2CDW_Init(LIBBASETYPEPTR LIBBASE)
         return FALSE;
     }
 
-    rp1base = OpenResource("rp1.resource");
-    if (!rp1base)
+    rp1 = OpenResource("rp1.resource");
+    if (!rp1 || !rp1->rp1_Present)
         return FALSE;
 
-    fields = (IPTR *)((UBYTE *)rp1base + sizeof(struct Library));
-    if (!fields[0])
-        return FALSE;
-
-    /* Use I2C1 (GPIO 2/3 on header) at BAR1 + 0x074000 */
-    base = fields[1] + 0x074000;
+    /* I2C1 is the one on GPIO 2/3 of the header */
+    base = rp1->rp1_I2C1;
     LIBBASE->i2c_RegBase = base;
 
     D(bug("[I2C-DW] DesignWare I2C at 0x%p\n", base));

--- a/arch/arm-native/soc/broadcom/2712/hidd/i2c-dw/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2712/hidd/i2c-dw/mmakefile.src
@@ -2,11 +2,12 @@
 include $(SRCDIR)/config/aros.cfg
 
 USER_LDFLAGS := -static
+USER_INCLUDES := -I$(SRCDIR)/arch/arm-native/soc/broadcom/2712/rp1
 
 #MM- hidd-i2c-dw-bcm2712 : hidd-i2c-dw-bcm2712-module
 
 %build_module mmake=hidd-i2c-dw-bcm2712-module \
-    modname=i2cdw modtype=hidd \
+    modname=i2cdw modtype=hidd conffile=i2c-dw.conf \
     files="i2c_dw"
 
 %common

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
@@ -473,8 +473,8 @@ static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridg
 
     if (first + count > size)
     {
-        D(bug("[PCIBcm2712] MSI-X table holds %u entries, %u wanted\n",
-              (unsigned)size, (unsigned)(first + count)));
+        BRINGUP(bug("[PCIBcm2712] MSI-X table holds %u entries, %u wanted\n",
+                    (unsigned)size, (unsigned)(first + count)));
         return FALSE;
     }
 
@@ -573,8 +573,6 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
     want = GetTagData(tHidd_PCIVector_Max, 1, (struct TagItem *)msg->requirements);
     if (want > bridge->msi_count)
         want = bridge->msi_count;
-    if (want < GetTagData(tHidd_PCIVector_Min, 1, (struct TagItem *)msg->requirements))
-        return FALSE;
 
     OOP_GetAttr(o, aHidd_PCIDevice_Bus, &bus);
     OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
@@ -582,6 +580,18 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
 
     if ((cap = FindCapability(bridge, bus, dev, sub, PCICAP_MSIX)) != 0)
     {
+        /* The device's table caps a run as much as the bridge's block does. */
+        ULONG size = ((PCIE_ReadConfig(bridge, bus, dev, sub, cap) >> 16) & PCIMSIXF_QSIZE) + 1;
+
+        if (want > size)
+            want = size;
+        if (want < GetTagData(tHidd_PCIVector_Min, 1, (struct TagItem *)msg->requirements))
+        {
+            BRINGUP(bug("[PCIBcm2712] %02x:%02x.%x: MSI-X table holds %u entries, fewer than asked\n",
+                        (unsigned)bus, (unsigned)dev, (unsigned)sub, (unsigned)size));
+            return FALSE;
+        }
+
         if ((first = AllocVectors(bridge, want)) < 0)
             return FALSE;
 
@@ -593,6 +603,9 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
     }
     else if ((cap = FindCapability(bridge, bus, dev, sub, PCICAP_MSI)) != 0)
     {
+        if (GetTagData(tHidd_PCIVector_Min, 1, (struct TagItem *)msg->requirements) > 1)
+            return FALSE;
+
         want = 1;
         if ((first = AllocVectors(bridge, 1)) < 0)
             return FALSE;
@@ -604,7 +617,12 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
         }
     }
     else
+    {
+        BRINGUP(bug("[PCIBcm2712] %02x:%02x.%x: neither MSI-X nor MSI capability (status %04x)\n",
+                    (unsigned)bus, (unsigned)dev, (unsigned)sub,
+                    (unsigned)(PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_COMMAND) >> 16)));
         return FALSE;
+    }
 
     data->firstVector = first + 1;
     data->nvectors    = want;

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
@@ -1,12 +1,13 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
 
-    Desc: BCM2712 (Raspberry Pi 5) PCIe Host Bridge OOP Driver Class.
+    Desc: BCM2712 PCIe host bridge OOP driver class. One object per bridge.
 */
 
 #define __OOP_NOATTRBASES__
 
 #include <exec/types.h>
+#include <hidd/hidd.h>
 #include <hidd/pci.h>
 #include <oop/oop.h>
 #include <utility/tagitem.h>
@@ -24,6 +25,7 @@
 #include <hardware/pci.h>
 
 #include "pcie2712.h"
+
 #include <aros/debug.h>
 
 #undef HiddPCIDriverAttrBase
@@ -34,15 +36,33 @@
 #define HiddPCIDeviceAttrBase (PSD(cl)->hiddPCIDeviceAB)
 #define HiddAttrBase          (PSD(cl)->hiddAB)
 
+static inline uint32_t rd32(volatile uint8_t *regs, uint32_t reg)
+{
+    return *(volatile uint32_t *)(regs + reg);
+}
+
+static inline void wr32(volatile uint8_t *regs, uint32_t reg, uint32_t val)
+{
+    *(volatile uint32_t *)(regs + reg) = val;
+}
+
+/*
+ * The bridge comes in as aHidd_DriverData; PCIE_BridgeSetup() either trains it
+ * or adopts what the firmware left. One that will not come up leaves no object.
+ */
 OOP_Object *PCIBcm2712__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 {
+    const struct pcie_bridge *bridge =
+        (const struct pcie_bridge *)GetTagData(aHidd_DriverData, 0, msg->attrList);
     struct pRoot_New mymsg;
-
     struct TagItem mytags[] = {
-        { aHidd_Name, (IPTR)"PCINative" },
-        { aHidd_HardwareName, (IPTR)"BCM2712 PCIe host bridge (RPi5 NVMe M.2)" },
+        { aHidd_Name,         (IPTR)"PCINative" },
+        { aHidd_HardwareName, (IPTR)(bridge ? bridge->name : "BCM2712 PCIe host bridge") },
         { TAG_DONE, 0 }
     };
+
+    if (!bridge)
+        return NULL;
 
     mymsg.mID = msg->mID;
     mymsg.attrList = (struct TagItem *)&mytags;
@@ -53,9 +73,23 @@ OOP_Object *PCIBcm2712__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New
         mytags[2].ti_Data = (IPTR)msg->attrList;
     }
 
-    msg = &mymsg;
+    o = (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)&mymsg);
+    if (o)
+    {
+        struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
 
-    return (OOP_Object *)OOP_DoSuperMethod(cl, o, (OOP_Msg)msg);
+        data->bridge = bridge;
+
+        if (!PCIE_BridgeSetup(PSD(cl), data))
+        {
+            OOP_MethodID dispose_mid = OOP_GetMethodID(IID_Root, moRoot_Dispose);
+
+            OOP_DoSuperMethod(cl, o, &dispose_mid);
+            return NULL;
+        }
+    }
+
+    return o;
 }
 
 VOID PCIBcm2712__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
@@ -72,169 +106,301 @@ VOID PCIBcm2712__Root__Get(OOP_Class *cl, OOP_Object *o, struct pRoot_Get *msg)
 }
 
 /*
- * ECAM Configuration Space Access:
- * Bus 0 = Root Complex Header (DBI memory mapped or ECAM)
- * Bus 1 = Endpoint (e.g. NVMe SSD attached to M.2 HAT)
+ * The root complex's own configuration header is memory mapped at offset 0
+ * of the register block; everything on the external bus goes through the
+ * indexed window. There is no ECAM on this bridge - the register block is
+ * only 0x9310 bytes, ending just past the index register. The link is a
+ * single point to point lane, so only device 0 exists on the external bus.
  */
-static inline uint32_t ecam_offset(UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg)
+ULONG PCIE_ReadConfig(struct PCIBcm2712Data *data, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg)
 {
-    return (((uint32_t)bus << 20) | ((uint32_t)dev << 15) | ((uint32_t)sub << 12) | (reg & 0xFFF));
-}
+    ULONG val = 0xffffffff;
 
-static ULONG ReadConfigLong(struct pci_staticdata *psd, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg)
-{
-    if (!psd->link_up && bus > 0)
-        return 0xFFFFFFFF;
-
-    /* Bus 0 (RC) or Bus 1 (Endpoint) via ECAM window */
-    if (psd->ecam)
+    if (bus == 0)
     {
-        uint32_t off = ecam_offset(bus, dev, sub, reg & ~3);
-        if (off < BCM2712_PCIE0_ECAM_SIZE)
-        {
-            volatile uint32_t *p = (volatile uint32_t *)(psd->ecam + off);
-            return AROS_LE2LONG(*p);
-        }
+        if (dev == 0 && sub == 0)
+            val = rd32(data->regs, reg & 0xffc);
+    }
+    else if (dev == 0 && data->link_up)
+    {
+        Disable();
+        wr32(data->regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(bus, dev, sub));
+        val = rd32(data->regs, PCIE_EXT_CFG_DATA + (reg & 0xffc));
+        Enable();
+
+        /*
+         * Nothing ever wrote the endpoint's interrupt line field, so report
+         * where the bridge actually raises INTx instead.
+         */
+        if ((reg & 0xffc) == PCI_INTLINE && data->intx_irq && val != 0xffffffff)
+            val = (val & ~0xffUL) | data->intx_irq;
     }
 
-    /* Fallback via DBI index window */
-    if (psd->regs)
-    {
-        volatile uint32_t *rc = (volatile uint32_t *)psd->regs;
-        rc[PCIE2712_EXT_CFG_INDEX / 4] = AROS_LONG2LE(((uint32_t)bus << 20) | ((uint32_t)dev << 15) | ((uint32_t)sub << 12));
-        volatile uint32_t *data = (volatile uint32_t *)(psd->regs + PCIE2712_EXT_CFG_DATA + (reg & 0xFFC));
-        return AROS_LE2LONG(*data);
-    }
-
-    return 0xFFFFFFFF;
+    return val;
 }
 
-static void WriteConfigLong(struct pci_staticdata *psd, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg, ULONG val)
+/*
+ * An adopted bridge's endpoint is placed by the firmware and not ours to
+ * move: on the x4 link RP1's peripheral window holds the debug console.
+ * BAR sizing writes all ones and reads back, and for that long the window
+ * stops decoding - a bug() in between hits nothing and SErrors. So base
+ * registers and the expansion ROM base are read only here. Addresses still
+ * read correctly; aHidd_PCIDevice_SizeN does not, and nothing uses it.
+ */
+static BOOL ConfigWriteAllowed(struct PCIBcm2712Data *data, UWORD reg)
 {
-    if (!psd->link_up && bus > 0)
-        return;
+    if (data->trained)
+        return TRUE;
 
-    if (psd->ecam)
+    reg &= 0xffc;
+
+    if ((reg >= PCI_BAR0) && (reg < PCI_BAR0 + 6 * 4))
+        return FALSE;
+    if (reg == PCI_ROMBASE)
+        return FALSE;
+
+    return TRUE;
+}
+
+void PCIE_WriteConfig(struct PCIBcm2712Data *data, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg, ULONG val)
+{
+    if (bus == 0)
     {
-        uint32_t off = ecam_offset(bus, dev, sub, reg & ~3);
-        if (off < BCM2712_PCIE0_ECAM_SIZE)
+        if (dev == 0 && sub == 0)
+            wr32(data->regs, reg & 0xffc, val);
+    }
+    else if (dev == 0 && data->link_up)
+    {
+        if (!ConfigWriteAllowed(data, reg))
         {
-            volatile uint32_t *p = (volatile uint32_t *)(psd->ecam + off);
-            *p = AROS_LONG2LE(val);
+            D(bug("[PCIBcm2712] %s: refusing a write to %02x on an adopted bridge\n",
+                  data->bridge->node, reg & 0xffc));
             return;
         }
-    }
 
-    if (psd->regs)
-    {
-        volatile uint32_t *rc = (volatile uint32_t *)psd->regs;
-        rc[PCIE2712_EXT_CFG_INDEX / 4] = AROS_LONG2LE(((uint32_t)bus << 20) | ((uint32_t)dev << 15) | ((uint32_t)sub << 12));
-        volatile uint32_t *data = (volatile uint32_t *)(psd->regs + PCIE2712_EXT_CFG_DATA + (reg & 0xFFC));
-        *data = AROS_LONG2LE(val);
+        Disable();
+        wr32(data->regs, PCIE_EXT_CFG_INDEX, EXT_CFG_ADDR(bus, dev, sub));
+        wr32(data->regs, PCIE_EXT_CFG_DATA + (reg & 0xffc), val);
+        Enable();
     }
 }
 
-UBYTE PCIBcm2712__Hidd_PCIDriver__ReadConfigByte(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_ReadConfigByte *msg)
+ULONG PCIBcm2712__Hidd_PCIDriver__ReadConfigLong(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigLong *msg)
 {
-    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
-    return (UBYTE)(val >> ((msg->reg & 3) * 8));
+    return PCIE_ReadConfig(OOP_INST_DATA(cl, o), msg->bus, msg->dev, msg->sub, msg->reg);
 }
 
-UWORD PCIBcm2712__Hidd_PCIDriver__ReadConfigWord(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_ReadConfigWord *msg)
+UWORD PCIBcm2712__Hidd_PCIDriver__ReadConfigWord(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigWord *msg)
 {
-    ULONG val = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
+    ULONG val = PCIE_ReadConfig(OOP_INST_DATA(cl, o), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
+
     return (UWORD)(val >> ((msg->reg & 2) * 8));
 }
 
-ULONG PCIBcm2712__Hidd_PCIDriver__ReadConfigLong(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_ReadConfigLong *msg)
+UBYTE PCIBcm2712__Hidd_PCIDriver__ReadConfigByte(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_ReadConfigByte *msg)
 {
-    return ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg);
+    ULONG val = PCIE_ReadConfig(OOP_INST_DATA(cl, o), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
+
+    return (UBYTE)(val >> ((msg->reg & 3) * 8));
 }
 
-VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigByte(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_WriteConfigByte *msg)
+VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigLong(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigLong *msg)
 {
-    ULONG shift = (msg->reg & 3) * 8;
-    ULONG mask  = ~(0xFFUL << shift);
-    ULONG val   = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
-
-    val = (val & mask) | ((ULONG)msg->val << shift);
-    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3, val);
+    PCIE_WriteConfig(OOP_INST_DATA(cl, o), msg->bus, msg->dev, msg->sub, msg->reg, msg->val);
 }
 
-VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigWord(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_WriteConfigWord *msg)
+VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigWord(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigWord *msg)
 {
+    struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
     ULONG shift = (msg->reg & 2) * 8;
     ULONG mask  = ~(0xFFFFUL << shift);
-    ULONG val   = ReadConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3);
+    ULONG val   = PCIE_ReadConfig(data, msg->bus, msg->dev, msg->sub, msg->reg & ~3);
 
     val = (val & mask) | ((ULONG)msg->val << shift);
-    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg & ~3, val);
+    PCIE_WriteConfig(data, msg->bus, msg->dev, msg->sub, msg->reg & ~3, val);
 }
 
-VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigLong(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_WriteConfigLong *msg)
+VOID PCIBcm2712__Hidd_PCIDriver__WriteConfigByte(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_WriteConfigByte *msg)
 {
-    WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg, msg->val);
+    struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
+    ULONG shift = (msg->reg & 3) * 8;
+    ULONG mask  = ~(0xFFUL << shift);
+    ULONG val   = PCIE_ReadConfig(data, msg->bus, msg->dev, msg->sub, msg->reg & ~3);
+
+    val = (val & mask) | ((ULONG)msg->val << shift);
+    PCIE_WriteConfig(data, msg->bus, msg->dev, msg->sub, msg->reg & ~3, val);
 }
 
 /*
- * Map PCI Memory (BARs) into CPU virtual address space.
+ * A BAR holds a PCI bus address; the CPU reaches it through whichever
+ * outbound window covers it. Nothing maps these windows for us, so the
+ * mapping is made here rather than assumed.
  */
-APTR PCIBcm2712__Hidd_PCIDriver__MapPCI(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_MapPCI *msg)
+APTR PCIBcm2712__Hidd_PCIDriver__MapPCI(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_MapPCI *msg)
 {
-    IPTR pci_addr = (IPTR)msg->PCIAddress;
-    IPTR cpu_addr;
+    struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
+    uint64_t addr = (uint64_t)(IPTR)msg->PCIAddress;
+    uint32_t i;
 
-    /* Outbound memory window translation */
-    if (pci_addr >= BCM2712_PCIE_PCI_WIN &&
-        pci_addr < (BCM2712_PCIE_PCI_WIN + BCM2712_PCIE_WIN_SIZE))
+    for (i = 0; i < data->nranges; i++)
     {
-        cpu_addr = (pci_addr - BCM2712_PCIE_PCI_WIN) + BCM2712_PCIE_CPU_WIN;
-    }
-    else
-    {
-        cpu_addr = pci_addr;
+        uint64_t pci_base = data->ranges[i].pci_base;
+
+        if (addr >= pci_base && (addr - pci_base) < data->ranges[i].size)
+        {
+            IPTR cpu = (IPTR)(addr - pci_base + data->ranges[i].cpu_base);
+
+            if (!KrnMapGlobal((void *)cpu, (void *)cpu, msg->Length,
+                              MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
+                return NULL;
+
+            return (APTR)cpu;
+        }
     }
 
-    /* Identity map as Device memory; the pointer is the CPU address. */
-    if (!KrnMapGlobal((void *)cpu_addr, (void *)cpu_addr, msg->Length,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
+    D(bug("[PCIBcm2712] MapPCI: %p is outside every outbound window\n", msg->PCIAddress));
+    return NULL;
+}
+
+/*
+ * What a bus master must be given to reach a system address, and back.
+ * Each dma-range carries its own offset, so this is a lookup rather than
+ * one global displacement: on this bridge the memory window and the MSI
+ * doorbell sit at unrelated bus addresses.
+ */
+IPTR PCIBcm2712__Hidd_PCIDriver__CPUtoPCI(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_CPUtoPCI *msg)
+{
+    struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
+    uint64_t addr = (uint64_t)(IPTR)msg->address;
+    uint32_t i;
+
+    for (i = 0; i < data->ndmaranges; i++)
+    {
+        uint64_t cpu_base = data->dmaranges[i].cpu_base;
+
+        if (addr >= cpu_base && (addr - cpu_base) < data->dmaranges[i].size)
+            return (IPTR)(addr - cpu_base + data->dmaranges[i].pci_base);
+    }
+
+    D(bug("[PCIBcm2712] CPUtoPCI: %p is outside every inbound window\n", msg->address));
+    return (IPTR)msg->address;
+}
+
+APTR PCIBcm2712__Hidd_PCIDriver__PCItoCPU(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_PCItoCPU *msg)
+{
+    struct PCIBcm2712Data *data = OOP_INST_DATA(cl, o);
+    uint64_t addr = (uint64_t)(IPTR)msg->address;
+    uint32_t i;
+
+    for (i = 0; i < data->ndmaranges; i++)
+    {
+        uint64_t pci_base = data->dmaranges[i].pci_base;
+
+        if (addr >= pci_base && (addr - pci_base) < data->dmaranges[i].size)
+            return (APTR)(IPTR)(addr - pci_base + data->dmaranges[i].cpu_base);
+    }
+
+    return msg->address;
+}
+
+/*
+ * Descriptor memory a bus master shares with us. The PCIe masters on this
+ * SoC are not cache coherent, and a ring the controller writes while the
+ * CPU reads it cannot be made to work with cache maintenance alone, so the
+ * memory is mapped Normal Non-Cacheable for as long as we hold it. The
+ * attribute belongs to whole pages, so whole pages are allocated. FreePCIMem()
+ * gets only an address, so the raw pointer and length sit in the two words
+ * ahead of the one returned - hence the page of slack.
+ */
+#define PCIMEM_PAGE     4096
+#define PCIMEM_ROUND(x) (((x) + PCIMEM_PAGE - 1) & ~(uintptr_t)(PCIMEM_PAGE - 1))
+
+APTR PCIBcm2712__Hidd_PCIDriver__AllocPCIMem(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_AllocPCIMem *msg)
+{
+    uintptr_t mapped = PCIMEM_ROUND(msg->Size);
+    APTR raw, addr;
+
+    if (!msg->Size)
         return NULL;
 
-    return (APTR)cpu_addr;
+    raw = AllocMem(mapped + PCIMEM_PAGE, MEMF_PUBLIC | MEMF_CLEAR);
+    if (!raw)
+        return NULL;
+
+    addr = (APTR)PCIMEM_ROUND((uintptr_t)raw + 2 * sizeof(APTR));
+    ((APTR *)addr)[-1] = raw;
+    ((APTR *)addr)[-2] = (APTR)mapped;
+
+    /*
+     * Write the pages back before they stop being cacheable: a dirty line
+     * left behind would land in memory later, on top of whatever the
+     * controller had put there.
+     */
+    CacheClearE(addr, mapped, CACRF_ClearD);
+
+    if (!KrnMapGlobal(addr, KrnVirtualToPhysical(addr), mapped,
+                      MAP_Readable | MAP_Writable | MAP_WriteThrough))
+    {
+        bug("[PCIBcm2712] could not map %u bytes uncached\n", (unsigned)mapped);
+        FreeMem(raw, mapped + PCIMEM_PAGE);
+        return NULL;
+    }
+
+    D(bug("[PCIBcm2712] AllocPCIMem(%u) = %p (%u bytes uncached)\n",
+          (unsigned)msg->Size, addr, (unsigned)mapped));
+
+    return addr;
 }
 
-IPTR PCIBcm2712__Hidd_PCIDriver__CPUtoPCI(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_CPUtoPCI *msg)
+VOID PCIBcm2712__Hidd_PCIDriver__FreePCIMem(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDriver_FreePCIMem *msg)
 {
-    return (IPTR)msg->address + PSD(cl)->dma_offset;
-}
+    APTR addr = msg->Address;
+    APTR raw;
+    uintptr_t mapped;
 
-APTR PCIBcm2712__Hidd_PCIDriver__PCItoCPU(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_PCItoCPU *msg)
-{
-    return (APTR)((IPTR)msg->address - PSD(cl)->dma_offset);
-}
+    if (!addr)
+        return;
 
-IPTR PCIBcm2712__Hidd_PCIDriver__AllocPCIMem(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_AllocPCIMem *msg)
-{
-    return 0;
-}
+    raw    = ((APTR *)addr)[-1];
+    mapped = (uintptr_t)((APTR *)addr)[-2];
 
-VOID PCIBcm2712__Hidd_PCIDriver__FreePCIMem(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_FreePCIMem *msg)
-{
+    /* Cacheable again before it goes back, or the next owner gets
+       uncached memory without having asked for it. */
+    KrnMapGlobal(addr, KrnVirtualToPhysical(addr), mapped,
+                 MAP_Readable | MAP_Writable);
+
+    FreeMem(raw, mapped + PCIMEM_PAGE);
 }
 
 /*
- * Device Subclass MSI/Interrupt Handling
+ * Message signalled interrupts are delivered by a separate MIP block on
+ * this SoC, which is not driven yet. Until it is, a device asking for
+ * vectors is told there are none and falls back to its INTx path.
  */
-ULONG PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_ObtainVectors *msg)
+ULONG PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_ObtainVectors *msg)
 {
     return 0;
 }
 
-VOID PCIBcm2712Dev__Hidd_PCIDevice__ReleaseVectors(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_ReleaseVectors *msg)
+VOID PCIBcm2712Dev__Hidd_PCIDevice__ReleaseVectors(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_ReleaseVectors *msg)
 {
 }
 
-ULONG PCIBcm2712Dev__Hidd_PCIDevice__GetVectorAttribs(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDevice_GetVectorAttribs *msg)
+ULONG PCIBcm2712Dev__Hidd_PCIDevice__GetVectorAttribs(OOP_Class *cl, OOP_Object *o,
+    struct pHidd_PCIDevice_GetVectorAttribs *msg)
 {
     return 0;
 }

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
@@ -132,7 +132,7 @@ ULONG PCIE_ReadConfig(struct PCIBcm2712Data *data, UBYTE bus, UBYTE dev, UBYTE s
          * Nothing ever wrote the endpoint's interrupt line field, so report
          * where the bridge actually raises INTx instead.
          */
-        if ((reg & 0xffc) == PCI_INTLINE && data->intx_irq && val != 0xffffffff)
+        if ((reg & 0xffc) == PCICS_INT_LINE && data->intx_irq && val != 0xffffffff)
             val = (val & ~0xffUL) | data->intx_irq;
     }
 
@@ -154,9 +154,9 @@ static BOOL ConfigWriteAllowed(struct PCIBcm2712Data *data, UWORD reg)
 
     reg &= 0xffc;
 
-    if ((reg >= PCI_BAR0) && (reg < PCI_BAR0 + 6 * 4))
+    if ((reg >= PCICS_BAR0) && (reg < PCICS_BAR0 + 6 * 4))
         return FALSE;
-    if (reg == PCI_ROMBASE)
+    if (reg == PCICS_EXPROM_BASE)
         return FALSE;
 
     return TRUE;
@@ -407,10 +407,10 @@ static ULONG FindCapability(struct PCIBcm2712Data *bridge, UBYTE bus, UBYTE dev,
 {
     ULONG cap, guard;
 
-    if (!((PCIE_ReadConfig(bridge, bus, dev, sub, PCI_CMD) >> 16) & PCISTF_CAPABILITIES))
+    if (!((PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_COMMAND) >> 16) & PCISTF_CAPABILITIES))
         return 0;
 
-    cap = PCIE_ReadConfig(bridge, bus, dev, sub, PCI_CAP_PTR) & 0xfc;
+    cap = PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_CAP_PTR) & 0xfc;
 
     for (guard = 48; cap && guard; guard--)
     {
@@ -425,23 +425,26 @@ static ULONG FindCapability(struct PCIBcm2712Data *bridge, UBYTE bus, UBYTE dev,
     return 0;
 }
 
+/* One bit per message in a run; count may be the whole block. */
+static uint64_t VectorMask(ULONG first, ULONG count)
+{
+    uint64_t bits = (count >= 64) ? ~0ULL : ((1ULL << count) - 1);
+
+    return bits << first;
+}
+
 /* Reserve a run of messages, returning the first or -1. */
 static LONG AllocVectors(struct PCIBcm2712Data *bridge, ULONG count)
 {
-    ULONG first, i;
+    ULONG first;
 
     for (first = 0; first + count <= bridge->msi_count; first++)
     {
-        for (i = 0; i < count; i++)
-        {
-            if (bridge->msi_used & (1UL << (first + i)))
-                break;
-        }
+        uint64_t mask = VectorMask(first, count);
 
-        if (i == count)
+        if (!(bridge->msi_used & mask))
         {
-            for (i = 0; i < count; i++)
-                bridge->msi_used |= (1UL << (first + i));
+            bridge->msi_used |= mask;
             return (LONG)first;
         }
     }
@@ -460,10 +463,10 @@ static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridg
                       ULONG first, ULONG count)
 {
     struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
-    ULONG tbl = PCIE_ReadConfig(bridge, bus, dev, sub, cap + PCI_MSIX_TABLE);
+    ULONG tbl = PCIE_ReadConfig(bridge, bus, dev, sub, cap + PCIMSIX_TABLE);
     ULONG ctrl = PCIE_ReadConfig(bridge, bus, dev, sub, cap);
-    ULONG bir = tbl & PCI_MSIX_TABLE_BIR_MASK;
-    ULONG size = ((ctrl & PCI_MSIX_CTRL_SIZE_MASK) >> 16) + 1;
+    ULONG bir = tbl & PCIMSIXF_BIRMASK;
+    ULONG size = (((ctrl >> 16) & PCIMSIXF_QSIZE) + 1);
     uint64_t bar;
     volatile uint32_t *table;
     ULONG i;
@@ -475,9 +478,9 @@ static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridg
         return FALSE;
     }
 
-    bar = PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4) & ~0xfUL;
-    if ((PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4) & 0x06) == 0x04)
-        bar |= (uint64_t)PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4 + 4) << 32;
+    bar = PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_BAR0 + bir * 4) & ~0xfUL;
+    if ((PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_BAR0 + bir * 4) & 0x06) == 0x04)
+        bar |= (uint64_t)PCIE_ReadConfig(bridge, bus, dev, sub, PCICS_BAR0 + bir * 4 + 4) << 32;
 
     if (!bar)
         return FALSE;
@@ -486,8 +489,8 @@ static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridg
     {
         struct pHidd_PCIDriver_MapPCI mapmsg = {
             .mID        = OOP_GetMethodID(IID_Hidd_PCIDriver, moHidd_PCIDriver_MapPCI),
-            .PCIAddress = (APTR)(IPTR)(bar + (tbl & PCI_MSIX_TABLE_OFF_MASK)),
-            .Length     = (first + count) * PCI_MSIX_ENTRY_SIZE,
+            .PCIAddress = (APTR)(IPTR)(bar + (tbl & ~(ULONG)PCIMSIXF_BIRMASK)),
+            .Length     = (first + count) * PCIMSIX_ENTRY_SIZE,
         };
         IPTR drv = 0;
 
@@ -508,7 +511,8 @@ static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridg
         e[3] = 0;                       /* unmasked */
     }
 
-    PCIE_WriteConfig(bridge, bus, dev, sub, cap, ctrl | PCI_MSIX_CTRL_ENABLE);
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap,
+                     (ctrl & 0xffff) | ((ULONG)(((ctrl >> 16) | PCIMSIXF_ENABLE)) << 16));
 
     data->msix = TRUE;
     return TRUE;
@@ -525,24 +529,27 @@ static BOOL SetupMSI(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridge
 {
     struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
     ULONG head = PCIE_ReadConfig(bridge, bus, dev, sub, cap);
-    ULONG datareg = (head & PCI_MSI_CTRL_64BIT) ? PCI_MSI_DATA64 : PCI_MSI_DATA32;
+    UWORD ctrl = (UWORD)(head >> 16);
+    ULONG datareg = (ctrl & PCIMSIF_64BIT) ? PCIMSI_DATA64 : PCIMSI_DATA32;
 
-    if (!(head & PCI_MSI_CTRL_64BIT) && (bridge->msi_target >> 32))
+    if (!(ctrl & PCIMSIF_64BIT) && (bridge->msi_target >> 32))
     {
         D(bug("[PCIBcm2712] the doorbell is above 4GB and this function is 32 bit only\n"));
         return FALSE;
     }
 
-    PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCI_MSI_ADDRESSLO,
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCIMSI_ADDRESSLO,
                      (ULONG)bridge->msi_target);
-    if (head & PCI_MSI_CTRL_64BIT)
-        PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCI_MSI_ADDRESSHI,
+    if (ctrl & PCIMSIF_64BIT)
+        PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCIMSI_ADDRESSHI,
                          (ULONG)(bridge->msi_target >> 32));
     PCIE_WriteConfig(bridge, bus, dev, sub, cap + datareg, first);
 
     /* One message, enabled. */
-    head &= ~PCI_MSI_CTRL_MME_MASK;
-    PCIE_WriteConfig(bridge, bus, dev, sub, cap, head | PCI_MSI_CTRL_ENABLE);
+    /* One message, enabled: 6:4 is ours to set, 3:1 is read only. */
+    ctrl = (ctrl & ~PCIMSIF_MMEN_MASK) | PCIMSIF_ENABLE;
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap,
+                     (head & 0xffff) | ((ULONG)ctrl << 16));
 
     data->msix = FALSE;
     return TRUE;
@@ -573,18 +580,18 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
     OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
     OOP_GetAttr(o, aHidd_PCIDevice_Sub, &sub);
 
-    if ((cap = FindCapability(bridge, bus, dev, sub, PCI_CAP_ID_MSIX)) != 0)
+    if ((cap = FindCapability(bridge, bus, dev, sub, PCICAP_MSIX)) != 0)
     {
         if ((first = AllocVectors(bridge, want)) < 0)
             return FALSE;
 
         if (!SetupMSIX(cl, o, bridge, bus, dev, sub, cap, first, want))
         {
-            bridge->msi_used &= ~(((1UL << want) - 1) << first);
+            bridge->msi_used &= ~VectorMask(first, want);
             return FALSE;
         }
     }
-    else if ((cap = FindCapability(bridge, bus, dev, sub, PCI_CAP_ID_MSI)) != 0)
+    else if ((cap = FindCapability(bridge, bus, dev, sub, PCICAP_MSI)) != 0)
     {
         want = 1;
         if ((first = AllocVectors(bridge, 1)) < 0)
@@ -592,7 +599,7 @@ BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
 
         if (!SetupMSI(cl, o, bridge, bus, dev, sub, cap, first))
         {
-            bridge->msi_used &= ~(1UL << first);
+            bridge->msi_used &= ~VectorMask(first, 1);
             return FALSE;
         }
     }
@@ -630,13 +637,13 @@ VOID PCIBcm2712Dev__Hidd_PCIDevice__ReleaseVectors(OOP_Class *cl, OOP_Object *o,
     if (data->msix)
         PCIE_WriteConfig(bridge, bus, dev, sub, data->cap,
                          PCIE_ReadConfig(bridge, bus, dev, sub, data->cap) &
-                         ~PCI_MSIX_CTRL_ENABLE);
+                         ~((ULONG)PCIMSIXF_ENABLE << 16));
     else
         PCIE_WriteConfig(bridge, bus, dev, sub, data->cap,
                          PCIE_ReadConfig(bridge, bus, dev, sub, data->cap) &
-                         ~PCI_MSI_CTRL_ENABLE);
+                         ~((ULONG)PCIMSIF_ENABLE << 16));
 
-    bridge->msi_used &= ~(((1UL << data->nvectors) - 1) << first);
+    bridge->msi_used &= ~VectorMask(first, data->nvectors);
     data->firstVector = 0;
     data->nvectors = 0;
 }

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/driverclass.c
@@ -384,23 +384,283 @@ VOID PCIBcm2712__Hidd_PCIDriver__FreePCIMem(OOP_Class *cl, OOP_Object *o,
 }
 
 /*
- * Message signalled interrupts are delivered by a separate MIP block on
- * this SoC, which is not driven yet. Until it is, a device asking for
- * vectors is told there are none and falls back to its INTx path.
+ * Message signalled interrupts. The bridge's MSI block raises a distinct
+ * GIC SPI per message, so a device that signals by message gets an
+ * interrupt of its own - no line shared with anything, and edge triggered
+ * rather than level, which is what the block emits.
  */
-ULONG PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
+
+/* The bridge this device hangs off, and its per bridge state. */
+static struct PCIBcm2712Data *BridgeOf(OOP_Class *cl, OOP_Object *o)
+{
+    IPTR drv = 0;
+
+    OOP_GetAttr(o, aHidd_PCIDevice_Driver, &drv);
+    if (!drv)
+        return NULL;
+
+    return OOP_INST_DATA(PSD(cl)->driverClass, (OOP_Object *)drv);
+}
+
+static ULONG FindCapability(struct PCIBcm2712Data *bridge, UBYTE bus, UBYTE dev,
+                            UBYTE sub, UBYTE want)
+{
+    ULONG cap, guard;
+
+    if (!((PCIE_ReadConfig(bridge, bus, dev, sub, PCI_CMD) >> 16) & PCISTF_CAPABILITIES))
+        return 0;
+
+    cap = PCIE_ReadConfig(bridge, bus, dev, sub, PCI_CAP_PTR) & 0xfc;
+
+    for (guard = 48; cap && guard; guard--)
+    {
+        ULONG head = PCIE_ReadConfig(bridge, bus, dev, sub, cap);
+
+        if ((head & 0xff) == want)
+            return cap;
+
+        cap = (head >> 8) & 0xfc;
+    }
+
+    return 0;
+}
+
+/* Reserve a run of messages, returning the first or -1. */
+static LONG AllocVectors(struct PCIBcm2712Data *bridge, ULONG count)
+{
+    ULONG first, i;
+
+    for (first = 0; first + count <= bridge->msi_count; first++)
+    {
+        for (i = 0; i < count; i++)
+        {
+            if (bridge->msi_used & (1UL << (first + i)))
+                break;
+        }
+
+        if (i == count)
+        {
+            for (i = 0; i < count; i++)
+                bridge->msi_used |= (1UL << (first + i));
+            return (LONG)first;
+        }
+    }
+
+    return -1;
+}
+
+/*
+ * MSI-X carries an address and a data word per message, in a table inside
+ * one of the device's own BARs, so every message can name a different
+ * number. That is what lets a driver put each of its queues on its own
+ * interrupt.
+ */
+static BOOL SetupMSIX(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridge,
+                      UBYTE bus, UBYTE dev, UBYTE sub, ULONG cap,
+                      ULONG first, ULONG count)
+{
+    struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
+    ULONG tbl = PCIE_ReadConfig(bridge, bus, dev, sub, cap + PCI_MSIX_TABLE);
+    ULONG ctrl = PCIE_ReadConfig(bridge, bus, dev, sub, cap);
+    ULONG bir = tbl & PCI_MSIX_TABLE_BIR_MASK;
+    ULONG size = ((ctrl & PCI_MSIX_CTRL_SIZE_MASK) >> 16) + 1;
+    uint64_t bar;
+    volatile uint32_t *table;
+    ULONG i;
+
+    if (first + count > size)
+    {
+        D(bug("[PCIBcm2712] MSI-X table holds %u entries, %u wanted\n",
+              (unsigned)size, (unsigned)(first + count)));
+        return FALSE;
+    }
+
+    bar = PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4) & ~0xfUL;
+    if ((PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4) & 0x06) == 0x04)
+        bar |= (uint64_t)PCIE_ReadConfig(bridge, bus, dev, sub, PCI_BAR0 + bir * 4 + 4) << 32;
+
+    if (!bar)
+        return FALSE;
+
+    /* The table is in PCI space; reach it the way any BAR is reached. */
+    {
+        struct pHidd_PCIDriver_MapPCI mapmsg = {
+            .mID        = OOP_GetMethodID(IID_Hidd_PCIDriver, moHidd_PCIDriver_MapPCI),
+            .PCIAddress = (APTR)(IPTR)(bar + (tbl & PCI_MSIX_TABLE_OFF_MASK)),
+            .Length     = (first + count) * PCI_MSIX_ENTRY_SIZE,
+        };
+        IPTR drv = 0;
+
+        OOP_GetAttr(o, aHidd_PCIDevice_Driver, &drv);
+        table = (volatile uint32_t *)OOP_DoMethod((OOP_Object *)drv, (OOP_Msg)&mapmsg);
+    }
+
+    if (!table)
+        return FALSE;
+
+    for (i = 0; i < count; i++)
+    {
+        volatile uint32_t *e = &table[(first + i) * 4];
+
+        e[0] = (uint32_t)bridge->msi_target;
+        e[1] = (uint32_t)(bridge->msi_target >> 32);
+        e[2] = first + i;               /* the message number is the data */
+        e[3] = 0;                       /* unmasked */
+    }
+
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap, ctrl | PCI_MSIX_CTRL_ENABLE);
+
+    data->msix = TRUE;
+    return TRUE;
+}
+
+/*
+ * Plain MSI has one address and one data word for the whole device, and the
+ * messages it may send are that word with the low bits varied - so a run has
+ * to be aligned on its own size, and only one bridge message can be aimed
+ * at precisely. A single vector is the useful case.
+ */
+static BOOL SetupMSI(OOP_Class *cl, OOP_Object *o, struct PCIBcm2712Data *bridge,
+                     UBYTE bus, UBYTE dev, UBYTE sub, ULONG cap, ULONG first)
+{
+    struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
+    ULONG head = PCIE_ReadConfig(bridge, bus, dev, sub, cap);
+    ULONG datareg = (head & PCI_MSI_CTRL_64BIT) ? PCI_MSI_DATA64 : PCI_MSI_DATA32;
+
+    if (!(head & PCI_MSI_CTRL_64BIT) && (bridge->msi_target >> 32))
+    {
+        D(bug("[PCIBcm2712] the doorbell is above 4GB and this function is 32 bit only\n"));
+        return FALSE;
+    }
+
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCI_MSI_ADDRESSLO,
+                     (ULONG)bridge->msi_target);
+    if (head & PCI_MSI_CTRL_64BIT)
+        PCIE_WriteConfig(bridge, bus, dev, sub, cap + PCI_MSI_ADDRESSHI,
+                         (ULONG)(bridge->msi_target >> 32));
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap + datareg, first);
+
+    /* One message, enabled. */
+    head &= ~PCI_MSI_CTRL_MME_MASK;
+    PCIE_WriteConfig(bridge, bus, dev, sub, cap, head | PCI_MSI_CTRL_ENABLE);
+
+    data->msix = FALSE;
+    return TRUE;
+}
+
+BOOL PCIBcm2712Dev__Hidd_PCIDevice__ObtainVectors(OOP_Class *cl, OOP_Object *o,
     struct pHidd_PCIDevice_ObtainVectors *msg)
 {
-    return 0;
+    struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
+    struct PCIBcm2712Data *bridge = BridgeOf(cl, o);
+    IPTR bus = 0, dev = 0, sub = 0;
+    ULONG want, cap;
+    LONG first;
+
+    if (!bridge || !bridge->msi_count)
+        return FALSE;
+
+    if (data->firstVector)
+        return TRUE;            /* already ours */
+
+    want = GetTagData(tHidd_PCIVector_Max, 1, (struct TagItem *)msg->requirements);
+    if (want > bridge->msi_count)
+        want = bridge->msi_count;
+    if (want < GetTagData(tHidd_PCIVector_Min, 1, (struct TagItem *)msg->requirements))
+        return FALSE;
+
+    OOP_GetAttr(o, aHidd_PCIDevice_Bus, &bus);
+    OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
+    OOP_GetAttr(o, aHidd_PCIDevice_Sub, &sub);
+
+    if ((cap = FindCapability(bridge, bus, dev, sub, PCI_CAP_ID_MSIX)) != 0)
+    {
+        if ((first = AllocVectors(bridge, want)) < 0)
+            return FALSE;
+
+        if (!SetupMSIX(cl, o, bridge, bus, dev, sub, cap, first, want))
+        {
+            bridge->msi_used &= ~(((1UL << want) - 1) << first);
+            return FALSE;
+        }
+    }
+    else if ((cap = FindCapability(bridge, bus, dev, sub, PCI_CAP_ID_MSI)) != 0)
+    {
+        want = 1;
+        if ((first = AllocVectors(bridge, 1)) < 0)
+            return FALSE;
+
+        if (!SetupMSI(cl, o, bridge, bus, dev, sub, cap, first))
+        {
+            bridge->msi_used &= ~(1UL << first);
+            return FALSE;
+        }
+    }
+    else
+        return FALSE;
+
+    data->firstVector = first + 1;
+    data->nvectors    = want;
+    data->cap         = cap;
+
+    bug("[PCIBcm2712] %02x:%02x.%x signals by message: %u vector(s) from %u -> INTID %u\n",
+        (unsigned)bus, (unsigned)dev, (unsigned)sub, (unsigned)want, (unsigned)first,
+        (unsigned)(bridge->msi_first_intid + first));
+
+    return TRUE;
 }
 
 VOID PCIBcm2712Dev__Hidd_PCIDevice__ReleaseVectors(OOP_Class *cl, OOP_Object *o,
     struct pHidd_PCIDevice_ReleaseVectors *msg)
 {
+    struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
+    struct PCIBcm2712Data *bridge = BridgeOf(cl, o);
+    IPTR bus = 0, dev = 0, sub = 0;
+    ULONG first;
+
+    if (!bridge || !data->firstVector)
+        return;
+
+    first = data->firstVector - 1;
+
+    OOP_GetAttr(o, aHidd_PCIDevice_Bus, &bus);
+    OOP_GetAttr(o, aHidd_PCIDevice_Dev, &dev);
+    OOP_GetAttr(o, aHidd_PCIDevice_Sub, &sub);
+
+    if (data->msix)
+        PCIE_WriteConfig(bridge, bus, dev, sub, data->cap,
+                         PCIE_ReadConfig(bridge, bus, dev, sub, data->cap) &
+                         ~PCI_MSIX_CTRL_ENABLE);
+    else
+        PCIE_WriteConfig(bridge, bus, dev, sub, data->cap,
+                         PCIE_ReadConfig(bridge, bus, dev, sub, data->cap) &
+                         ~PCI_MSI_CTRL_ENABLE);
+
+    bridge->msi_used &= ~(((1UL << data->nvectors) - 1) << first);
+    data->firstVector = 0;
+    data->nvectors = 0;
 }
 
-ULONG PCIBcm2712Dev__Hidd_PCIDevice__GetVectorAttribs(OOP_Class *cl, OOP_Object *o,
+VOID PCIBcm2712Dev__Hidd_PCIDevice__GetVectorAttribs(OOP_Class *cl, OOP_Object *o,
     struct pHidd_PCIDevice_GetVectorAttribs *msg)
 {
-    return 0;
+    struct PCIBcm2712DevData *data = OOP_INST_DATA(cl, o);
+    struct PCIBcm2712Data *bridge = BridgeOf(cl, o);
+    struct TagItem *tag, *tstate = msg->attribs;
+    BOOL have = bridge && data->firstVector && (msg->vectorno < data->nvectors);
+    ULONG vec = have ? (data->firstVector - 1 + msg->vectorno) : 0;
+
+    while ((tag = NextTagItem(&tstate)) != NULL)
+    {
+        switch (tag->ti_Tag)
+        {
+        case tHidd_PCIVector_Native:
+            tag->ti_Data = have ? vec : (IPTR)-1;
+            break;
+
+        case tHidd_PCIVector_Int:
+            tag->ti_Data = have ? (bridge->msi_first_intid + vec) : (IPTR)-1;
+            break;
+        }
+    }
 }

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/mmakefile.src
@@ -2,9 +2,7 @@ include $(SRCDIR)/config/aros.cfg
 
 USER_LDFLAGS := -static
 
-#MM- kernel-pcie-bcm2712 : kernel-pcie-bcm2712-module
-
-%build_module mmake=kernel-pcie-bcm2712-module \
+%build_module mmake=kernel-pcie-bcm2712 \
   modname=pcibcm2712 modtype=hidd \
   files="pcie2712_init driverclass"
 

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcibcm2712.conf
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcibcm2712.conf
@@ -4,6 +4,7 @@ libbasetype struct pcibcm2712base
 version     1.0
 residentpri 87
 classptr_field  psd.driverClass
+classdatatype   struct PCIBcm2712Data
 superclass  CLID_Hidd_PCIDriver
 options     noexpunge
 ##end config

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
@@ -1,8 +1,27 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
 
-    Desc: BCM2712 (Raspberry Pi 5) PCIe Host Bridge Header
-          Supports PCIe RC0 (16-pin M.2 NVMe HAT connector) and PCIe RC1 (RP1).
+    The Broadcom register map and the bring-up sequence below follow OpenBSD's
+    sys/dev/fdt/bcm2711_pcie.c, which drives both brcm,bcm2711-pcie and
+    brcm,bcm2712-pcie. The BCM2712 PCIe block is not covered by any published
+    Broadcom documentation, so that driver is the reference this one is
+    written against:
+
+    Copyright (c) 2020, 2025 Mark Kettenis <kettenis@openbsd.org>
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    Desc: BCM2712 (Raspberry Pi 5 / 500 / 500+) PCIe host bridge.
 */
 
 #ifndef PCIE_BCM2712_H
@@ -16,62 +35,208 @@
 #include LC_LIBDEFS_FILE
 
 /*
- * BCM2712 PCIe host bridge register bases in 40-bit ARM physical space.
- * RC0: External 16-pin FPC connector for M.2 NVMe HATs (Gen 2/3 x1).
- * RC1: Internal RP1 Southbridge connection (Gen 2 x4).
+ * BCM2712 has three host bridges, each a separate root complex with its own
+ * register block, reset bit, windows and MSI block. pcie0 is not brought out
+ * on any board we know of. pcie1 is the x1 link - Pi 5 FPC connector, Pi 500+
+ * M.2 slot - and needs "dtparam=nvme" or its node stays disabled. pcie2 is the
+ * x4 link, hardwired to the RP1 southbridge. One driver object per bridge.
  */
-#define BCM2712_PCIE0_REG_BASE          0x1000100000ULL
-#define BCM2712_PCIE0_REG_SIZE          0x10000
-#define BCM2712_PCIE0_ECAM_BASE         0x1000000000ULL
-#define BCM2712_PCIE0_ECAM_SIZE         0x10000000ULL   /* 256MB standard ECAM space */
+#define BCM2712_PCIE_REG_SIZE           0x9310
 
-#define BCM2712_PCIE1_REG_BASE          0x1000110000ULL
-#define BCM2712_PCIE1_REG_SIZE          0x10000
-#define BCM2712_PCIE1_ECAM_BASE         0x1000020000ULL
+/*
+ * The rescal block and the reset controller are shared by all three
+ * bridges and live in /soc. Neither is described by anything but the
+ * device tree; these are the addresses after /soc's ranges translation.
+ */
+#define BCM2712_RESCAL_BASE             0x1000119500ULL
+#define BCM2712_RESCAL_SIZE             0x10
+#define BCM2712_RESET_BASE              0x1001504318ULL
+#define BCM2712_RESET_SIZE              0x30
 
-/* Outbound 32-bit/64-bit memory window */
-#define BCM2712_PCIE_CPU_WIN            0x1800000000ULL
-#define BCM2712_PCIE_PCI_WIN            0xC0000000UL
-#define BCM2712_PCIE_WIN_SIZE           0x40000000UL    /* 1GB window */
+/* Rescal: self-deasserting, so only the assert side exists. */
+#define RESCAL_START                    0x00
+#define  RESCAL_START_BIT               (1 << 0)
+#define RESCAL_STATUS                   0x08
+#define  RESCAL_STATUS_BIT              (1 << 0)
 
-/* Inbound DMA mapping defaults */
-#define BCM2712_DMA_EXP                 36              /* 64GB max RAM window */
+/* brcmstb reset: banks of 32 bits, set/clear registers 24 bytes apart. */
+#define RESET_SW_INIT_SET(bank)         (0x00 + (bank) * 24)
+#define RESET_SW_INIT_CLR(bank)         (0x04 + (bank) * 24)
 
-/* PCIe Controller Register Offsets */
-#define PCIE2712_MISC_CTRL              0x4008
-#define  PCIE2712_MISC_CTRL_SCB_EN      (1 << 12)
-#define  PCIE2712_MISC_CTRL_CFG_UR_MODE (1 << 13)
-#define PCIE2712_STATUS                 0x4068
-#define  PCIE2712_STATUS_PHYLINKUP      (1 << 4)
-#define  PCIE2712_STATUS_DL_ACTIVE      (1 << 5)
-#define PCIE2712_REVISION               0x406c
+/*
+ * The root complex configuration header is memory mapped at offset 0 of
+ * the register block; external configuration space is reached through the
+ * indexed window at the top of it. There is no ECAM.
+ */
+#define PCIE_RC_CFG_PRIV1_ID_VAL3                       0x043c
+#define  PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_MASK           (0xffffff << 0)
 
-#define PCIE2712_EXT_CFG_INDEX          0x9000
-#define PCIE2712_EXT_CFG_DATA           0x8000
+/* MDIO to the SerDes, used to pick the reference clock. */
+#define PCIE_RC_DL_MDIO_ADDR                            0x1100
+#define  PCIE_RC_DL_MDIO_PORT_SHIFT                     16
+#define  PCIE_RC_DL_MDIO_CMD_READ                       (1 << 20)
+#define  PCIE_RC_DL_MDIO_CMD_WRITE                      (0 << 20)
+#define PCIE_RC_DL_MDIO_WR_DATA                         0x1104
+#define PCIE_RC_DL_MDIO_RD_DATA                         0x1108
+#define  PCIE_RC_DL_MDIO_DATA_DONE                      (1U << 31)
 
-/* Standard AROS OOP Driver Static Data */
+#define PCIE_RC_PL_PHY_CTL_15                           0x184c
+#define  PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK       (0xff << 0)
+
+#define PCIE_MISC_MISC_CTRL                             0x4008
+#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_64B_MODE          (1 << 7)
+#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_MPS_MODE          (1 << 10)
+#define  PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN              (1 << 12)
+#define  PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE           (1 << 13)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK        (0x3 << 20)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_512         (0x2 << 20)
+
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO                0x400c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI                0x4010
+
+/* Inbound windows: one per dma-range, 8 bytes apart from BAR1. */
+#define PCIE_MISC_RC_BAR1_CONFIG_LO                     0x402c
+#define  PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK              (0x1f << 0)
+#define PCIE_MISC_RC_BAR1_CONFIG_HI                     0x4030
+
+#define PCIE_MISC_PCIE_CTRL                             0x4064
+#define  PCIE_MISC_PCIE_CTRL_PCIE_PERSTB                (1 << 2)
+#define PCIE_MISC_PCIE_STATUS                           0x4068
+#define  PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP           (1 << 4)
+#define  PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE           (1 << 5)
+#define PCIE_MISC_REVISION                              0x406c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT        0x4070
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI           0x4080
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI          0x4084
+
+/* UBUS remap: the CPU-side half of each inbound window. 2711 has no UBUS. */
+#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO             0x40ac
+#define  PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN            (1 << 0)
+#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI             0x40b0
+
+#define PCIE_MISC_AXI_READ_ERROR_DATA                   0x4170
+
+/* Not 0x4204 as on 2711 - the block moved on this SoC. */
+#define PCIE_HARD_DEBUG                                 0x4304
+#define  PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE            (1 << 1)
+#define  PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE             (1 << 16)
+#define  PCIE_HARD_DEBUG_REFCLK_OVRD_OUT                (1 << 20)
+#define  PCIE_HARD_DEBUG_L1SS_ENABLE                    (1 << 21)
+#define  PCIE_HARD_DEBUG_SERDES_IDDQ                    (1 << 27)
+#define  PCIE_HARD_DEBUG_CLKREQ_MASK \
+    (PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE | PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE | \
+     PCIE_HARD_DEBUG_REFCLK_OVRD_OUT | PCIE_HARD_DEBUG_L1SS_ENABLE)
+
+#define PCIE_EXT_CFG_DATA                               0x8000
+#define PCIE_EXT_CFG_INDEX                              0x9000
+
+/* External config index encoding, also the tag layout used internally. */
+#define EXT_CFG_ADDR(bus, dev, func)    (((bus) << 20) | ((dev) << 15) | ((func) << 12))
+
+/* Configuration header offsets used on the root port itself. */
+#define PCI_CMD                         0x04
+#define  PCI_CMD_MEMORY                 (1 << 1)
+#define  PCI_CMD_MASTER                 (1 << 2)
+#define PCI_BAR0                        0x10
+#define PCI_BUSNUM                      0x18
+#define PCI_MEMBASE                     0x20
+#define PCI_ROMBASE                     0x30
+#define PCI_INTLINE                     0x3c
+
+/* GIC interrupt IDs start above the 32 SGIs and PPIs. */
+#define GIC_SPI_BASE                    32
+
+/*
+ * Bring-up tracing. None of this can be exercised under emulation - QEMU's
+ * raspi models have no PCIe - so the first run on real hardware is also the
+ * first test. Leave this on until a controller has been seen to enumerate.
+ */
+#define PCIE_BRINGUP                    1
+
+#if PCIE_BRINGUP
+#define BRINGUP(x)                      x
+#else
+#define BRINGUP(x)
+#endif
+
+/*
+ * A translation window, from either "ranges" (outbound) or "dma-ranges"
+ * (inbound). Both properties use the same cell layout on this bridge.
+ */
+struct pcie_range
+{
+    uint32_t        flags;
+    uint64_t        pci_base;
+    uint64_t        cpu_base;
+    uint64_t        size;
+};
+
+/* Each bridge publishes two of each; leave room for a tree that grows one. */
+#define PCIE_MAX_RANGES                 4
+
+/* Which bridge a driver object drives, handed to it via aHidd_DriverData. */
+struct pcie_bridge
+{
+    const char         *node;           /* device tree path */
+    uint64_t            reg_base;
+    const char         *name;
+};
+
+/*
+ * Per bridge state, the instance data of one driver object.
+ *
+ * Everything here is read back out of the registers once the bridge is
+ * running, whether we programmed it or the firmware did - see BridgeAdopt().
+ * Nothing downstream needs to know which of the two happened.
+ */
+struct PCIBcm2712Data
+{
+    const struct pcie_bridge *bridge;
+
+    volatile uint8_t   *regs;
+    volatile uint8_t   *rescal;
+    volatile uint8_t   *reset;
+
+    /* Which bit of the reset controller holds this bridge, from "resets". */
+    uint32_t            reset_cell;
+
+    struct pcie_range   ranges[PCIE_MAX_RANGES];
+    uint32_t            nranges;
+    struct pcie_range   dmaranges[PCIE_MAX_RANGES];
+    uint32_t            ndmaranges;
+
+    /* The MEM32 outbound window, which is where endpoint BARs are placed. */
+    uint64_t            mem_pci_base;
+    uint64_t            mem_cpu_base;
+    uint64_t            mem_size;
+    uint64_t            mem_next;       /* bump allocator over the window */
+
+    /* The bridge's secondary bus, read from its own config header rather
+       than assumed: on a firmware initialised bridge it is already set. */
+    UBYTE               secondary_bus;
+
+    /*
+     * The GIC INTID the bridge raises for the endpoint's INTA, from the
+     * node's interrupt-map. Config space carries no usable interrupt line
+     * on this bridge, so this is substituted when one is read.
+     */
+    uint32_t            intx_irq;
+
+    BOOL                link_up;
+    BOOL                trained;        /* we brought it up, firmware had not */
+};
+
+/* Per module state. Only what genuinely has one instance lives here. */
 struct pci_staticdata
 {
     OOP_Class          *driverClass;
     OOP_Class          *deviceClass;
-    OOP_Class          *busClass;
-
-    OOP_Object         *driverObject;
-    OOP_Object         *busObject;
 
     OOP_AttrBase        hiddPCIDriverAB;
     OOP_AttrBase        hiddPCIDeviceAB;
     OOP_AttrBase        hiddAB;
 
     struct Library     *kernelBase;
-    struct Library     *openFirmwareBase;
-
-    volatile uint8_t   *regs;
-    volatile uint8_t   *ecam;
-    uint64_t            dma_offset;
-    uint32_t            dma_exp;
-    uint32_t            msi_irq;
-    BOOL                link_up;
 };
 
 struct pcibcm2712base
@@ -82,10 +247,14 @@ struct pcibcm2712base
 
 struct PCIBcm2712DevData
 {
-    struct pci_staticdata *psd;
     uint32_t               devfn;
 };
 
-#define PSD(cl) ((struct pci_staticdata *)(cl)->UserData)
+#define PSD(cl) (&((struct pcibcm2712base *)(cl)->UserData)->psd)
+
+/* Shared between the two source files. */
+ULONG PCIE_ReadConfig(struct PCIBcm2712Data *data, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg);
+void  PCIE_WriteConfig(struct PCIBcm2712Data *data, UBYTE bus, UBYTE dev, UBYTE sub, UWORD reg, ULONG val);
+BOOL  PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data);
 
 #endif /* PCIE_BCM2712_H */

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
@@ -147,6 +147,45 @@
 #define GIC_SPI_BASE                    32
 
 /*
+ * The MSI-X Interrupt Peripheral. Each host bridge has one, named by its
+ * msi-parent; a device signals by writing the message number to the target
+ * address, and the block raises one GIC SPI per message - so there is no
+ * status register to demultiplex, unlike the 2711 bridge's own MSI matcher.
+ *
+ * Register layout from OpenBSD's bcm2712_mip.c (ISC, same author as the
+ * bridge driver this one follows).
+ */
+#define MIP_INT_CFGL_HOST               0x20
+#define MIP_INT_CFGH_HOST               0x30
+#define MIP_INT_MASKL_HOST              0x40
+#define MIP_INT_MASKH_HOST              0x50
+#define MIP_INT_MASKL_VPU               0x60
+#define MIP_INT_MASKH_VPU               0x70
+
+#define MIP_REG_SIZE                    0xc0
+#define MIP_MAX_VECTORS                 32      /* what one bitmap word holds */
+
+/* Capabilities we hand out vectors through. */
+#define PCI_CAP_PTR                     0x34
+#define PCI_CAP_ID_MSI                  0x05
+#define PCI_CAP_ID_MSIX                 0x11
+
+#define PCI_MSI_CTRL_ENABLE             (1 << 16)   /* bit 0 of the 16 bit control */
+#define PCI_MSI_CTRL_64BIT              (1 << 23)   /* bit 7 */
+#define PCI_MSI_CTRL_MME_MASK           (7 << 20)   /* bits 6:4 */
+#define PCI_MSI_ADDRESSLO               0x04
+#define PCI_MSI_ADDRESSHI               0x08
+#define PCI_MSI_DATA32                  0x08
+#define PCI_MSI_DATA64                  0x0c
+
+#define PCI_MSIX_CTRL_ENABLE            (1U << 31)  /* bit 15 */
+#define PCI_MSIX_CTRL_SIZE_MASK         0x07ff0000  /* table size less one */
+#define PCI_MSIX_TABLE                  0x04
+#define  PCI_MSIX_TABLE_BIR_MASK        0x7
+#define  PCI_MSIX_TABLE_OFF_MASK        (~0x7U)
+#define PCI_MSIX_ENTRY_SIZE             16
+
+/*
  * Bring-up tracing. None of this can be exercised under emulation - QEMU's
  * raspi models have no PCIe - so the first run on real hardware is also the
  * first test. Leave this on until a controller has been seen to enumerate.
@@ -222,8 +261,31 @@ struct PCIBcm2712Data
      */
     uint32_t            intx_irq;
 
+    /*
+     * This bridge's MSI block. msi_first_intid already carries the message
+     * offset, so message n of ours raises msi_first_intid + n; msi_used is
+     * one bit per message handed out.
+     */
+    volatile uint8_t   *mip;
+    uint64_t            msi_target;     /* the PCI address a device writes */
+    uint32_t            msi_first_intid;
+    uint32_t            msi_count;
+    uint32_t            msi_used;
+
     BOOL                link_up;
     BOOL                trained;        /* we brought it up, firmware had not */
+};
+
+/*
+ * Per device vector bookkeeping. firstVector holds the first message plus
+ * one, so a freshly created device reads as holding none.
+ */
+struct PCIBcm2712DevData
+{
+    ULONG               firstVector;
+    ULONG               nvectors;
+    ULONG               cap;            /* config offset of the capability */
+    BOOL                msix;
 };
 
 /* Per module state. Only what genuinely has one instance lives here. */
@@ -243,11 +305,6 @@ struct pcibcm2712base
 {
     struct Library        lib;
     struct pci_staticdata psd;
-};
-
-struct PCIBcm2712DevData
-{
-    uint32_t               devfn;
 };
 
 #define PSD(cl) (&((struct pcibcm2712base *)(cl)->UserData)->psd)

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712.h
@@ -1,27 +1,10 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
 
-    The Broadcom register map and the bring-up sequence below follow OpenBSD's
-    sys/dev/fdt/bcm2711_pcie.c, which drives both brcm,bcm2711-pcie and
-    brcm,bcm2712-pcie. The BCM2712 PCIe block is not covered by any published
-    Broadcom documentation, so that driver is the reference this one is
-    written against:
+    Desc: BCM2712 PCIe host bridge driver, private state.
 
-    Copyright (c) 2020, 2025 Mark Kettenis <kettenis@openbsd.org>
-
-    Permission to use, copy, modify, and distribute this software for any
-    purpose with or without fee is hereby granted, provided that the above
-    copyright notice and this permission notice appear in all copies.
-
-    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-    Desc: BCM2712 (Raspberry Pi 5 / 500 / 500+) PCIe host bridge.
+    The register map is in <hardware/bcm2712_pcie.h>; configuration space
+    offsets and capability layouts come from <hardware/pci.h>.
 */
 
 #ifndef PCIE_BCM2712_H
@@ -32,158 +15,12 @@
 #include <exec/libraries.h>
 #include <oop/oop.h>
 
+#include <hardware/bcm2712_pcie.h>
+
 #include LC_LIBDEFS_FILE
 
-/*
- * BCM2712 has three host bridges, each a separate root complex with its own
- * register block, reset bit, windows and MSI block. pcie0 is not brought out
- * on any board we know of. pcie1 is the x1 link - Pi 5 FPC connector, Pi 500+
- * M.2 slot - and needs "dtparam=nvme" or its node stays disabled. pcie2 is the
- * x4 link, hardwired to the RP1 southbridge. One driver object per bridge.
- */
-#define BCM2712_PCIE_REG_SIZE           0x9310
-
-/*
- * The rescal block and the reset controller are shared by all three
- * bridges and live in /soc. Neither is described by anything but the
- * device tree; these are the addresses after /soc's ranges translation.
- */
-#define BCM2712_RESCAL_BASE             0x1000119500ULL
-#define BCM2712_RESCAL_SIZE             0x10
-#define BCM2712_RESET_BASE              0x1001504318ULL
-#define BCM2712_RESET_SIZE              0x30
-
-/* Rescal: self-deasserting, so only the assert side exists. */
-#define RESCAL_START                    0x00
-#define  RESCAL_START_BIT               (1 << 0)
-#define RESCAL_STATUS                   0x08
-#define  RESCAL_STATUS_BIT              (1 << 0)
-
-/* brcmstb reset: banks of 32 bits, set/clear registers 24 bytes apart. */
-#define RESET_SW_INIT_SET(bank)         (0x00 + (bank) * 24)
-#define RESET_SW_INIT_CLR(bank)         (0x04 + (bank) * 24)
-
-/*
- * The root complex configuration header is memory mapped at offset 0 of
- * the register block; external configuration space is reached through the
- * indexed window at the top of it. There is no ECAM.
- */
-#define PCIE_RC_CFG_PRIV1_ID_VAL3                       0x043c
-#define  PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_MASK           (0xffffff << 0)
-
-/* MDIO to the SerDes, used to pick the reference clock. */
-#define PCIE_RC_DL_MDIO_ADDR                            0x1100
-#define  PCIE_RC_DL_MDIO_PORT_SHIFT                     16
-#define  PCIE_RC_DL_MDIO_CMD_READ                       (1 << 20)
-#define  PCIE_RC_DL_MDIO_CMD_WRITE                      (0 << 20)
-#define PCIE_RC_DL_MDIO_WR_DATA                         0x1104
-#define PCIE_RC_DL_MDIO_RD_DATA                         0x1108
-#define  PCIE_RC_DL_MDIO_DATA_DONE                      (1U << 31)
-
-#define PCIE_RC_PL_PHY_CTL_15                           0x184c
-#define  PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK       (0xff << 0)
-
-#define PCIE_MISC_MISC_CTRL                             0x4008
-#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_64B_MODE          (1 << 7)
-#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_MPS_MODE          (1 << 10)
-#define  PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN              (1 << 12)
-#define  PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE           (1 << 13)
-#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK        (0x3 << 20)
-#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_512         (0x2 << 20)
-
-#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO                0x400c
-#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI                0x4010
-
-/* Inbound windows: one per dma-range, 8 bytes apart from BAR1. */
-#define PCIE_MISC_RC_BAR1_CONFIG_LO                     0x402c
-#define  PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK              (0x1f << 0)
-#define PCIE_MISC_RC_BAR1_CONFIG_HI                     0x4030
-
-#define PCIE_MISC_PCIE_CTRL                             0x4064
-#define  PCIE_MISC_PCIE_CTRL_PCIE_PERSTB                (1 << 2)
-#define PCIE_MISC_PCIE_STATUS                           0x4068
-#define  PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP           (1 << 4)
-#define  PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE           (1 << 5)
-#define PCIE_MISC_REVISION                              0x406c
-#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT        0x4070
-#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI           0x4080
-#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI          0x4084
-
-/* UBUS remap: the CPU-side half of each inbound window. 2711 has no UBUS. */
-#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO             0x40ac
-#define  PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN            (1 << 0)
-#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI             0x40b0
-
-#define PCIE_MISC_AXI_READ_ERROR_DATA                   0x4170
-
-/* Not 0x4204 as on 2711 - the block moved on this SoC. */
-#define PCIE_HARD_DEBUG                                 0x4304
-#define  PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE            (1 << 1)
-#define  PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE             (1 << 16)
-#define  PCIE_HARD_DEBUG_REFCLK_OVRD_OUT                (1 << 20)
-#define  PCIE_HARD_DEBUG_L1SS_ENABLE                    (1 << 21)
-#define  PCIE_HARD_DEBUG_SERDES_IDDQ                    (1 << 27)
-#define  PCIE_HARD_DEBUG_CLKREQ_MASK \
-    (PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE | PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE | \
-     PCIE_HARD_DEBUG_REFCLK_OVRD_OUT | PCIE_HARD_DEBUG_L1SS_ENABLE)
-
-#define PCIE_EXT_CFG_DATA                               0x8000
-#define PCIE_EXT_CFG_INDEX                              0x9000
-
-/* External config index encoding, also the tag layout used internally. */
-#define EXT_CFG_ADDR(bus, dev, func)    (((bus) << 20) | ((dev) << 15) | ((func) << 12))
-
-/* Configuration header offsets used on the root port itself. */
-#define PCI_CMD                         0x04
-#define  PCI_CMD_MEMORY                 (1 << 1)
-#define  PCI_CMD_MASTER                 (1 << 2)
-#define PCI_BAR0                        0x10
-#define PCI_BUSNUM                      0x18
-#define PCI_MEMBASE                     0x20
-#define PCI_ROMBASE                     0x30
-#define PCI_INTLINE                     0x3c
-
-/* GIC interrupt IDs start above the 32 SGIs and PPIs. */
-#define GIC_SPI_BASE                    32
-
-/*
- * The MSI-X Interrupt Peripheral. Each host bridge has one, named by its
- * msi-parent; a device signals by writing the message number to the target
- * address, and the block raises one GIC SPI per message - so there is no
- * status register to demultiplex, unlike the 2711 bridge's own MSI matcher.
- *
- * Register layout from OpenBSD's bcm2712_mip.c (ISC, same author as the
- * bridge driver this one follows).
- */
-#define MIP_INT_CFGL_HOST               0x20
-#define MIP_INT_CFGH_HOST               0x30
-#define MIP_INT_MASKL_HOST              0x40
-#define MIP_INT_MASKH_HOST              0x50
-#define MIP_INT_MASKL_VPU               0x60
-#define MIP_INT_MASKH_VPU               0x70
-
-#define MIP_REG_SIZE                    0xc0
-#define MIP_MAX_VECTORS                 32      /* what one bitmap word holds */
-
-/* Capabilities we hand out vectors through. */
-#define PCI_CAP_PTR                     0x34
-#define PCI_CAP_ID_MSI                  0x05
-#define PCI_CAP_ID_MSIX                 0x11
-
-#define PCI_MSI_CTRL_ENABLE             (1 << 16)   /* bit 0 of the 16 bit control */
-#define PCI_MSI_CTRL_64BIT              (1 << 23)   /* bit 7 */
-#define PCI_MSI_CTRL_MME_MASK           (7 << 20)   /* bits 6:4 */
-#define PCI_MSI_ADDRESSLO               0x04
-#define PCI_MSI_ADDRESSHI               0x08
-#define PCI_MSI_DATA32                  0x08
-#define PCI_MSI_DATA64                  0x0c
-
-#define PCI_MSIX_CTRL_ENABLE            (1U << 31)  /* bit 15 */
-#define PCI_MSIX_CTRL_SIZE_MASK         0x07ff0000  /* table size less one */
-#define PCI_MSIX_TABLE                  0x04
-#define  PCI_MSIX_TABLE_BIR_MASK        0x7
-#define  PCI_MSIX_TABLE_OFF_MASK        (~0x7U)
-#define PCI_MSIX_ENTRY_SIZE             16
+/* The x4 bridge's MSI block has 64 messages, and RP1 uses all of them. */
+#define MIP_MAX_VECTORS                 64
 
 /*
  * Bring-up tracing. None of this can be exercised under emulation - QEMU's
@@ -270,7 +107,7 @@ struct PCIBcm2712Data
     uint64_t            msi_target;     /* the PCI address a device writes */
     uint32_t            msi_first_intid;
     uint32_t            msi_count;
-    uint32_t            msi_used;
+    uint64_t            msi_used;
 
     BOOL                link_up;
     BOOL                trained;        /* we brought it up, firmware had not */

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
@@ -28,6 +28,7 @@
 #include <proto/kernel.h>
 
 #include <aros/macros.h>
+#include <hardware/pci.h>
 
 #include <string.h>
 
@@ -453,7 +454,7 @@ static void SetupOutbound(struct PCIBcm2712Data *data)
     wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI, (uint32_t)(cpu_limit >> 32));
 
     /* Forward it through the bridge's own header as well */
-    wr32(data->regs, PCI_MEMBASE,
+    wr32(data->regs, PCIBR_MEMBASE,
          (((uint32_t)(cpu_limit >> 16) << 16) & 0xfff00000) |
          ((uint32_t)(pci_base >> 16) & 0xfff0));
 }
@@ -490,7 +491,7 @@ static void SetupInbound(struct PCIBcm2712Data *data)
         wr32(data->regs, PCIE_MISC_RC_BAR1_CONFIG_HI + i * 8, (uint32_t)(pci_base >> 32));
 
         wr32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO + i * 8,
-             (uint32_t)cpu_base | PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN);
+             (uint32_t)cpu_base | PCIE_MISC_UBUS_REMAP_EN);
         wr32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI + i * 8, (uint32_t)(cpu_base >> 32));
     }
 }
@@ -510,8 +511,8 @@ static uint64_t RCBarSize(uint32_t enc)
  * The inbound windows as the registers hold them. Each RC_BAR carries a PCI
  * base and a size code; the CPU address it lands on is in the UBUS remap
  * register beside it, with its own enable bit. Only BAR1 through BAR3 are read
- * - the contiguous group this driver programs; a higher BAR the firmware used
- * keeps working, we just do not describe it.
+ * - the contiguous group SetupInbound() programs; a higher BAR the firmware
+ * used keeps working, we just do not describe it.
  */
 static void AdoptInbound(struct PCIBcm2712Data *data)
 {
@@ -525,7 +526,7 @@ static void AdoptInbound(struct PCIBcm2712Data *data)
         uint32_t rhi  = rd32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI + i * 8);
         uint64_t size = RCBarSize(lo & PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK);
 
-        if (!size || !(rlo & PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN))
+        if (!size || !(rlo & PCIE_MISC_UBUS_REMAP_EN))
             continue;
 
         data->dmaranges[n].flags    = 0x03000000;
@@ -746,15 +747,10 @@ static BOOL BridgeTrain(struct PCIBcm2712Data *data, void *key)
 
     SetupClkreq(data, key);
     SetupOutbound(data);
-    SetupInbound(data);
 
     /* Bus numbers: primary 0, secondary 1, subordinate 1 */
-    reg = rd32(data->regs, PCI_BUSNUM);
-    wr32(data->regs, PCI_BUSNUM, (reg & 0xff000000) | 0x00010100);
-
-    /* Memory decode and bus mastering on the root port itself. */
-    reg = rd32(data->regs, PCI_CMD);
-    wr32(data->regs, PCI_CMD, reg | PCI_CMD_MEMORY | PCI_CMD_MASTER);
+    reg = rd32(data->regs, PCIBR_PRIBUS);
+    wr32(data->regs, PCIBR_PRIBUS, (reg & 0xff000000) | 0x00010100);
 
     data->trained = TRUE;
     return TRUE;
@@ -763,8 +759,8 @@ static BOOL BridgeTrain(struct PCIBcm2712Data *data, void *key)
 /*
  * Read the bridge's translation state back out of its registers, whoever
  * programmed it, so downstream sees what the hardware does rather than what
- * a property says. On the x4 link the firmware points the window at a PCI
- * address in no "ranges" entry, with the debug console behind it.
+ * a property says. On the x4 link the firmware points the outbound window at
+ * a PCI address in no "ranges" entry, with the debug console behind it.
  */
 static BOOL BridgeAdopt(struct PCIBcm2712Data *data)
 {
@@ -775,7 +771,7 @@ static BOOL BridgeAdopt(struct PCIBcm2712Data *data)
         return FALSE;
 
     data->link_up = TRUE;
-    data->secondary_bus = (UBYTE)(rd32(data->regs, PCI_BUSNUM) >> 8);
+    data->secondary_bus = (UBYTE)(rd32(data->regs, PCIBR_PRIBUS) >> 8);
 
     lo = rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO);
     hi = rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI);
@@ -876,14 +872,14 @@ static void SetupEndpoint(struct PCIBcm2712Data *data)
     PCIE_WriteConfig(data, bus, 0, 0, 0x0c,
                      (PCIE_ReadConfig(data, bus, 0, 0, 0x0c) & ~0xffUL) | 16);
 
-    PCIE_WriteConfig(data, bus, 0, 0, PCI_CMD,
-                     PCIE_ReadConfig(data, bus, 0, 0, PCI_CMD) | PCI_CMD_MEMORY);
+    PCIE_WriteConfig(data, bus, 0, 0, PCICS_COMMAND,
+                     PCIE_ReadConfig(data, bus, 0, 0, PCICS_COMMAND) | PCICMF_MEMDECODE);
 
     BRINGUP(bug("[PCIBcm2712] %s: endpoint %u:0.0 %04x:%04x class %06x cmd %04x BAR0 %08x%08x (%u bytes)\n",
                 data->bridge->node, (unsigned)bus,
                 (unsigned)(id & 0xffff), (unsigned)(id >> 16),
                 (unsigned)(PCIE_ReadConfig(data, bus, 0, 0, 0x08) >> 8),
-                (unsigned)(PCIE_ReadConfig(data, bus, 0, 0, PCI_CMD) & 0xffff),
+                (unsigned)(PCIE_ReadConfig(data, bus, 0, 0, PCICS_COMMAND) & 0xffff),
                 (unsigned)(is64 ? PCIE_ReadConfig(data, bus, 0, 0, 0x14) : 0),
                 (unsigned)PCIE_ReadConfig(data, bus, 0, 0, 0x10), (unsigned)size));
 }
@@ -897,6 +893,7 @@ static void SetupEndpoint(struct PCIBcm2712Data *data)
 BOOL PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
 {
     void *key;
+    uint32_t reg;
 
     key = PCIeNode(data->bridge);
     if (!key)
@@ -941,6 +938,17 @@ BOOL PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
     else
         BRINGUP(bug("[PCIBcm2712] %s: link already up, adopting it\n", data->bridge->node));
 
+    /*
+     * The inbound side is ours on both paths. Nothing is transferring during
+     * boot, and the console is outbound traffic, so reprogramming these
+     * windows costs nothing - while the firmware's leave the x4 endpoint's
+     * DMA and its MSI doorbell pointing at nothing we describe.
+     */
+    SetupInbound(data);
+
+    reg = rd32(data->regs, PCICS_COMMAND);
+    wr32(data->regs, PCICS_COMMAND, reg | PCICMF_MEMDECODE | PCICMF_BUSMASTER);
+
     if (!BridgeAdopt(data))
         return FALSE;
 
@@ -948,15 +956,14 @@ BOOL PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
      * The bus numbers, on an adopted bridge too: the firmware leaves them
      * at zero on the x4 link, and config space cannot reach an endpoint on
      * a bus the bridge does not forward. This touches no window, so it
-     * costs the console nothing - and rp1.resource reads the secondary bus
-     * back out of the same register rather than assuming it.
+     * costs the console nothing.
      */
     if (!data->secondary_bus)
     {
-        uint32_t reg = rd32(data->regs, PCI_BUSNUM);
+        uint32_t reg = rd32(data->regs, PCIBR_PRIBUS);
 
-        wr32(data->regs, PCI_BUSNUM, (reg & 0xff000000) | 0x00010100);
-        data->secondary_bus = (UBYTE)(rd32(data->regs, PCI_BUSNUM) >> 8);
+        wr32(data->regs, PCIBR_PRIBUS, (reg & 0xff000000) | 0x00010100);
+        data->secondary_bus = (UBYTE)(rd32(data->regs, PCIBR_PRIBUS) >> 8);
 
         BRINGUP(bug("[PCIBcm2712] %s: bus numbers were unset, secondary bus now %u\n",
                     data->bridge->node, (unsigned)data->secondary_bus));

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
@@ -1,14 +1,19 @@
 /*
     Copyright (C) 2026, The AROS Development Team. All rights reserved.
 
-    Desc: BCM2712 (Raspberry Pi 5) PCIe Host Bridge Bring-Up and Driver Registration.
+    Desc: BCM2712 PCIe host bridge bring-up and driver registration.
+
+    The sequence follows OpenBSD's sys/dev/fdt/bcm2711_pcie.c; see pcie2712.h
+    for the licence of that work.
 */
 
 #define __OOP_NOATTRBASES__
 
 #include <aros/symbolsets.h>
+
 #include <exec/types.h>
 #include <exec/memory.h>
+#include <hidd/hidd.h>
 #include <hidd/pci.h>
 #include <oop/oop.h>
 
@@ -22,17 +27,61 @@
 #define __NOLIBBASE__
 #include <proto/kernel.h>
 
-#include <hardware/bcm2708.h>
 #include <aros/macros.h>
+
 #include <string.h>
 
 #include "pcie2712.h"
+
 #include <aros/debug.h>
+
+/* aHidd_* is written in terms of the interface's attribute base, which
+   __OOP_NOATTRBASES__ leaves to us; psd is in scope where it is used. */
+#undef HiddAttrBase
+#define HiddAttrBase (psd->hiddAB)
 
 void *OpenFirmwareBase;
 APTR  BootLoaderBase;
 
-/* Check if PCIe is enabled in boot arguments (default TRUE) */
+/*
+ * The bridges this driver takes. pcie0 is not brought out on any board we
+ * know of, so it is not listed. The x4 link is adopted rather than trained -
+ * resetting it takes away RP1's UART0, which is the debug console.
+ * PCIE_BridgeSetup() decides that from the link, not from this table.
+ */
+static const struct pcie_bridge bcm2712_bridges[] =
+{
+    { "/axi/pcie@1000110000", 0x1000110000ULL, "BCM2712 PCIe host bridge (x1, M.2)" },
+    { "/axi/pcie@1000120000", 0x1000120000ULL, "BCM2712 PCIe host bridge (x4, RP1)" },
+};
+
+#define BCM2712_NBRIDGES  (sizeof(bcm2712_bridges) / sizeof(bcm2712_bridges[0]))
+
+static inline uint32_t rd32(volatile uint8_t *regs, uint32_t reg)
+{
+    return *(volatile uint32_t *)(regs + reg);
+}
+
+static inline void wr32(volatile uint8_t *regs, uint32_t reg, uint32_t val)
+{
+    *(volatile uint32_t *)(regs + reg) = val;
+}
+
+/* Busy wait on the generic counter; init runs before timer.device. */
+static void delay_us(uint32_t us)
+{
+    uint64_t freq, now, end;
+
+    asm volatile("mrs %0, CNTFRQ_EL0" : "=r"(freq));
+    asm volatile("mrs %0, CNTPCT_EL0" : "=r"(now));
+    end = now + (freq * us) / 1000000;
+
+    do {
+        asm volatile("mrs %0, CNTPCT_EL0" : "=r"(now));
+    } while (now < end);
+}
+
+/* "PCIE=disable" on the kernel command line keeps the bridges untouched. */
 static BOOL PCIeEnabled(void)
 {
     struct List *list;
@@ -51,7 +100,7 @@ static BOOL PCIeEnabled(void)
         if (strncmp(node->ln_Name, "PCIE=", 5) == 0 &&
             strstr(&node->ln_Name[5], "disable"))
         {
-            D(bug("[PCIBcm2712] disabled on command line\n"));
+            D(bug("[PCIBcm2712] disabled on the command line\n"));
             return FALSE;
         }
     }
@@ -59,127 +108,790 @@ static BOOL PCIeEnabled(void)
     return TRUE;
 }
 
-/* Check if running on BCM2712 with PCIe RC0 */
-static BOOL PCIeNodeUsable(void)
+/*
+ * A bridge's registers raise an external abort while it is held disabled,
+ * so the tree is consulted before the first register access. The x1 link is
+ * disabled in the base device tree - "dtparam=nvme" in config.txt is what
+ * turns it on.
+ */
+static void *PCIeNode(const struct pcie_bridge *bridge)
 {
     void *key, *prop;
+    const char *val;
 
-    OpenFirmwareBase = OpenResource("openfirmware.resource");
-    if (!OpenFirmwareBase)
-        return TRUE; /* Standalone fallback */
-
-    key = OF_OpenKey("/axi/pcie@1000100000");
-    if (!key)
-        key = OF_FindNodeByCompatible(NULL, "brcm,bcm2712-pcie");
-
+    key = OF_OpenKey((char *)bridge->node);
     if (!key)
     {
-        D(bug("[PCIBcm2712] no BCM2712 PCIe node in device tree\n"));
-        return FALSE;
+        D(bug("[PCIBcm2712] no %s in the device tree\n", bridge->node));
+        return NULL;
+    }
+
+    /* OF_OpenKey falls back to the last resolved node; make sure this
+     * really is a 2712 PCIe controller. */
+    prop = OF_FindProperty(key, "compatible");
+    if (!prop)
+        return NULL;
+    val = OF_GetPropValue(prop);
+    if (!val || !strstr(val, "2712-pcie"))
+    {
+        D(bug("[PCIBcm2712] %s is not a PCIe controller (%s)\n",
+              bridge->node, val ? val : "?"));
+        return NULL;
     }
 
     prop = OF_FindProperty(key, "status");
     if (prop)
     {
-        const char *val = OF_GetPropValue(prop);
-        if (val && strcmp(val, "okay") != 0 && strcmp(val, "ok") != 0)
+        val = OF_GetPropValue(prop);
+        if (val && strcmp(val, "okay") != 0)
         {
-            D(bug("[PCIBcm2712] node status '%s', leaving bridge alone\n", val));
-            return FALSE;
+            BRINGUP(bug("[PCIBcm2712] %s status '%s' - add \"dtparam=nvme\" to "
+                        "config.txt to enable the slot\n", bridge->node, val));
+            return NULL;
         }
+    }
+
+    return key;
+}
+
+static uint32_t PropCells(void *key, const char *name, uint32_t missing)
+{
+    void *prop = OF_FindProperty(key, (char *)name);
+
+    if (!prop || OF_GetPropLen(prop) < 4)
+        return missing;
+
+    return AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop));
+}
+
+/*
+ * "ranges" and "dma-ranges" share a cell layout: a child address of
+ * child_ac cells (the first of which is the PCI flags word), a parent
+ * address of parent_ac cells, and a length of child_sc cells. The counts
+ * are read rather than assumed - a firmware that changes them would
+ * otherwise be silently misparsed.
+ */
+static uint32_t ParseRanges(void *key, const char *name, struct pcie_range *out)
+{
+    void *parent, *prop;
+    const uint32_t *r;
+    uint32_t child_ac, child_sc, parent_ac, entry_cells;
+    uint32_t cells, n = 0;
+
+    prop = OF_FindProperty(key, (char *)name);
+    if (!prop)
+        return 0;
+
+    child_ac = PropCells(key, "#address-cells", 3);
+    child_sc = PropCells(key, "#size-cells", 2);
+
+    parent = OF_OpenKey("/axi");
+    parent_ac = parent ? PropCells(parent, "#address-cells", 2) : 2;
+
+    entry_cells = child_ac + parent_ac + child_sc;
+    if (child_ac < 1 || entry_cells == 0)
+        return 0;
+
+    r = (const uint32_t *)OF_GetPropValue(prop);
+    cells = OF_GetPropLen(prop) / 4;
+
+    while ((cells >= entry_cells) && (n < PCIE_MAX_RANGES))
+    {
+        uint64_t pci = 0, cpu = 0, size = 0;
+        uint32_t i;
+
+        /* The first child cell is the PCI address space descriptor. */
+        out[n].flags = AROS_BE2LONG(*r++);
+        for (i = 1; i < child_ac; i++)
+            pci = (pci << 32) | AROS_BE2LONG(*r++);
+        for (i = 0; i < parent_ac; i++)
+            cpu = (cpu << 32) | AROS_BE2LONG(*r++);
+        for (i = 0; i < child_sc; i++)
+            size = (size << 32) | AROS_BE2LONG(*r++);
+
+        out[n].pci_base = pci;
+        out[n].cpu_base = cpu;
+        out[n].size = size;
+
+        BRINGUP(bug("[PCIBcm2712] %s[%u]: flags %08x pci %08x%08x <- cpu %08x%08x, %08x%08x bytes\n",
+                    name, (unsigned)n, (unsigned)out[n].flags,
+                    (unsigned)(pci >> 32), (unsigned)pci,
+                    (unsigned)(cpu >> 32), (unsigned)cpu,
+                    (unsigned)(size >> 32), (unsigned)size));
+
+        cells -= entry_cells;
+        n++;
+    }
+
+    return n;
+}
+
+/*
+ * Which bit of the reset controller holds this bridge. The property is
+ * <&rescal, &reset, cell>: rescal takes no cells, the reset controller
+ * takes one, so the bridge's bit is the last word.
+ */
+static uint32_t ResetCellFromDT(void *key)
+{
+    void *prop = OF_FindProperty(key, "resets");
+    uint32_t len;
+
+    if (!prop)
+        return ~0U;
+
+    len = OF_GetPropLen(prop);
+    if (len < 4)
+        return ~0U;
+
+    return AROS_BE2LONG(((const uint32_t *)OF_GetPropValue(prop))[len / 4 - 1]);
+}
+
+/*
+ * Where the bridge raises the endpoint's legacy interrupt. "interrupt-map"
+ * lists, per entry, a child unit address, the INTx pin, the interrupt
+ * parent, and that parent's specifier - for the GIC, <type, number, flags>.
+ * The link carries a single device, so its INTA is the first entry and the
+ * only one that can fire.
+ */
+static uint32_t IntxIrqFromDT(void *key)
+{
+    void *prop = OF_FindProperty(key, "interrupt-map");
+    uint32_t child_ac, child_ic, entry_cells;
+    const uint32_t *m;
+
+    if (!prop)
+        return 0;
+
+    child_ac = PropCells(key, "#address-cells", 3);
+    child_ic = PropCells(key, "#interrupt-cells", 1);
+
+    /* child address + pin + parent phandle + a three cell GIC specifier */
+    entry_cells = child_ac + child_ic + 1 + 3;
+    if (OF_GetPropLen(prop) < entry_cells * 4)
+        return 0;
+
+    m = (const uint32_t *)OF_GetPropValue(prop);
+
+    /* The specifier's first cell is the interrupt type; only SPIs are routed
+       here, and a PPI would mean we have misread the property. */
+    if (AROS_BE2LONG(m[child_ac + child_ic + 1]) != 0)
+        return 0;
+
+    return GIC_SPI_BASE + AROS_BE2LONG(m[child_ac + child_ic + 2]);
+}
+
+static volatile uint8_t *MapDevice(struct pci_staticdata *psd, uint64_t base, uint32_t size)
+{
+    APTR KernelBase = psd->kernelBase;
+
+    if (!KrnMapGlobal((void *)(IPTR)base, (void *)(IPTR)base, size,
+                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
+        return NULL;
+
+    return (volatile uint8_t *)(IPTR)base;
+}
+
+/* Rescal is self-deasserting, so only the assert side is implemented. */
+static void RescalReset(struct PCIBcm2712Data *data)
+{
+    int timo;
+
+    if (!data->rescal)
+        return;
+
+    wr32(data->rescal, RESCAL_START, rd32(data->rescal, RESCAL_START) | RESCAL_START_BIT);
+
+    for (timo = 10; timo > 0; timo--)
+    {
+        if (rd32(data->rescal, RESCAL_STATUS) & RESCAL_STATUS_BIT)
+            break;
+        delay_us(100);
+    }
+
+    if (timo == 0)
+        bug("[PCIBcm2712] rescal timeout\n");
+
+    wr32(data->rescal, RESCAL_START, rd32(data->rescal, RESCAL_START) & ~RESCAL_START_BIT);
+}
+
+static void BridgeReset(struct PCIBcm2712Data *data, BOOL assert)
+{
+    uint32_t bank, bit;
+
+    if (!data->reset || data->reset_cell == ~0U)
+        return;
+
+    bank = data->reset_cell / 32;
+    bit  = data->reset_cell % 32;
+
+    if ((bank + 1) * 24 > BCM2712_RESET_SIZE)
+        return;
+
+    wr32(data->reset, assert ? RESET_SW_INIT_SET(bank) : RESET_SW_INIT_CLR(bank), 1U << bit);
+}
+
+static void Perst(struct PCIBcm2712Data *data, BOOL assert)
+{
+    uint32_t reg = rd32(data->regs, PCIE_MISC_PCIE_CTRL);
+
+    /* Active low: the bit is the deasserted state. */
+    if (assert)
+        reg &= ~PCIE_MISC_PCIE_CTRL_PCIE_PERSTB;
+    else
+        reg |= PCIE_MISC_PCIE_CTRL_PCIE_PERSTB;
+
+    wr32(data->regs, PCIE_MISC_PCIE_CTRL, reg);
+}
+
+static BOOL MDIOWrite(struct PCIBcm2712Data *data, uint8_t port, uint16_t addr, uint32_t val)
+{
+    int timo;
+
+    wr32(data->regs, PCIE_RC_DL_MDIO_ADDR,
+         PCIE_RC_DL_MDIO_CMD_WRITE | ((uint32_t)port << PCIE_RC_DL_MDIO_PORT_SHIFT) | addr);
+    rd32(data->regs, PCIE_RC_DL_MDIO_ADDR);
+
+    wr32(data->regs, PCIE_RC_DL_MDIO_WR_DATA, val | PCIE_RC_DL_MDIO_DATA_DONE);
+    for (timo = 10; timo > 0; timo--)
+    {
+        if (!(rd32(data->regs, PCIE_RC_DL_MDIO_WR_DATA) & PCIE_RC_DL_MDIO_DATA_DONE))
+            break;
+        delay_us(10);
+    }
+
+    if (timo == 0)
+    {
+        bug("[PCIBcm2712] MDIO write timeout (reg %04x)\n", addr);
+        return FALSE;
     }
 
     return TRUE;
 }
 
-static inline uint32_t rd32(volatile uint8_t *regs, uint32_t reg)
+/*
+ * Pick the 54MHz reference clock and set the L1 sub-state timers to match
+ * it. Without this the SerDes has no usable clock and the link never
+ * trains. The register/value pairs are the ones OpenBSD programs; they are
+ * not documented anywhere we can cite.
+ */
+static BOOL SetupRefClk(struct PCIBcm2712Data *data)
 {
-    return *(volatile uint32_t *)(regs + reg);
+    static const struct { uint16_t addr; uint16_t data; } regs[] = {
+        { 0x16, 0x50b9 }, { 0x17, 0xbda1 }, { 0x18, 0x0094 }, { 0x19, 0x97b4 },
+        { 0x1b, 0x5030 }, { 0x1c, 0x5030 }, { 0x1e, 0x0007 },
+    };
+    uint32_t reg;
+    unsigned int i;
+
+    /* Make failed reads return 0xffffffff rather than 0xdeaddead, or
+       probing an absent function looks like a device that answered. */
+    wr32(data->regs, PCIE_MISC_AXI_READ_ERROR_DATA, 0xffffffff);
+
+    if (!MDIOWrite(data, 0, 0x1f, 0x1600))
+        return FALSE;
+    for (i = 0; i < sizeof(regs) / sizeof(regs[0]); i++)
+    {
+        if (!MDIOWrite(data, 0, regs[i].addr, regs[i].data))
+            return FALSE;
+    }
+
+    delay_us(100);
+
+    reg = rd32(data->regs, PCIE_RC_PL_PHY_CTL_15);
+    reg &= ~PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK;
+    reg |= 18;
+    wr32(data->regs, PCIE_RC_PL_PHY_CTL_15, reg);
+
+    return TRUE;
 }
 
-static inline void wr32(volatile uint8_t *regs, uint32_t reg, uint32_t val)
+/*
+ * CLKREQ handling. The x1 link asks for "safe" mode, which is simply all
+ * four bits clear; the other modes exist for boards that wire CLKREQ# up.
+ */
+static void SetupClkreq(struct PCIBcm2712Data *data, void *key)
 {
-    *(volatile uint32_t *)(regs + reg) = val;
+    uint32_t reg = rd32(data->regs, PCIE_HARD_DEBUG) & ~PCIE_HARD_DEBUG_CLKREQ_MASK;
+    void *prop = OF_FindProperty(key, "brcm,clkreq-mode");
+    const char *mode = prop ? OF_GetPropValue(prop) : NULL;
+
+    if (mode && strcmp(mode, "no-l1ss") == 0)
+        reg |= PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE;
+    else if (mode && strcmp(mode, "default") == 0)
+        reg |= PCIE_HARD_DEBUG_L1SS_ENABLE;
+
+    wr32(data->regs, PCIE_HARD_DEBUG, reg);
 }
 
-static int PCIBcm2712_Init(LIBBASETYPEPTR LIBBASE)
+/* Program the MEM32 outbound window from the device tree. */
+static void SetupOutbound(struct PCIBcm2712Data *data)
 {
-    struct pci_staticdata *psd = &LIBBASE->psd;
+    uint64_t pci_base = 0, cpu_base = 0, size = 0, cpu_limit;
+    uint32_t i;
 
-    if (!PCIeEnabled() || !PCIeNodeUsable())
-        return TRUE;
+    for (i = 0; i < data->nranges; i++)
+    {
+        if ((data->ranges[i].flags & 0x03000000) == 0x02000000)
+        {
+            pci_base = data->ranges[i].pci_base;
+            cpu_base = data->ranges[i].cpu_base;
+            size     = data->ranges[i].size;
+            break;
+        }
+    }
 
-    D(bug("[PCIBcm2712] Initializing BCM2712 PCIe host bridge (RPi5 NVMe M.2)\n"));
+    if (!size)
+        return;
 
-    APTR KernelBase = OpenResource("kernel.resource");
-    psd->kernelBase = (struct Library *)KernelBase;
-    if (!KernelBase)
+    cpu_limit = cpu_base + size - 1;
+
+    wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO, (uint32_t)pci_base);
+    wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI, (uint32_t)(pci_base >> 32));
+    wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
+         ((uint32_t)(cpu_base >> 20) & 0xfff) << 4 | ((uint32_t)(cpu_limit >> 20) & 0xfff) << 20);
+    wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI, (uint32_t)(cpu_base >> 32));
+    wr32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI, (uint32_t)(cpu_limit >> 32));
+
+    /* Forward it through the bridge's own header as well */
+    wr32(data->regs, PCI_MEMBASE,
+         (((uint32_t)(cpu_limit >> 16) << 16) & 0xfff00000) |
+         ((uint32_t)(pci_base >> 16) & 0xfff0));
+}
+
+/*
+ * One inbound window per dma-range. Unlike 2711 - which funnels everything
+ * through BAR2 plus an SCB size field - 2712 pairs each RC_BAR with a UBUS
+ * remap register holding the CPU address the window lands on. The size field
+ * is log2 less 15, with a separate encoding below 64KB - that branch matters,
+ * the 4KB dma-range is the MSI doorbell.
+ */
+static void SetupInbound(struct PCIBcm2712Data *data)
+{
+    uint32_t i;
+
+    for (i = 0; i < data->ndmaranges; i++)
+    {
+        uint64_t pci_base = data->dmaranges[i].pci_base;
+        uint64_t cpu_base = data->dmaranges[i].cpu_base;
+        uint32_t shift = 0, size;
+
+        while ((1ULL << shift) < data->dmaranges[i].size)
+            shift++;
+
+        if (shift >= 12 && shift <= 15)
+            size = 0x1c + (shift - 12);
+        else if (shift >= 16 && shift <= 36)
+            size = shift - 15;
+        else
+            size = 0;
+
+        wr32(data->regs, PCIE_MISC_RC_BAR1_CONFIG_LO + i * 8,
+             ((uint32_t)pci_base & ~PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK) | size);
+        wr32(data->regs, PCIE_MISC_RC_BAR1_CONFIG_HI + i * 8, (uint32_t)(pci_base >> 32));
+
+        wr32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO + i * 8,
+             (uint32_t)cpu_base | PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN);
+        wr32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI + i * 8, (uint32_t)(cpu_base >> 32));
+    }
+}
+
+/* Inverse of the size field SetupInbound() writes. 0 means the window is off. */
+static uint64_t RCBarSize(uint32_t enc)
+{
+    if ((enc >= 1) && (enc <= 21))
+        return 1ULL << (enc + 15);
+    if ((enc >= 0x1c) && (enc <= 0x1f))
+        return 1ULL << (enc - 0x1c + 12);
+
+    return 0;
+}
+
+/*
+ * The inbound windows as the registers hold them. Each RC_BAR carries a PCI
+ * base and a size code; the CPU address it lands on is in the UBUS remap
+ * register beside it, with its own enable bit. Only BAR1 through BAR3 are read
+ * - the contiguous group this driver programs; a higher BAR the firmware used
+ * keeps working, we just do not describe it.
+ */
+static void AdoptInbound(struct PCIBcm2712Data *data)
+{
+    uint32_t i, n = 0;
+
+    for (i = 0; (i < 3) && (n < PCIE_MAX_RANGES); i++)
+    {
+        uint32_t lo   = rd32(data->regs, PCIE_MISC_RC_BAR1_CONFIG_LO + i * 8);
+        uint32_t hi   = rd32(data->regs, PCIE_MISC_RC_BAR1_CONFIG_HI + i * 8);
+        uint32_t rlo  = rd32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO + i * 8);
+        uint32_t rhi  = rd32(data->regs, PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI + i * 8);
+        uint64_t size = RCBarSize(lo & PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK);
+
+        if (!size || !(rlo & PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_EN))
+            continue;
+
+        data->dmaranges[n].flags    = 0x03000000;
+        data->dmaranges[n].pci_base = ((uint64_t)hi << 32) |
+                                      (lo & ~(uint32_t)PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK);
+        data->dmaranges[n].cpu_base = ((uint64_t)rhi << 32) | (rlo & 0xfffff000);
+        data->dmaranges[n].size     = size;
+
+        BRINGUP(bug("[PCIBcm2712] %s: inbound bar%u pci %08x%08x <- cpu %08x%08x, %08x%08x bytes\n",
+                    data->bridge->node, (unsigned)(i + 1),
+                    (unsigned)(data->dmaranges[n].pci_base >> 32),
+                    (unsigned)data->dmaranges[n].pci_base,
+                    (unsigned)(data->dmaranges[n].cpu_base >> 32),
+                    (unsigned)data->dmaranges[n].cpu_base,
+                    (unsigned)(size >> 32), (unsigned)size));
+        n++;
+    }
+
+    if (n)
+        data->ndmaranges = n;
+    else
+        BRINGUP(bug("[PCIBcm2712] %s: no inbound window is programmed, keeping the tree's\n",
+                    data->bridge->node));
+}
+
+static BOOL LinkUp(struct PCIBcm2712Data *data)
+{
+    uint32_t reg = rd32(data->regs, PCIE_MISC_PCIE_STATUS);
+
+    return (reg & PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP) &&
+           (reg & PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE);
+}
+
+/*
+ * Take a bridge from reset to a trained link with its windows programmed.
+ * Only for a bridge we own outright: this resets it, and a bridge whose
+ * endpoint the firmware set up - or which carries the debug console - must
+ * be adopted instead.
+ */
+static BOOL BridgeTrain(struct PCIBcm2712Data *data, void *key)
+{
+    uint32_t reg;
+    int timo;
+
+    RescalReset(data);
+
+    Perst(data, TRUE);
+
+    BridgeReset(data, TRUE);
+    delay_us(200);
+    BridgeReset(data, FALSE);
+
+    /* Power up the PHY */
+    reg = rd32(data->regs, PCIE_HARD_DEBUG);
+    wr32(data->regs, PCIE_HARD_DEBUG, reg & ~PCIE_HARD_DEBUG_SERDES_IDDQ);
+    delay_us(200);
+
+    BRINGUP(bug("[PCIBcm2712] %s: revision %08x\n", data->bridge->node,
+                rd32(data->regs, PCIE_MISC_REVISION)));
+
+    reg = rd32(data->regs, PCIE_MISC_MISC_CTRL);
+    reg &= ~PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK;
+    reg |= PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_512;
+    reg |= PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN;
+    reg |= PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE;
+    reg |= PCIE_MISC_MISC_CTRL_PCIE_RCB_64B_MODE;
+    reg |= PCIE_MISC_MISC_CTRL_PCIE_RCB_MPS_MODE;
+    wr32(data->regs, PCIE_MISC_MISC_CTRL, reg);
+
+    /* Present the root port as a PCI-PCI bridge */
+    reg = rd32(data->regs, PCIE_RC_CFG_PRIV1_ID_VAL3);
+    reg &= ~PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_MASK;
+    wr32(data->regs, PCIE_RC_CFG_PRIV1_ID_VAL3, reg | 0x060400);
+
+    if (!SetupRefClk(data))
         return FALSE;
 
-    /* Map DBI/Registers (identity map, Device memory) */
-    if (!KrnMapGlobal((void *)(IPTR)BCM2712_PCIE0_REG_BASE,
-                      (void *)(IPTR)BCM2712_PCIE0_REG_BASE, BCM2712_PCIE0_REG_SIZE,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
+    Perst(data, FALSE);
+
+    for (timo = 100; timo > 0; timo--)
     {
-        D(bug("[PCIBcm2712] Failed to map PCIe registers\n"));
+        if (LinkUp(data))
+            break;
+        delay_us(1000);
+    }
+
+    if (timo == 0)
+    {
+        bug("[PCIBcm2712] %s: link did not come up (status %08x)\n", data->bridge->node,
+            rd32(data->regs, PCIE_MISC_PCIE_STATUS));
         return FALSE;
     }
-    psd->regs = (volatile uint8_t *)(IPTR)BCM2712_PCIE0_REG_BASE;
 
-    /* Map ECAM Window (Bus 0 & 1) */
-    if (KrnMapGlobal((void *)(IPTR)BCM2712_PCIE0_ECAM_BASE,
-                     (void *)(IPTR)BCM2712_PCIE0_ECAM_BASE, BCM2712_PCIE0_ECAM_SIZE,
-                     MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
-        psd->ecam = (volatile uint8_t *)(IPTR)BCM2712_PCIE0_ECAM_BASE;
+    BRINGUP(bug("[PCIBcm2712] %s: link up after %dms\n", data->bridge->node, 100 - timo));
+
+    SetupClkreq(data, key);
+    SetupOutbound(data);
+    SetupInbound(data);
+
+    /* Bus numbers: primary 0, secondary 1, subordinate 1 */
+    reg = rd32(data->regs, PCI_BUSNUM);
+    wr32(data->regs, PCI_BUSNUM, (reg & 0xff000000) | 0x00010100);
+
+    /* Memory decode and bus mastering on the root port itself. */
+    reg = rd32(data->regs, PCI_CMD);
+    wr32(data->regs, PCI_CMD, reg | PCI_CMD_MEMORY | PCI_CMD_MASTER);
+
+    data->trained = TRUE;
+    return TRUE;
+}
+
+/*
+ * Read the bridge's translation state back out of its registers, whoever
+ * programmed it, so downstream sees what the hardware does rather than what
+ * a property says. On the x4 link the firmware points the window at a PCI
+ * address in no "ranges" entry, with the debug console behind it.
+ */
+static BOOL BridgeAdopt(struct PCIBcm2712Data *data)
+{
+    uint32_t base_limit, lo, hi;
+    uint64_t cpu_base, cpu_limit, pci_base;
+
+    if (!LinkUp(data))
+        return FALSE;
+
+    data->link_up = TRUE;
+    data->secondary_bus = (UBYTE)(rd32(data->regs, PCI_BUSNUM) >> 8);
+
+    lo = rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO);
+    hi = rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI);
+    pci_base = ((uint64_t)hi << 32) | lo;
+
+    base_limit = rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT);
+    cpu_base  = ((uint64_t)rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI) << 32) |
+                ((uint64_t)(base_limit & 0x0000fff0) << 16);
+    cpu_limit = ((uint64_t)rd32(data->regs, PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI) << 32) |
+                ((uint64_t)(base_limit & 0xfff00000)) | 0xfffff;
+
+    if (cpu_limit <= cpu_base)
+    {
+        bug("[PCIBcm2712] %s: outbound window is empty (%08x)\n",
+            data->bridge->node, (unsigned)base_limit);
+        return FALSE;
+    }
+
+    /*
+     * The window the hardware holds replaces whatever the tree said: it is
+     * the only outbound translation this driver knows how to perform, so it
+     * is the only one MapPCI may offer.
+     */
+    data->ranges[0].flags    = 0x02000000;
+    data->ranges[0].pci_base = pci_base;
+    data->ranges[0].cpu_base = cpu_base;
+    data->ranges[0].size     = cpu_limit - cpu_base + 1;
+    data->nranges = 1;
+
+    data->mem_pci_base = pci_base;
+    data->mem_cpu_base = cpu_base;
+    data->mem_size     = data->ranges[0].size;
+    data->mem_next     = pci_base;
+
+    AdoptInbound(data);
+
+    BRINGUP(bug("[PCIBcm2712] %s: %s, secondary bus %u, window pci %08x%08x -> cpu %08x%08x, %08x%08x bytes\n",
+                data->bridge->node, data->trained ? "trained here" : "adopted from firmware",
+                (unsigned)data->secondary_bus,
+                (unsigned)(pci_base >> 32), (unsigned)pci_base,
+                (unsigned)(cpu_base >> 32), (unsigned)cpu_base,
+                (unsigned)(data->mem_size >> 32), (unsigned)data->mem_size));
+
+    return TRUE;
+}
+
+/*
+ * The endpoint comes out of reset with no resources. Size BAR0 and place
+ * it at the bottom of the outbound window, then let it decode: on a PC the
+ * firmware does this before any driver runs, and nothing in AROS will -
+ * aHidd_PCIDevice_isMaster covers only bus mastering. Without it the first
+ * read of the BAR SErrors. Bus mastering is left to the endpoint's driver.
+ */
+static void SetupEndpoint(struct PCIBcm2712Data *data)
+{
+    UBYTE bus = data->secondary_bus;
+    ULONG id, lo, size;
+    BOOL is64;
+
+    id = PCIE_ReadConfig(data, bus, 0, 0, 0x00);
+    if (id == 0xffffffff || id == 0)
+    {
+        BRINGUP(bug("[PCIBcm2712] %s: no endpoint at %u:0.0\n",
+                    data->bridge->node, (unsigned)bus));
+        return;
+    }
+
+    lo = PCIE_ReadConfig(data, bus, 0, 0, 0x10);
+    is64 = ((lo & 0x06) == 0x04);
+
+    /* Size the BAR: all-ones comes back with the writable bits set. */
+    PCIE_WriteConfig(data, bus, 0, 0, 0x10, 0xffffffff);
+    size = PCIE_ReadConfig(data, bus, 0, 0, 0x10) & ~0xfUL;
+    size = size ? (~size + 1) : 0;
+
+    if (size && data->mem_size)
+    {
+        uint64_t addr = (data->mem_next + size - 1) & ~(uint64_t)(size - 1);
+
+        if (addr + size <= data->mem_pci_base + data->mem_size)
+        {
+            PCIE_WriteConfig(data, bus, 0, 0, 0x10, (ULONG)addr);
+            if (is64)
+                PCIE_WriteConfig(data, bus, 0, 0, 0x14, (ULONG)(addr >> 32));
+            data->mem_next = addr + size;
+        }
+        else
+        {
+            bug("[PCIBcm2712] %s: BAR0 (%u bytes) does not fit the window\n",
+                data->bridge->node, (unsigned)size);
+            PCIE_WriteConfig(data, bus, 0, 0, 0x10, lo);
+        }
+    }
     else
-        psd->ecam = NULL;
+        PCIE_WriteConfig(data, bus, 0, 0, 0x10, lo);
 
-    /* Inbound DMA offset */
-    psd->dma_offset = 0;
-    psd->dma_exp    = BCM2712_DMA_EXP;
+    /* Cache line size, as every reference stack programs */
+    PCIE_WriteConfig(data, bus, 0, 0, 0x0c,
+                     (PCIE_ReadConfig(data, bus, 0, 0, 0x0c) & ~0xffUL) | 16);
 
-    /* Check PHY link and data link status */
-    uint32_t status = rd32(psd->regs, PCIE2712_STATUS);
-    psd->link_up = (status & (PCIE2712_STATUS_PHYLINKUP | PCIE2712_STATUS_DL_ACTIVE)) != 0;
+    PCIE_WriteConfig(data, bus, 0, 0, PCI_CMD,
+                     PCIE_ReadConfig(data, bus, 0, 0, PCI_CMD) | PCI_CMD_MEMORY);
 
-    D(bug("[PCIBcm2712] Status=0x%08x link_up=%ld\n", (unsigned)status, (long)psd->link_up));
+    BRINGUP(bug("[PCIBcm2712] %s: endpoint %u:0.0 %04x:%04x class %06x cmd %04x BAR0 %08x%08x (%u bytes)\n",
+                data->bridge->node, (unsigned)bus,
+                (unsigned)(id & 0xffff), (unsigned)(id >> 16),
+                (unsigned)(PCIE_ReadConfig(data, bus, 0, 0, 0x08) >> 8),
+                (unsigned)(PCIE_ReadConfig(data, bus, 0, 0, PCI_CMD) & 0xffff),
+                (unsigned)(is64 ? PCIE_ReadConfig(data, bus, 0, 0, 0x14) : 0),
+                (unsigned)PCIE_ReadConfig(data, bus, 0, 0, 0x10), (unsigned)size));
+}
 
-    /* Obtain OOP Attribute Bases */
+/*
+ * Called from Root::New, once per bridge. Maps the registers, reads what the
+ * tree says, trains the bridge if nothing has, and then reads the result
+ * back. Returns FALSE if there is nothing usable, in which case no driver
+ * object is left behind.
+ */
+BOOL PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
+{
+    void *key;
+
+    key = PCIeNode(data->bridge);
+    if (!key)
+        return FALSE;
+
+    data->regs = MapDevice(psd, data->bridge->reg_base, BCM2712_PCIE_REG_SIZE);
+    if (!data->regs)
+    {
+        bug("[PCIBcm2712] %s: could not map the registers\n", data->bridge->node);
+        return FALSE;
+    }
+
+    data->rescal = MapDevice(psd, BCM2712_RESCAL_BASE, BCM2712_RESCAL_SIZE);
+    data->reset  = MapDevice(psd, BCM2712_RESET_BASE, BCM2712_RESET_SIZE);
+    data->reset_cell = ResetCellFromDT(key);
+    data->intx_irq   = IntxIrqFromDT(key);
+
+    data->nranges    = ParseRanges(key, "ranges", data->ranges);
+    data->ndmaranges = ParseRanges(key, "dma-ranges", data->dmaranges);
+
+    BRINGUP(bug("[PCIBcm2712] %s: INTA -> INTID %u\n", data->bridge->node,
+                (unsigned)data->intx_irq));
+
+    if (!data->ndmaranges)
+    {
+        /* Without an inbound window a bus master reaches no memory at all,
+           and there is no sane default to fall back on. */
+        bug("[PCIBcm2712] %s: no dma-ranges in the device tree\n", data->bridge->node);
+        return FALSE;
+    }
+
+    /*
+     * A link the firmware already trained is left alone. Resetting one
+     * costs whatever the firmware set up behind it, which on the x4 link
+     * is the console this would be reporting through.
+     */
+    if (!LinkUp(data))
+    {
+        if (!BridgeTrain(data, key))
+            return FALSE;
+    }
+    else
+        BRINGUP(bug("[PCIBcm2712] %s: link already up, adopting it\n", data->bridge->node));
+
+    if (!BridgeAdopt(data))
+        return FALSE;
+
+    if (data->trained)
+        SetupEndpoint(data);
+
+    return TRUE;
+}
+
+static int PCIBcm2712_InitClass(LIBBASETYPEPTR LIBBASE)
+{
+    struct pci_staticdata *psd = &LIBBASE->psd;
+    APTR KernelBase;
+    OOP_Object *pci;
+    unsigned int i;
+
+    if (!PCIeEnabled())
+        return TRUE;
+
+    OpenFirmwareBase = OpenResource("openfirmware.resource");
+    if (!OpenFirmwareBase)
+        return TRUE;
+
+    KernelBase = OpenResource("kernel.resource");
+    psd->kernelBase = (struct Library *)KernelBase;
+    if (!KernelBase)
+        return TRUE;
+
     psd->hiddPCIDriverAB = OOP_ObtainAttrBase(IID_Hidd_PCIDriver);
     psd->hiddPCIDeviceAB = OOP_ObtainAttrBase(IID_Hidd_PCIDevice);
     psd->hiddAB = OOP_ObtainAttrBase(IID_Hidd);
     if (psd->hiddPCIDriverAB == 0 || psd->hiddPCIDeviceAB == 0 || psd->hiddAB == 0)
     {
         D(bug("[PCIBcm2712] ObtainAttrBases failed\n"));
-        return FALSE;
+        return TRUE;
     }
 
-    /* Instantiate Driver Object */
-    psd->driverObject = OOP_NewObject(psd->driverClass, NULL, TAG_DONE);
-    if (!psd->driverObject)
+    pci = OOP_NewObject(NULL, CLID_Hidd_PCI, NULL);
+    if (!pci)
     {
-        D(bug("[PCIBcm2712] Failed to create driver object\n"));
-        return FALSE;
+        bug("[PCIBcm2712] could not create a pci.hidd object\n");
+        return TRUE;
     }
 
-    /* Register the driver with pci.hidd */
+    for (i = 0; i < BCM2712_NBRIDGES; i++)
     {
+        struct TagItem instanceTags[] = {
+            { aHidd_DriverData, (IPTR)&bcm2712_bridges[i] },
+            { TAG_DONE,         0                         }
+        };
         struct pHidd_PCI_AddHardwareDriver msg;
-        OOP_Object *pci;
 
-        msg.driverClass = psd->driverClass;
-        msg.mID = OOP_GetMethodID(IID_Hidd_PCI, moHidd_PCI_AddHardwareDriver);
+        BRINGUP(bug("[PCIBcm2712] starting bring-up of %s\n", bcm2712_bridges[i].node));
 
-        pci = OOP_NewObject(NULL, CLID_Hidd_PCI, NULL);
-        if (pci)
-        {
-            OOP_DoMethod(pci, (OOP_Msg)&msg);
-            OOP_DisposeObject(pci);
-            D(bug("[PCIBcm2712] driver registered\n"));
-        }
+        msg.mID          = OOP_GetMethodID(IID_Hidd_PCI, moHidd_PCI_AddHardwareDriver);
+        msg.driverClass  = psd->driverClass;
+        msg.instanceTags = instanceTags;
+
+        OOP_DoMethod(pci, (OOP_Msg)&msg);
     }
+
+    OOP_DisposeObject(pci);
 
     return TRUE;
 }
 
-ADD2INITLIB(PCIBcm2712_Init, 0)
+static int PCIBcm2712_ExpungeClass(LIBBASETYPEPTR LIBBASE)
+{
+    OOP_ReleaseAttrBase(IID_Hidd_PCIDriver);
+    OOP_ReleaseAttrBase(IID_Hidd_PCIDevice);
+    OOP_ReleaseAttrBase(IID_Hidd);
+
+    return TRUE;
+}
+
+ADD2INITLIB(PCIBcm2712_InitClass, 0)
+ADD2EXPUNGELIB(PCIBcm2712_ExpungeClass, 0)

--- a/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
+++ b/arch/arm-native/soc/broadcom/2712/hidd/pci-bcm2712/pcie2712_init.c
@@ -551,6 +551,129 @@ static void AdoptInbound(struct PCIBcm2712Data *data)
                     data->bridge->node));
 }
 
+/*
+ * Depth first for the mip node whose registers are at base. msi-parent is not
+ * followed - the openfirmware resource cannot resolve a phandle - but the MSI
+ * block sits at the CPU address of the bridge's own 4KB dma-range, so matching
+ * on the first reg entry picks the right one of the two.
+ *
+ * OF_FindNodeByCompatible() cannot walk this: its start argument is a subtree,
+ * not a cursor, and its own root is tested first, so a match returns itself.
+ */
+static void *FindMIPNode(void *node, uint64_t base)
+{
+    void *child = NULL;
+    void *prop = OF_FindProperty(node, "compatible");
+
+    if (prop)
+    {
+        const char *val = OF_GetPropValue(prop);
+
+        /* One string in this property, so the first is the whole list. */
+        if (val && (strcmp(val, "brcm,bcm2712-mip") == 0))
+        {
+            prop = OF_FindProperty(node, "reg");
+            if (prop && (OF_GetPropLen(prop) >= 4 * 4))
+            {
+                const uint32_t *r = (const uint32_t *)OF_GetPropValue(prop);
+
+                /* Parent is /axi: two cells of address, two of size. */
+                if ((((uint64_t)AROS_BE2LONG(r[0]) << 32) | AROS_BE2LONG(r[1])) == base)
+                    return node;
+            }
+        }
+    }
+
+    while ((child = OF_GetChild(node, child)) != NULL)
+    {
+        void *found = FindMIPNode(child, base);
+
+        if (found)
+            return found;
+    }
+
+    return NULL;
+}
+
+static void AdoptMSI(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
+{
+    uint64_t doorbell_cpu = 0, doorbell_pci = 0;
+    const uint32_t *r;
+    void *node, *prop;
+    uint32_t i;
+
+    for (i = 0; i < data->ndmaranges; i++)
+    {
+        if (data->dmaranges[i].size == 4096)
+        {
+            doorbell_cpu = data->dmaranges[i].cpu_base;
+            doorbell_pci = data->dmaranges[i].pci_base;
+            break;
+        }
+    }
+
+    if (!doorbell_cpu)
+    {
+        BRINGUP(bug("[PCIBcm2712] %s: no doorbell window, no MSI\n", data->bridge->node));
+        return;
+    }
+
+    node = FindMIPNode(OF_OpenKey("/"), doorbell_cpu);
+    if (!node)
+    {
+        BRINGUP(bug("[PCIBcm2712] %s: no mip node at 0x%p\n", data->bridge->node,
+                    (APTR)(IPTR)doorbell_cpu));
+        return;
+    }
+
+    /* msi-ranges is <phandle, type, base, flags, count>; only an edge
+       triggered SPI range is usable. */
+    prop = OF_FindProperty(node, "msi-ranges");
+    if (!prop || (OF_GetPropLen(prop) < 5 * 4))
+        return;
+
+    r = (const uint32_t *)OF_GetPropValue(prop);
+    if ((AROS_BE2LONG(r[1]) != 0) || (AROS_BE2LONG(r[3]) != 1))
+    {
+        BRINGUP(bug("[PCIBcm2712] %s: MSI range is not an edge triggered SPI range\n",
+                    data->bridge->node));
+        return;
+    }
+
+    data->msi_count = AROS_BE2LONG(r[4]);
+    data->msi_first_intid = AROS_BE2LONG(r[2]) + GIC_SPI_BASE;
+
+    prop = OF_FindProperty(node, "brcm,msi-offset");
+    if (prop && (OF_GetPropLen(prop) >= 4))
+        data->msi_first_intid += AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop));
+
+    if (data->msi_count > MIP_MAX_VECTORS)
+        data->msi_count = MIP_MAX_VECTORS;
+
+    data->mip = MapDevice(psd, doorbell_cpu, MIP_REG_SIZE);
+    if (!data->mip)
+    {
+        data->msi_count = 0;
+        return;
+    }
+
+    data->msi_target = doorbell_pci;
+
+    /* Everything to the host, nothing to the VideoCore, unmasked. */
+    wr32(data->mip, MIP_INT_MASKL_VPU, 0xffffffff);
+    wr32(data->mip, MIP_INT_MASKH_VPU, 0xffffffff);
+    wr32(data->mip, MIP_INT_CFGL_HOST, 0xffffffff);
+    wr32(data->mip, MIP_INT_CFGH_HOST, 0xffffffff);
+    wr32(data->mip, MIP_INT_MASKL_HOST, 0);
+    wr32(data->mip, MIP_INT_MASKH_HOST, 0);
+
+    BRINGUP(bug("[PCIBcm2712] %s: MSI at 0x%p, target %08x%08x, %u messages -> INTID %u..%u\n",
+                data->bridge->node, (APTR)(IPTR)doorbell_cpu,
+                (unsigned)(doorbell_pci >> 32), (unsigned)doorbell_pci,
+                (unsigned)data->msi_count, (unsigned)data->msi_first_intid,
+                (unsigned)(data->msi_first_intid + data->msi_count - 1)));
+}
+
 static BOOL LinkUp(struct PCIBcm2712Data *data)
 {
     uint32_t reg = rd32(data->regs, PCIE_MISC_PCIE_STATUS);
@@ -820,6 +943,26 @@ BOOL PCIE_BridgeSetup(struct pci_staticdata *psd, struct PCIBcm2712Data *data)
 
     if (!BridgeAdopt(data))
         return FALSE;
+
+    /*
+     * The bus numbers, on an adopted bridge too: the firmware leaves them
+     * at zero on the x4 link, and config space cannot reach an endpoint on
+     * a bus the bridge does not forward. This touches no window, so it
+     * costs the console nothing - and rp1.resource reads the secondary bus
+     * back out of the same register rather than assuming it.
+     */
+    if (!data->secondary_bus)
+    {
+        uint32_t reg = rd32(data->regs, PCI_BUSNUM);
+
+        wr32(data->regs, PCI_BUSNUM, (reg & 0xff000000) | 0x00010100);
+        data->secondary_bus = (UBYTE)(rd32(data->regs, PCI_BUSNUM) >> 8);
+
+        BRINGUP(bug("[PCIBcm2712] %s: bus numbers were unset, secondary bus now %u\n",
+                    data->bridge->node, (unsigned)data->secondary_bus));
+    }
+
+    AdoptMSI(psd, data);
 
     if (data->trained)
         SetupEndpoint(data);

--- a/arch/arm-native/soc/broadcom/2712/include/hardware/bcm2712_pcie.h
+++ b/arch/arm-native/soc/broadcom/2712/include/hardware/bcm2712_pcie.h
@@ -1,0 +1,187 @@
+/*
+    Copyright (C) 2026, The AROS Development Team. All rights reserved.
+
+    Desc: BCM2712 PCIe host bridge, MSI block and their reset blocks.
+
+    The register map is not covered by any published Broadcom document. It
+    follows OpenBSD's sys/dev/fdt/bcm2711_pcie.c and sys/arch/arm64/dev/
+    bcm2712_mip.c, which drive this hardware:
+
+    Copyright (c) 2020, 2025 Mark Kettenis <kettenis@openbsd.org>
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    The inbound window size encoding and the UBUS remap registers are also
+    described in worproject/edk2-platforms, branch rpi5-dev, file
+    Silicon/Broadcom/Bcm27xx/Library/Bcm2712PciHostBridgeLib (BSD-2-Clause
+    with patent grant).
+*/
+
+#ifndef HARDWARE_BCM2712_PCIE_H
+#define HARDWARE_BCM2712_PCIE_H
+
+/*
+ * BCM2712 has three host bridges, each a separate root complex with its own
+ * copy of this register block, its own reset bit and its own MSI block. They
+ * share only the rescal and reset blocks below. The block is the size the
+ * device tree declares; the indexed configuration window at the top of it is
+ * the last thing in it, and there is no ECAM anywhere.
+ */
+#define BCM2712_PCIE_REG_SIZE                           0x9310
+
+/* The root complex's own configuration header is at offset 0. */
+#define PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1         0x0188
+#define  PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_MASK            (0x3 << 2)
+#define  PCIE_RC_CFG_VENDOR_ENDIAN_BAR2_LITTLE          (0x0 << 2)
+#define PCIE_RC_CFG_PRIV1_ID_VAL3                       0x043c
+#define  PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_MASK           (0xffffff << 0)
+
+/* MDIO to the SerDes, used to pick the reference clock. */
+#define PCIE_RC_DL_MDIO_ADDR                            0x1100
+#define  PCIE_RC_DL_MDIO_PORT_SHIFT                     16
+#define  PCIE_RC_DL_MDIO_CMD_READ                       (1 << 20)
+#define  PCIE_RC_DL_MDIO_CMD_WRITE                      (0 << 20)
+#define PCIE_RC_DL_MDIO_WR_DATA                         0x1104
+#define PCIE_RC_DL_MDIO_RD_DATA                         0x1108
+#define  PCIE_RC_DL_MDIO_DATA_DONE                      (1U << 31)
+
+#define PCIE_RC_PL_PHY_CTL_15                           0x184c
+#define  PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK       (0xff << 0)
+
+#define PCIE_MISC_MISC_CTRL                             0x4008
+#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_64B_MODE          (1 << 7)
+#define  PCIE_MISC_MISC_CTRL_PCIE_RCB_MPS_MODE          (1 << 10)
+#define  PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN              (1 << 12)
+#define  PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE           (1 << 13)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK        (0x3 << 20)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_128         (0x0 << 20)
+#define  PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_512         (0x2 << 20)
+
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO                0x400c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI                0x4010
+
+/*
+ * Inbound windows. BAR1 through BAR3 are a contiguous group eight bytes
+ * apart, so a loop over them works - but BAR4 is not part of it, which is
+ * why every one is named here.
+ */
+#define PCIE_MISC_RC_BAR1_CONFIG_LO                     0x402c
+#define PCIE_MISC_RC_BAR1_CONFIG_HI                     0x4030
+#define PCIE_MISC_RC_BAR2_CONFIG_LO                     0x4034
+#define PCIE_MISC_RC_BAR2_CONFIG_HI                     0x4038
+#define PCIE_MISC_RC_BAR3_CONFIG_LO                     0x403c
+#define PCIE_MISC_RC_BAR3_CONFIG_HI                     0x4040
+#define PCIE_MISC_RC_BAR4_CONFIG_LO                     0x40d4
+#define PCIE_MISC_RC_BAR4_CONFIG_HI                     0x40d8
+#define  PCIE_MISC_RC_BAR_CONFIG_SIZE_MASK              (0x1f << 0)
+
+/* The bridge's own MSI matcher, which the 2712 does not use - its messages
+   go to the separate MSI block below. Kept because the register exists. */
+#define PCIE_MISC_MSI_BAR_CONFIG_LO                     0x4044
+#define PCIE_MISC_MSI_BAR_CONFIG_HI                     0x4048
+
+#define PCIE_MISC_PCIE_CTRL                             0x4064
+#define  PCIE_MISC_PCIE_CTRL_PCIE_PERSTB                (1 << 2)
+#define PCIE_MISC_PCIE_STATUS                           0x4068
+#define  PCIE_MISC_PCIE_STATUS_PCIE_PHYLINKUP           (1 << 4)
+#define  PCIE_MISC_PCIE_STATUS_PCIE_DL_ACTIVE           (1 << 5)
+#define PCIE_MISC_REVISION                              0x406c
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT        0x4070
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI           0x4080
+#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI          0x4084
+
+/*
+ * The CPU side of each inbound window, with its own enable bit. The 2711
+ * has no UBUS: there an inbound window is implicitly anchored at CPU
+ * address zero, so RC_BAR alone routes it. Here it is a register pair, and
+ * without it the window has a bus address but no CPU side to land on.
+ */
+#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_LO             0x40ac
+#define PCIE_MISC_UBUS_BAR1_CONFIG_REMAP_HI             0x40b0
+#define PCIE_MISC_UBUS_BAR2_CONFIG_REMAP_LO             0x40b4
+#define PCIE_MISC_UBUS_BAR2_CONFIG_REMAP_HI             0x40b8
+#define PCIE_MISC_UBUS_BAR4_CONFIG_REMAP_LO             0x410c
+#define PCIE_MISC_UBUS_BAR4_CONFIG_REMAP_HI             0x4110
+#define  PCIE_MISC_UBUS_REMAP_EN                        (1 << 0)
+#define  PCIE_MISC_UBUS_REMAP_LO_MASK                   0xfffff000
+#define  PCIE_MISC_UBUS_REMAP_HI_MASK                   0xff
+
+#define PCIE_MISC_AXI_READ_ERROR_DATA                   0x4170
+
+/* Not 0x4204 as on the 2711 - the block moved on this SoC. */
+#define PCIE_HARD_DEBUG                                 0x4304
+#define  PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE            (1 << 1)
+#define  PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE             (1 << 16)
+#define  PCIE_HARD_DEBUG_REFCLK_OVRD_OUT                (1 << 20)
+#define  PCIE_HARD_DEBUG_L1SS_ENABLE                    (1 << 21)
+#define  PCIE_HARD_DEBUG_SERDES_IDDQ                    (1 << 27)
+#define  PCIE_HARD_DEBUG_CLKREQ_MASK \
+    (PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE | PCIE_HARD_DEBUG_REFCLK_OVRD_ENABLE | \
+     PCIE_HARD_DEBUG_REFCLK_OVRD_OUT | PCIE_HARD_DEBUG_L1SS_ENABLE)
+
+#define PCIE_EXT_CFG_DATA                               0x8000
+#define PCIE_EXT_CFG_INDEX                              0x9000
+
+/* External config index encoding, also the tag layout drivers use. */
+#define EXT_CFG_ADDR(bus, dev, func)    (((bus) << 20) | ((dev) << 15) | ((func) << 12))
+
+/*
+ * An inbound window's size field is log2 less 15 from 64KB up, and a
+ * separate encoding below that. The small branch is not a curiosity: the
+ * MSI doorbell window is 4KB.
+ */
+#define PCIE_RC_BAR_SIZE_4K                             0x1c
+
+/*
+ * Shared by all three bridges. Neither block is described by anything but
+ * the device tree; these are the addresses after /soc's ranges translation.
+ */
+#define BCM2712_RESCAL_BASE             0x1000119500ULL
+#define BCM2712_RESCAL_SIZE             0x10
+#define BCM2712_RESET_BASE              0x1001504318ULL
+#define BCM2712_RESET_SIZE              0x30
+
+/* Rescal is self-deasserting, so only the assert side is ever used. */
+#define RESCAL_START                    0x00
+#define  RESCAL_START_BIT               (1 << 0)
+#define RESCAL_STATUS                   0x08
+#define  RESCAL_STATUS_BIT              (1 << 0)
+
+/* brcmstb reset: banks of 32 bits, set and clear registers 24 bytes apart. */
+#define RESET_SW_INIT_SET(bank)         (0x00 + (bank) * 24)
+#define RESET_SW_INIT_CLR(bank)         (0x04 + (bank) * 24)
+
+/*
+ * The MSI-X Interrupt Peripheral. Each host bridge has one, named by its
+ * msi-parent; a device signals by writing the message number to the target
+ * address, and the block raises one GIC SPI per message - so there is no
+ * status register to demultiplex, unlike the 2711 bridge's own matcher.
+ */
+#define MIP_INT_RAISE                   0x00
+#define MIP_INT_CLEAR                   0x10
+#define MIP_INT_CFGL_HOST               0x20
+#define MIP_INT_CFGH_HOST               0x30
+#define MIP_INT_MASKL_HOST              0x40
+#define MIP_INT_MASKH_HOST              0x50
+#define MIP_INT_MASKL_VPU               0x60
+#define MIP_INT_MASKH_VPU               0x70
+#define MIP_INT_STATUSL_HOST            0x80
+#define MIP_INT_STATUSH_HOST            0x90
+
+#define MIP_REG_SIZE                    0xc0
+
+/* GIC interrupt IDs start above the 32 SGIs and PPIs; the device tree
+   numbers shared peripheral interrupts from zero. */
+#define GIC_SPI_BASE                    32
+
+#endif /* HARDWARE_BCM2712_PCIE_H */

--- a/arch/arm-native/soc/broadcom/2712/include/mmakefile.src
+++ b/arch/arm-native/soc/broadcom/2712/include/mmakefile.src
@@ -1,0 +1,4 @@
+include $(SRCDIR)/config/aros.cfg
+
+INCLUDE_FILES := $(call WILDCARD, hardware/*.h)
+%copy_includes mmake=compiler-includes path=hardware dir=hardware

--- a/arch/arm-native/soc/broadcom/2712/rp1/pcirp1.conf
+++ b/arch/arm-native/soc/broadcom/2712/rp1/pcirp1.conf
@@ -20,7 +20,7 @@ struct pcirp1_staticdata
     OOP_Class          *driverClass;
     OOP_AttrBase        hiddAB;
     struct Library     *kernelBase;
-    IPTR                dma_offset;
+    OOP_Object         *bridge;         /* the root complex RP1 sits behind */
     /* One synthetic type 0 header per xHCI; vendor 0 = not present. */
     ULONG               cfg[RP1_XHCI_COUNT][16];
 };

--- a/arch/arm-native/soc/broadcom/2712/rp1/rp1.h
+++ b/arch/arm-native/soc/broadcom/2712/rp1/rp1.h
@@ -10,6 +10,7 @@
 
 #include <exec/types.h>
 #include <exec/libraries.h>
+#include <oop/oop.h>
 
 #define RP1_PCIE_VENDOR_ID      0x1DE4
 #define RP1_PCIE_DEVICE_ID      0x0001
@@ -34,8 +35,10 @@ struct RP1Base {
     BOOL            rp1_Present;
     IPTR            rp1_BAR1;       /* PCIe BAR1 base address */
 
-    /* Added to a CPU address to get the bus address a master must use. */
-    IPTR            rp1_DMAOffset;
+    /* RP1 as pci.hidd sees it, and the root complex it hangs off - which
+       is what translates DMA addresses for anything behind RP1. */
+    OOP_Object     *rp1_PCIDevice;
+    OOP_Object     *rp1_PCIDriver;
 
     /* GIC INTIDs the xHCI controllers signal on, 0 if MSI is not up. */
     ULONG           rp1_USBIrq0;

--- a/arch/arm-native/soc/broadcom/2712/rp1/rp1_init.c
+++ b/arch/arm-native/soc/broadcom/2712/rp1/rp1_init.c
@@ -8,164 +8,36 @@
 /* Bring-up diagnostics: window and peripheral addresses. */
 #define DEBUG 1
 
+#define __OOP_NOATTRBASES__
+
 #include <exec/types.h>
-#include <exec/memory.h>
+#include <inttypes.h>
 #include <aros/debug.h>
 #include <aros/symbolsets.h>
-#include <aros/macros.h>
-#include <proto/exec.h>
-#include <proto/kernel.h>
-#include <proto/openfirmware.h>
+#include <hidd/hidd.h>
+#include <hidd/pci.h>
+#include <oop/oop.h>
+#include <utility/hooks.h>
+#include <utility/tagitem.h>
 
-#include <string.h>
+#include <proto/exec.h>
+#include <proto/oop.h>
 
 #include "rp1.h"
 
 #include LC_LIBDEFS_FILE
 
-/* Named for the OF_ macros, which call through a base of this name. */
-static IPTR query_rp1(APTR OpenFirmwareBase, IPTR *dmaoff)
-{
-    void *key, *prop;
-    const uint32_t *r;
-    uint32_t child_ac, child_sc, parent_ac, entry_cells, cells;
-    IPTR win = 0;
+/*
+ * RP1 is an endpoint on the x4 root complex, which pcibcm2712.hidd has
+ * already adopted and pci.hidd has enumerated. Everything about the link -
+ * config space, the outbound window BAR1 lives in, inbound DMA windows, the
+ * MSI block and the MSI-X table - belongs to that driver. What is left here
+ * is RP1's own: which of its interrupts go out as which message.
+ */
 
-    *dmaoff = 0;
-
-    key = OF_OpenKey("/axi/pcie@1000120000");
-    if (!key)
-    {
-        D(bug("[RP1] no PCIe node for RP1 in the device tree\n"));
-        return 0;
-    }
-
-    /* OF_OpenKey falls back to the last resolved node on a miss. */
-    prop = OF_FindProperty(key, "compatible");
-    if (!prop || !strstr(OF_GetPropValue(prop), "2712-pcie"))
-    {
-        D(bug("[RP1] node is not a BCM2712 PCIe bridge\n"));
-        return 0;
-    }
-
-    if (!OF_GetChild(key, NULL))
-    {
-        D(bug("[RP1] PCIe bridge has no devices below it\n"));
-        return 0;
-    }
-
-    prop = OF_FindProperty(key, "#address-cells");
-    child_ac = prop ? AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop)) : 3;
-    prop = OF_FindProperty(key, "#size-cells");
-    child_sc = prop ? AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop)) : 2;
-
-    key = OF_OpenKey("/axi");
-    prop = key ? OF_FindProperty(key, "#address-cells") : NULL;
-    parent_ac = prop ? AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop)) : 2;
-
-    key = OF_OpenKey("/axi/pcie@1000120000");
-    prop = OF_FindProperty(key, "ranges");
-    if (!prop)
-        return 0;
-
-    entry_cells = child_ac + parent_ac + child_sc;
-    r = (const uint32_t *)OF_GetPropValue(prop);
-    cells = OF_GetPropLen(prop) / 4;
-
-    while (cells >= entry_cells)
-    {
-        /* The first child cell is the PCI space code, not an address. */
-        uint32_t space = AROS_BE2LONG(r[0]);
-        uint64_t cpu = 0, len = 0;
-        uint32_t i;
-
-        r += child_ac;
-        for (i = 0; i < parent_ac; i++)
-            cpu = (cpu << 32) | AROS_BE2LONG(*r++);
-        for (i = 0; i < child_sc; i++)
-            len = (len << 32) | AROS_BE2LONG(*r++);
-
-        D(bug("[RP1] window: space %08x -> 0x%p, 0x%p bytes\n",
-              space, (APTR)(IPTR)cpu, (APTR)(IPTR)len));
-
-        /* Prefetchable memory (space code 0x03) is the one in use. */
-        if (!win && ((space >> 24) & 0x03) == 0x03)
-            win = (IPTR)cpu;
-
-        cells -= entry_cells;
-    }
-
-    /* Inbound windows; the widest one covers system memory. */
-    prop = OF_FindProperty(key, "dma-ranges");
-    if (prop)
-    {
-        uint64_t best = 0;
-
-        r = (const uint32_t *)OF_GetPropValue(prop);
-        cells = OF_GetPropLen(prop) / 4;
-
-        while (cells >= entry_cells)
-        {
-            uint64_t pci = 0, cpu = 0, len = 0;
-            uint32_t i;
-
-            r++;                        /* space code */
-            for (i = 1; i < child_ac; i++)
-                pci = (pci << 32) | AROS_BE2LONG(*r++);
-            for (i = 0; i < parent_ac; i++)
-                cpu = (cpu << 32) | AROS_BE2LONG(*r++);
-            for (i = 0; i < child_sc; i++)
-                len = (len << 32) | AROS_BE2LONG(*r++);
-
-            D(bug("[RP1] dma window: pci 0x%p <- cpu 0x%p, 0x%p bytes\n",
-                  (APTR)(IPTR)pci, (APTR)(IPTR)cpu, (APTR)(IPTR)len));
-
-            if (len > best)
-            {
-                best = len;
-                *dmaoff = (IPTR)(pci - cpu);
-            }
-
-            cells -= entry_cells;
-        }
-    }
-    else
-    {
-        D(bug("[RP1] no dma-ranges - assuming an identity inbound window\n"));
-    }
-
-    return win;
-}
-
-/* Offsets into the BCM2712 PCIe RC, same layout as arch/../2711/pcie/pcie.h */
-#define RC_VENDOR_SPECIFIC_REG1 0x0188
-#define  RC_ENDIAN_BAR2_MASK    (0x3 << 2)
-#define  RC_ENDIAN_BAR2_LITTLE  (0x0 << 2)
-#define RC_MISC_CTRL            0x4008
-#define RC_MEM_WIN0_LO          0x400c
-#define RC_MEM_WIN0_HI          0x4010
-#define RC_MEM_WIN0_BASE_LIMIT  0x4070
-#define RC_MEM_WIN0_BASE_HI     0x4080
-#define RC_MEM_WIN0_LIMIT_HI    0x4084
-#define RC_BAR2_CONFIG_LO       0x4034
-#define RC_BAR2_CONFIG_HI       0x4038
-/* 2712 only: the CPU side of an inbound window, with its own enable. */
-#define RC_UBUS_BAR2_REMAP_LO   0x40b4
-#define RC_UBUS_BAR2_REMAP_HI   0x40b8
-#define  RC_UBUS_REMAP_ENABLE   (1 << 0)
-#define  RC_UBUS_REMAP_LO_MASK  0xfffff000
-#define  RC_UBUS_REMAP_HI_MASK  0xff
-#define RC_MSI_BAR_CONFIG_LO    0x4044
-#define RC_MSI_BAR_CONFIG_HI    0x4048
-#define RC_EXT_CFG_DATA         0x8000
-#define RC_EXT_CFG_INDEX        0x9000
-#define RC_REGS_SIZE            0xa000
-
-#define EXT_CFG_ADDR(bus, dev, fn)  (((bus) << 20) | ((dev) << 15) | ((fn) << 12))
-
-/* PCI command register bits we care about */
-#define PCI_CMD_MEMORY          (1 << 1)
-#define PCI_CMD_MASTER          (1 << 2)
+/* Named for proto/oop.h and the aHidd_* macros. */
+struct Library *OOPBase;
+static OOP_AttrBase HiddPCIDeviceAttrBase;
 
 /* RP1 interrupt-to-message block in BAR1; REG_SET is an atomic set alias.
    Datasheet 6.2, register layout from edk2-platforms Rp1BusDxe. */
@@ -176,229 +48,100 @@ static IPTR query_rp1(APTR OpenFirmwareBase, IPTR *dmaoff)
 #define RP1_INT_USBHOST0_0      31
 #define RP1_INT_USBHOST1_0      36
 
-/* Inbound window 1, for the MSI target: it sits outside the memory window. */
-#define RC_BAR4_CONFIG_LO       0x40d4
-#define RC_BAR4_CONFIG_HI       0x40d8
-#define RC_UBUS_BAR4_REMAP_LO   0x410c
-#define RC_UBUS_BAR4_REMAP_HI   0x4110
-#define  RC_IB_SIZE_4K          0x1c        /* edk2 PcieEncodeInboundSize */
+/* Interrupt n leaves as message n, so the table has to hold all of them. */
+#define RP1_MSI_COUNT           64
 
-/* MSI Interrupt Peripheral, one dedicated SPI per message - nothing to
-   demultiplex.  Register layout from OpenBSD bcm2712_mip.c (ISC). */
-#define MIP_INT_CFGL_HOST       0x20
-#define MIP_INT_CFGH_HOST       0x30
-#define MIP_INT_MASKL_HOST      0x40
-#define MIP_INT_MASKH_HOST      0x50
-#define MIP_INT_MASKL_VPU       0x60
-#define MIP_INT_MASKH_VPU       0x70
-
-#define GIC_SPI_BASE            32          /* INTID = SPI + 32 */
-
-/* MSI-X capability, and the table it points at */
-#define PCI_CAP_ID_MSIX         0x11
-#define  MSIX_CTRL_ENABLE       (1 << 31)   /* bit 15 of the 16-bit ctrl */
-#define  MSIX_TABLE_BIR_MASK    0x7
-#define  MSIX_TABLE_OFF_MASK    ~0x7u
-
-#define RCRD(rc, o) (*(volatile uint32_t *)((IPTR)(rc) + (o)))
-
-/* Root port config space is the first 4K of the register block; the
-   endpoint's goes through the shared EXT_CFG window, so index and data
-   have to stay together.  The bus number is the programmed secondary -
-   a wrong one answers every read with all ones. */
-static uint32_t rc_cfg_read(IPTR rc, uint32_t reg)
+AROS_UFH3(static void, rp1_enum,
+    AROS_UFHA(struct Hook *, hook, A0),
+    AROS_UFHA(OOP_Object *, dev, A2),
+    AROS_UFHA(APTR, unused, A1))
 {
-    return RCRD(rc, reg);
+    AROS_USERFUNC_INIT
+
+    OOP_Object **found = hook->h_Data;
+
+    if (!*found)
+        *found = dev;
+
+    AROS_USERFUNC_EXIT
 }
 
-static uint8_t rc_secondary_bus(IPTR rc)
+static OOP_Object *find_rp1(void)
 {
-    return (uint8_t)(rc_cfg_read(rc, 0x18) >> 8);
-}
+    OOP_Object *pci, *dev = NULL;
+    struct Hook hook = {
+        .h_Entry = (IPTR (*)())rp1_enum,
+        .h_Data  = &dev,
+    };
+    struct TagItem req[] = {
+        { tHidd_PCI_VendorID,  RP1_PCIE_VENDOR_ID },
+        { tHidd_PCI_ProductID, RP1_PCIE_DEVICE_ID },
+        { TAG_DONE,            0                  }
+    };
+    struct pHidd_PCI_EnumDevices msg = {
+        .mID          = OOP_GetMethodID(IID_Hidd_PCI, moHidd_PCI_EnumDevices),
+        .callback     = &hook,
+        .requirements = req,
+    };
 
-static uint32_t ep_cfg_read(IPTR rc, uint32_t reg)
-{
-    uint32_t val;
-
-    Disable();
-    RCRD(rc, RC_EXT_CFG_INDEX) = EXT_CFG_ADDR(rc_secondary_bus(rc), 0, 0);
-    val = RCRD(rc, RC_EXT_CFG_DATA + reg);
-    Enable();
-
-    return val;
-}
-
-static void ep_cfg_write(IPTR rc, uint32_t reg, uint32_t val)
-{
-    Disable();
-    RCRD(rc, RC_EXT_CFG_INDEX) = EXT_CFG_ADDR(rc_secondary_bus(rc), 0, 0);
-    RCRD(rc, RC_EXT_CFG_DATA + reg) = val;
-    Enable();
-}
-
-/* Mapped writable - the inbound windows are programmed through it. */
-static IPTR map_rc(APTR OpenFirmwareBase, APTR KernelBase)
-{
-    void *key, *prop;
-    uint64_t rc = 0;
-
-    key = OF_OpenKey("/axi/pcie@1000120000");
-    prop = key ? OF_FindProperty(key, "reg") : NULL;
-    if (prop && (OF_GetPropLen(prop) >= 8))
-    {
-        const uint32_t *r = (const uint32_t *)OF_GetPropValue(prop);
-
-        rc = ((uint64_t)AROS_BE2LONG(r[0]) << 32) | AROS_BE2LONG(r[1]);
-    }
-
-    if (!rc)
-    {
-        D(bug("[RP1] no usable reg on the PCIe bridge\n"));
-        return 0;
-    }
-
-    if (!KrnMapGlobal((void *)(IPTR)rc, (void *)(IPTR)rc, RC_REGS_SIZE,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
-    {
-        D(bug("[RP1] failed to map the bridge registers at 0x%p\n", (APTR)(IPTR)rc));
-        return 0;
-    }
-
-    return (IPTR)rc;
-}
-
-/* Where the window actually is, not where dma-ranges says it should be.
-   The low five bits are the size code. */
-static IPTR rc_dma_offset(IPTR rc)
-{
-    uint32_t lo = RCRD(rc, RC_BAR2_CONFIG_LO);
-    uint32_t hi = RCRD(rc, RC_BAR2_CONFIG_HI);
-
-    return (IPTR)(((uint64_t)hi << 32) | (lo & ~0x1fU));
-}
-
-/* Nothing else resolves phandles for us. */
-static void *find_by_phandle(APTR OpenFirmwareBase, void *key, uint32_t want, int depth)
-{
-    void *child, *prop, *hit;
-
-    if (depth > 6)
+    pci = OOP_NewObject(NULL, CLID_Hidd_PCI, NULL);
+    if (!pci)
         return NULL;
 
-    prop = OF_FindProperty(key, "phandle");
-    if (prop && (OF_GetPropLen(prop) >= 4) &&
-        (AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop)) == want))
-        return key;
+    OOP_DoMethod(pci, (OOP_Msg)&msg);
+    OOP_DisposeObject(pci);
 
-    for (child = OF_GetChild(key, NULL); child; child = OF_GetChild(key, child))
-    {
-        hit = find_by_phandle(OpenFirmwareBase, child, want, depth + 1);
-        if (hit)
-            return hit;
-    }
-
-    return NULL;
+    return dev;
 }
 
-/* Inbound window, MIP, MSI-X table and the two USB vectors. */
-static void setup_msi(APTR OpenFirmwareBase, APTR KernelBase, IPTR rc, IPTR win,
-                      uint64_t msi_target, IPTR mipbase, uint32_t base_spi,
-                      LIBBASETYPEPTR LIBBASE)
+static ULONG vector_intid(OOP_Object *dev, ULONG vector)
 {
-    uint32_t cap, ctrl, tbl;
-    IPTR bar0, mip, table;
+    struct TagItem attr[] = {
+        { tHidd_PCIVector_Int, 0 },
+        { TAG_DONE,            0 }
+    };
+    struct pHidd_PCIDevice_GetVectorAttribs msg = {
+        .mID      = OOP_GetMethodID(IID_Hidd_PCIDevice, moHidd_PCIDevice_GetVectorAttribs),
+        .vectorno = vector,
+        .attribs  = attr,
+    };
 
-    /* Inbound window 1, so a message written to the target reaches the MIP. */
-    RCRD(rc, RC_BAR4_CONFIG_LO) = ((uint32_t)msi_target & ~0x1fu) | RC_IB_SIZE_4K;
-    RCRD(rc, RC_BAR4_CONFIG_HI) = (uint32_t)(msi_target >> 32);
-    RCRD(rc, RC_UBUS_BAR4_REMAP_LO) = ((uint32_t)mipbase & RC_UBUS_REMAP_LO_MASK) |
-                                      RC_UBUS_REMAP_ENABLE;
-    RCRD(rc, RC_UBUS_BAR4_REMAP_HI) = (uint32_t)((UQUAD)mipbase >> 32) & RC_UBUS_REMAP_HI_MASK;
+    OOP_DoMethod(dev, (OOP_Msg)&msg);
 
-    D(bug("[RP1MSI] ib win1 %08x:%08x remap %08x:%08x\n",
-          (unsigned)RCRD(rc, RC_BAR4_CONFIG_HI), (unsigned)RCRD(rc, RC_BAR4_CONFIG_LO),
-          (unsigned)RCRD(rc, RC_UBUS_BAR4_REMAP_HI), (unsigned)RCRD(rc, RC_UBUS_BAR4_REMAP_LO)));
+    return (attr[0].ti_Data == (IPTR)-1) ? 0 : (ULONG)attr[0].ti_Data;
+}
 
-    /* The MIP itself: keep the VPU out, route everything to the host. */
-    if (!KrnMapGlobal((void *)mipbase, (void *)mipbase, 0x1000,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
+/* The bridge fills the MSI-X table with message i in entry i; RP1 is then
+   told which of its interrupts to send, and we learn where they land. */
+static void setup_msi(OOP_Object *dev, IPTR win, LIBBASETYPEPTR LIBBASE)
+{
+    struct TagItem req[] = {
+        { tHidd_PCIVector_Min, RP1_MSI_COUNT },
+        { tHidd_PCIVector_Max, RP1_MSI_COUNT },
+        { TAG_DONE,            0             }
+    };
+    struct pHidd_PCIDevice_ObtainVectors msg = {
+        .mID          = OOP_GetMethodID(IID_Hidd_PCIDevice, moHidd_PCIDevice_ObtainVectors),
+        .requirements = req,
+    };
+    volatile uint32_t *set0, *set1;
+
+    if (!OOP_DoMethod(dev, (OOP_Msg)&msg))
     {
-        D(bug("[RP1MSI] failed to map the MIP at 0x%p\n", (APTR)mipbase));
-        return;
-    }
-    mip = mipbase;
-
-    RCRD(mip, MIP_INT_MASKL_VPU) = 0xffffffff;
-    RCRD(mip, MIP_INT_MASKH_VPU) = 0xffffffff;
-    RCRD(mip, MIP_INT_CFGL_HOST) = 0xffffffff;
-    RCRD(mip, MIP_INT_CFGH_HOST) = 0xffffffff;
-    RCRD(mip, MIP_INT_MASKL_HOST) = 0;
-    RCRD(mip, MIP_INT_MASKH_HOST) = 0;
-
-    /* The table's BAR sits next to BAR1 in the outbound window. */
-    for (cap = ep_cfg_read(rc, 0x34) & 0xfc; cap && (cap != 0xfc); cap = (ep_cfg_read(rc, cap) >> 8) & 0xfc)
-        if ((ep_cfg_read(rc, cap) & 0xff) == PCI_CAP_ID_MSIX)
-            break;
-
-    if (!cap || (cap == 0xfc))
-    {
-        D(bug("[RP1MSI] no MSI-X capability\n"));
+        D(bug("[RP1MSI] the bridge has no %u messages for RP1 - no MSI\n", RP1_MSI_COUNT));
         return;
     }
 
-    tbl  = ep_cfg_read(rc, cap + 4);
-    bar0 = ep_cfg_read(rc, 0x10) & ~0xfu;
-    table = win + (bar0 - (ep_cfg_read(rc, 0x14) & ~0xfu)) + (tbl & MSIX_TABLE_OFF_MASK);
+    LIBBASE->rp1_USBIrq0 = vector_intid(dev, RP1_INT_USBHOST0_0);
+    LIBBASE->rp1_USBIrq1 = vector_intid(dev, RP1_INT_USBHOST1_0);
 
-    D(bug("[RP1MSI] msix cap @%02x tbl %08x bir %u -> table at 0x%p\n",
-          (unsigned)cap, (unsigned)tbl, (unsigned)(tbl & MSIX_TABLE_BIR_MASK), (APTR)table));
+    set0 = (volatile uint32_t *)(win + RP1_PCIE_REG_SET + RP1_PCIE_MSIX_CFG(RP1_INT_USBHOST0_0));
+    set1 = (volatile uint32_t *)(win + RP1_PCIE_REG_SET + RP1_PCIE_MSIX_CFG(RP1_INT_USBHOST1_0));
+    *set0 = RP1_MSIX_CFG_ENABLE;
+    *set1 = RP1_MSIX_CFG_ENABLE;
 
-    if (!KrnMapGlobal((void *)(table & ~0xfffUL), (void *)(table & ~0xfffUL), 0x1000,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
-    {
-        D(bug("[RP1MSI] failed to map the MSI-X table\n"));
-        return;
-    }
-
-    /* Every entry carries its own index, so which one an interrupt picks
-       does not have to be assumed. */
-    {
-        volatile uint32_t *e = (volatile uint32_t *)table;
-        uint32_t i, n = (ep_cfg_read(rc, cap) >> 16) & 0x7ff;
-
-        for (i = 0; i <= n; i++)
-        {
-            e[i * 4 + 0] = (uint32_t)msi_target;
-            e[i * 4 + 1] = (uint32_t)(msi_target >> 32);
-            e[i * 4 + 2] = i;       /* message data = MSI number */
-            e[i * 4 + 3] = 0;       /* unmasked */
-        }
-
-        D(bug("[RP1MSI] programmed %u msix table entries\n", (unsigned)(n + 1)));
-    }
-
-    /* Nothing has ever set MSI-X Enable, so the endpoint would stay silent. */
-    ctrl = ep_cfg_read(rc, cap);
-    ep_cfg_write(rc, cap, ctrl | MSIX_CTRL_ENABLE);
-    D(bug("[RP1MSI] msix ctrl %08x -> %08x\n",
-          (unsigned)ctrl, (unsigned)ep_cfg_read(rc, cap)));
-
-    /* Entry i carries message i, so the MIP raises base_spi + i. */
-    {
-        volatile uint32_t *set0 = (volatile uint32_t *)
-            (win + RP1_PCIE_REG_SET + RP1_PCIE_MSIX_CFG(RP1_INT_USBHOST0_0));
-        volatile uint32_t *set1 = (volatile uint32_t *)
-            (win + RP1_PCIE_REG_SET + RP1_PCIE_MSIX_CFG(RP1_INT_USBHOST1_0));
-
-        *set0 = RP1_MSIX_CFG_ENABLE;
-        *set1 = RP1_MSIX_CFG_ENABLE;
-
-        LIBBASE->rp1_USBIrq0 = base_spi + RP1_INT_USBHOST0_0 + GIC_SPI_BASE;
-        LIBBASE->rp1_USBIrq1 = base_spi + RP1_INT_USBHOST1_0 + GIC_SPI_BASE;
-
-        D(bug("[RP1MSI] usb irqs: host0 INTID %u, host1 INTID %u\n",
-              (unsigned)LIBBASE->rp1_USBIrq0, (unsigned)LIBBASE->rp1_USBIrq1));
-    }
+    D(bug("[RP1MSI] usb irqs: host0 INTID %u, host1 INTID %u\n",
+          (unsigned)LIBBASE->rp1_USBIrq0, (unsigned)LIBBASE->rp1_USBIrq1));
 
     /* MSIX_CFG.TEST is avoided: it latches through the set alias and
        leaves no rising edge for real interrupts. */
@@ -406,126 +149,58 @@ static void setup_msi(APTR OpenFirmwareBase, APTR KernelBase, IPTR rc, IPTR win,
 
 static int RP1_Init(LIBBASETYPEPTR LIBBASE)
 {
-    IPTR win, dtoff, dmaoff, rc;
+    OOP_Object *dev, *drv = NULL;
+    IPTR bar1 = 0, win;
+    struct TagItem enable[] = {
+        { aHidd_PCIDevice_isMEM,    TRUE },
+        { aHidd_PCIDevice_isMaster, TRUE },
+        { TAG_DONE,                 0    }
+    };
 
-    APTR OpenFirmwareBase = OpenResource("openfirmware.resource");
-    /* Named for the KrnMapGlobal macro below, as OpenFirmwareBase is for
-     * the OF_ ones. */
-    APTR KernelBase = OpenResource("kernel.resource");
-
-    /* Without a device tree */
-    if (!OpenFirmwareBase || !KernelBase)
+    OOPBase = OpenLibrary("oop.library", 0);
+    if (!OOPBase)
         return TRUE;
 
-    win = query_rp1(OpenFirmwareBase, &dtoff);
-    if (!win)
+    HiddPCIDeviceAttrBase = OOP_ObtainAttrBase(IID_Hidd_PCIDevice);
+    if (!HiddPCIDeviceAttrBase)
+        return TRUE;
+
+    dev = find_rp1();
+    if (!dev)
         return TRUE;                    /* not an RP1 board */
 
-    rc = map_rc(OpenFirmwareBase, KernelBase);
-
-    /* The firmware leaves this at 0, which claims nothing RP1 emits. */
-    if (rc && dtoff)
+    OOP_GetAttr(dev, aHidd_PCIDevice_Driver, (IPTR *)&drv);
+    OOP_GetAttr(dev, aHidd_PCIDevice_Base1, &bar1);
+    if (!drv || !bar1)
     {
-        uint32_t lo = RCRD(rc, RC_BAR2_CONFIG_LO);
-
-        RCRD(rc, RC_BAR2_CONFIG_LO) = (uint32_t)dtoff | (lo & 0x1f);
-        RCRD(rc, RC_BAR2_CONFIG_HI) = (uint32_t)((UQUAD)dtoff >> 32);
-
-        /* CPU side of the same window: system memory starts at 0. */
-        RCRD(rc, RC_UBUS_BAR2_REMAP_LO) = (0 & RC_UBUS_REMAP_LO_MASK) |
-                                          RC_UBUS_REMAP_ENABLE;
-        RCRD(rc, RC_UBUS_BAR2_REMAP_HI) = 0 & RC_UBUS_REMAP_HI_MASK;
-
-        D(bug("[RP1] inbound window: bar2 %08x:%08x remap %08x:%08x\n",
-              (unsigned)RCRD(rc, RC_BAR2_CONFIG_HI),
-              (unsigned)RCRD(rc, RC_BAR2_CONFIG_LO),
-              (unsigned)RCRD(rc, RC_UBUS_BAR2_REMAP_HI),
-              (unsigned)RCRD(rc, RC_UBUS_BAR2_REMAP_LO)));
-    }
-    else if (!rc)
-    {
-        D(bug("[RP1] no bridge mapping - inbound window left as the firmware set it\n"));
-    }
-
-    /* No device object to set aHidd_PCIDevice_isMaster on here. */
-    if (rc)
-    {
-        uint32_t cs = rc_cfg_read(rc, 0x04);
-
-        if ((cs & (PCI_CMD_MEMORY | PCI_CMD_MASTER)) != (PCI_CMD_MEMORY | PCI_CMD_MASTER))
-        {
-            RCRD(rc, 0x04) = cs | PCI_CMD_MEMORY | PCI_CMD_MASTER;
-            D(bug("[RP1] root port cmd %04x -> %04x\n", (unsigned)(cs & 0xffff),
-                  (unsigned)(rc_cfg_read(rc, 0x04) & 0xffff)));
-        }
-    }
-
-    if (rc && (ep_cfg_read(rc, 0x00) != 0xffffffff))
-    {
-        uint32_t cs = ep_cfg_read(rc, 0x04);
-
-        if ((cs & (PCI_CMD_MEMORY | PCI_CMD_MASTER)) != (PCI_CMD_MEMORY | PCI_CMD_MASTER))
-        {
-            ep_cfg_write(rc, 0x04, cs | PCI_CMD_MEMORY | PCI_CMD_MASTER);
-            D(bug("[RP1] endpoint cmd %04x -> %04x\n", (unsigned)(cs & 0xffff),
-                  (unsigned)(ep_cfg_read(rc, 0x04) & 0xffff)));
-        }
-    }
-
-    dmaoff = rc ? rc_dma_offset(rc) : dtoff;
-
-    if (!KrnMapGlobal((void *)win, (void *)win, RP1_BAR1_SIZE,
-                      MAP_Readable | MAP_Writable | MAP_CacheInhibit | MAP_Guarded))
-    {
-        D(bug("[RP1] failed to map the peripheral window at 0x%p\n", (APTR)win));
+        D(bug("[RP1] endpoint found but BAR1 is unset\n"));
         return TRUE;
     }
-    
-    /*
-     * Does an MSI from RP1 reach the bridge at all?  MSIX_CFG.TEST fires
-     * one without needing a working controller behind it, and the 2711
-     * style latch is the only place we know to look.  Nothing is wired to
-     * the GIC yet, so a latched bit is read and cleared here.
-     */
-    if (rc)
+
+    /* BAR1 is a bus address; the bridge maps it and says where it landed. */
     {
-        void *key = OF_OpenKey("/axi/pcie@1000120000");
-        void *root = OF_OpenKey("/");
-        void *prop = key ? OF_FindProperty(key, "msi-parent") : NULL;
-        void *mipnode = NULL;
+        struct pHidd_PCIDriver_MapPCI map = {
+            .mID        = OOP_GetMethodID(IID_Hidd_PCIDriver, moHidd_PCIDriver_MapPCI),
+            .PCIAddress = (APTR)bar1,
+            .Length     = RP1_BAR1_SIZE,
+        };
 
-        if (prop && (OF_GetPropLen(prop) >= 4) && root)
-            mipnode = find_by_phandle(OpenFirmwareBase, root,
-                          AROS_BE2LONG(*(const uint32_t *)OF_GetPropValue(prop)), 0);
-
-        prop = mipnode ? OF_FindProperty(mipnode, "reg") : NULL;
-        if (prop && (OF_GetPropLen(prop) >= 32))
-        {
-            const uint32_t *r = (const uint32_t *)OF_GetPropValue(prop);
-            IPTR     mipbase = ((IPTR)AROS_BE2LONG(r[0]) << 32) | AROS_BE2LONG(r[1]);
-            uint64_t target  = ((uint64_t)AROS_BE2LONG(r[4]) << 32) | AROS_BE2LONG(r[5]);
-            uint32_t base_spi = 0;
-            void *mr = OF_FindProperty(mipnode, "msi-ranges");
-
-            /* <gic-phandle, type, base SPI, flags, count> */
-            if (mr && (OF_GetPropLen(mr) >= 20))
-                base_spi = AROS_BE2LONG(((const uint32_t *)OF_GetPropValue(mr))[2]);
-
-            D(bug("[RP1MSI] mip regs 0x%p, msi target 0x%p, base spi %u\n",
-                  (APTR)mipbase, (APTR)(IPTR)target, (unsigned)base_spi));
-
-            if (base_spi)
-                setup_msi(OpenFirmwareBase, KernelBase, rc, win, target, mipbase,
-                          base_spi, LIBBASE);
-        }
-        else
-        {
-            D(bug("[RP1MSI] no usable MIP node - MSI left alone\n"));
-        }
+        win = (IPTR)OOP_DoMethod(drv, (OOP_Msg)&map);
     }
 
+    if (!win)
+    {
+        D(bug("[RP1] could not map the peripheral window at bus 0x%p\n", (APTR)bar1));
+        return TRUE;
+    }
+
+    OOP_SetAttrs(dev, enable);
+
+    setup_msi(dev, win, LIBBASE);
+
     LIBBASE->rp1_BAR1 = win;
-    LIBBASE->rp1_DMAOffset = dmaoff;
+    LIBBASE->rp1_PCIDevice = dev;
+    LIBBASE->rp1_PCIDriver = drv;
     LIBBASE->rp1_Present = TRUE;
 
     /* Export peripheral addresses */
@@ -537,10 +212,11 @@ static int RP1_Init(LIBBASETYPEPTR LIBBASE)
     LIBBASE->rp1_I2C1  = win + RP1_I2C1_OFFSET;
     LIBBASE->rp1_UART0 = win + RP1_UART0_OFFSET;
 
-    D(bug("[RP1] USB0=0x%p USB1=0x%p ETH=0x%p GPIO=0x%p I2C0=0x%p I2C1=0x%p UART0=0x%p\n",
-          LIBBASE->rp1_USB0, LIBBASE->rp1_USB1, LIBBASE->rp1_ETH,
-          LIBBASE->rp1_GPIO, LIBBASE->rp1_I2C0, LIBBASE->rp1_I2C1,
-          LIBBASE->rp1_UART0));
+    D(bug("[RP1] window 0x%p (bus 0x%p) USB0=0x%p USB1=0x%p ETH=0x%p GPIO=0x%p I2C0=0x%p I2C1=0x%p UART0=0x%p\n",
+          (APTR)win, (APTR)bar1,
+          (APTR)LIBBASE->rp1_USB0, (APTR)LIBBASE->rp1_USB1, (APTR)LIBBASE->rp1_ETH,
+          (APTR)LIBBASE->rp1_GPIO, (APTR)LIBBASE->rp1_I2C0, (APTR)LIBBASE->rp1_I2C1,
+          (APTR)LIBBASE->rp1_UART0));
 
     return TRUE;
 }

--- a/arch/arm-native/soc/broadcom/2712/rp1/rp1_init.c
+++ b/arch/arm-native/soc/broadcom/2712/rp1/rp1_init.c
@@ -48,8 +48,10 @@ static OOP_AttrBase HiddPCIDeviceAttrBase;
 #define RP1_INT_USBHOST0_0      31
 #define RP1_INT_USBHOST1_0      36
 
-/* Interrupt n leaves as message n, so the table has to hold all of them. */
-#define RP1_MSI_COUNT           64
+/* Interrupt n leaves as message n, so entries 0 through the last USB
+   interrupt must exist; the table may hold fewer than the block's 64. */
+#define RP1_MSI_MIN             (RP1_INT_USBHOST1_0 + 1)
+#define RP1_MSI_MAX             64
 
 AROS_UFH3(static void, rp1_enum,
     AROS_UFHA(struct Hook *, hook, A0),
@@ -116,8 +118,8 @@ static ULONG vector_intid(OOP_Object *dev, ULONG vector)
 static void setup_msi(OOP_Object *dev, IPTR win, LIBBASETYPEPTR LIBBASE)
 {
     struct TagItem req[] = {
-        { tHidd_PCIVector_Min, RP1_MSI_COUNT },
-        { tHidd_PCIVector_Max, RP1_MSI_COUNT },
+        { tHidd_PCIVector_Min, RP1_MSI_MIN },
+        { tHidd_PCIVector_Max, RP1_MSI_MAX },
         { TAG_DONE,            0             }
     };
     struct pHidd_PCIDevice_ObtainVectors msg = {
@@ -128,7 +130,7 @@ static void setup_msi(OOP_Object *dev, IPTR win, LIBBASETYPEPTR LIBBASE)
 
     if (!OOP_DoMethod(dev, (OOP_Msg)&msg))
     {
-        D(bug("[RP1MSI] the bridge has no %u messages for RP1 - no MSI\n", RP1_MSI_COUNT));
+        D(bug("[RP1MSI] could not get %u messages for RP1 - no MSI\n", RP1_MSI_MIN));
         return;
     }
 

--- a/arch/arm-native/soc/broadcom/2712/rp1/rp1_pci.c
+++ b/arch/arm-native/soc/broadcom/2712/rp1/rp1_pci.c
@@ -36,7 +36,7 @@
 
 /*
  * The xHCI blocks are not PCI functions of their own; they sit in RP1's
- * BAR1 window, which rp1.resource has already mapped.  Each is given a
+ * BAR1 window, which rp1.resource had the root complex map.  Each is given a
  * synthetic type 0 header at 00:0n.0, so pcixhci finds them like any
  * other controller.  The BAR holds the CPU address.
  */
@@ -151,20 +151,22 @@ VOID PCIRP1__Hidd_PCIDriver__WriteConfigLong(OOP_Class *cl, OOP_Object *o, struc
     WriteConfigLong(PSD(cl), msg->bus, msg->dev, msg->sub, msg->reg, msg->val);
 }
 
-/* The BAR is a CPU address inside the window rp1.resource mapped. */
+/* The BAR is a CPU address inside the already mapped BAR1 window. */
 APTR PCIRP1__Hidd_PCIDriver__MapPCI(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_MapPCI *msg)
 {
     return msg->PCIAddress;
 }
 
+/* A master inside RP1 goes through the root complex's inbound windows, so
+   the bridge answers these; the message is the same interface's. */
 APTR PCIRP1__Hidd_PCIDriver__CPUtoPCI(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_CPUtoPCI *msg)
 {
-    return (APTR)((IPTR)msg->address + PSD(cl)->dma_offset);
+    return (APTR)OOP_DoMethod(PSD(cl)->bridge, (OOP_Msg)msg);
 }
 
 APTR PCIRP1__Hidd_PCIDriver__PCItoCPU(OOP_Class *cl, OOP_Object *o, struct pHidd_PCIDriver_PCItoCPU *msg)
 {
-    return (APTR)((IPTR)msg->address - PSD(cl)->dma_offset);
+    return (APTR)OOP_DoMethod(PSD(cl)->bridge, (OOP_Msg)msg);
 }
 
 /*
@@ -244,7 +246,7 @@ static int PCIRP1_Init(LIBBASETYPEPTR LIBBASE)
     if (!psd->kernelBase || !psd->hiddAB)
         return FALSE;
 
-    psd->dma_offset = rp1->rp1_DMAOffset;
+    psd->bridge = rp1->rp1_PCIDriver;
 
     base[0] = rp1->rp1_USB0;
     base[1] = rp1->rp1_USB1;


### PR DESCRIPTION
Brings up the BCM2712 PCIe host bridges on the Raspberry Pi 5 / 500 / 500+,
so NVMe on the M.2 slot and RP1's peripherals both work. Six commits, in order:

- **kernel/bcm2712: edge trigger every MIP's SPIs** — the MSI range came from
  the x4 bridge's `msi-parent` alone, so the x1 link's edge pulses landed on
  lines configured for level and were never latched. All three bridges are
  consulted, and `brcm,msi-offset` is applied.
- **soc/bcm2712: drive the PCIe host bridges** — the driver itself: one object
  per bridge, trained or adopted from the firmware. The x4 link is adopted
  because resetting it takes away RP1's UART0, which is the debug console.
- **soc/bcm2712: hand out MSI vectors from the bridge's MSI block** — MSI/MSI-X
  via the MIP, found from the bridge's own doorbell dma-range.
- **kernel/bcm2712: fix the peripheral base type mismatch** — one line.
- **bcm2712: let the PCIe bridge own pcie2, make rp1 a pci.hidd consumer** —
  rp1 stops driving the bridge itself and becomes an ordinary pci.hidd
  consumer; the shared register map moves to `hardware/bcm2712_pcie.h`.
- **soc/bcm2712: clamp MSI vector runs to what the device's table holds** —
  RP1 was given a run longer than its MSI-X table could address, so USB never
  saw an interrupt.