### PR TITLE
m68k: memory footprint reduction

### DIFF
--- a/arch/m68k-all/kernel/cpu_m68k.h
+++ b/arch/m68k-all/kernel/cpu_m68k.h
@@ -17,6 +17,9 @@
 /* Number of exceptions supported by the CPU. Needed by kernel_base.h */
 #define EXCEPTIONS_COUNT 256
 
+/* m68k has many exception vectors, but normally no registered raw handlers. */
+#define KERNEL_SPARSE_EXCEPTIONS
+
 /* CPU context stored in task's et_RegFrame. */
 struct AROSCPUContext
 {

--- a/arch/m68k-all/kernel/createcontext.c
+++ b/arch/m68k-all/kernel/createcontext.c
@@ -1,0 +1,38 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Allocate only the CPU context state supported by this m68k CPU.
+*/
+
+#include <stddef.h>
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+#include <exec/execbase.h>
+#include <exec/memory.h>
+#include <proto/exec.h>
+
+#include <kernel_base.h>
+#include <kernel_cpu.h>
+
+#include <proto/kernel.h>
+
+AROS_LH0(void *, KrnCreateContext,
+         struct KernelBase *, KernelBase, 18, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    ULONG size;
+
+    /* The bootstrap context predates CPU detection and must fit every CPU. */
+    if (SysBase->ThisTask == NULL || (SysBase->AttnFlags & AFF_68080))
+        size = sizeof(struct AROSCPUContext);
+    else if (SysBase->AttnFlags & AFF_FPU)
+        size = offsetof(struct AROSCPUContext, ammx);
+    else
+        size = sizeof(struct ExceptionContext);
+
+    return AllocVec(size, MEMF_CLEAR);
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/m68k-all/kernel/deletecontext.c
+++ b/arch/m68k-all/kernel/deletecontext.c
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 1995-2026, The AROS Development Team. All rights reserved.
+
+    Desc: Free a variable-sized m68k CPU context.
+*/
+
+#include <aros/kernel.h>
+#include <aros/libcall.h>
+#include <proto/exec.h>
+
+#include <kernel_base.h>
+
+#include <proto/kernel.h>
+
+AROS_LH1(void, KrnDeleteContext,
+         AROS_LHA(void *, context, A0),
+         struct KernelBase *, KernelBase, 19, Kernel)
+{
+    AROS_LIBFUNC_INIT
+
+    FreeVec(context);
+
+    AROS_LIBFUNC_EXIT
+}

--- a/arch/m68k-all/kernel/mmakefile.src
+++ b/arch/m68k-all/kernel/mmakefile.src
@@ -30,6 +30,8 @@ FILES := \
         platform_init \
         setprotection \
         mapglobal \
+        createcontext \
+        deletecontext \
         mmu \
         virtualtophysical \
         bushandler

--- a/rom/devs/gameport/gameport.c
+++ b/rom/devs/gameport/gameport.c
@@ -185,8 +185,7 @@ static int GM_UNIQUENAME(open)
     
     if (GPBase->gp_eventBuffer == NULL)
     {
-        GPBase->gp_eventBuffer = AllocMem(sizeof(UWORD) * GP_BUFFERSIZE,
-                                          MEMF_ANY);
+        GPBase->gp_eventBuffer = AllocMem(GP_BUFFER_BYTES, MEMF_ANY);
     }
     
     /* No memory for key buffer? */

--- a/rom/devs/gameport/gameport_intern.h
+++ b/rom/devs/gameport/gameport_intern.h
@@ -19,7 +19,7 @@
 /* Must always be a multiple of 4 since one event consists of code, x, y and flags */
 
 #define  GP_NUMELEMENTS 	(100 * 4)
-#define  GP_BUFFERSIZE  	(sizeof (WORD) * GP_NUMELEMENTS) 
+#define  GP_BUFFER_BYTES	(sizeof (WORD) * GP_NUMELEMENTS)
 
 #define  GP_NUNITS        	2 /* Number of units supported by gameport.device */
 

--- a/rom/dos/runcommand.c
+++ b/rom/dos/runcommand.c
@@ -127,7 +127,12 @@
     if(stacksize < AROS_STACKSIZE)
         stacksize = AROS_STACKSIZE;
 
+#ifdef __mc68000
+    /* Keep temporary command stacks out of the low-address free region. */
+    stack=(UBYTE *)AllocMem(stacksize,MEMF_ANY | MEMF_REVERSE);
+#else
     stack=(UBYTE *)AllocMem(stacksize,MEMF_ANY);
+#endif
     if(stack==NULL)
         return -1;
 

--- a/rom/exec/alert.c
+++ b/rom/exec/alert.c
@@ -120,13 +120,13 @@ void Exec_ExtAlert(ULONG alertNum, APTR location, APTR stack, UBYTE type, APTR d
             D(bug("[Alert] Setting alert context, type %u, data 0x%p\n", type, data));
 
             iet->iet_AlertType = type;
-            CopyMem(data, &iet->iet_AlertData, contextSizes[type]);
+            CopyMem(data, ETaskAlertData(iet), contextSizes[type]);
         }
         else
         {
             /* Either no data or already present */
             type = iet->iet_AlertType;
-            data = &iet->iet_AlertData;
+            data = ETaskAlertData(iet);
             
             D(bug("[Alert] Got stored alert context, type %u, data 0x%p\n", type, data));
         }

--- a/rom/exec/createpool.c
+++ b/rom/exec/createpool.c
@@ -123,7 +123,7 @@
      * so nothing downstream changes; with zero free bytes it can never
      * satisfy an allocation nor be reclaimed as an empty puddle.
      */
-    headerSize = MEMHEADER_TOTAL + mhac_GetCtxSize()
+    headerSize = MEMHEADER_TOTAL
         + ((poolstruct_size + MEMCHUNK_TOTAL - 1) & ~(MEMCHUNK_TOTAL - 1));
 
     firstPuddle = nommu_AllocMem(headerSize, requirements & ~MEMF_SEM_PROTECTED, &tp, SysBase);
@@ -206,7 +206,12 @@
              * Note that we use ln_Name of our MemHeader to point back to
              * our pool (directly or indirectly).
              */
-            mhac_PoolMemHeaderSetup(firstPuddle, pool);
+            /*
+             * The compact handle block has no allocatable space after the
+             * pool structure.  It therefore needs no allocator search
+             * context; only real data puddles need one.
+             */
+            firstPuddle->mh_Node.ln_Name = NULL;
             AddTail((struct List *)&pool->pool.PuddleList, &firstPuddle->mh_Node);
         }
     }

