### PR TITLE
tools/package: normalize extracted paths safely

### DIFF
--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -54,8 +54,7 @@ def readFile( file ):
         file.read( struct.calcsize( PKG_FILE_PATHLENGTH_FORMAT ) )
     )
     
-    path = file.read( pathLength[0] )
-    file.read(1)
+    path = file.read( pathLength[0] + 1 ).split( b'\0', 1 )[0]
     
     dataLength = struct.unpack(
         PKG_FILE_DATALENGTH_FORMAT,
@@ -100,6 +99,7 @@ def unpack( source, destination ):
     
     oldwd = os.getcwd()
     os.chdir( destination )
+    destinationRoot = os.path.realpath( os.getcwdb() )
     
     version = readHeader( input )
     
@@ -108,8 +108,16 @@ def unpack( source, destination ):
         
         print('« %s (%d bytes)' % (path, len( data )))
         
+        target = os.path.realpath( os.path.abspath( path ) )
+        try:
+            contained = os.path.commonpath((destinationRoot, target)) == destinationRoot
+        except ValueError:
+            contained = False
+        if os.path.isabs( path ) or not contained:
+            raise ValueError('Package member path escapes destination: %r' % path)
+
         directory = os.path.dirname( path )
-        if directory != '' and not os.path.exists( directory ):
+        if directory and not os.path.exists( directory ):
             os.makedirs( directory )
             
         output = open( path, 'wb' )


### PR DESCRIPTION
Root-level PKG members fail to extract under Python 3 because `os.path.dirname()` returns `b''`, while the extractor compares it against `''`.

Review also uncovered the more general cause: the on-disk pathname field is padded to a 4-byte boundary, and `readFile()` currently exposes that padding to callers. This breaks nested members as well as root-level members whenever the pathname length requires padding.

Normalize the pathname at the format boundary in `readFile()` using C-string semantics, so both root and nested members receive the actual pathname.

Doing that also makes previously padded absolute or `../` member names usable pathnames instead of failing incidentally on embedded NULs. Therefore extraction now resolves each normalized member against the destination root and rejects absolute paths, parent traversal, and escapes through pre-existing symlinks before creating directories or files.

Verified against the current upstream master and an AROS-generated `aros-bsp.pkg`:

* package creation remains byte-identical
* root and nested extraction succeeds
* all four pathname alignment classes are covered
* all 24 historical BSP members extract with matching payload/cursor behavior
* absolute and parent-relative paths are rejected
* pre-existing symlink escapes are rejected
* apply/reverse/recovery checks pass

This also subsumes the pathname-containment work from #1178.