### PR TITLE
posixc: answer sysconf(_SC_CLK_TCK)

### DIFF
--- a/compiler/crt/posixc/sysconf.c
+++ b/compiler/crt/posixc/sysconf.c
@@ -10,6 +10,7 @@
 /*****************************************************************************
 
     NAME */
+#include <time.h>
 #include <unistd.h>
 
         long sysconf(
@@ -24,7 +25,8 @@
     RESULT
 
     NOTES
-        Currently only _SC_ARG_MAX handling is implemented
+        Only _SC_ARG_MAX, _SC_PAGESIZE/_SC_PAGE_SIZE and _SC_CLK_TCK are
+        implemented; other names fail with EINVAL.
 
     EXAMPLE
 
@@ -44,6 +46,11 @@
         case _SC_PAGESIZE: /* same value expected for _SC_PAGE_SIZE */
         case _SC_PAGE_SIZE:
             return 4096;
+
+        case _SC_CLK_TCK:
+            /* What times() and clock() count in; CPython refuses to start
+               when this query fails. */
+            return CLOCKS_PER_SEC;
 
         default:
             errno = EINVAL;

--- a/developer/debug/test/crt/posixc/mmakefile.src
+++ b/developer/debug/test/crt/posixc/mmakefile.src
@@ -24,6 +24,7 @@ POSIXCTESTFILES := \
         statfs \
         strptime \
         strtok_r \
+        sysconf_clktck \
         termios_tty \
         time_r \
         uname \

--- a/developer/debug/test/crt/posixc/sysconf_clktck.c
+++ b/developer/debug/test/crt/posixc/sysconf_clktck.c
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026, The AROS Development Team. All rights reserved. */
+/* sysconf(_SC_CLK_TCK) must answer, and agree with CLOCKS_PER_SEC. */
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+
+int main(void)
+{
+    long ticks, pagesize;
+    int failed = 0, error = 0;
+#define CHECK(x) do { if (!(x)) { failed = __LINE__; error = errno; goto done; } } while (0)
+    errno = 0;
+    ticks = sysconf(_SC_CLK_TCK);
+    CHECK(ticks > 0);
+    CHECK(ticks == CLOCKS_PER_SEC);
+    errno = 0;
+    pagesize = sysconf(_SC_PAGESIZE);
+    CHECK(pagesize > 0);
+    errno = 0;
+    CHECK(sysconf(-1) == -1 && errno == EINVAL);
+done:
+    if (failed) printf("SYSCONF CLK_TCK FAIL line=%d errno=%d ticks=%ld\n", failed, error, ticks);
+    else printf("SYSCONF CLK_TCK PASS: ticks=%ld pagesize=%ld unknown=EINVAL\n", ticks, pagesize);
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
`sysconf()` in posixc answers `_SC_ARG_MAX` and the page size and fails every other name with `EINVAL`. `_SC_CLK_TCK` is the first thing CPython 3.14 asks at startup: `posixmodule` init calls `_Py_GetTicksPerSecond()`, and a failed `sysconf(_SC_CLK_TCK)` is fatal there, so the interpreter stops before importing anything with `RuntimeError: cannot read ticks_per_second`. Any other program that sizes `times()` output the POSIX way meets the same wall.

## Change

Return `CLOCKS_PER_SEC` for `_SC_CLK_TCK`, which is the unit `clock()` and `times()` count in here (50 on every AROS target, from `aros/stdc/time.h`). The autodoc note now lists what is implemented. Unknown names still fail with `EINVAL`.

Nothing here depends on the CPU: the same value and code path apply to x86_64 and aarch64.

## Verification

A regression probe is added and registered in the test build: `developer/debug/test/crt/posixc/sysconf_clktck.c`. It requires `sysconf(_SC_CLK_TCK)` to be positive and equal to `CLOCKS_PER_SEC`, `_SC_PAGESIZE` to be positive, and an unknown name to fail with `EINVAL`. It cross-compiles with GNU99, O2, Wall/Wextra/Werror against the mainline x86_64 SDK.

Run in the installed x86_64 AROS guest (`pc,accel=tcg`), first with the guest's own posixc.library, then with a rebuilt one copied into `SYS:Libs` and a reboot:

```text
posixc.library 0.35
SYSCONF CLK_TCK FAIL line=15 errno=22 ticks=-1

posixc.library 0.35
SYSCONF CLK_TCK PASS: ticks=50 pagesize=4096 unknown=EINVAL
```

With the rebuilt library installed, a CPython 3.14.7 built for AROS gets past `posixmodule` init and runs (that build carries a local fallback to `CLOCKS_PER_SEC` for the same reason; this change makes the fallback unnecessary).

## Limits

Only `_SC_CLK_TCK` is added; the other `_SC_*` names still return `EINVAL`. No aarch64 runtime test was performed. The guest was rebooted between the two runs so the resident library was really the new one; no other change was made to it.