--- a/rom/exec/etask.h
+++ b/rom/exec/etask.h
@@ -2,7 +2,7 @@
 #define _ETASK_H
 
 /*
-    Copyright © 1995-2017, The AROS Development Team. All rights reserved.
+    Copyright (C) 1995-2017, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc: Internal description of the ETask structure
@@ -48,14 +48,18 @@ struct IntETask
     struct timespec     iet_StartTime;          /* time the task was launched              */
     struct timespec     iet_CpuTime;            /* time the task has spent running         */
     ULONG               iet_CpuUsage;           /* CPU Usage of this task                  */
+#ifndef __mc68000
     UQUAD               iet_private1;
     UQUAD               iet_private2;
+#endif
     ULONG               iet_AlertCode;          /* Alert code for crash handler            */
     UBYTE               iet_AlertType;          /* Type of the alert context               */
     UBYTE               iet_AlertFlags;         /* See below                               */
     APTR                iet_AlertLocation;      /* Alert location for crash handler        */
     APTR                iet_AlertStack;         /* Frame pointer for stack backtrace       */
+#ifndef __mc68000
     struct AlertContext iet_AlertData;          /* Extra data coming with the crash        */
+#endif
 #if defined(__AROSEXEC_SMP__)
     void                *iet_Session;
     spinlock_t          iet_TaskLock;
@@ -63,10 +67,12 @@ struct IntETask
     cpumask_t           *iet_CpuAffinity;        /* bitmap of cores this task can run on    */
     spinlock_t          *iet_SpinLock;          /* pointer to spinlock task is spinning on */
 #endif
+#ifndef __mc68000
     /* Last CPU-usage sample, for arches that sweep iet_CpuUsage. */
     UQUAD               iet_LastBusy;           /* iet_private2 at the last sample         */
     UQUAD               iet_LastUsageStamp;     /* when that sample was taken              */
     ULONG               iet_QuantumLeft;        /* scheduler ticks left of this task's slice */
+#endif
 #ifdef DEBUG_ETASK
     STRPTR              iet_Me;
 #endif
@@ -74,6 +80,13 @@ struct IntETask
 
 #define GetIntETask(task)   ((struct IntETask *)GetETask(task))
 #define IntETask(etask)     ((struct IntETask *)(etask))
+#ifdef __mc68000
+/* Integer task state lives on the task stack, leaving this context available
+ * to retain alert details while the failed task is stopped. */
+#define ETaskAlertData(iet) ((struct AlertContext *)(iet)->iet_ETask.et_RegFrame)
+#else
+#define ETaskAlertData(iet) (&(iet)->iet_AlertData)
+#endif
 
 /* iet_AlertFlags */
 #define AF_Alert    0x01    /* The task is in alert state      */

--- a/rom/exec/memory.c
+++ b/rom/exec/memory.c
@@ -1105,19 +1105,46 @@ APTR InternalAllocPooled(APTR poolHeader, IPTR memSize, ULONG flags, struct Trac
                 /* Align the size up to page boundary */
                 puddleSize = (puddleSize + align) & ~align;
             }
-            else if (head->ln_Succ && head->ln_Succ->ln_Succ == NULL)
+            else
             {
+                struct MemHeader *puddle;
+                IPTR neededSize;
+
                 /*
-                 * Slow start: the only list entry is the pool's header
-                 * block, so this is the pool's first data puddle. Many
-                 * pools only ever hold a handful of small allocations;
-                 * size the first puddle for the request instead of
-                 * committing a full puddleSize up front. Pools that
-                 * keep allocating get full-size puddles from the
-                 * second one on.
+                 * Grow small pools gradually.  A large default puddle is a
+                 * useful steady-state size, but committing all of it on the
+                 * second small allocation wastes a considerable amount of
+                 * memory in pools which only ever contain a few objects.
+                 *
+                 * Derive the next size from existing puddles rather than
+                 * adding growth state to the pool header.  Only puddles with
+                 * compatible physical attributes participate because pools
+                 * are allowed to mix, for example, CHIP and FAST memory.
                  */
-                puddleSize = memSize + MEMHEADER_TOTAL + mhac_GetCtxSize();
-                puddleSize = (puddleSize + MEMCHUNK_TOTAL - 1) & ~(MEMCHUNK_TOTAL - 1);
+                neededSize = memSize + MEMHEADER_TOTAL + mhac_GetCtxSize();
+                neededSize = (neededSize + MEMCHUNK_TOTAL - 1) & ~(MEMCHUNK_TOTAL - 1);
+
+                puddleSize = neededSize;
+                for (puddle = (struct MemHeader *)head;
+                     puddle->mh_Node.ln_Succ != NULL;
+                     puddle = (struct MemHeader *)puddle->mh_Node.ln_Succ)
+                {
+                    IPTR oldSize;
+
+                    if ((APTR)puddle == poolHeader ||
+                        (physFlags & ~puddle->mh_Attributes))
+                        continue;
+
+                    oldSize = (IPTR)puddle->mh_Upper - (IPTR)puddle;
+                    if (oldSize < pool->pool.PuddleSize &&
+                        oldSize > puddleSize / 2)
+                        puddleSize = oldSize * 2;
+                }
+
+                if (puddleSize > pool->pool.PuddleSize)
+                    puddleSize = pool->pool.PuddleSize;
+                if (puddleSize < neededSize)
+                    puddleSize = neededSize;
             }
 
             mh = AllocMemHeader(puddleSize, flags, loc, SysBase);

