### PR TITLE
wanderer: preserve multiline hidden volume list

### DIFF
--- a/workbench/system/Wanderer/wandererprefs.c
+++ b/workbench/system/Wanderer/wandererprefs.c
@@ -1011,7 +1011,7 @@ IPTR WandererPrefs__MUIM_WandererPrefs_ReloadHiddenVolumes
     D(bug("[Wanderer:Prefs] %s()\n", __func__));
 
     len = GetVar((STRPTR)wandererPrefs_HiddenVolumesVar, buffer, sizeof(buffer) - 1,
-        GVF_GLOBAL_ONLY);
+        GVF_GLOBAL_ONLY | GVF_BINARY_VAR);
 
     if (len < 0)
         len = 0;


### PR DESCRIPTION
Wanderer's hidden volume list is newline-separated, but `ReloadHiddenVolumes()` reads it with the normal text-variable semantics of `GetVar()`, so only the first entry is loaded.

Use `GVF_BINARY_VAR` when reading the variable so the existing multiline matcher receives the complete list.
