### PR TITLE
tools/package: fix zero-argument fallback

### DIFF
--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -142,7 +142,7 @@ def pack( destination, files ):
 
         oldwd = os.getcwd()
         try:
-            if os.path.isdir( files[0] ):
+            if files and os.path.isdir( files[0] ):
                 os.chdir( files[0] )
                 files = files[1:]
 


### PR DESCRIPTION
`pack()` supports falling back to `listFiles()` when no input files are
specified, but currently indexes `files[0]` before reaching that fallback.

Guard the directory check so an empty file list reaches the existing
zero-argument fallback instead of raising `IndexError`.

Package format handling is unchanged.