### PR TITLE
tools/package: restore cwd on failure

### DIFF
--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -98,33 +98,35 @@ def unpack( source, destination ):
     input     = open( source, 'rb' )
     
     oldwd = os.getcwd()
-    os.chdir( destination )
-    destinationRoot = os.path.realpath( os.getcwdb() )
-    
-    version = readHeader( input )
-    
-    while input.tell() < inputSize:
-        (path, data) = readFile( input )
-        
-        print('« %s (%d bytes)' % (path, len( data )))
-        
-        target = os.path.realpath( os.path.abspath( path ) )
-        try:
-            contained = os.path.commonpath((destinationRoot, target)) == destinationRoot
-        except ValueError:
-            contained = False
-        if os.path.isabs( path ) or not contained:
-            raise ValueError('Package member path escapes destination: %r' % path)
+    try:
+        os.chdir( destination )
+        destinationRoot = os.path.realpath( os.getcwdb() )
 
-        directory = os.path.dirname( path )
-        if directory and not os.path.exists( directory ):
-            os.makedirs( directory )
-            
-        output = open( path, 'wb' )
-        output.write( data )
-        output.close()
-        
-    os.chdir( oldwd )
+        version = readHeader( input )
+
+        while input.tell() < inputSize:
+            (path, data) = readFile( input )
+
+            print('« %s (%d bytes)' % (path, len( data )))
+
+            target = os.path.realpath( os.path.abspath( path ) )
+            try:
+                contained = os.path.commonpath((destinationRoot, target)) == destinationRoot
+            except ValueError:
+                contained = False
+            if os.path.isabs( path ) or not contained:
+                raise ValueError('Package member path escapes destination: %r' % path)
+
+            directory = os.path.dirname( path )
+            if directory and not os.path.exists( directory ):
+                os.makedirs( directory )
+
+            output = open( path, 'wb' )
+            output.write( data )
+            output.close()
+
+    finally:
+        os.chdir( oldwd )
     
 
 def pack( destination, files ):
@@ -133,27 +135,29 @@ def pack( destination, files ):
     output = open( destination, 'wb' )
 
     oldwd = os.getcwd()
-    if os.path.isdir( files[0] ):
-        os.chdir( files[0] )
-        files = files[1:]
-    
-    if len(files) == 0:
-    	files = listFiles()   
+    try:
+        if os.path.isdir( files[0] ):
+            os.chdir( files[0] )
+            files = files[1:]
 
-    writeHeader( output, PKG_VERSION )
-    
-    for path in files:
-        print('» %s (%d bytes)' % (path, os.path.getsize( path )))
-        
-        input = open( path, 'rb' )
-        # Record the name the file is known by, never the path it
-        # happened to be built at - an absolute path is a property of
-        # the build machine, not of the package.
-        name = os.path.basename( path ) if os.path.isabs( path ) else path
-        writeFile( output, name, input.read() )
-        input.close()
-    
-    os.chdir( oldwd )
+        if len(files) == 0:
+            files = listFiles()
+
+        writeHeader( output, PKG_VERSION )
+
+        for path in files:
+            print('» %s (%d bytes)' % (path, os.path.getsize( path )))
+
+            input = open( path, 'rb' )
+            # Record the name the file is known by, never the path it
+            # happened to be built at - an absolute path is a property of
+            # the build machine, not of the package.
+            name = os.path.basename( path ) if os.path.isabs( path ) else path
+            writeFile( output, name, input.read() )
+            input.close()
+
+    finally:
+        os.chdir( oldwd )
     
     output.seek( struct.calcsize( PKG_HEADER_FORMAT ) )
     st = os.fstat( output.fileno() )


### PR DESCRIPTION
Both `unpack()` and `pack()` change the process working directory and currently restore it only on the normal completion path. An exception after `chdir()` therefore leaves the caller in the package source or extraction directory.

Wrap the cwd-dependent sections in `try/finally` so the original working directory is restored on both success and failure.

Stream lifetime and the existing zero-argument behavior remain separate follow-ups.

The larger textual diff is from reindenting the affected blocks under `try/finally`; pre-existing mixed whitespace in those touched lines was normalized at the same time.
