### PR TITLE
 tools/package: contain extracted member paths

### DIFF
--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -100,7 +100,8 @@ def unpack( source, destination ):
     
     oldwd = os.getcwd()
     os.chdir( destination )
-    
+    destinationRoot = os.path.realpath( os.getcwdb() )
+
     version = readHeader( input )
     
     while input.tell() < inputSize:
@@ -108,6 +109,15 @@ def unpack( source, destination ):
         
         print('« %s (%d bytes)' % (path, len( data )))
         
+        securityPath = path.rstrip(b'\0')
+        target = os.path.realpath( os.path.abspath( securityPath ) )
+        try:
+            contained = os.path.commonpath((destinationRoot, target)) == destinationRoot
+        except ValueError:
+            contained = False
+        if os.path.isabs( securityPath ) or not contained:
+            raise ValueError('Package member path escapes destination: %r' % path)
+
         directory = os.path.dirname( path )
         if not directory:
             path = path.rstrip(b'\0')

--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -109,7 +109,9 @@ def unpack( source, destination ):
         print('« %s (%d bytes)' % (path, len( data )))
         
         directory = os.path.dirname( path )
-        if directory != '' and not os.path.exists( directory ):
+        if not directory:
+            path = path.rstrip(b'\0')
+        elif not os.path.exists( directory ):
             os.makedirs( directory )
             
         output = open( path, 'wb' )


### PR DESCRIPTION
Package member paths are currently used directly during extraction, allowing absolute or parent-relative paths to escape the selected destination.

Resolve each member path against the extraction root and reject paths that resolve outside it before creating directories or writing the file. This also prevents escapes through pre-existing symlinks that resolve outside the destination.

Valid root-level and nested relative paths remain unchanged, and package creation output is unaffected.