--- a/rom/exec/supervisoralert.c
+++ b/rom/exec/supervisoralert.c
@@ -63,7 +63,7 @@ void SupervisorAlertTask(struct ExecBase *SysBase)
             }
 
             Alert_DisplayKrnAlert(t, alertNum | AT_DeadEnd, iet->iet_AlertLocation, iet->iet_AlertStack,
-                    iet->iet_AlertType, (APTR)&iet->iet_AlertData, SysBase);
+                    iet->iet_AlertType, (APTR)ETaskAlertData(iet), SysBase);
 
             if (alertNum & AT_DeadEnd)
             {

--- a/rom/exec/systemalert.c
+++ b/rom/exec/systemalert.c
@@ -53,7 +53,7 @@ void Exec_SystemAlert(ULONG alertNum, APTR location, APTR stack, UBYTE type, APT
             location = iet->iet_AlertLocation;
             stack = iet->iet_AlertStack;
             type = iet->iet_AlertType;
-            data = (APTR)&iet->iet_AlertData;
+            data = (APTR)ETaskAlertData(iet);
         }
         else
             t = PrivExecBase(SysBase)->SAT.sat_Task;

--- a/rom/exec/traphandler.c
+++ b/rom/exec/traphandler.c
@@ -109,7 +109,7 @@ void Exec_TrapHandler(ULONG trapNum, struct ExceptionContext *ctx)
              * Note that we store only GPR part of the context. We don't copy
              * attached FPU data (if any). This can be considered TODO.
              */
-            CopyMem(ctx, &iet->iet_AlertData, sizeof(struct ExceptionContext));
+            CopyMem(ctx, ETaskAlertData(iet), sizeof(struct ExceptionContext));
 
             /*
              * Make the task to jump to crash handler. We don't care about return address etc because

--- a/rom/exec/useralert.c
+++ b/rom/exec/useralert.c
@@ -116,7 +116,7 @@ reshow:
             if ((choice == 1) && !full)
             {
                 /* 'More' has been pressed. Append full alert data */
-                FormatAlertExtra(end, iet->iet_AlertStack, iet ? iet->iet_AlertType : AT_NONE, iet ? &iet->iet_AlertData : NULL, SysBase);
+                FormatAlertExtra(end, iet->iet_AlertStack, iet ? iet->iet_AlertType : AT_NONE, iet ? ETaskAlertData(iet) : NULL, SysBase);
 
                 /* Sanite the text before using in BuildEasyRequestArgs. Make sure all formatting strings are removed */
                 Sanitize(end);

--- a/rom/filesys/CDVDFS/src/cdrom.c
+++ b/rom/filesys/CDVDFS/src/cdrom.c
@@ -140,7 +140,7 @@ CDROM *Open_CDROM
         if (NULL == cd->buffer_data)
             break;
 
-        cd->buffer_io = AllocVec(SCSI_BUFSIZE, p_memory_type);
+        cd->buffer_io = AllocVec(SCSI_IO_BUFSIZE, p_memory_type);
         if (NULL == cd->buffer_io)
             break;
 
@@ -469,7 +469,7 @@ t_toc_data *Read_TOC
     /*
      * make sure it never happens (shouldn't)
      */
-    if (toc_len > SCSI_BUFSIZE)
+    if (toc_len > SCSI_IO_BUFSIZE)
         return NULL;
 
     /*
@@ -751,4 +751,3 @@ int Find_Last_Session(CDROM *p_cd, uint32_t *p_result)
     *p_result = (data[8] << 24) | (data[9] << 16) | (data[10] << 8) | (data[11]);
     return TRUE;
 }
-

--- a/rom/filesys/CDVDFS/src/cdrom.h
+++ b/rom/filesys/CDVDFS/src/cdrom.h
@@ -19,6 +19,8 @@
 #define VERSION "CDROM-Handler 1.15 (03.11.94)"
 
 #define SCSI_BUFSIZE 2048
+/* Four-byte TOC header, 99 track descriptors and the lead-out descriptor. */
+#define SCSI_IO_BUFSIZE (4 + 100 * 8)
 
 
 typedef struct CDROM {

--- a/rom/filesys/CDVDFS/src/device.c
+++ b/rom/filesys/CDVDFS/src/device.c
@@ -349,7 +349,10 @@ ULONG signals;
       global->g_time = 0;
     }
 
-    global->g_vol_name = AllocVec(128, MEMF_PUBLIC | MEMF_CLEAR);
+    /* ISO/HFS Volume_ID() is capped at 32 characters below. Keep the
+     * BCPL length byte and the trailing C string terminator as well.
+     */
+    global->g_vol_name = AllocVec(34, MEMF_PUBLIC | MEMF_CLEAR);
     global->g_dos_sigbit = 1L << global->DosProc->pr_MsgPort.mp_SigBit;
     returnpacket(global, packet);
     Prefs_Init(global);

--- a/rom/filesys/CDVDFS/src/iso9660.c
+++ b/rom/filesys/CDVDFS/src/iso9660.c
@@ -239,12 +239,19 @@ t_bool Iso_Init_Vol_Info(VOLUME *p_volume, int p_skip, t_ulong p_offset, t_ulong
 
         if ((p_volume->cd->buffer[0] == 1) || (p_volume->cd->buffer[0] == 2))
         {
-            CopyMem
-                (
-                 p_volume->cd->buffer,
-                 &VOL(p_volume,pvd),
-                 sizeof (prim_vol_desc)
-                );
+            const prim_vol_desc *pvd =
+                (const prim_vol_desc *)p_volume->cd->buffer;
+
+            CopyMem(pvd->system_id, VOL(p_volume,pvd).system_id,
+                    sizeof(VOL(p_volume,pvd).system_id));
+            CopyMem(pvd->volume_id, VOL(p_volume,pvd).volume_id,
+                    sizeof(VOL(p_volume,pvd).volume_id));
+            VOL(p_volume,pvd).space_size = pvd->space_size;
+            VOL(p_volume,pvd).block_size = pvd->block_size;
+            CopyMem(&pvd->root, &VOL(p_volume,pvd).root,
+                    sizeof(VOL(p_volume,pvd).root));
+            CopyMem(pvd->vol_creation, VOL(p_volume,pvd).vol_creation,
+                    sizeof(VOL(p_volume,pvd).vol_creation));
             break;
         }
 
@@ -277,7 +284,7 @@ t_bool Iso_Init_Vol_Info(VOLUME *p_volume, int p_skip, t_ulong p_offset, t_ulong
     /*
        Look at the system ID to find out if the CD is supposed
        to feature proper file names. These are CDs made for use
-       with the CDTV and the CD³² (both share the "CDTV" system ID)
+       with the CDTV and the CD32 (both share the "CDTV" system ID)
        and the "Fresh Fish", "Frozen Fish" and "Gold Fish" CDs
        created by Mkisofs. If any of these IDs is found the
        file name to lower case conversion is temporarily
@@ -1095,4 +1102,3 @@ static t_handler const g_iso_handler =
     Iso_File_Length,
     Iso_Block_Size
 };
-

--- a/rom/filesys/CDVDFS/src/iso9660.h
+++ b/rom/filesys/CDVDFS/src/iso9660.h
@@ -131,7 +131,14 @@ typedef struct prim_vol_desc {
 /* for internal use only: */
 
 typedef struct iso_vol_info {
-  prim_vol_desc		pvd;
+  struct {
+    char                system_id[32];
+    char                volume_id[32];
+    uint32_t            space_size;
+    unsigned short      block_size;
+    directory_record    root;
+    time_and_date       vol_creation;
+  } pvd;
   int			skip;
   unsigned short	blockshift;
 } t_iso_vol_info;

--- a/rom/intuition/intuition_init.c
+++ b/rom/intuition/intuition_init.c
@@ -237,16 +237,6 @@ static int IntuitionInit(LIBBASETYPEPTR LIBBASE)
     GetPrivIBase(LIBBASE)->mosmenuclass = InitMuiMenuClass(LIBBASE);
 #endif
 
-    DEBUG_INIT(dprintf("LIB_Init: create menu handler task\n"));
-    /* FIXME: no cleanup routines for MenuHandler task */
-    if (!InitDefaultMenuHandler(GetPubIBase(LIBBASE)))
-        return FALSE;
-
-    /* FIXME: no cleanup routines for ScreennotifyHandler task */
-    if (!InitDefaultScreennotifyHandler(GetPubIBase(LIBBASE)))
-        return FALSE;
-
-
     DEBUG_INIT(dprintf("LIB_Init: load default preferences\n"));
     LoadDefaultPreferences(GetPubIBase(LIBBASE));
 #ifdef USEGETIPREFS
@@ -481,20 +471,6 @@ static int IntuitionOpen(LIBBASETYPEPTR LIBBASE)
     }
 # endif
 #endif
-
-    /* FIXME: no cleanup routines for MenuHandler task */
-    if (!GetPrivIBase(LIBBASE)->MenuHandlerPort)
-    {
-        if (!InitDefaultMenuHandler(GetPubIBase(LIBBASE)))
-            return FALSE;
-    }
-
-    /* FIXME: no cleanup routines for ScreennotifyHandler task */
-    if (!GetPrivIBase(LIBBASE)->ScreenNotifyReplyPort)
-    {
-        if (!InitDefaultScreennotifyHandler(GetPubIBase(LIBBASE)))
-            return FALSE;
-    }
 
 #ifdef INTUITION_NOTIFY_SUPPORT
     /* Add screennotify.library base if not there yet - Piru

--- a/rom/intuition/makeclass.c
+++ b/rom/intuition/makeclass.c
@@ -81,8 +81,6 @@
 {
     AROS_LIBFUNC_INIT
 
-#define MAX_PUDDLE_SIZE (__WORDSIZE * 1024 / 2)     /* Maximum puddle size */
-
 /*
  * Make sure class instance data is adequately aligned on SMP capable platforms
  */
@@ -137,8 +135,6 @@
             
             if (iclass != NULL)
             {
-                int perpuddle;
-
                 /* Initialize fields */
                 iclass->cl_Super      = superClassPtr;
                 iclass->cl_ID         = classID;
@@ -155,37 +151,13 @@
                         bug("[Intuition] %s: (orig offset %d)\n", __func__, superClassPtr->cl_InstOffset + superClassPtr->cl_InstSize);
                     }
                 )
-                /* Try to limit the puddle to MAX_PUDDLE_SIZE.
-                 * This comes in to play, for example, with
-                 * picture.library, where 32 instances of the
-                 * picture class is a whopping 280K.
-                 */
-                perpuddle = MAX_PUDDLE_SIZE / iclass->cl_ObjectSize;
-                if (perpuddle == 0)
-                    perpuddle = 1;
-                if (perpuddle > 32)
-                    perpuddle = 32;
-                D(
-                    bug("[Intuition] %s:%d alloc(s) per %dbyte puddle\n", __func__, perpuddle, MAX_PUDDLE_SIZE);
-                    bug("[Intuition] %s: needed = %dbyte  puddle\n", __func__, perpuddle * iclass->cl_ObjectSize);
-                )
-                /* Initialize memory subsystem */
-                iclass->cl_MemoryPool = CreatePool
-                (
-                    MEMF_ANY | MEMF_CLEAR | MEMF_SEM_PROTECTED,
-                    perpuddle * iclass->cl_ObjectSize, iclass->cl_ObjectSize
-                );
-                   
-                if (iclass->cl_MemoryPool != NULL)
-                {
-                    /* SuperClass is used one more time now */
-                    AROS_ATOMIC_INC(superClassPtr->cl_SubclassCount);
-                }
-                else
-                {
-                    FreeMem(iclass, sizeof(Class));
-                    iclass = NULL;
-                }
+                /* The per-class pool is created by NewObjectA() when the
+                 * class is first instantiated. Most registered classes are
+                 * never used during a given session. */
+                iclass->cl_MemoryPool = NULL;
+
+                /* SuperClass is used one more time now */
+                AROS_ATOMIC_INC(superClassPtr->cl_SubclassCount);
             }
         }
         else

