### PR TITLE
tools/package: exclude output from implicit enumeration

### DIFF
--- a/tools/package/pkg
+++ b/tools/package/pkg
@@ -147,7 +147,9 @@ def pack( destination, files ):
                 files = files[1:]
 
             if len(files) == 0:
-                files = listFiles()
+                outputStat = os.fstat( output.fileno() )
+                files = [path for path in listFiles()
+                         if not os.path.samestat( os.stat( path ), outputStat )]
 
             writeHeader( output, PKG_VERSION )
 


### PR DESCRIPTION
When `pack()` is called without explicit input files, it falls back to
enumerating the current directory.

At that point the destination package has already been opened, so the
enumeration can include the package being written and feed it back into
itself.

Exclude the output file by file identity when building the implicit input
list. This also handles aliases such as hard links to the same file.

Explicit input-file handling and the package format are unchanged.