--- a/rom/intuition/menutask.c
+++ b/rom/intuition/menutask.c
@@ -254,6 +254,21 @@ BOOL InitDefaultMenuHandler(struct IntuitionBase *IntuitionBase)
     return result;
 }
 
+/**************************************************************************************************/
+
+BOOL EnsureDefaultMenuHandler(struct IntuitionBase *IntuitionBase)
+{
+    struct IntIntuitionBase *priv = GetPrivIBase(IntuitionBase);
+    BOOL result = TRUE;
+
+    ObtainSemaphore(priv->IBaseLock);
+    if (!priv->MenuHandlerPort)
+        result = InitDefaultMenuHandler(IntuitionBase);
+    ReleaseSemaphore(priv->IBaseLock);
+
+    return result;
+}
+
 
 /**************************************************************************************************/
 
@@ -2018,4 +2033,3 @@ static void AddToSelection(struct MenuHandlerData *mhd, struct IntuitionBase *In
 
     } /* if ((mhd->activemenunum != -1) && (mhd->activeitemnum != -1)) */
 }
-

--- a/rom/intuition/menutask.h
+++ b/rom/intuition/menutask.h
@@ -127,6 +127,7 @@ struct MenuHandlerData
 #endif /* SKINS */
 
 BOOL InitDefaultMenuHandler(struct IntuitionBase *IntuitionBase);
+BOOL EnsureDefaultMenuHandler(struct IntuitionBase *IntuitionBase);
 struct Task *CreateMenuHandlerTask(APTR taskparams, struct IntuitionBase *IntuitionBase);
 void DefaultMenuHandler(struct MenuTaskParams *taskparams);
 

--- a/rom/intuition/newobjecta.c
+++ b/rom/intuition/newobjecta.c
@@ -12,6 +12,8 @@
 #include <proto/utility.h>
 #include "intuition_intern.h"
 
+#define MAX_PUDDLE_SIZE (__WORDSIZE * 1024 / 2)
+
 /*****************************************************************************
 
     NAME */
@@ -96,11 +98,30 @@
         }
     )
 
-    ObtainSemaphoreShared (&GetPrivIBase(IntuitionBase)->ClassListLock);
+    ObtainSemaphore(&GetPrivIBase(IntuitionBase)->ClassListLock);
 
     /* No classPtr ? */
     if (!classPtr)
         classPtr = FindClass (classID);
+
+    /* Create the class pool only when the first object actually needs it.
+     * The exclusive class lock also serializes concurrent first use. */
+    if (classPtr && !classPtr->cl_MemoryPool)
+    {
+        ULONG perpuddle = MAX_PUDDLE_SIZE / classPtr->cl_ObjectSize;
+
+        if (perpuddle == 0)
+            perpuddle = 1;
+        if (perpuddle > 32)
+            perpuddle = 32;
+
+        classPtr->cl_MemoryPool = CreatePool(
+            MEMF_ANY | MEMF_CLEAR | MEMF_SEM_PROTECTED,
+            perpuddle * classPtr->cl_ObjectSize,
+            classPtr->cl_ObjectSize);
+        if (!classPtr->cl_MemoryPool)
+            classPtr = NULL;
+    }
 
     /* Make sure the class doesn't go away while we create the object */
     if (classPtr)

--- a/rom/intuition/screennotifytask.c
+++ b/rom/intuition/screennotifytask.c
@@ -111,3 +111,17 @@ BOOL InitDefaultScreennotifyHandler(struct IntuitionBase *IntuitionBase)
     return result;
 }
 
+/**************************************************************************************************/
+
+BOOL EnsureDefaultScreennotifyHandler(struct IntuitionBase *IntuitionBase)
+{
+    struct IntIntuitionBase *priv = GetPrivIBase(IntuitionBase);
+    BOOL result = TRUE;
+
+    ObtainSemaphore(priv->IBaseLock);
+    if (!priv->ScreenNotifyReplyPort)
+        result = InitDefaultScreennotifyHandler(IntuitionBase);
+    ReleaseSemaphore(priv->IBaseLock);
+
+    return result;
+}

--- a/rom/intuition/screennotifytask.h
+++ b/rom/intuition/screennotifytask.h
@@ -22,6 +22,7 @@
 /* Structure passed to the DefaultMenuHandler task when it's initialized */
 
 BOOL InitDefaultScreennotifyHandler(struct IntuitionBase *IntuitionBase);
+BOOL EnsureDefaultScreennotifyHandler(struct IntuitionBase *IntuitionBase);
 
 struct ScreennotifyTaskParams
 {

--- a/rom/intuition/setmenustrip.c
+++ b/rom/intuition/setmenustrip.c
@@ -5,6 +5,7 @@
 
 #include "intuition_intern.h"
 #include "menus.h"
+#include "menutask.h"
 
 void CalculateDims(struct Window *win, struct Menu *menu);
 void Characterize(struct Menu *menu);
@@ -57,6 +58,9 @@ void Characterize(struct Menu *menu);
     AROS_LIBFUNC_INIT
 
     SANITY_CHECKR(window,FALSE)
+
+    if (!EnsureDefaultMenuHandler(IntuitionBase))
+        return FALSE;
 
 #define HASSUBITEM 0x8000
 

--- a/rom/intuition/startscreennotifytaglist.c
+++ b/rom/intuition/startscreennotifytaglist.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "intuition_intern.h"
+#include "screennotifytask.h"
 
 /*****************************************************************************
 
@@ -85,8 +86,18 @@
         notify->node.ln_Pri = (BYTE) GetTagData(SNA_Priority, 0, tags);
         notify->pubname = NULL;
 
+        /* Only asynchronous port notifications need the permanent reply
+         * task. Signal, hook, and synchronous notifications do not.
+         */
+        if (notify->port && !(notify->flags & SNOTIFY_WAIT_REPLY) &&
+            !EnsureDefaultScreennotifyHandler(IntuitionBase))
+        {
+            FreeVec(notify);
+            notify = NULL;
+        }
+
         char *pubname = (char *) GetTagData(SNA_PubName, 0, tags);
-        if (pubname)
+        if (notify && pubname)
         {
             notify->pubname = AllocVec(strlen(pubname) + 1, MEMF_CLEAR);
             if (notify->pubname)

--- a/rom/kernel/addexceptionhandler.c
+++ b/rom/kernel/addexceptionhandler.c
@@ -116,7 +116,7 @@ void *krnAddExceptionHandler(UBYTE num, APTR handler,  APTR handlerData, APTR ha
 #if defined(__AROSEXEC_SMP__)
             KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_WRITE);
 #endif
-            ADDHEAD(&KernelBase->kb_Exceptions[num], &handle->in_Node);
+            ADDHEAD(KERNEL_EXCEPTION_LIST(num), &handle->in_Node);
 #if defined(__AROSEXEC_SMP__)
             KrnSpinUnLock(&KernelBase->kb_IntrSpinLock);
 #endif
@@ -134,8 +134,12 @@ int krnRunExceptionHandlers(struct KernelBase *KernelBase, uint8_t exception, vo
     int ret = 0;
 
     /* We can be called really early. Protect against this. */
-    if (!KernelBase || (EXCEPTIONS_COUNT < exception))
+    if (!KernelBase)
         return 0;
+#if EXCEPTIONS_COUNT < 256
+    if (exception >= EXCEPTIONS_COUNT)
+        return 0;
+#endif
 
 #if defined(__AROSEXEC_SMP__)
     /*
@@ -159,9 +163,9 @@ int krnRunExceptionHandlers(struct KernelBase *KernelBase, uint8_t exception, vo
         unsigned int n = 0, i;
 
         KrnSpinLock(&KernelBase->kb_IntrSpinLock, NULL, SPINLOCK_MODE_READ);
-        ForeachNodeSafe(&KernelBase->kb_Exceptions[exception], in, in2)
+        ForeachNodeSafe(KERNEL_EXCEPTION_LIST(exception), in, in2)
         {
-            if (in->in_Handler)
+            if (KERNEL_EXCEPTION_MATCH(in, exception) && in->in_Handler)
             {
                 if (n < sizeof(snap) / sizeof(snap[0]))
                 {
@@ -181,11 +185,11 @@ int krnRunExceptionHandlers(struct KernelBase *KernelBase, uint8_t exception, vo
             ret |= snap[i].h(ctx, snap[i].d1, snap[i].d2);
     }
 #else
-    ForeachNodeSafe(&KernelBase->kb_Exceptions[exception], in, in2)
+    ForeachNodeSafe(KERNEL_EXCEPTION_LIST(exception), in, in2)
     {
         exhandler_t h = in->in_Handler;
 
-        if (h)
+        if (KERNEL_EXCEPTION_MATCH(in, exception) && h)
             ret |= h(ctx, in->in_HandlerData, in->in_HandlerData2);
     }
 #endif

--- a/rom/kernel/kernel_base.h
+++ b/rom/kernel/kernel_base.h
@@ -92,7 +92,11 @@ struct KernelBase
     struct List         kb_ICList;                      /* list of all controller types         */
     struct List         kb_InterruptMappings;
 #endif
+#ifdef KERNEL_SPARSE_EXCEPTIONS
+    struct MinList      kb_Exceptions;
+#else
     struct MinList      kb_Exceptions[EXCEPTIONS_COUNT];
+#endif
     struct KernelInt    kb_Interrupts[HW_IRQ_COUNT];
 #if defined(__AROSEXEC_SMP__)
     spinlock_t          kb_IntrSpinLock;            /* guards kb_Exceptions/kb_Interrupts chains */
@@ -109,6 +113,14 @@ struct KernelBase
     KrnSymResolver_t    kb_gResolver;
     APTR                kb_gResolvPrivate;
 };
+
+#ifdef KERNEL_SPARSE_EXCEPTIONS
+#define KERNEL_EXCEPTION_LIST(num) (&KernelBase->kb_Exceptions)
+#define KERNEL_EXCEPTION_MATCH(node, num) ((node)->in_nr == (num))
+#else
+#define KERNEL_EXCEPTION_LIST(num) (&KernelBase->kb_Exceptions[num])
+#define KERNEL_EXCEPTION_MATCH(node, num) (TRUE)
+#endif
 
 /*
  * Some useful global variables. They are global because:

--- a/rom/kernel/kernel_init.c
+++ b/rom/kernel/kernel_init.c
@@ -104,8 +104,12 @@ AROS_UFH3S(struct KernelBase *, Kernel_Init,
 
     D(bug("[KRN] KernelBase 0x%p\n", KernelBase));
 
+#ifdef KERNEL_SPARSE_EXCEPTIONS
+    NEWLIST(&KernelBase->kb_Exceptions);
+#else
     for (i=0; i < EXCEPTIONS_COUNT; i++)
         NEWLIST(&KernelBase->kb_Exceptions[i]);
+#endif
 
     for (i=0; i < HW_IRQ_COUNT; i++)
         NEWLIST(&KERNELIRQ_LIST(i));

--- a/rom/oop/hiddmetaclass.c
+++ b/rom/oop/hiddmetaclass.c
@@ -58,8 +58,8 @@ struct hiddmeta_inst
         {
             /* The globally unique ID of the interface */
             CONST_STRPTR interface_id;
-            ULONG num_methods;
-            ULONG mtab_offset;
+            UWORD num_methods;
+            UWORD mtab_offset;
             
         } *ifinfo;
         struct IFMethod *methodtable;
@@ -156,20 +156,27 @@ static BOOL hiddmeta_allocdisptabs(OOP_Class *cl, OOP_Object *o, struct P_meta_a
     D(bug("Number of  interfaces: %ld, methods %ld\n",
         total_num_ifs, total_num_methods));
     
-    /* Allocate the dispatch table */
+    /* Allocate the dispatch and interface tables together. */
     disptab_size = UB(&mtab[total_num_methods]) - UB(&mtab[0]);
+    if (total_num_methods > 0xffff)
+        ReturnBool("HIIDMeta::allocdisptabs", FALSE);
 
-    data->methodtable = AllocVec(disptab_size, MEMF_ANY|MEMF_CLEAR);
+    {
+        struct if_info *ifinfo = NULL;
+        ULONG ifinfo_size = UB(&ifinfo[total_num_ifs]) - UB(&ifinfo[0]);
+
+        data->methodtable = AllocVec(disptab_size + ifinfo_size,
+            MEMF_ANY | MEMF_CLEAR);
+        if (data->methodtable)
+            data->ifinfo = (struct if_info *)
+                (UB(data->methodtable) + disptab_size);
+    }
     if (data->methodtable)
     {
         struct if_info *ifinfo = NULL;
-        ULONG ifinfo_size;
         
         mtab = data->methodtable;
 
-        /* Allocate memory for interface info table */
-        ifinfo_size = UB(&ifinfo[total_num_ifs]) - UB(&ifinfo[0]);
-        data->ifinfo = AllocVec(ifinfo_size, MEMF_ANY|MEMF_CLEAR);
         if (data->ifinfo)
         {
             /* Iterate through all parent interfaces, copying relevant info
@@ -329,11 +336,12 @@ static BOOL hiddmeta_allocdisptabs(OOP_Class *cl, OOP_Object *o, struct P_meta_a
             
             ReturnBool("HIIDMeta::allocdisptabs", TRUE);
 init_err:
-            FreeVec(data->ifinfo);
-
+            ;
         } /* if (interface info table allocated) */
         
         FreeVec(data->methodtable);
+        data->methodtable = NULL;
+        data->ifinfo = NULL;
     
     } /* if (methodtable allocated) */
     
@@ -348,7 +356,6 @@ static VOID hiddmeta_freedisptabs(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
     struct hiddmeta_inst *inst = (struct hiddmeta_inst *)o;
     
     FreeVec(inst->data.methodtable);
-    FreeVec(inst->data.ifinfo);
     return;
 }
 

--- a/rom/oop/rootclass.c
+++ b/rom/oop/rootclass.c
@@ -107,13 +107,16 @@
 OOP_Object *root_new(OOP_Class *root_cl, OOP_Class *cl, struct pRoot_New *param)
 {
     struct _OOP_Object *o;
+    ULONG size;
 
     EnterFunc(bug("Root::New(cl=%s, param = %p)\n",
         cl->ClassNode.ln_Name, param));
     
     /* Allocate memory for the object */
-    D(bug("Object size: %ld\n", MD(cl)->public.InstOffset + MD(cl)->instsize + sizeof (struct _OOP_Object)));
-    o = AllocVec(MD(cl)->public.InstOffset + MD(cl)->instsize + sizeof (struct _OOP_Object), MEMF_ANY|MEMF_CLEAR);
+    size = MD(cl)->public.InstOffset + MD(cl)->instsize
+        + sizeof(struct _OOP_Object);
+    D(bug("Object size: %ld\n", size));
+    o = AllocMem(size, MEMF_ANY | MEMF_CLEAR);
     if (o)
     {
         D(bug("Mem allocated: %p\n", o));
@@ -133,13 +136,17 @@ OOP_Object *root_new(OOP_Class *root_cl, OOP_Class *cl, struct pRoot_New *param)
 ****************/
 static VOID root_dispose(OOP_Class *root_cl, OOP_Object *o, OOP_Msg msg)
 {
+    OOP_Class *cl = OOP_OCLASS(o);
+    ULONG size = MD(cl)->public.InstOffset + MD(cl)->instsize
+        + sizeof(struct _OOP_Object);
+
     EnterFunc(bug("Root::Dispose(o=%p, oclass=%s)\n", o, _OOP_OBJECT(o)->o_Class->ClassNode.ln_Name));
 
-    AROS_ATOMIC_DEC(MD(OOP_OCLASS(o))->objectcount);
-    D(bug("Object mem: %p, size: %ld\n", _OOP_OBJECT(o), ((ULONG *)_OOP_OBJECT(o))[-1] ));
+    AROS_ATOMIC_DEC(MD(cl)->objectcount);
+    D(bug("Object mem: %p, size: %ld\n", _OOP_OBJECT(o), size));
     
     /* Free object's memory */
-    FreeVec(_OOP_OBJECT(o));
+    FreeMem(_OOP_OBJECT(o), size);
     
     ReturnVoid("Root::Dispose");
 }
@@ -243,5 +250,3 @@ static IPTR root_coercemethod(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
 }
 
 */
-
-

--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -747,8 +747,7 @@ __startup AROS_CLI(ShellStart)
 
     D(bug("Shell %ld: exiting, error = %ld\n", ss->cliNumber, error));
 
-    if (ss->arg_rd)
-        FreeDosObject(DOS_RDARGS, ss->arg_rd);
+    freeInterpreterState(ss);
 
     FreeMem(ss, sizeof(ShellState));
 
@@ -763,4 +762,3 @@ __startup AROS_CLI(ShellStart)
 
     return error ? RETURN_FAIL : RETURN_OK;
 }
-

--- a/workbench/c/Shell/Shell.c
+++ b/workbench/c/Shell/Shell.c
@@ -485,10 +485,16 @@ static LONG executeLine(ShellState *ss, STRPTR commandArgs)
     BPTR module, scriptLock = BNULL;
     LONG error = 0;
     TEXT *cmd;
+    ULONG cmdSize = (commandArgs ? strlen(commandArgs) : 0)
+        + FILE_MAX + 4;
 
     D(bug("[Shell] executeLine: %s %s\n", command, commandArgs));
 
-    cmd = AllocVec(4096 * sizeof(TEXT), MEMF_ANY);
+    /* Reserve only what can be written below: an optional quoted path
+     * (limited to FILE_MAX by NameFromLock), a separating space, the
+     * already parsed argument string, and the terminator.
+     */
+    cmd = AllocVec(cmdSize, MEMF_ANY);
     if (!cmd) {
         PrintFault(ERROR_NO_FREE_STORE, NULL);
         return ERROR_NO_FREE_STORE;

--- a/workbench/c/Shell/Shell.h
+++ b/workbench/c/Shell/Shell.h
@@ -138,6 +138,7 @@ void cliPrompt(ShellState *ss);
  * FIXME: some doc ?
  */
 void initDefaultInterpreterState(ShellState *ss);
+void freeInterpreterState(ShellState *ss);
 void popInterpreterState(ShellState *ss);
 LONG pushInterpreterState(ShellState *ss);
 

--- a/workbench/c/Shell/buffer.c
+++ b/workbench/c/Shell/buffer.c
@@ -11,7 +11,7 @@
 
 #include "Shell.h"
 
-#define BUF_SIZE 512
+#define BUF_SIZE 128
 
 static BOOL bufferExpand(Buffer *out, LONG size, ShellState *ss)
 {

--- a/workbench/c/Shell/convertArg.c
+++ b/workbench/c/Shell/convertArg.c
@@ -45,9 +45,9 @@ LONG convertArg(ShellState *ss, Buffer *in, Buffer *out, BOOL *quoted)
 
     for (i = 0; i < ss->argcount; ++i)
     {
-        struct SArg *a = ss->args + i;
+        struct SArg *a = ss->arguments->args + i;
         STRPTR arg = NULL;
-        IPTR val = ss->arg[i];
+        IPTR val = ss->arguments->values[i];
         UBYTE t = a->type;
         LONG j, len = a->namelen;
 

--- a/workbench/c/Shell/convertLineDot.c
+++ b/workbench/c/Shell/convertLineDot.c
@@ -10,6 +10,15 @@
 
 #include "Shell.h"
 
+static BOOL ensureArguments(ShellState *ss)
+{
+    if (!ss->arguments)
+        ss->arguments = AllocMem(sizeof(*ss->arguments),
+                                 MEMF_LOCAL | MEMF_CLEAR);
+
+    return ss->arguments != NULL;
+}
+
 static LONG getArgumentIdx(ShellState *ss, STRPTR name, LONG len)
 {
     struct SArg *a;
@@ -20,7 +29,7 @@ static LONG getArgumentIdx(ShellState *ss, STRPTR name, LONG len)
 
     for (i = 0; i < ss->argcount; ++i)
     {
-        a = ss->args + i;
+        a = ss->arguments->args + i;
 
         if (a->namelen == len && strncmp(a->name, name, len) == 0)
             return i;
@@ -29,8 +38,11 @@ static LONG getArgumentIdx(ShellState *ss, STRPTR name, LONG len)
     if (ss->argcount >= MAXARGS)
         return -1;
 
+    if (!ensureArguments(ss))
+        return -1;
+
     ss->argcount++;
-    a = ss->args + i;
+    a = ss->arguments->args + i;
     CopyMem(name, a->name, len);
     a->name[len] = '\0';
     a->namelen = len;
@@ -58,7 +70,7 @@ static LONG dotDef(ShellState *ss, STRPTR szz, Buffer *in, LONG len)
         if (i < 0)
             return ERROR_TOO_MANY_ARGS;
 
-        a = ss->args + i;
+        a = ss->arguments->args + i;
         i = ++in->cur;
 
         switch (bufferReadItem(buf, sizeof(buf), in, ss))
@@ -107,10 +119,16 @@ static LONG dotKey(ShellState *ss, STRPTR s, Buffer *in)
 
     /* Free the old ReadArgs value */
     if (ss->arg_rd)
+    {
         FreeDosObject(DOS_RDARGS, ss->arg_rd);
+        ss->arg_rd = NULL;
+    }
 
-    memset(ss->arg, 0, sizeof(IPTR) * MAXARGS);
-    if ((ss->arg_rd = ReadArgs(t, ss->arg, NULL)) == NULL)
+    if (!ensureArguments(ss))
+        return ERROR_NO_FREE_STORE;
+
+    memset(ss->arguments->values, 0, sizeof(ss->arguments->values));
+    if ((ss->arg_rd = ReadArgs(t, ss->arguments->values, NULL)) == NULL)
         return IoErr();
 
     ss->argcount = 0;
@@ -129,8 +147,8 @@ static LONG dotKey(ShellState *ss, STRPTR s, Buffer *in)
         if (j < 0)
             return ERROR_TOO_MANY_ARGS;
 
-        arg = (STRPTR) ss->arg[j];
-        a = ss->args + j;
+        arg = (STRPTR) ss->arguments->values[j];
+        a = ss->arguments->args + j;
 
         while (*s == '/')
         {

--- a/workbench/c/Shell/interpreter.c
+++ b/workbench/c/Shell/interpreter.c
@@ -9,30 +9,14 @@
 
 void initDefaultInterpreterState(ShellState *ss)
 {
-    LONG i;
-
     ss->argcount = 0;
+    ss->arguments = NULL;
 
     /* Preset the first bytes to "C:" to handle C: multiassigns */
     ss->command[0] = 'C';
     ss->command[1] = ':';
 
-    for (i =  0; i < MAXARGS; ++i)
-    {
-        struct SArg *a = ss->args + i;
-
-        a->namelen  = 0;
-        a->name[0]  = '\0';
-        a->len      = 0;
-        a->def      = 0;
-        a->deflen   = 0;
-        a->type     = NORMAL;
-
-        ss->arg[i]  = 0;
-    }
-
     ss->arg_rd = NULL;
-
     ss->bra    = '<';
     ss->ket    = '>';
     ss->dollar = '$';
@@ -56,15 +40,14 @@ LONG pushInterpreterState(ShellState *ss)
     return ERROR_NO_FREE_STORE;
 }
 
-void popInterpreterState(ShellState *ss)
+void freeInterpreterState(ShellState *ss)
 {
-    ShellState *tmp_ss = ss->stack;
     struct SArg *a;
     LONG i;
 
-    for (i = 0; i < ss->argcount; ++i)
+    for (i = 0; ss->arguments && i < ss->argcount; ++i)
     {
-        a = ss->args + i;
+        a = ss->arguments->args + i;
 
         if (a->def)
             FreeMem((APTR) a->def, a->deflen + 1);
@@ -72,6 +55,20 @@ void popInterpreterState(ShellState *ss)
 
     if (ss->arg_rd)
         FreeDosObject(DOS_RDARGS, ss->arg_rd);
+
+    if (ss->arguments)
+        FreeMem(ss->arguments, sizeof(*ss->arguments));
+
+    ss->arg_rd = NULL;
+    ss->arguments = NULL;
+    ss->argcount = 0;
+}
+
+void popInterpreterState(ShellState *ss)
+{
+    ShellState *tmp_ss = ss->stack;
+
+    freeInterpreterState(ss);
 
     if (tmp_ss)
     {

--- a/workbench/c/Shell/state.h
+++ b/workbench/c/Shell/state.h
@@ -24,6 +24,12 @@ struct SArg
     UBYTE  type;
 };
 
+struct ShellArguments
+{
+    struct SArg args[MAXARGS];
+    IPTR values[MAXARGS];
+};
+
 typedef struct _ShellState
 {
     BPTR	newIn;
@@ -40,8 +46,7 @@ typedef struct _ShellState
     BOOL	background;	/* shell was created as a background one */
 
     LONG	argcount;	/* script args count */
-    struct SArg	args[MAXARGS];	/* args definitions */
-    IPTR	arg[MAXARGS];	/* args values */
+    struct ShellArguments *arguments; /* allocated only for .key/.def */
     struct RDArgs *arg_rd;	/* Current RDArgs return state */
 
     TEXT	bra, ket, dollar, dot;


### PR DESCRIPTION
This branch reduces m68k memory use through several small, compatible optimizations:

- Shrinks CPU, task, exception-handler, Exec-pool and HIDD bookkeeping structures.
- Makes small Exec pools grow gradually instead of reserving large blocks immediately—the largest saving.
- Right-sizes gameport and CDVDFS buffers and retains only necessary ISO metadata.
- Removes per-object allocation overhead from OOP objects.
- Creates optional Intuition pools and helper tasks only when needed.
- Reduces Shell command/parsing buffers and allocates script arguments on demand.
- Improves allocation placement to preserve larger contiguous blocks for programs.

Measured with WB1.3:

- 96,600 bytes saved at Startup-Sequence entry
- 117,928 bytes saved after reaching the desktop
- Memory usage at the desktop falls from about 587 KiB to 472 KiB